### PR TITLE
Landing page redesign + per-type note polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ site/dist/
 .cache/
 coverage/
 .tmp-test-vault*/
+.playwright-mcp/
+/*.png

--- a/site/src/components/GlossaryPrimer.astro
+++ b/site/src/components/GlossaryPrimer.astro
@@ -1,0 +1,69 @@
+---
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+
+const TERMS: { term: string; gloss: string; anchor: string }[] = [
+  { term: 'Mold',     gloss: 'Abstract, structured template for one workflow-construction action. Cast into self-contained skills.', anchor: 'mold' },
+  { term: 'Pipeline', gloss: 'Ordered sequence of phases that compose a harness journey (e.g. paper-to-galaxy).', anchor: 'pipeline' },
+  { term: 'Phase',    gloss: 'One atomic unit of a Pipeline — Mold-shaped, [branch], or future [gate].', anchor: 'phase' },
+  { term: 'Branch',   gloss: 'A non-Mold phase encoding harness-level routing or fallback (e.g. discover-or-author).', anchor: 'branch' },
+  { term: 'Cast',     gloss: 'Produce a self-contained skill artifact from a Mold via the casting process.', anchor: 'cast' },
+  { term: 'Pattern',  gloss: 'Reference page describing a Galaxy workflow construction pattern. Referenced by Molds.', anchor: 'pattern-page' },
+  { term: 'Foundry',  gloss: 'The standalone knowledge base where Pipelines, Molds, patterns, and CLI manuals live.', anchor: 'foundry' },
+];
+---
+<section aria-labelledby="concept-primer-heading">
+  <div class="section-rule">
+    <h2 id="concept-primer-heading">Concept primer</h2>
+    <span class="section-tail">/ 7 core terms</span>
+    <a href={`${base}/glossary/`} class="ml-auto text-sm text-(--color-link) hover:text-(--color-link-hover)">
+      full glossary →
+    </a>
+  </div>
+
+  <dl class="primer-grid m-0">
+    {TERMS.map(t => (
+      <a href={`${base}/glossary/#${t.anchor}`} class="primer-row no-underline">
+        <dt class="primer-term">{t.term}</dt>
+        <dd class="primer-gloss">{t.gloss}</dd>
+      </a>
+    ))}
+  </dl>
+</section>
+
+<style>
+  .primer-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
+    gap: 0;
+  }
+  .primer-row {
+    display: block;
+    padding: 0.7rem 0.9rem;
+    border-left: 2px solid var(--color-border-subtle);
+    color: inherit;
+    transition: border-color 0.15s ease, background 0.15s ease, padding-left 0.15s ease;
+  }
+  .primer-row:hover {
+    border-left-color: var(--color-accent);
+    background: color-mix(in srgb, var(--color-accent) 5%, transparent);
+    padding-left: 1.1rem;
+  }
+  .primer-term {
+    font-family: var(--font-mono);
+    font-weight: 700;
+    font-size: 0.95rem;
+    letter-spacing: -0.01em;
+    color: var(--color-link);
+    margin-bottom: 0.15rem;
+  }
+  .primer-row:hover .primer-term {
+    color: var(--color-accent);
+  }
+  .primer-gloss {
+    margin: 0;
+    font-size: 0.875rem;
+    line-height: 1.5;
+    color: var(--color-text-secondary);
+    text-wrap: pretty;
+  }
+</style>

--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -3,7 +3,7 @@ import Search from 'astro-pagefind/components/Search';
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const pathname = Astro.url.pathname.replace(/\/$/, '') || '/';
 const navLinks = [
-  { href: `${base}/`, label: 'Dashboard', match: (p: string) => p === (base || '') || p === '/' },
+  { href: `${base}/dashboard/`, label: 'Dashboard', match: (p: string) => p.startsWith(`${base}/dashboard`) },
   { href: `${base}/molds/`, label: 'Molds', match: (p: string) => p.startsWith(`${base}/molds`) },
   { href: `${base}/pipelines/`, label: 'Pipelines', match: (p: string) => p.startsWith(`${base}/pipelines`) && !p.includes('/molds') },
   { href: `${base}/index/`, label: 'Index', match: (p: string) => p.startsWith(`${base}/index`) },

--- a/site/src/components/NoteHeader.astro
+++ b/site/src/components/NoteHeader.astro
@@ -5,35 +5,116 @@ interface Props {
   entry: CollectionEntry<'content'>;
   pageTitle: string;
   typeLabel: string;
+  eyebrow?: string;
+  showActions?: boolean;
 }
 
-const { entry, pageTitle, typeLabel } = Astro.props;
+const { entry, pageTitle, typeLabel, eyebrow, showActions = false } = Astro.props;
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const data = entry.data;
 ---
-<header class="mb-6 border-l-2 border-(--color-accent) pl-4 sm:pl-5">
-  <a href={`${base}/`} class="inline-flex items-center gap-1 text-xs text-(--color-text-secondary) hover:text-(--color-link) no-underline transition-colors">
-    <span aria-hidden="true">&larr;</span> Dashboard
+<header class="note-header">
+  <a href={`${base}/`} class="note-back">
+    <span aria-hidden="true">&larr;</span> Home
   </a>
-  <div class="mt-1 flex items-baseline gap-2">
-    <span class="text-xs uppercase tracking-wider text-(--color-text-secondary)">{typeLabel}</span>
-  </div>
-  <h1 class="mt-1 text-3xl font-bold text-balance text-(--color-text-primary)" data-pagefind-meta="title">{pageTitle}</h1>
+  <span class="note-eyebrow">
+    <span class="note-eyebrow-rule" aria-hidden="true"></span>
+    <span>{eyebrow ?? typeLabel}</span>
+  </span>
+  <h1 class="note-title text-balance" data-pagefind-meta="title">{pageTitle}</h1>
   {data.summary && (
-    <p class="mt-2 text-base text-(--color-text-secondary) text-pretty" data-pagefind-weight="10" data-pagefind-meta="summary">{data.summary}</p>
+    <p class="note-summary text-pretty" data-pagefind-weight="10" data-pagefind-meta="summary">{data.summary}</p>
   )}
-  <div class="mt-3 flex flex-wrap gap-2 items-center">
+  <div class="note-tags">
     <span class={`badge badge-${data.status}`}>{data.status}</span>
     {data.tags.map(t => <a href={`${base}/tags/${t}/`} class="no-underline"><span class="tag">{t}</span></a>)}
   </div>
-  <div class="mt-3 flex gap-2">
-    <a href={`${base}/raw/${entry.id}.md`}
-       class="text-xs px-2.5 py-1 rounded border border-(--color-border) text-(--color-text-secondary) no-underline hover:bg-(--color-surface-hover) hover:text-(--color-text-primary) transition-colors">
-      Raw
-    </a>
-    <button class="copy-raw text-xs px-2.5 py-1 rounded border border-(--color-border) text-(--color-text-secondary) cursor-pointer hover:bg-(--color-surface-hover) hover:text-(--color-text-primary) transition-colors"
-       data-url={`${base}/raw/${entry.id}.md`}>
-      Copy
-    </button>
-  </div>
+  {showActions && (
+    <div class="note-actions">
+      <a href={`${base}/raw/${entry.id}.md`} class="note-action">Raw</a>
+      <button class="copy-raw note-action" data-url={`${base}/raw/${entry.id}.md`}>Copy</button>
+    </div>
+  )}
 </header>
+
+<style>
+  .note-header {
+    margin-bottom: 1.75rem;
+    padding-bottom: 1.25rem;
+    border-bottom: 1px solid var(--color-border-subtle);
+  }
+  .note-back {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    text-decoration: none;
+    transition: color 0.15s ease;
+  }
+  .note-back:hover {
+    color: var(--color-link);
+  }
+  .note-eyebrow {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-top: 0.65rem;
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+  }
+  .note-eyebrow-rule {
+    width: 1.5rem;
+    height: 2px;
+    background: var(--color-accent);
+  }
+  .note-title {
+    margin: 0.4rem 0 0;
+    font-size: clamp(1.85rem, 3.2vw + 0.5rem, 2.65rem);
+    font-weight: 700;
+    line-height: 1.08;
+    letter-spacing: -0.02em;
+    color: var(--color-text-primary);
+  }
+  .note-summary {
+    margin: 0.6rem 0 0;
+    max-width: 65ch;
+    font-size: 1rem;
+    line-height: 1.55;
+    color: var(--color-text-secondary);
+  }
+  .note-tags {
+    margin-top: 0.9rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    align-items: center;
+  }
+  .note-actions {
+    margin-top: 0.85rem;
+    display: flex;
+    gap: 0.5rem;
+  }
+  .note-action {
+    font-size: 0.72rem;
+    padding: 0.3rem 0.6rem;
+    border-radius: 0.25rem;
+    border: 1px solid var(--color-border);
+    color: var(--color-text-secondary);
+    background: transparent;
+    text-decoration: none;
+    cursor: pointer;
+    font-family: var(--font-mono);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+  }
+  .note-action:hover {
+    background: var(--color-surface-hover);
+    color: var(--color-text-primary);
+    border-color: var(--color-accent);
+  }
+</style>

--- a/site/src/components/NoteMeta.astro
+++ b/site/src/components/NoteMeta.astro
@@ -5,9 +5,11 @@ import { resolveWikiLink, type WikiLinkTarget } from '../lib/wiki-links';
 interface Props {
   entry: CollectionEntry<'content'>;
   linkMap: Map<string, WikiLinkTarget>;
+  mode?: 'full' | 'related-only';
 }
 
-const { entry, linkMap } = Astro.props;
+const { entry, linkMap, mode = 'full' } = Astro.props;
+const showRevision = mode === 'full';
 const data = entry.data as any;
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 
@@ -24,86 +26,148 @@ const parentPattern = data.parent_pattern ? resolveWikiLink(data.parent_pattern,
 const relatedNotes = resolveAll(data.related_notes);
 const relatedPatterns = resolveAll(data.related_patterns);
 const relatedMolds = resolveAll(data.related_molds);
+const hasSources = data.sources && data.sources.length > 0;
+const hasAnything =
+  showRevision ||
+  parentPattern ||
+  (showRevision && hasSources) ||
+  relatedPatterns.length > 0 ||
+  relatedMolds.length > 0 ||
+  relatedNotes.length > 0;
 ---
-<dl class="meta mb-6 p-3 rounded-lg bg-(--color-surface-raised) border-l-4 border-(--color-accent)">
-  <dt>Revised:</dt>
-  <dd>{formatDate(data.revised)}</dd>
-
-  <dt>Revision:</dt>
-  <dd>{data.revision}</dd>
-
-  {parentPattern && (
+{hasAnything && (
+<dl class="note-meta">
+  {showRevision && (
     <>
-      <dt>Parent Pattern:</dt>
-      <dd>
-        {parentPattern.href
-          ? <a href={parentPattern.href} title={parentPattern.summary || undefined} class="text-(--color-link) hover:underline">{parentPattern.label}</a>
-          : <span class="dangling">{parentPattern.label}</span>}
-      </dd>
+      <div class="meta-pair">
+        <dt>Revised</dt>
+        <dd>{formatDate(data.revised)}</dd>
+      </div>
+      <div class="meta-pair">
+        <dt>Rev</dt>
+        <dd>{data.revision}</dd>
+      </div>
     </>
   )}
 
-  {data.sources && data.sources.length > 0 && (
-    <>
-      <dt>Sources:</dt>
+  {parentPattern && (
+    <div class="meta-pair">
+      <dt>Parent</dt>
+      <dd>
+        {parentPattern.href
+          ? <a href={parentPattern.href} title={parentPattern.summary || undefined}>{parentPattern.label}</a>
+          : <span class="dangling">{parentPattern.label}</span>}
+      </dd>
+    </div>
+  )}
+
+  {showRevision && hasSources && (
+    <div class="meta-pair meta-pair-block">
+      <dt>Sources</dt>
       <dd>
         {data.sources.map((s: string, i: number) => (
           <>
             {/^https?:\/\//.test(s)
-              ? <a href={s} class="text-(--color-link) hover:underline break-all">{s}</a>
+              ? <a href={s} class="break-all">{s}</a>
               : <span class="break-all">{s}</span>}
             {i < data.sources!.length - 1 ? <br /> : null}
           </>
         ))}
       </dd>
-    </>
+    </div>
   )}
 
   {relatedPatterns.length > 0 && (
-    <>
-      <dt>Related Patterns:</dt>
+    <div class="meta-pair">
+      <dt>Patterns</dt>
       <dd>
         {relatedPatterns.map((l, i) => (
           <>
             {l.href
-              ? <a href={l.href} title={l.summary || undefined} class="text-(--color-link) hover:underline">{l.label}</a>
+              ? <a href={l.href} title={l.summary || undefined}>{l.label}</a>
               : <span class="dangling">{l.label}</span>}
             {i < relatedPatterns.length - 1 ? ', ' : ''}
           </>
         ))}
       </dd>
-    </>
+    </div>
   )}
 
   {relatedMolds.length > 0 && (
-    <>
-      <dt>Related Molds:</dt>
+    <div class="meta-pair">
+      <dt>Molds</dt>
       <dd>
         {relatedMolds.map((l, i) => (
           <>
             {l.href
-              ? <a href={l.href} title={l.summary || undefined} class="text-(--color-link) hover:underline">{l.label}</a>
+              ? <a href={l.href} title={l.summary || undefined}>{l.label}</a>
               : <span class="dangling">{l.label}</span>}
             {i < relatedMolds.length - 1 ? ', ' : ''}
           </>
         ))}
       </dd>
-    </>
+    </div>
   )}
 
   {relatedNotes.length > 0 && (
-    <>
-      <dt>Related Notes:</dt>
+    <div class="meta-pair">
+      <dt>Related</dt>
       <dd>
         {relatedNotes.map((l, i) => (
           <>
             {l.href
-              ? <a href={l.href} title={l.summary || undefined} class="text-(--color-link) hover:underline">{l.label}</a>
+              ? <a href={l.href} title={l.summary || undefined}>{l.label}</a>
               : <span class="dangling">{l.label}</span>}
             {i < relatedNotes.length - 1 ? ', ' : ''}
           </>
         ))}
       </dd>
-    </>
+    </div>
   )}
 </dl>
+)}
+
+<style>
+  .note-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 1.5rem;
+    margin: 0 0 1.75rem;
+    padding: 0;
+  }
+  .meta-pair {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    font-size: 0.85rem;
+    color: var(--color-text-secondary);
+    font-variant-numeric: tabular-nums;
+  }
+  .meta-pair-block {
+    flex-basis: 100%;
+    align-items: flex-start;
+  }
+  .meta-pair dt {
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+    font-weight: 600;
+    margin: 0;
+    flex-shrink: 0;
+  }
+  .meta-pair dd {
+    margin: 0;
+  }
+  .meta-pair a {
+    color: var(--color-link);
+    text-decoration: none;
+    border-bottom: 1px solid color-mix(in srgb, var(--color-link) 30%, transparent);
+    transition: color 0.15s ease, border-color 0.15s ease;
+  }
+  .meta-pair a:hover {
+    color: var(--color-link-hover);
+    border-color: var(--color-accent);
+  }
+</style>

--- a/site/src/components/PhaseGraph.astro
+++ b/site/src/components/PhaseGraph.astro
@@ -1,15 +1,6 @@
 ---
 import { resolveWikiLink, type WikiLinkTarget } from '../lib/wiki-links';
 
-// Phase shape from frontmatter:
-//   { mold: "[[slug]]", loop?: bool }
-//   { branch: "label", loop?: bool, branches?: [...] | chain?: [...] }
-// branch/chain items are wiki-link strings, free-text strings, or { fallthrough: "[[slug]]" }.
-//
-// v1 visual: stacked boxes with downward arrows; branches render as side-by-side columns;
-// chain renders as a vertical sub-stack.
-// See issue #2 for the rich-sitemap redesign tracking this.
-
 interface Props {
   phases: any[];
   linkMap: Map<string, WikiLinkTarget>;
@@ -18,191 +9,315 @@ interface Props {
 const { phases, linkMap } = Astro.props;
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 
-function moldBox(wl: string, loop = false) {
-  const r = resolveWikiLink(wl, linkMap, base);
-  return { kind: 'mold' as const, href: r.href, label: r.label, summary: r.summary, loop };
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+function resolved(wl: string) {
+  return resolveWikiLink(wl, linkMap, base);
+}
+
+function isWikiLink(s: string): boolean {
+  return /^\[\[.+\]\]$/.test(s);
 }
 ---
 
-<div class="phase-graph not-prose">
-  {phases.map((p, idx) => (
-    <>
-      {idx > 0 && <div class="phase-arrow" aria-hidden="true">↓</div>}
-      {p.mold ? (
-        (() => {
-          const m = moldBox(p.mold, !!p.loop);
-          return (
-            <div class:list={['phase-node phase-mold', m.loop && 'phase-loop']}>
-              {m.href ? (
-                <a href={m.href} title={m.summary || undefined} class="phase-link">{m.label}</a>
-              ) : (
-                <span class="dangling">{m.label}</span>
-              )}
-              {m.loop && <span class="phase-tag">loop</span>}
-            </div>
-          );
-        })()
-      ) : p.branch ? (
-        <div class:list={['phase-node phase-branch-wrap', p.loop && 'phase-loop']}>
-          <div class="phase-branch-label">
-            <span class="text-xs uppercase tracking-wider text-(--color-text-secondary)">branch</span>
-            <span class="font-mono text-sm">{p.branch}</span>
-            {p.loop && <span class="phase-tag">loop</span>}
+<ol class="subway not-prose">
+  {phases.map((p, idx) => {
+    const num = pad2(idx + 1);
+    if (p.mold) {
+      const r = resolved(p.mold);
+      return (
+        <li class:list={['stop', 'stop-mold', p.loop && 'stop-loop']}>
+          <span class="stop-num font-mono" aria-hidden="true">{num}</span>
+          <span class="stop-marker" aria-hidden="true"></span>
+          <div class="stop-body">
+            {r.href
+              ? <a href={r.href} title={r.summary || undefined} class="stop-link">{r.label}</a>
+              : <span class="dangling">{r.label}</span>}
+            {p.loop && <span class="stop-tag stop-tag-loop">loop</span>}
           </div>
-          {p.branches && (
-            <div class="phase-branches">
-              {p.branches.map((b: any) => (
-                <div class="phase-branch-col">
-                  {typeof b === 'string' ? (
-                    /^\[\[.+\]\]$/.test(b) ? (
-                      (() => {
-                        const r = resolveWikiLink(b, linkMap, base);
-                        return r.href
-                          ? <a href={r.href} title={r.summary || undefined} class="phase-leaf phase-link">{r.label}</a>
-                          : <span class="phase-leaf dangling">{r.label}</span>;
-                      })()
-                    ) : (
-                      <span class="phase-leaf phase-leaf-text">{b}</span>
-                    )
-                  ) : b.fallthrough ? (
-                    (() => {
-                      const r = resolveWikiLink(b.fallthrough, linkMap, base);
+        </li>
+      );
+    }
+    if (p.branch) {
+      return (
+        <li class:list={['stop', 'stop-branch', p.loop && 'stop-loop']}>
+          <span class="stop-num font-mono" aria-hidden="true">{num}</span>
+          <span class="stop-marker stop-marker-branch" aria-hidden="true"></span>
+          <div class="stop-body">
+            <div class="stop-branch-head">
+              <span class="stop-eyebrow font-mono">branch</span>
+              <span class="stop-link stop-branch-name">{p.branch}</span>
+              {p.loop && <span class="stop-tag stop-tag-loop">loop</span>}
+            </div>
+            {p.branches && (
+              <ul class="branch-paths" aria-label="branches">
+                {p.branches.map((b: any) => {
+                  if (typeof b === 'string') {
+                    if (isWikiLink(b)) {
+                      const r = resolved(b);
                       return (
-                        <div class="phase-leaf phase-fallthrough">
-                          <span class="phase-tag">fallthrough</span>
+                        <li class="branch-leaf">
                           {r.href
-                            ? <a href={r.href} title={r.summary || undefined} class="phase-link">{r.label}</a>
+                            ? <a href={r.href} title={r.summary || undefined} class="stop-link">{r.label}</a>
                             : <span class="dangling">{r.label}</span>}
-                        </div>
+                        </li>
                       );
-                    })()
-                  ) : null}
-                </div>
-              ))}
-            </div>
-          )}
-          {p.chain && (
-            <div class="phase-chain">
-              {p.chain.map((c: any, i: number) => (
-                <>
-                  {i > 0 && <div class="phase-arrow phase-arrow-sub" aria-hidden="true">↓</div>}
-                  {typeof c === 'string' ? (
-                    /^\[\[.+\]\]$/.test(c) ? (
-                      (() => {
-                        const r = resolveWikiLink(c, linkMap, base);
-                        return r.href
-                          ? <a href={r.href} title={r.summary || undefined} class="phase-leaf phase-link">{r.label}</a>
-                          : <span class="phase-leaf dangling">{r.label}</span>;
-                      })()
-                    ) : (
-                      <span class="phase-leaf phase-leaf-text">{c}</span>
-                    )
-                  ) : c.fallthrough ? (
-                    <span class="phase-leaf">{c.fallthrough}</span>
-                  ) : null}
-                </>
-              ))}
-            </div>
-          )}
-        </div>
-      ) : null}
-    </>
-  ))}
-</div>
+                    }
+                    return <li class="branch-leaf branch-leaf-text">{b}</li>;
+                  }
+                  if (b.fallthrough) {
+                    const r = resolved(b.fallthrough);
+                    return (
+                      <li class="branch-leaf branch-leaf-fallthrough">
+                        <span class="stop-tag stop-tag-fallthrough">fallthrough</span>
+                        {r.href
+                          ? <a href={r.href} title={r.summary || undefined} class="stop-link">{r.label}</a>
+                          : <span class="dangling">{r.label}</span>}
+                      </li>
+                    );
+                  }
+                  return null;
+                })}
+              </ul>
+            )}
+            {p.chain && (
+              <ol class="branch-chain" aria-label="chain">
+                {p.chain.map((c: any) => {
+                  if (typeof c === 'string') {
+                    if (isWikiLink(c)) {
+                      const r = resolved(c);
+                      return (
+                        <li class="branch-leaf">
+                          {r.href
+                            ? <a href={r.href} title={r.summary || undefined} class="stop-link">{r.label}</a>
+                            : <span class="dangling">{r.label}</span>}
+                        </li>
+                      );
+                    }
+                    return <li class="branch-leaf branch-leaf-text">{c}</li>;
+                  }
+                  return null;
+                })}
+              </ol>
+            )}
+          </div>
+        </li>
+      );
+    }
+    return null;
+  })}
+</ol>
 
 <style>
-  .phase-graph {
-    display: flex;
-    flex-direction: column;
-    align-items: stretch;
-    gap: 0.25rem;
-    margin: 1rem 0 2rem;
-  }
-  .phase-node {
+  .subway {
+    list-style: none;
+    margin: 1.25rem 0 2rem;
+    padding: 0;
     position: relative;
-    border: 1px solid var(--color-border);
-    border-radius: 0.5rem;
-    padding: 0.625rem 0.875rem;
-    background: var(--color-surface-raised);
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    flex-wrap: wrap;
   }
-  .phase-mold {
-    border-left: 4px solid var(--color-galaxy-primary);
+  /* The continuous rail */
+  .subway::before {
+    content: "";
+    position: absolute;
+    left: 3.4rem;
+    top: 0.5rem;
+    bottom: 0.5rem;
+    width: 2px;
+    background: linear-gradient(
+      to bottom,
+      transparent 0,
+      var(--color-rail) 0.5rem,
+      var(--color-rail) calc(100% - 0.5rem),
+      transparent 100%
+    );
+    z-index: 0;
   }
-  .phase-loop {
-    border-left-color: var(--color-accent);
+
+  .stop {
+    display: grid;
+    grid-template-columns: 2.5rem 1.8rem 1fr;
+    align-items: start;
+    column-gap: 0;
+    padding: 0.4rem 0;
+    position: relative;
   }
-  .phase-link {
+  .stop-num {
+    grid-column: 1;
+    align-self: center;
+    font-size: 0.78rem;
+    color: var(--color-text-muted);
+    letter-spacing: 0.06em;
+    text-align: right;
+    padding-right: 0.6rem;
+    font-variant-numeric: tabular-nums;
+  }
+  .stop-marker {
+    grid-column: 2;
+    align-self: center;
+    justify-self: center;
+    width: 0.85rem;
+    height: 0.85rem;
+    border-radius: 999px;
+    background: var(--color-surface);
+    border: 2px solid var(--color-rail);
+    z-index: 1;
+    transition: transform 0.15s ease, background 0.15s ease;
+  }
+  .stop-loop .stop-marker {
+    background: var(--color-accent);
+    border-color: var(--color-accent);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-accent) 20%, transparent);
+  }
+
+  /* Branch marker = diamond */
+  .stop-marker-branch {
+    width: 1rem;
+    height: 1rem;
+    border-radius: 0.15rem;
+    transform: rotate(45deg);
+    background: var(--color-surface);
+    border: 2px solid var(--color-galaxy-grey);
+  }
+  .stop-loop.stop-branch .stop-marker {
+    background: var(--color-accent);
+    border-color: var(--color-accent);
+  }
+
+  .stop-body {
+    grid-column: 3;
+    align-self: center;
+    padding-left: 0.9rem;
+    min-width: 0;
+  }
+
+  .stop-link {
     color: var(--color-link);
-    font-weight: 500;
     text-decoration: none;
+    font-weight: 600;
+    font-size: 1rem;
+    letter-spacing: -0.005em;
   }
-  .phase-link:hover {
-    text-decoration: underline;
+  a.stop-link {
+    border-bottom: 1px solid color-mix(in srgb, var(--color-link) 25%, transparent);
+    transition: color 0.15s ease, border-color 0.15s ease;
   }
-  .phase-tag {
-    font-size: 0.7rem;
+  a.stop-link:hover {
+    color: var(--color-link-hover);
+    border-color: var(--color-accent);
+  }
+  .stop:hover .stop-marker {
+    transform: scale(1.15);
+  }
+  .stop-branch:hover .stop-marker-branch {
+    transform: rotate(45deg) scale(1.15);
+  }
+
+  .stop-eyebrow {
+    font-size: 0.65rem;
     text-transform: uppercase;
-    letter-spacing: 0.05em;
+    letter-spacing: 0.16em;
+    color: var(--color-text-muted);
+    margin-right: 0.65rem;
+  }
+  .stop-branch-head {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+  }
+  .stop-branch-name {
+    font-family: var(--font-mono);
+    font-size: 0.95rem;
+    color: var(--color-text-primary);
+  }
+
+  .stop-tag {
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    padding: 0.12rem 0.45rem;
+    border-radius: 0.2rem;
+    margin-left: 0.5rem;
+  }
+  .stop-tag-loop {
     background: var(--color-accent);
     color: var(--color-galaxy-dark);
-    padding: 0.1rem 0.4rem;
-    border-radius: 0.25rem;
   }
-  .phase-arrow {
-    text-align: center;
-    color: var(--color-text-muted);
-    font-size: 1rem;
-    line-height: 1;
-    margin: 0.125rem 0;
+  .stop-tag-fallthrough {
+    background: color-mix(in srgb, var(--color-galaxy-grey) 18%, transparent);
+    color: var(--color-text-secondary);
+    border: 1px solid color-mix(in srgb, var(--color-galaxy-grey) 40%, transparent);
   }
-  .phase-arrow-sub {
-    font-size: 0.875rem;
-  }
-  .phase-branch-wrap {
-    flex-direction: column;
-    align-items: stretch;
-    border-left: 4px solid var(--color-galaxy-grey);
-  }
-  .phase-branch-label {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    margin-bottom: 0.5rem;
-  }
-  .phase-branches {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
-    gap: 0.5rem;
-  }
-  .phase-branch-col {
+
+  /* Branch inner paths */
+  .branch-paths,
+  .branch-chain {
+    list-style: none;
+    margin: 0.4rem 0 0.2rem;
+    padding: 0 0 0 0.85rem;
+    border-left: 1px dashed color-mix(in srgb, var(--color-galaxy-grey) 50%, transparent);
     display: flex;
     flex-direction: column;
     gap: 0.25rem;
   }
-  .phase-chain {
-    display: flex;
-    flex-direction: column;
-    align-items: stretch;
-    gap: 0.125rem;
-  }
-  .phase-leaf {
-    border: 1px dashed var(--color-border);
-    border-radius: 0.375rem;
-    padding: 0.4rem 0.6rem;
-    background: var(--color-surface);
+  .branch-leaf {
     font-size: 0.9rem;
-  }
-  .phase-leaf-text {
     color: var(--color-text-secondary);
-    font-style: italic;
+    position: relative;
+    padding-left: 0.65rem;
   }
-  .phase-fallthrough {
+  .branch-leaf::before {
+    content: "";
+    position: absolute;
+    left: -0.85rem;
+    top: 0.65em;
+    width: 0.7rem;
+    height: 1px;
+    background: color-mix(in srgb, var(--color-galaxy-grey) 50%, transparent);
+  }
+  .branch-leaf-text {
+    font-style: italic;
+    color: var(--color-text-muted);
+  }
+  .branch-leaf-fallthrough {
     display: flex;
-    align-items: center;
+    align-items: baseline;
     gap: 0.4rem;
+    flex-wrap: wrap;
+  }
+  .branch-leaf-fallthrough .stop-tag {
+    margin-left: 0;
+  }
+  .branch-chain {
+    counter-reset: chain-step;
+  }
+  .branch-chain > li {
+    counter-increment: chain-step;
+  }
+  .branch-chain > li::after {
+    content: counter(chain-step, decimal-leading-zero);
+    position: absolute;
+    right: 0;
+    top: 0;
+    font-family: var(--font-mono);
+    font-size: 0.65rem;
+    color: var(--color-text-muted);
+    opacity: 0.6;
+  }
+
+  @media (max-width: 540px) {
+    .stop {
+      grid-template-columns: 2rem 1.4rem 1fr;
+    }
+    .subway::before {
+      left: 2.7rem;
+    }
+    .stop-num {
+      font-size: 0.7rem;
+      padding-right: 0.4rem;
+    }
   }
 </style>

--- a/site/src/components/PipelineBody.astro
+++ b/site/src/components/PipelineBody.astro
@@ -10,8 +10,21 @@ interface Props {
 
 const { entry, linkMap } = Astro.props;
 const data = entry.data as any;
+const phaseCount = Array.isArray(data.phases) ? data.phases.length : 0;
 ---
-<section class="mb-6">
-  <h2 class="text-lg font-semibold mb-2">Phases</h2>
+<section class="pipeline-body">
+  <div class="section-rule">
+    <h2>Phases</h2>
+    <span class="section-tail">/ subway map</span>
+    <span class="ml-auto text-xs font-mono text-(--color-text-muted)">
+      {phaseCount} {phaseCount === 1 ? 'phase' : 'phases'}
+    </span>
+  </div>
   <PhaseGraph phases={data.phases} linkMap={linkMap} />
 </section>
+
+<style>
+  .pipeline-body {
+    margin-bottom: 1.5rem;
+  }
+</style>

--- a/site/src/components/PipelineMatrix.astro
+++ b/site/src/components/PipelineMatrix.astro
@@ -1,0 +1,217 @@
+---
+import { getCollection } from 'astro:content';
+
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+const all = await getCollection('content');
+const pipelines = all.filter(n => n.data.type === 'pipeline' && n.data.status !== 'archived');
+
+const SOURCES = ['paper', 'cwl', 'nextflow'] as const;
+const TARGETS = ['galaxy', 'cwl'] as const;
+
+type Cell = {
+  slug: string;
+  title: string;
+  summary: string;
+  status: string;
+  phaseCount: number;
+} | null;
+
+const grid = new Map<string, Cell>();
+for (const src of SOURCES) for (const tgt of TARGETS) grid.set(`${src}|${tgt}`, null);
+
+for (const p of pipelines) {
+  const tags: string[] = (p.data as any).tags ?? [];
+  const src = tags.find(t => t.startsWith('source/'))?.split('/')[1];
+  const tgt = tags.find(t => t.startsWith('target/'))?.split('/')[1];
+  if (!src || !tgt) continue;
+  const key = `${src}|${tgt}`;
+  if (!grid.has(key)) continue;
+  const d = p.data as any;
+  grid.set(key, {
+    slug: p.id,
+    title: d.title,
+    summary: d.summary ?? '',
+    status: d.status,
+    phaseCount: Array.isArray(d.phases) ? d.phases.length : 0,
+  });
+}
+
+const liveCount = [...grid.values()].filter(c => c !== null).length;
+
+function truncate(s: string, n: number): string {
+  return s.length > n ? s.slice(0, n - 1).trimEnd() + '…' : s;
+}
+---
+<section aria-labelledby="pipeline-matrix-heading">
+  <div class="section-rule">
+    <h2 id="pipeline-matrix-heading">Pipelines</h2>
+    <span class="section-tail">/ source × target</span>
+    <span class="ml-auto text-xs font-mono text-(--color-text-muted)">
+      {liveCount} live · 1 open
+    </span>
+  </div>
+
+  <div class="matrix-wrap">
+    <div class="matrix-grid">
+      <div class="matrix-corner" aria-hidden="true">
+        <span>source</span>
+        <span class="matrix-corner-arrow">↓</span>
+        <span>target</span>
+        <span class="matrix-corner-arrow">→</span>
+      </div>
+      {TARGETS.map(t => (
+        <div class="matrix-col-head">{t}</div>
+      ))}
+
+      {SOURCES.map(src => (
+        <>
+          <div class="matrix-row-head">{src}</div>
+          {TARGETS.map(tgt => {
+            const cell = grid.get(`${src}|${tgt}`);
+            if (!cell) {
+              return (
+                <div class="pipeline-cell pipeline-cell-ghost" aria-label={`${src} to ${tgt} (open — not yet defined)`}>
+                  <span class="ghost-label">open</span>
+                  <span class="ghost-route font-mono">{src} → {tgt}</span>
+                </div>
+              );
+            }
+            return (
+              <a href={`${base}/${cell.slug}/`} class="pipeline-cell pipeline-cell-live tinted-shadow tinted-shadow-hover no-underline">
+                <span class="cell-route font-mono">{src} → {tgt}</span>
+                <span class="cell-title">{cell.title}</span>
+                <p class="cell-summary">{truncate(cell.summary, 120)}</p>
+                <span class="cell-foot">
+                  <span class={`badge badge-${cell.status}`}>{cell.status}</span>
+                  <span class="cell-phases font-mono">
+                    {cell.phaseCount} {cell.phaseCount === 1 ? 'phase' : 'phases'}
+                  </span>
+                </span>
+              </a>
+            );
+          })}
+        </>
+      ))}
+    </div>
+  </div>
+</section>
+
+<style>
+  .matrix-wrap {
+    overflow-x: auto;
+    margin-bottom: 1rem;
+  }
+  .matrix-grid {
+    display: grid;
+    grid-template-columns: minmax(7rem, auto) repeat(2, minmax(15rem, 1fr));
+    gap: 0.75rem;
+    min-width: 600px;
+  }
+  .matrix-corner {
+    display: grid;
+    grid-template-columns: auto auto;
+    gap: 0.25rem 0.4rem;
+    align-items: center;
+    padding: 0.5rem 0.25rem 0.25rem;
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+    line-height: 1.3;
+  }
+  .matrix-corner-arrow {
+    color: var(--color-accent);
+    font-size: 0.8rem;
+  }
+  .matrix-col-head,
+  .matrix-row-head {
+    font-family: var(--font-mono);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--color-text-primary);
+    font-weight: 700;
+    font-size: 0.85rem;
+    padding: 0.5rem 0.25rem;
+    align-self: end;
+    border-bottom: 2px solid var(--color-accent);
+  }
+  .matrix-row-head {
+    align-self: center;
+    border-bottom: none;
+    border-right: 2px solid var(--color-accent);
+    padding-right: 0.75rem;
+  }
+
+  .pipeline-cell {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+    padding: 0.9rem 1rem;
+    border: 1px solid var(--color-border-subtle);
+    border-radius: 0.5rem;
+    background: var(--color-surface-raised);
+    min-height: 8rem;
+    transition: border-color 0.18s ease, transform 0.18s ease, box-shadow 0.18s ease;
+  }
+  .pipeline-cell-live:hover {
+    border-color: var(--color-accent);
+    transform: translateY(-2px);
+  }
+  .cell-route {
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+  }
+  .cell-title {
+    font-weight: 700;
+    font-size: 1.05rem;
+    color: var(--color-link);
+    letter-spacing: -0.01em;
+  }
+  .cell-summary {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--color-text-secondary);
+    line-height: 1.5;
+    flex: 1;
+  }
+  .cell-foot {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    margin-top: 0.25rem;
+  }
+  .cell-phases {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .pipeline-cell-ghost {
+    border-style: dashed;
+    background: transparent;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    color: var(--color-text-muted);
+    opacity: 0.7;
+  }
+  .ghost-label {
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+    border: 1px solid color-mix(in srgb, var(--color-text-muted) 40%, transparent);
+    border-radius: 999px;
+    padding: 0.15rem 0.6rem;
+  }
+  .ghost-route {
+    font-size: 0.8rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+</style>

--- a/site/src/lib/render-vault-doc.ts
+++ b/site/src/lib/render-vault-doc.ts
@@ -19,5 +19,27 @@ export function renderContentDoc(
     const { href, label } = resolveWikiLink(`[[${inner}]]`, linkMap, base);
     return href ? `[${label}](${href})` : `**${label}**`;
   });
-  return marked.parse(withLinks, { async: false }) as string;
+  const html = marked.parse(withLinks, { async: false }) as string;
+  return addBoldTermAnchors(html);
+}
+
+function slugifyTerm(term: string): string {
+  return term
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-');
+}
+
+// Glossary entries are paragraphs starting with **Term**. Inject an id on the
+// containing <p> so that #term anchor links from the landing page resolve.
+function addBoldTermAnchors(html: string): string {
+  return html.replace(
+    /<p>(\s*)<strong>([^<]+)<\/strong>/g,
+    (match, ws, term) => {
+      const id = slugifyTerm(term);
+      if (!id) return match;
+      return `<p id="${id}">${ws}<strong>${term}</strong>`;
+    }
+  );
 }

--- a/site/src/pages/[...slug].astro
+++ b/site/src/pages/[...slug].astro
@@ -53,11 +53,25 @@ function defaultTitle(): string {
 
 const pageTitle = defaultTitle();
 const typeLabel = TYPE_LABELS[data.type] ?? data.type;
+
+function pipelineEyebrow(): string | undefined {
+  if (data.type !== 'pipeline') return undefined;
+  const tags: string[] = data.tags ?? [];
+  const src = tags.find(t => t.startsWith('source/'))?.split('/')[1];
+  const tgt = tags.find(t => t.startsWith('target/'))?.split('/')[1];
+  if (!src || !tgt) return undefined;
+  return `pipeline · ${src} → ${tgt}`;
+}
+const eyebrow = pipelineEyebrow();
+
+const showActions = data.type === 'research';
+const showMeta = data.type !== 'pipeline';
+const metaMode: 'full' | 'related-only' = data.type === 'mold' ? 'related-only' : 'full';
 ---
 <Base title={pageTitle}>
   <div data-pagefind-body>
-    <NoteHeader entry={entry} pageTitle={pageTitle} typeLabel={typeLabel} />
-    <NoteMeta entry={entry} linkMap={linkMap} />
+    <NoteHeader entry={entry} pageTitle={pageTitle} typeLabel={typeLabel} eyebrow={eyebrow} showActions={showActions} />
+    {showMeta && <NoteMeta entry={entry} linkMap={linkMap} mode={metaMode} />}
 
     {data.type === 'mold' && <MoldBody entry={entry} linkMap={linkMap} />}
     {data.type === 'pipeline' && <PipelineBody entry={entry} linkMap={linkMap} />}

--- a/site/src/pages/dashboard/index.astro
+++ b/site/src/pages/dashboard/index.astro
@@ -1,0 +1,56 @@
+---
+import { getCollection } from 'astro:content';
+import Base from '../../layouts/Base.astro';
+import sections from '../../../../dashboard_sections.json';
+
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+const allNotes = await getCollection('content');
+
+const dashboardSections = sections.map(s => ({
+  label: s.label,
+  notes: allNotes
+    .filter(n => n.data.tags.includes(s.tag) && n.data.status !== 'archived')
+    .sort((a, b) => b.data.revised.getTime() - a.data.revised.getTime()),
+}));
+
+function formatDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function noteTitle(n: typeof allNotes[number]): string {
+  const data = n.data as any;
+  if (data.title) return data.title;
+  if (data.name) return data.name;
+  return n.id.split('/').pop()!.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+}
+---
+<Base title="Dashboard">
+  <h1 class="mb-4 text-2xl font-bold text-balance">Galaxy Workflow Foundry</h1>
+  <p class="mb-6 text-(--color-text-secondary)">Knowledge base + casting pipeline for Galaxy workflows.</p>
+
+  {dashboardSections.filter(s => s.notes.length > 0).map(section => (
+    <section aria-labelledby={`section-${section.label.replace(/\s+/g, '-').toLowerCase()}`}>
+      <h2
+        id={`section-${section.label.replace(/\s+/g, '-').toLowerCase()}`}
+        class="mt-8 mb-3 text-xl font-bold border-b-2 border-(--color-accent)/20 pb-2 text-balance"
+      >
+        {section.label}
+        <span class="ml-2 text-sm font-normal text-(--color-text-muted)">({section.notes.length})</span>
+      </h2>
+      <table class="data-table">
+        <thead><tr><th>Name</th><th>Summary</th><th>Status</th><th>Revised</th><th>Rev</th></tr></thead>
+        <tbody>
+          {section.notes.map(n => (
+            <tr>
+              <td><a href={`${base}/${n.id}/`}>{noteTitle(n)}</a></td>
+              <td class="text-sm text-(--color-text-muted)">{n.data.summary}</td>
+              <td><span class={`badge badge-${n.data.status}`}>{n.data.status}</span></td>
+              <td>{formatDate(n.data.revised)}</td>
+              <td>{n.data.revision}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  ))}
+</Base>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -1,56 +1,187 @@
 ---
-import { getCollection } from 'astro:content';
 import Base from '../layouts/Base.astro';
-import sections from '../../../dashboard_sections.json';
+import PipelineMatrix from '../components/PipelineMatrix.astro';
+import GlossaryPrimer from '../components/GlossaryPrimer.astro';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
-const allNotes = await getCollection('content');
 
-const dashboardSections = sections.map(s => ({
-  label: s.label,
-  notes: allNotes
-    .filter(n => n.data.tags.includes(s.tag) && n.data.status !== 'archived')
-    .sort((a, b) => b.data.revised.getTime() - a.data.revised.getTime()),
-}));
-
-function formatDate(d: Date): string {
-  return d.toISOString().slice(0, 10);
-}
-
-function noteTitle(n: typeof allNotes[number]): string {
-  const data = n.data as any;
-  if (data.title) return data.title;
-  if (data.name) return data.name;
-  return n.id.split('/').pop()!.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
-}
+const navCards = [
+  { href: `${base}/dashboard/`, label: 'Dashboard', desc: 'Sectioned tables of every active note.', kbd: 'D' },
+  { href: `${base}/molds/`, label: 'Molds', desc: 'Abstract templates grouped by axis.', kbd: 'M' },
+  { href: `${base}/pipelines/`, label: 'Pipelines', desc: 'Flat list of all pipelines.', kbd: 'P' },
+  { href: `${base}/glossary/`, label: 'Glossary', desc: 'Pinned definitions for Foundry terminology.', kbd: 'G' },
+  { href: `${base}/log/`, label: 'Log', desc: 'Append-only project log.', kbd: 'L' },
+];
 ---
-<Base title="Dashboard">
-  <h1 class="mb-4 text-2xl font-bold text-balance">Galaxy Workflow Foundry</h1>
-  <p class="mb-6 text-(--color-text-secondary)">Knowledge base + casting pipeline for Galaxy workflows.</p>
+<Base title="Galaxy Workflow Foundry">
+  <section class="hero relative bg-grain mb-10" aria-labelledby="hero-heading">
+    <span class="eyebrow mb-4">Galaxy Workflow Foundry</span>
+    <h1
+      id="hero-heading"
+      class="hero-title text-balance text-(--color-galaxy-dark) dark:text-(--color-text-primary)"
+    >
+      Build Galaxy workflows<br />
+      <span class="hero-title-accent">from anything.</span>
+    </h1>
+    <p class="hero-lede max-w-3xl text-(--color-text-secondary) text-pretty">
+      Convert workflows authored in other systems — papers, Nextflow pipelines, CWL workflows —
+      into validated Galaxy workflows in the <code class="font-mono">gxformat2</code> format.
+      The Foundry decomposes that conversion into atomic, schema-validated steps an LLM agent
+      can execute reliably, grounded in <code class="font-mono">gxwf</code>'s static validation.
+    </p>
+    <div class="hero-meta">
+      <a href={`${base}/pipelines/`} class="hero-cta">
+        Browse pipelines
+        <span aria-hidden="true">→</span>
+      </a>
+      <span class="hero-meta-sep" aria-hidden="true">·</span>
+      <a href={`${base}/glossary/`} class="hero-cta-secondary">
+        Read the glossary
+      </a>
+    </div>
+  </section>
 
-  {dashboardSections.filter(s => s.notes.length > 0).map(section => (
-    <section aria-labelledby={`section-${section.label.replace(/\s+/g, '-').toLowerCase()}`}>
-      <h2
-        id={`section-${section.label.replace(/\s+/g, '-').toLowerCase()}`}
-        class="mt-8 mb-3 text-xl font-bold border-b-2 border-(--color-accent)/20 pb-2 text-balance"
-      >
-        {section.label}
-        <span class="ml-2 text-sm font-normal text-(--color-text-muted)">({section.notes.length})</span>
-      </h2>
-      <table class="data-table">
-        <thead><tr><th>Name</th><th>Summary</th><th>Status</th><th>Revised</th><th>Rev</th></tr></thead>
-        <tbody>
-          {section.notes.map(n => (
-            <tr>
-              <td><a href={`${base}/${n.id}/`}>{noteTitle(n)}</a></td>
-              <td class="text-sm text-(--color-text-muted)">{n.data.summary}</td>
-              <td><span class={`badge badge-${n.data.status}`}>{n.data.status}</span></td>
-              <td>{formatDate(n.data.revised)}</td>
-              <td>{n.data.revision}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </section>
-  ))}
+  <PipelineMatrix />
+  <GlossaryPrimer />
+
+  <section aria-labelledby="nav-cards-heading">
+    <div class="section-rule">
+      <h2 id="nav-cards-heading">Browse</h2>
+      <span class="section-tail">/ everything else</span>
+    </div>
+    <ul class="nav-list list-none p-0 m-0">
+      {navCards.map((c, i) => (
+        <li>
+          <a href={c.href} class="nav-row no-underline">
+            <span class="nav-row-num font-mono">0{i + 1}</span>
+            <span class="nav-row-label">{c.label}</span>
+            <span class="nav-row-desc">{c.desc}</span>
+            <span class="nav-row-arrow" aria-hidden="true">→</span>
+          </a>
+        </li>
+      ))}
+    </ul>
+  </section>
 </Base>
+
+<style>
+  .hero {
+    padding: 1.5rem 0 2.5rem;
+  }
+  .hero-title {
+    font-size: clamp(2.25rem, 5vw + 0.5rem, 3.75rem);
+    font-weight: 700;
+    line-height: 1.02;
+    letter-spacing: -0.025em;
+    margin: 0 0 1.25rem;
+  }
+  .hero-title-accent {
+    color: var(--color-link);
+    font-style: italic;
+    position: relative;
+  }
+  .hero-title-accent::after {
+    content: "";
+    display: inline-block;
+    width: 0.55ch;
+    height: 0.55ch;
+    margin-left: 0.2ch;
+    background: var(--color-accent);
+    transform: translateY(-0.05em);
+  }
+  .hero-lede {
+    font-size: 1.05rem;
+    line-height: 1.65;
+    margin: 0 0 1.5rem;
+  }
+  .hero-meta {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    font-size: 0.95rem;
+  }
+  .hero-cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.55rem 1rem;
+    background: var(--color-galaxy-dark);
+    color: var(--color-text-on-dark);
+    border-radius: 0.375rem;
+    text-decoration: none;
+    font-weight: 600;
+    transition: transform 0.15s ease, background 0.15s ease;
+  }
+  .hero-cta:hover {
+    background: var(--color-galaxy-primary);
+    transform: translateX(2px);
+  }
+  .hero-cta:active {
+    transform: translateX(2px) scale(0.98);
+  }
+  .hero-cta-secondary {
+    color: var(--color-link);
+    text-decoration: none;
+    border-bottom: 1px solid color-mix(in srgb, var(--color-link) 35%, transparent);
+    padding-bottom: 1px;
+    transition: color 0.15s ease, border-color 0.15s ease;
+  }
+  .hero-cta-secondary:hover {
+    color: var(--color-link-hover);
+    border-color: var(--color-accent);
+  }
+  .hero-meta-sep {
+    color: var(--color-text-muted);
+  }
+
+  .nav-list {
+    border-top: 1px solid var(--color-border-subtle);
+  }
+  .nav-row {
+    display: grid;
+    grid-template-columns: auto auto 1fr auto;
+    align-items: baseline;
+    gap: 1rem;
+    padding: 0.9rem 0.25rem;
+    border-bottom: 1px solid var(--color-border-subtle);
+    color: inherit;
+    transition: background 0.15s ease, padding-left 0.15s ease;
+  }
+  .nav-row:hover {
+    background: color-mix(in srgb, var(--color-accent) 6%, transparent);
+    padding-left: 0.75rem;
+  }
+  .nav-row-num {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    letter-spacing: 0.08em;
+  }
+  .nav-row-label {
+    font-weight: 700;
+    font-size: 1.05rem;
+    color: var(--color-text-primary);
+    min-width: 7rem;
+  }
+  .nav-row-desc {
+    color: var(--color-text-muted);
+    font-size: 0.9rem;
+  }
+  .nav-row-arrow {
+    color: var(--color-text-muted);
+    transition: transform 0.15s ease, color 0.15s ease;
+  }
+  .nav-row:hover .nav-row-arrow {
+    color: var(--color-accent);
+    transform: translateX(4px);
+  }
+  @media (max-width: 640px) {
+    .nav-row {
+      grid-template-columns: auto 1fr auto;
+    }
+    .nav-row-desc {
+      grid-column: 2 / 4;
+      font-size: 0.85rem;
+    }
+  }
+</style>

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -37,6 +37,10 @@
   --color-accent: #e8c547;
   --color-accent-hover: #f2d55a;
 
+  /* Rail / station colors for the subway-style phase graph; flip in dark. */
+  --color-rail: #25537b;
+  --color-rail-on: #e8c547;
+
   /* Badges */
   --color-badge-draft-bg: #fff3cd;
   --color-badge-draft-text: #856404;
@@ -66,8 +70,10 @@
   --color-border: #30363d;
   --color-border-subtle: #21262d;
   --color-text-primary: #e6edf3;
-  --color-text-secondary: #8b949e;
-  --color-text-muted: #6e7681;
+  --color-text-secondary: #b6bfca;
+  --color-text-muted: #8b94a0;
+  --color-rail: #6fa5d4;
+  --color-rail-on: #e8c547;
   --color-link: #6fa5d4;
   --color-link-hover: #ffd700;
   --color-badge-draft-bg: #3d2e00;
@@ -113,7 +119,10 @@
 .tag {
   @apply inline-block px-2 py-0.5 rounded-full text-xs font-medium transition-colors duration-150;
   background-color: var(--color-tag-bg);
-  color: var(--color-galaxy-primary);
+  color: var(--color-link);
+}
+.dark .tag {
+  color: #9bb8d6;
 }
 a:hover .tag {
   background-color: var(--color-accent);
@@ -237,4 +246,78 @@ a:hover .tag {
   background-color: var(--color-galaxy-primary);
   color: white;
   padding: 0.5rem 0.75rem;
+}
+
+/* --- Landing-only flourish --- */
+
+.bg-grain {
+  position: relative;
+}
+.bg-grain::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.035;
+  mix-blend-mode: multiply;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 0.6 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
+}
+.dark .bg-grain::after {
+  opacity: 0.06;
+  mix-blend-mode: screen;
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+.eyebrow::before {
+  content: "";
+  width: 1.5rem;
+  height: 2px;
+  background: var(--color-accent);
+}
+
+.section-rule {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  margin: 2.5rem 0 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--color-accent) 30%, transparent);
+}
+.section-rule h2 {
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+.section-rule .section-tail {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.tinted-shadow {
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--color-galaxy-primary) 8%, transparent),
+              0 8px 24px -12px color-mix(in srgb, var(--color-galaxy-primary) 18%, transparent);
+}
+.tinted-shadow-hover:hover {
+  box-shadow: 0 2px 4px color-mix(in srgb, var(--color-galaxy-primary) 12%, transparent),
+              0 16px 32px -10px color-mix(in srgb, var(--color-galaxy-primary) 28%, transparent);
+}
+
+/* Notes duplicate their title as the first body H1 (consistent across all
+ * note types). NoteHeader already renders the title, so suppress the prose
+ * duplicate. */
+.prose > h1:first-child {
+  display: none;
 }


### PR DESCRIPTION
Closes #4.

## Summary

- New `/` landing: hero, pipeline matrix (5 live + 1 ghost), 7-term concept primer, numbered Browse list.
- Dashboard moved to `/dashboard/` (header link updated).
- Glossary anchor links from the primer actually resolve — bold-term paragraphs now get auto-injected `id` attrs.
- Per-type note polish:
  - **Pipelines** get a literal subway map (numbered rail + decision diamonds for `[branch]`); ~halves the vertical height vs. the prior stacked-cards-with-arrows. No Raw/Copy, no Revised/Rev meta strip — header → tags → straight into the map.
  - **Molds** keep `related-*` meta only; no Raw/Copy, no Revised/Rev.
  - **Research** keeps everything (Raw/Copy + full meta).
- NoteHeader unified across types: mono eyebrow with accent rule, tighter display title (`clamp(1.85rem, ..., 2.65rem)`, `-0.02em` tracking). Pipelines get a route eyebrow (`pipeline · paper → galaxy`).
- Tag/text contrast lifted in dark mode (`--color-text-muted` 4.0:1 → ~5.5:1).
- Caught a real Astro gotcha: scoped `<style>` blocks rewrite `.dark X` selectors with a `[data-astro-cid-...]` attribute, but `.dark` lives on `<html>` which doesn't carry the cid — so those overrides silently never match. Switched theme-flipping colors to globally-defined CSS vars (`--color-rail`, `--color-rail-on`).

## Test plan

- [x] `npm run validate` — 40 files, 0 errors, 0 warnings
- [x] `npm test` — 24/24 passing
- [x] `astro build` — 61 pages clean
- [x] Visual smoke test: landing, /dashboard/, paper-to-galaxy pipeline, summarize-paper mold, iwc-test-data-conventions research — all in light + dark mode
- [x] Glossary anchor links (`/glossary/#mold`, `/glossary/#branch`, ...) resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)