### PR TITLE
Vendor Galaxy collection-semantics spec as research note

### DIFF
--- a/content/research/galaxy-apply-rules-dsl.md
+++ b/content/research/galaxy-apply-rules-dsl.md
@@ -1,0 +1,1577 @@
+---
+type: research
+subtype: component
+title: "Galaxy Apply Rules DSL"
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-04-30
+revised: 2026-04-30
+revision: 1
+ai_generated: true
+related_notes:
+  - "[[galaxy-collection-tools]]"
+  - "[[galaxy-collection-semantics]]"
+sources:
+  - "https://github.com/jmchilton/galaxy-agentic-collection-transform (initial research seed)"
+  - "https://github.com/galaxyproject/galaxy/blob/main/lib/galaxy/util/rules_dsl.py"
+  - "https://github.com/galaxyproject/galaxy/blob/main/lib/galaxy/util/rules_dsl_spec.yml"
+summary: "Reference for Galaxy's Apply Rules DSL: rule operations, mapping operations, composition patterns, pitfalls."
+---
+
+Reference for Galaxy's Apply Rules DSL — the rule grammar consumed by `__APPLY_RULES__` (see [[galaxy-collection-tools]] for the surrounding tool catalog and [[galaxy-collection-semantics]] for collection mapping/reduction semantics).
+
+**Key principle:** rules transform collection metadata (identifiers, indices, tags) as tabular data; mapping operations turn the resulting columns back into collection structure.
+
+**Sources of truth in Galaxy:**
+- `lib/galaxy/util/rules_dsl.py` — rule implementation
+- `lib/galaxy/util/rules_dsl_spec.yml` — test spec covering every rule type
+- `lib/galaxy/managers/collections.py` — collection building from rules
+- [PR #5819](https://github.com/galaxyproject/galaxy/pull/5819) — original implementation
+
+This note is the consumer-facing companion to those files. Verify against the spec YAML when in doubt.
+
+## Rules DSL Architecture
+
+### Core Concepts
+
+**Data Model:**
+```
+data: [[cell values]]      # 2D array of strings (tabular data)
+sources: [source objects]   # Metadata for each row (identifiers, indices, tags)
+```
+
+**Initial State Example:**
+```python
+# Input: list:paired with elements [sample1/forward, sample1/reverse, sample2/forward, sample2/reverse]
+
+data = [[], [], [], []]  # Empty rows, one per dataset
+sources = [
+    {"identifiers": ["sample1", "forward"], "indices": [0, 0], "dataset": <hda>, "tags": []},
+    {"identifiers": ["sample1", "reverse"], "indices": [0, 1], "dataset": <hda>, "tags": []},
+    {"identifiers": ["sample2", "forward"], "indices": [1, 0], "dataset": <hda>, "tags": []},
+    {"identifiers": ["sample2", "reverse"], "indices": [1, 1], "dataset": <hda>, "tags": []},
+]
+```
+
+**Execution Flow:**
+1. Collection metadata extracted to tabular format
+2. Rules applied sequentially to transform data
+3. Mapping operations convert transformed data to new collection
+
+**Example:**
+```
+Input collection: list [i1, i2]
+
+Initial state:
+  data: [["value1"], ["value2"]]
+  sources: [
+    {"identifiers": ["i1"], "indices": [0]},
+    {"identifiers": ["i2"], "indices": [1]}
+  ]
+
+After rules:
+  data: [["value1", "i1"], ["value2", "i2"]]  # Added identifier column
+
+After mapping:
+  Output collection: list [i1, i2]
+```
+
+---
+
+## Rule Operations
+
+Rules are applied **sequentially** in the order specified. Each rule transforms the data table.
+
+### 1. Column Addition Rules
+
+#### add_column_basename
+
+**Purpose:** Extract basename from file paths
+
+**Parameters:**
+- `target_column` (int): Column containing paths
+
+**Example:**
+```yaml
+rules:
+  - type: add_column_basename
+    target_column: 0
+```
+
+**Transformation:**
+```
+Input:  [["/path/to/moo.txt"], ["moo.txt"]]
+Output: [["/path/to/moo.txt", "moo.txt"], ["moo.txt", "moo.txt"]]
+```
+
+**Use cases:**
+- Extract filenames from full paths
+- Create identifiers from uploaded file paths
+- Normalize identifiers across different upload methods
+
+---
+
+#### add_column_regex
+
+**Purpose:** Capture regex groups or perform replacements
+
+**Parameters:**
+- `target_column` (int): Column to process
+- `expression` (string): Regular expression pattern
+- `replacement` (string, optional): Replacement template with `\1`, `\2` for groups
+- `group_count` (int, optional): Number of groups to capture as separate columns
+- `allow_unmatched` (bool, default: false): If false, errors on unmatched rows
+
+**Mode 1: Simple capture (default)**
+```yaml
+rules:
+  - type: add_column_regex
+    target_column: 0
+    expression: '(o)+'
+```
+```
+Input:  [["foo"], ["cow"]]
+Output: [["foo", "oo"], ["cow", "o"]]
+```
+
+**Mode 2: Replacement**
+```yaml
+rules:
+  - type: add_column_regex
+    target_column: 0
+    expression: '(o+)'
+    replacement: 'the os \1'
+```
+```
+Input:  [["foo"], ["cow"]]
+Output: [["foo", "the os oo"], ["cow", "the os o"]]
+```
+
+**Mode 3: Multiple groups**
+```yaml
+rules:
+  - type: add_column_regex
+    target_column: 0
+    expression: '.*(o)(o)'
+    group_count: 2
+```
+```
+Input:  [["foo"], ["boo"]]
+Output: [["foo", "o", "o"], ["boo", "o", "o"]]
+```
+
+**Mode 4: Allow unmatched**
+```yaml
+rules:
+  - type: add_column_regex
+    target_column: 0
+    expression: '(o)+'
+    allow_unmatched: true
+```
+```
+Input:  [["foo"], ["cow"], ["cat"]]
+Output: [["foo", "oo"], ["cow", "o"], ["cat", ""]]
+```
+
+**Use cases:**
+- Extract sample names from filenames (e.g., `sample_(\w+)_R1.fastq`)
+- Parse structured identifiers (e.g., `TCGA-(\w+)-(\d+)`)
+- Clean up identifiers (remove prefixes/suffixes)
+- Extract metadata embedded in filenames
+
+**Common patterns:**
+```yaml
+# Extract sample ID from "sample_123_R1.fastq"
+expression: 'sample_(\w+)_R\d'
+
+# Extract prefix before underscore
+expression: '([^_]+)_.*'
+
+# Extract everything before last dot
+expression: '(.+)\.[^.]+$'
+```
+
+---
+
+#### add_column_substr
+
+**Purpose:** Extract or remove fixed-length substrings
+
+**Parameters:**
+- `target_column` (int): Column to process
+- `substr_type` (enum): Operation type
+  - `keep_prefix`: Keep first N characters
+  - `keep_suffix`: Keep last N characters
+  - `drop_prefix`: Remove first N characters
+  - `drop_suffix`: Remove last N characters
+- `length` (int): Number of characters
+
+**Examples:**
+```yaml
+# Keep first 2 characters
+rules:
+  - type: add_column_substr
+    target_column: 0
+    substr_type: keep_prefix
+    length: 2
+```
+```
+Input:  [["foo"], ["cow"], ["ba"], ["d"]]
+Output: [["foo", "fo"], ["cow", "co"], ["ba", "ba"], ["d", "d"]]
+```
+
+```yaml
+# Drop last 2 characters
+rules:
+  - type: add_column_substr
+    target_column: 0
+    substr_type: drop_suffix
+    length: 2
+```
+```
+Input:  [["foo"], ["cow"], ["ba"], ["d"]]
+Output: [["foo", "f"], ["cow", "c"], ["ba", ""], ["d", ""]]
+```
+
+**Use cases:**
+- Remove common prefixes/suffixes
+- Extract barcodes from fixed positions
+- Truncate long identifiers
+
+---
+
+#### add_column_rownum
+
+**Purpose:** Add sequential row numbers
+
+**Parameters:**
+- `start` (int): Starting number (0 or 1)
+
+**Example:**
+```yaml
+rules:
+  - type: add_column_rownum
+    start: 1
+```
+```
+Input:  [["foo"], ["cow"], ["ba"], ["d"]]
+Output: [["foo", "1"], ["cow", "2"], ["ba", "3"], ["d", "4"]]
+```
+
+**Use cases:**
+- Create numerical identifiers
+- Track original row order after sorting
+- Generate replicate numbers
+
+---
+
+#### add_column_value
+
+**Purpose:** Add constant value to all rows
+
+**Parameters:**
+- `value` (string): Constant value
+
+**Example:**
+```yaml
+rules:
+  - type: add_column_value
+    value: "control"
+```
+```
+Input:  [["foo"], ["cow"]]
+Output: [["foo", "control"], ["cow", "control"]]
+```
+
+**Use cases:**
+- Add condition labels (treatment/control)
+- Add constant metadata
+- Create separator columns for concatenation
+
+---
+
+#### add_column_concatenate
+
+**Purpose:** Combine two columns into one
+
+**Parameters:**
+- `target_column_0` (int): First column
+- `target_column_1` (int): Second column
+
+**Example:**
+```yaml
+rules:
+  - type: add_column_concatenate
+    target_column_0: 0
+    target_column_1: 1
+```
+```
+Input:  [["sample", "001"], ["sample", "002"]]
+Output: [["sample", "001", "sample001"], ["sample", "002", "sample002"]]
+```
+
+**Use cases:**
+- Combine sample ID + replicate number
+- Build hierarchical identifiers
+- Create unique identifiers from multiple parts
+
+**Common pattern - add separator:**
+```yaml
+rules:
+  - type: add_column_value
+    value: "_"
+  - type: add_column_concatenate
+    target_column_0: 0
+    target_column_1: 2  # The "_" column
+  - type: add_column_concatenate
+    target_column_0: 3
+    target_column_1: 1  # Result + second original column
+```
+
+---
+
+#### add_column_metadata
+
+**Purpose:** Extract metadata from source objects
+
+**Parameters:**
+- `value` (enum): Metadata type
+  - `identifier0`, `identifier1`, `identifier2`, ...
+  - `index0`, `index1`, `index2`, ...
+  - `tags`
+
+**Identifier extraction:**
+```yaml
+rules:
+  - type: add_column_metadata
+    value: identifier0  # Outermost identifier
+```
+```
+Input:  [["moo"], ["meow"], ["bark"]]
+Sources: [{"identifiers": ["cow"]}, {"identifiers": ["cat"]}, {"identifiers": ["dog"]}]
+Output:  [["moo", "cow"], ["meow", "cat"], ["bark", "dog"]]
+```
+
+**Multiple levels:**
+```yaml
+rules:
+  - type: add_column_metadata
+    value: identifier0  # Outer identifier
+  - type: add_column_metadata
+    value: identifier1  # Inner identifier
+```
+```
+Sources: [
+  {"identifiers": ["sample1", "forward"]},
+  {"identifiers": ["sample1", "reverse"]}
+]
+Output:  [["data", "sample1", "forward"], ["data", "sample1", "reverse"]]
+```
+
+**Index extraction:**
+```yaml
+rules:
+  - type: add_column_metadata
+    value: index0
+  - type: add_column_metadata
+    value: index1
+```
+```
+Sources: [
+  {"indices": [0, 0]},  # First sample, forward
+  {"indices": [0, 1]},  # First sample, reverse
+  {"indices": [1, 0]},  # Second sample, forward
+  {"indices": [1, 1]}   # Second sample, reverse
+]
+Output:  [
+  ["samp1for", "0", "0"],
+  ["samp1rev", "0", "1"],
+  ["samp2for", "1", "0"],
+  ["samp2rev", "1", "1"]
+]
+```
+
+**Tags extraction:**
+```yaml
+rules:
+  - type: add_column_metadata
+    value: tags
+```
+```
+Sources: [
+  {"identifiers": ["cow"], "tags": ["farm"]},
+  {"identifiers": ["dog"], "tags": ["house", "firestation"]}
+]
+Output:  [["moo", "farm"], ["bark", "firestation,house"]]  # Sorted, comma-joined
+```
+
+**Use cases:**
+- Access collection structure metadata
+- Build identifiers from nested collections
+- Use positional indices for numerical IDs
+- Extract tags for grouping/filtering
+
+---
+
+#### add_column_group_tag_value
+
+**Purpose:** Extract specific group tag value
+
+**Parameters:**
+- `value` (string): Group tag name (e.g., "condition", "type")
+- `default_value` (string): Value if tag not present
+
+**Example:**
+```yaml
+rules:
+  - type: add_column_group_tag_value
+    value: condition
+    default_value: 'control'
+```
+```
+Sources: [
+  {"tags": ["group:condition:treated"]},
+  {"tags": ["group:condition:control"]},
+  {"tags": []}  # No condition tag
+]
+Output:  [["data", "treated"], ["data", "control"], ["data", "control"]]
+```
+
+**Multiple tags - first alphabetically wins:**
+```yaml
+rules:
+  - type: add_column_group_tag_value
+    value: where
+    default_value: 'barn'
+```
+```
+Sources: [
+  {"tags": ["group:where:house", "group:where:firestation"]}
+]
+Output:  [["data", "firestation"]]  # "firestation" < "house" alphabetically
+```
+
+**Use cases:**
+- Group samples by experimental condition
+- Extract sample type (single-end/paired-end)
+- Use tags for nested collection organization
+
+---
+
+#### add_column_from_sample_sheet_index
+
+**Purpose:** Retrieve values from sample sheet columns
+
+**Parameters:**
+- `value` (int): Sample sheet column index
+
+**Example:**
+```yaml
+rules:
+  - type: add_column_from_sample_sheet_index
+    value: 0
+  - type: add_column_from_sample_sheet_index
+    value: 1
+```
+```
+Sources: [
+  {"columns": [0, 1]},
+  {"columns": [2, 3]}
+]
+Output:  [["moo", 0, 1], ["cow", 2, 3]]
+```
+
+**Use cases:**
+- Extract metadata from uploaded sample sheets
+- Access additional columns beyond identifiers
+- Incorporate external metadata
+
+---
+
+### 2. Filter Rules
+
+Filters **remove rows** from the data table based on conditions.
+
+#### add_filter_regex
+
+**Purpose:** Keep/remove rows matching pattern
+
+**Parameters:**
+- `target_column` (int): Column to test
+- `expression` (string): Regular expression
+- `invert` (bool, default: false): If true, keep non-matching rows
+
+**Keep matching:**
+```yaml
+rules:
+  - type: add_filter_regex
+    target_column: 0
+    expression: '(a+)'
+    invert: false
+```
+```
+Input:  [["a", "b", "c"], ["e", "f", "g"]]
+Output: [["a", "b", "c"]]
+```
+
+**Remove matching:**
+```yaml
+rules:
+  - type: add_filter_regex
+    target_column: 2
+    expression: '(c+)'
+    invert: true
+```
+```
+Input:  [["a", "b", "c"], ["e", "f", "g"]]
+Output: [["e", "f", "g"]]
+```
+
+**Use cases:**
+- Filter by sample name pattern
+- Remove control samples
+- Select specific file types
+
+---
+
+#### add_filter_count
+
+**Purpose:** Keep/remove first or last N rows
+
+**Parameters:**
+- `count` (int): Number of rows
+- `which` (enum): `first` or `last`
+- `invert` (bool, default: false): If true, reverse filter
+
+**Remove first row:**
+```yaml
+rules:
+  - type: add_filter_count
+    count: 1
+    which: first
+    invert: false  # Remove first, keep rest
+```
+```
+Input:  [["a", "b", "c"], ["e", "f", "g"], ["h", "i", "j"]]
+Output: [["e", "f", "g"], ["h", "i", "j"]]
+```
+
+**Keep only last row:**
+```yaml
+rules:
+  - type: add_filter_count
+    count: 1
+    which: last
+    invert: true  # Remove all but last
+```
+```
+Input:  [["a", "b", "c"], ["e", "f", "g"], ["h", "i", "j"]]
+Output: [["h", "i", "j"]]
+```
+
+**Use cases:**
+- Remove header rows
+- Skip first N samples
+- Select specific replicates
+
+---
+
+#### add_filter_empty
+
+**Purpose:** Remove rows with empty cells
+
+**Parameters:**
+- `target_column` (int): Column to check
+- `invert` (bool, default: false): If true, keep only empty
+
+**Remove empty:**
+```yaml
+rules:
+  - type: add_filter_empty
+    target_column: 0
+    invert: false
+```
+```
+Input:  [["", "b", "c"], ["a", "b", "c"]]
+Output: [["a", "b", "c"]]
+```
+
+**Use cases:**
+- Remove rows with missing identifiers
+- Clean up sparse data
+- Filter failed extractions
+
+---
+
+#### add_filter_matches
+
+**Purpose:** Exact value matching (case-sensitive)
+
+**Parameters:**
+- `value` (string): Exact value to match
+- `target_column` (int): Column to check
+- `invert` (bool, default: false): If true, keep non-matching
+
+**Example:**
+```yaml
+rules:
+  - type: add_filter_matches
+    value: "a"
+    target_column: 0
+    invert: false
+```
+```
+Input:  [["a", "b", "c"], ["e", "f", "g"], ["h", "i", "j"]]
+Output: [["a", "b", "c"]]
+```
+
+**Important:** Exact match only, no partial matches:
+```yaml
+rules:
+  - type: add_filter_matches
+    value: "a"
+    target_column: 1
+```
+```
+Input:  [["a ", "b", "c"]]  # Note space after "a"
+Output: []  # No match - "a " != "a"
+```
+
+**Use cases:**
+- Filter by specific sample ID
+- Select exact condition matches
+- Boolean filtering (match "true"/"false")
+
+---
+
+#### add_filter_compare
+
+**Purpose:** Numeric comparisons
+
+**Parameters:**
+- `target_column` (int): Column with numeric values
+- `value` (number): Comparison value
+- `compare_type` (enum):
+  - `less_than`
+  - `less_than_equal`
+  - `greater_than`
+  - `greater_than_equal`
+
+**Example:**
+```yaml
+rules:
+  - type: add_filter_compare
+    target_column: 0
+    value: 13
+    compare_type: less_than
+```
+```
+Input:  [["1", "moo"], ["10", "cow"], ["13", "rat"], ["20", "dog"]]
+Output: [["1", "moo"], ["10", "cow"]]
+```
+
+**Use cases:**
+- Filter by quality scores
+- Select samples by replicate number
+- Threshold-based filtering
+
+---
+
+### 3. Structural Rules
+
+#### remove_columns
+
+**Purpose:** Delete specified columns
+
+**Parameters:**
+- `target_columns` (list[int]): Column indices to remove
+
+**Example:**
+```yaml
+rules:
+  - type: remove_columns
+    target_columns: [0, 1]
+```
+```
+Input:  [["a", "b", "c"], ["e", "f", "g"]]
+Output: [["c"], ["g"]]
+```
+
+**Use cases:**
+- Clean up intermediate columns
+- Remove temporary concatenation columns
+- Keep only final identifier columns
+
+---
+
+#### sort
+
+**Purpose:** Sort rows by column value
+
+**Parameters:**
+- `target_column` (int): Column to sort by
+- `numeric` (bool): If true, numeric sort; if false, alphabetic
+
+**Alphabetic sort:**
+```yaml
+rules:
+  - type: sort
+    numeric: false
+    target_column: 0
+```
+```
+Input:  [["moo", "cow"], ["meow", "cat"], ["bark", "dog"]]
+Output: [["bark", "dog"], ["meow", "cat"], ["moo", "cow"]]
+```
+
+**Note:** Case-sensitive, uppercase sorts before lowercase
+```
+Input:  [["Dog"], ["cat"], ["cow"]]
+Output: [["Dog"], ["cat"], ["cow"]]  # "Dog" < "cat" < "cow"
+```
+
+**Use cases:**
+- Alphabetize samples
+- Order by numerical IDs
+- Group similar identifiers together
+
+---
+
+#### swap_columns
+
+**Purpose:** Exchange two column positions
+
+**Parameters:**
+- `target_column_0` (int): First column
+- `target_column_1` (int): Second column
+
+**Example:**
+```yaml
+rules:
+  - type: swap_columns
+    target_column_0: 0
+    target_column_1: 1
+```
+```
+Input:  [["moo", "cow"], ["meow", "cat"]]
+Output: [["cow", "moo"], ["cat", "meow"]]
+```
+
+**Use cases:**
+- Reorder identifier columns for mapping
+- Fix column order mistakes
+- Prepare for specific mapping requirements
+
+---
+
+#### split_columns
+
+**Purpose:** Create Cartesian product of column groups (split rows)
+
+**Parameters:**
+- `target_columns_0` (list[int]): First column group
+- `target_columns_1` (list[int]): Second column group
+
+**Example:**
+```yaml
+rules:
+  - type: split_columns
+    target_columns_0: [0]
+    target_columns_1: [1]
+```
+```
+Input:  [["moo", "cow", "A"], ["meow", "cat", "B"]]
+Output: [
+  ["moo", "A"],
+  ["cow", "A"],
+  ["meow", "B"],
+  ["cat", "B"]
+]
+```
+
+**How it works:**
+- For each row, creates N×M new rows where:
+  - N = number of columns in group 0
+  - M = number of columns in group 1
+- Each new row contains one value from group 0 + one value from group 1 + all other columns
+
+**Use cases:**
+- Split paired-end data into forward/reverse
+- Expand multiple samples per row
+- Create all combinations for comparisons
+
+---
+
+## Mapping Operations
+
+Mapping operations define how transformed data columns become collection structure. These are the **final step** that converts tabular data back to collections.
+
+### Available Mapping Types
+
+#### list_identifiers
+
+**Purpose:** Create list structure with specified nesting levels
+
+**Parameters:**
+- `columns` (list[int]): Column indices for identifiers
+
+**Single column = simple list:**
+```yaml
+mapping:
+  - type: list_identifiers
+    columns: [0]
+```
+```
+Data: [["sample1"], ["sample2"]]
+Result: list [sample1, sample2]
+```
+
+**Two columns = nested list:list:**
+```yaml
+mapping:
+  - type: list_identifiers
+    columns: [0, 1]
+```
+```
+Data: [["group1", "s1"], ["group1", "s2"], ["group2", "s3"]]
+Result: list:list [
+  group1 → [s1, s2],
+  group2 → [s3]
+]
+```
+
+**Three columns = list:list:list:**
+```yaml
+mapping:
+  - type: list_identifiers
+    columns: [0, 1, 2]
+```
+
+**Nesting logic:**
+- Column 0 = outermost identifier
+- Column 1 = next level identifier
+- Column 2 = innermost identifier
+- Groups rows by matching outer identifiers
+
+---
+
+#### paired_identifier
+
+**Purpose:** Add paired collection level
+
+**Parameters:**
+- `columns` (list[int]): Single column with paired identifier
+
+**Valid identifier values:**
+- `forward`, `f`, `1`, `R1` → becomes `forward`
+- `reverse`, `r`, `2`, `R2` → becomes `reverse`
+
+**Simple paired:**
+```yaml
+mapping:
+  - type: paired_identifier
+    columns: [0]
+```
+```
+Data: [["forward"], ["reverse"]]
+Result: paired {forward, reverse}
+```
+
+**Combined with list:**
+```yaml
+mapping:
+  - type: list_identifiers
+    columns: [0]
+  - type: paired_identifier
+    columns: [1]
+```
+```
+Data: [
+  ["sample1", "forward"],
+  ["sample1", "reverse"],
+  ["sample2", "forward"],
+  ["sample2", "reverse"]
+]
+Result: list:paired [
+  sample1 → {forward, reverse},
+  sample2 → {forward, reverse}
+]
+```
+
+---
+
+#### paired_or_unpaired_identifier
+
+**Purpose:** Add paired_or_unpaired collection level (allows unpaired single datasets)
+
+**Parameters:**
+- `columns` (list[int]): Single column with paired/unpaired identifier
+
+**Valid identifier values:**
+- All paired values above, plus:
+- `unpaired`, `u` → becomes `unpaired`
+
+**Example:**
+```yaml
+mapping:
+  - type: list_identifiers
+    columns: [0]
+  - type: paired_or_unpaired_identifier
+    columns: [1]
+```
+
+**Note:** If a sample has only `forward` and no `reverse`, it becomes `unpaired` automatically.
+
+---
+
+#### tags
+
+**Purpose:** Apply tags to collection elements
+
+**Parameters:**
+- `columns` (list[int]): Columns containing tag values
+
+**Example:**
+```yaml
+mapping:
+  - type: list_identifiers
+    columns: [0]
+  - type: tags
+    columns: [1]
+```
+```
+Data: [["sample1", "replicate1"], ["sample2", "replicate2"]]
+Result: list with tags [
+  sample1 (tags: ["replicate1"]),
+  sample2 (tags: ["replicate2"])
+]
+```
+
+---
+
+#### group_tags
+
+**Purpose:** Apply group tags (format: `group:name:value`)
+
+**Parameters:**
+- `columns` (list[int]): Columns containing group tag values
+
+**Example:**
+```yaml
+mapping:
+  - type: list_identifiers
+    columns: [1, 0]  # Group by column 1, element ID column 0
+  - type: group_tags
+    columns: [1]     # Apply as group tag
+```
+```
+Data: [["s1", "treated"], ["s2", "control"]]
+Result: list:list with group tags [
+  treated → [s1 (tags: ["group:treated"])],
+  control → [s2 (tags: ["group:control"])]
+]
+```
+
+---
+
+## Collection Type Determination
+
+The output collection type is determined solely by the mapping:
+
+```python
+# From RuleSet.collection_type property:
+list_columns = mapping_as_dict.get("list_identifiers", {"columns": []})["columns"]
+collection_type = ":".join("list" for c in list_columns)
+if "paired_identifier" in mapping_as_dict:
+    collection_type += ":paired" if collection_type else "paired"
+if "paired_or_unpaired_identifier" in mapping_as_dict:
+    collection_type += ":paired_or_unpaired" if collection_type else "paired_or_unpaired"
+```
+
+**Examples:**
+- `list_identifiers: [0]` → `list`
+- `list_identifiers: [0, 1]` → `list:list`
+- `list_identifiers: [0]` + `paired_identifier: [1]` → `list:paired`
+- `list_identifiers: [0, 1]` + `paired_identifier: [2]` → `list:list:paired`
+
+---
+
+## Complete Example: list:record to list:paired
+
+This example demonstrates complex transformation combining multiple rule types:
+
+**Goal:** Convert `list:record` collection where records have "mother" and "child" elements into `list:paired` with "forward" and "reverse".
+
+```yaml
+rules:
+  - type: add_column_metadata
+    value: identifier0  # Sample identifier
+  - type: add_column_metadata
+    value: identifier1  # Record type (mother/father/child)
+  - type: add_column_regex
+    target_column: 2
+    expression: 'mother'
+    replacement: 'forward'
+    allow_unmatched: true  # Leaves others as ""
+  - type: add_column_regex
+    target_column: 2
+    expression: 'child'
+    replacement: 'reverse'
+    allow_unmatched: true
+  - type: add_column_concatenate
+    target_column_0: 3  # Result of first regex
+    target_column_1: 4  # Result of second regex
+  - type: add_filter_empty
+    target_column: 5  # Remove rows that didn't match (father)
+    invert: false
+  - type: remove_columns
+    target_columns: [2, 3, 4]  # Clean up intermediate columns
+
+mapping:
+  - type: list_identifiers
+    columns: [1, 2]  # Sample ID, then forward/reverse
+```
+
+**Transformation steps:**
+
+```
+Initial:
+  data: [["el1"], ["el2"], ["el3"]]
+  sources: [
+    {"identifiers": ["samp1", "mother"]},
+    {"identifiers": ["samp1", "father"]},
+    {"identifiers": ["samp1", "child"]}
+  ]
+
+After add_column_metadata (identifier0, identifier1):
+  [["el1", "samp1", "mother"],
+   ["el2", "samp1", "father"],
+   ["el3", "samp1", "child"]]
+
+After first regex (mother → forward):
+  [["el1", "samp1", "mother", "forward"],
+   ["el2", "samp1", "father", ""],
+   ["el3", "samp1", "child", ""]]
+
+After second regex (child → reverse):
+  [["el1", "samp1", "mother", "forward", ""],
+   ["el2", "samp1", "father", "", ""],
+   ["el3", "samp1", "child", "", "reverse"]]
+
+After concatenate (cols 3+4):
+  [["el1", "samp1", "mother", "forward", "", "forward"],
+   ["el2", "samp1", "father", "", "", ""],
+   ["el3", "samp1", "child", "", "reverse", "reverse"]]
+
+After filter empty (col 5):
+  [["el1", "samp1", "mother", "forward", "", "forward"],
+   ["el3", "samp1", "child", "", "reverse", "reverse"]]
+
+After remove_columns [2, 3, 4]:
+  [["el1", "samp1", "forward"],
+   ["el3", "samp1", "reverse"]]
+
+Final mapping with list_identifiers [1, 2]:
+  Result: list:paired [
+    samp1 → {forward, reverse}
+  ]
+```
+
+---
+
+## Rule Composition Patterns
+
+### Pattern 1: Extract and Flatten
+
+**Goal:** Flatten `list:paired` → `list` with combined identifiers
+
+```yaml
+rules:
+  - type: add_column_metadata
+    value: identifier0  # Outer ID
+  - type: add_column_metadata
+    value: identifier1  # Pair ID (forward/reverse)
+  - type: add_column_concatenate
+    target_column_0: 1
+    target_column_1: 2  # Combine them
+
+mapping:
+  - type: list_identifiers
+    columns: [3]  # Use concatenated column
+```
+
+---
+
+### Pattern 2: Group by Tag
+
+**Goal:** Reorganize by tag value into nested structure
+
+```yaml
+rules:
+  - type: add_column_metadata
+    value: identifier0
+  - type: add_column_group_tag_value
+    value: condition  # Extract "condition" tag
+    default_value: "unassigned"
+
+mapping:
+  - type: list_identifiers
+    columns: [1, 0]  # Group by condition, then sample ID
+  - type: group_tags
+    columns: [1]     # Apply as group tags
+```
+
+---
+
+### Pattern 3: Filter and Sort
+
+**Goal:** Select subset and alphabetize
+
+```yaml
+rules:
+  - type: add_column_metadata
+    value: identifier0
+  - type: add_filter_regex
+    target_column: 0
+    expression: '^control_'  # Only controls
+    invert: false
+  - type: sort
+    numeric: false
+    target_column: 0
+
+mapping:
+  - type: list_identifiers
+    columns: [0]
+```
+
+---
+
+### Pattern 4: Parse Filename Structure
+
+**Goal:** Extract sample info from "sample_123_R1.fastq.gz" format
+
+```yaml
+rules:
+  - type: add_column_metadata
+    value: identifier0  # Original filename
+  - type: add_column_regex
+    target_column: 0
+    expression: 'sample_(\w+)_R(\d)'
+    group_count: 2  # Sample ID and read number
+  - type: add_column_value
+    value: "_R"
+  - type: add_column_concatenate
+    target_column_0: 3
+    target_column_1: 2  # "_R" + "1" = "_R1"
+  - type: add_column_concatenate
+    target_column_0: 1
+    target_column_1: 4  # "123" + "_R1" = "123_R1"
+  - type: remove_columns
+    target_columns: [0, 2, 3, 4]  # Keep only final identifier
+
+mapping:
+  - type: list_identifiers
+    columns: [0]
+```
+
+---
+
+### Pattern 5: Create Paired from Separate Lists
+
+**Goal:** Combine separate forward/reverse lists into paired
+
+**Assumption:** Files named like `sample1_R1.fastq`, `sample1_R2.fastq`
+
+```yaml
+rules:
+  - type: add_column_metadata
+    value: identifier0
+  - type: add_column_regex
+    target_column: 0
+    expression: '(.+)_R([12])'
+    group_count: 2  # Sample name and read number
+  - type: add_column_regex
+    target_column: 2
+    expression: '1'
+    replacement: 'forward'
+    allow_unmatched: true
+  - type: add_column_regex
+    target_column: 2
+    expression: '2'
+    replacement: 'reverse'
+    allow_unmatched: true
+  - type: add_column_concatenate
+    target_column_0: 3
+    target_column_1: 4
+  - type: sort
+    numeric: false
+    target_column: 1  # Ensure pairs adjacent
+  - type: remove_columns
+    target_columns: [0, 2, 3, 4]
+
+mapping:
+  - type: list_identifiers
+    columns: [0]     # Sample ID
+  - type: paired_identifier
+    columns: [1]     # forward/reverse
+```
+
+---
+
+## Best Practices
+
+### 1. Plan Column Layout
+
+Before writing rules, sketch the transformations:
+```
+Col 0: Original identifier
+Col 1: Extracted sample ID (regex)
+Col 2: Extracted replicate (regex)
+Col 3: Separator "_"
+Col 4: Concatenate 1+3+2
+Col 5: Final identifier after cleanup
+```
+
+### 2. Test Incrementally
+
+Add rules one at a time and verify output:
+- Start with metadata extraction
+- Add one transformation
+- Check result
+- Continue
+
+### 3. Use allow_unmatched Carefully
+
+Only use when genuinely optional:
+```yaml
+# BAD - silently fails to extract
+- type: add_column_regex
+  expression: 'wrong_pattern'
+  allow_unmatched: true
+
+# GOOD - errors if pattern doesn't match
+- type: add_column_regex
+  expression: 'expected_pattern'
+  allow_unmatched: false
+```
+
+### 4. Remove Intermediate Columns
+
+Clean up before mapping:
+```yaml
+rules:
+  - type: add_column_metadata
+    value: identifier0
+  # ... many transformations ...
+  - type: remove_columns
+    target_columns: [0, 2, 3]  # Remove temp columns
+
+mapping:
+  - type: list_identifiers
+    columns: [0]  # Only final column remains
+```
+
+### 5. Validate with Filters
+
+Use filters to ensure data quality:
+```yaml
+rules:
+  - type: add_column_regex
+    expression: 'pattern'
+    allow_unmatched: false  # Errors if doesn't match
+  - type: add_filter_empty
+    target_column: 1
+    invert: false  # Remove any that became empty
+```
+
+### 6. Document Complex Rules
+
+Add comments explaining logic:
+```yaml
+rules:
+  # Extract sample ID from filename "sample_123_R1.fastq"
+  - type: add_column_regex
+    target_column: 0
+    expression: 'sample_(\w+)_R\d'
+
+  # Remove original filename column
+  - type: remove_columns
+    target_columns: [0]
+```
+
+---
+
+## Common Pitfalls
+
+### Pitfall 1: Column Indices Shift
+
+**Problem:** After removing columns, indices change
+
+```yaml
+# WRONG
+rules:
+  - type: remove_columns
+    target_columns: [0]
+  - type: add_column_regex
+    target_column: 1  # This is now wrong! Column 1 became 0
+```
+
+**Solution:** Remove columns last, or recalculate indices
+
+### Pitfall 2: Forgetting Invert Logic
+
+**Problem:** Confusion about filter invert
+
+```yaml
+# Remove matching rows (keep non-matching)
+- type: add_filter_regex
+  expression: 'control_'
+  invert: false  # FALSE means "remove matching"
+
+# Keep matching rows
+- type: add_filter_regex
+  expression: 'sample_'
+  invert: true  # TRUE means "remove non-matching" = keep matching
+```
+
+**Clearer thinking:** `invert: false` = "remove matches", `invert: true` = "remove non-matches"
+
+### Pitfall 3: Regex Escaping
+
+**Problem:** Special regex characters not escaped
+
+```yaml
+# WRONG - . matches any character
+expression: 'file.fastq'
+
+# RIGHT
+expression: 'file\.fastq'
+
+# For literal parentheses
+expression: '\(sample\)'
+```
+
+### Pitfall 4: Case Sensitivity
+
+**Problem:** Filters are case-sensitive
+
+```yaml
+# Doesn't match "Sample1"
+- type: add_filter_matches
+  value: "sample1"
+  target_column: 0
+```
+
+**Solution:** Use regex with case-insensitive flag or normalize case first
+
+### Pitfall 5: Empty Sources After Filtering
+
+**Problem:** All rows filtered out
+
+```yaml
+rules:
+  - type: add_filter_regex
+    expression: 'nonexistent'
+    invert: false
+# Result: Empty collection!
+```
+
+**Solution:** Test filters carefully, use `allow_unmatched: true` when appropriate
+
+---
+
+## When to Use / When NOT to Use Apply Rules
+
+### When to Use Apply Rules
+
+- Complex identifier parsing (multiple regex extractions)
+- Tag-based restructuring (group by experimental condition)
+- Conditional filtering combined with restructuring
+- Structure transformations not covered by simple tools
+- Multiple transformations needed in one step
+
+### When NOT to Use Apply Rules
+
+| Operation | Use This Instead | Why |
+|-----------|------------------|-----|
+| Simple filtering | `__FILTER_FROM_FILE__` | Simpler, clearer intent |
+| Basic flattening | `__FLATTEN__` | One-step operation |
+| Sort collection | `__SORTLIST__` | Dedicated tool |
+| Extract element | `__EXTRACT_DATASET__` | Direct operation |
+| Zip two lists | `__ZIP_COLLECTION__` | Simpler syntax |
+| Unzip paired | `__UNZIP_COLLECTION__` | Straightforward |
+| Relabel identifiers | `__RELABEL_FROM_FILE__` | If mapping from file |
+
+### Comparison Table
+
+| Operation | Simple Tool | When to use Apply Rules instead |
+|-----------|-------------|--------------------------------|
+| Filter | Filter Collection | Need to filter on derived metadata, combine with restructuring |
+| Flatten | Flatten Collection | Need control over identifier format, filter simultaneously |
+| Relabel | Relabel Identifiers | Need regex-based transformation, derive from existing metadata |
+| Sort | Sort Collection | Need to sort by derived values, combine with other operations |
+| Restructure | N/A | Full control over nesting structure from any metadata |
+
+**Key Insight:** Apply Rules is the tool of choice when:
+- Multiple transformations needed in one step
+- Restructuring based on metadata (tags, identifier patterns)
+- Complex identifier manipulation required
+- Standard tools don't cover the use case
+
+---
+
+## Use Case Examples
+
+### Use Case 1: Standard Paired-End RNA-seq
+
+**Files:** `sample1_R1.fastq.gz`, `sample1_R2.fastq.gz`, `sample2_R1.fastq.gz`, `sample2_R2.fastq.gz`
+
+**Goal:** Create `list:paired` collection
+
+```yaml
+rules:
+  - type: add_column_metadata
+    value: identifier0
+  - type: add_column_regex
+    target_column: 0
+    expression: '(.+)_R([12])\.fastq\.gz'
+    group_count: 2
+  - type: add_column_regex
+    target_column: 2
+    expression: '1'
+    replacement: 'forward'
+    allow_unmatched: true
+  - type: add_column_regex
+    target_column: 2
+    expression: '2'
+    replacement: 'reverse'
+    allow_unmatched: true
+  - type: add_column_concatenate
+    target_column_0: 3
+    target_column_1: 4
+  - type: sort
+    target_column: 1
+    numeric: false
+  - type: remove_columns
+    target_columns: [0, 2, 3, 4]
+
+mapping:
+  - type: list_identifiers
+    columns: [0]
+  - type: paired_identifier
+    columns: [1]
+```
+
+---
+
+### Use Case 2: Remove Control Samples
+
+**Goal:** Filter out samples starting with "control_"
+
+```yaml
+rules:
+  - type: add_column_metadata
+    value: identifier0
+  - type: add_filter_regex
+    target_column: 0
+    expression: '^control_'
+    invert: true  # Remove matches = keep non-controls
+
+mapping:
+  - type: list_identifiers
+    columns: [0]
+```
+
+---
+
+### Use Case 3: Group by Treatment Condition
+
+**Goal:** Reorganize by "group:condition:*" tag into nested list
+
+```yaml
+rules:
+  - type: add_column_metadata
+    value: identifier0
+  - type: add_column_group_tag_value
+    value: condition
+    default_value: 'unassigned'
+
+mapping:
+  - type: list_identifiers
+    columns: [1, 0]  # Group by condition, then sample
+  - type: group_tags
+    columns: [1]
+```
+
+---
+
+### Use Case 4: Select Top N by Quality Score
+
+**Assumption:** Quality score in sample name like "sample_123_q95"
+
+**Goal:** Keep only samples with quality >= 90
+
+```yaml
+rules:
+  - type: add_column_metadata
+    value: identifier0
+  - type: add_column_regex
+    target_column: 0
+    expression: 'sample_\w+_q(\d+)'
+  - type: add_filter_compare
+    target_column: 1
+    value: 90
+    compare_type: greater_than_equal
+  - type: remove_columns
+    target_columns: [1]
+
+mapping:
+  - type: list_identifiers
+    columns: [0]
+```
+
+---
+
+### Use Case 5: Replicate Structure
+
+**Files:** `treatment_rep1`, `treatment_rep2`, `control_rep1`, `control_rep2`
+
+**Goal:** Create `list:list` [treatment → [rep1, rep2], control → [rep1, rep2]]
+
+```yaml
+rules:
+  - type: add_column_metadata
+    value: identifier0
+  - type: add_column_regex
+    target_column: 0
+    expression: '(.+)_rep(\d+)'
+    group_count: 2
+  - type: sort
+    target_column: 1
+    numeric: false
+  - type: remove_columns
+    target_columns: [0]
+
+mapping:
+  - type: list_identifiers
+    columns: [0, 1]  # Condition, then replicate
+```
+
+---
+
+## API Usage
+
+```python
+inputs = {
+    "input": {"src": "hdca", "id": collection_id},
+    "rules": {
+        "rules": [...],
+        "mapping": [...]
+    }
+}
+response = POST /api/tools {"tool_id": "__APPLY_RULES__", "history_id": "...", "inputs": inputs}
+```
+
+---

--- a/content/research/galaxy-collection-semantics.md
+++ b/content/research/galaxy-collection-semantics.md
@@ -1,0 +1,2086 @@
+---
+type: research
+subtype: component
+title: "Galaxy collection semantics"
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-04-30
+revised: 2026-04-30
+revision: 1
+ai_generated: false
+sources:
+  - "https://github.com/galaxyproject/galaxy/blob/0683385f5da57c6065c5408f033fdcafd66a27b6/lib/galaxy/model/dataset_collections/types/collection_semantics.yml"
+summary: "Vendored formal spec of Galaxy dataset-collection mapping/reduction semantics, with labeled examples and pinned test references."
+---
+
+> **Vendored from upstream.** This note is a copy of `lib/galaxy/model/dataset_collections/types/collection_semantics.yml` from [galaxyproject/galaxy](https://github.com/galaxyproject/galaxy/blob/0683385f5da57c6065c5408f033fdcafd66a27b6/lib/galaxy/model/dataset_collections/types/collection_semantics.yml) (pinned at SHA `0683385`). The raw YAML lives next to this note at `galaxy-collection-semantics.yml`. Sync is manual until the cross-project sync tooling lands.
+>
+> **When to consult:** authoring or reasoning about Molds and patterns that touch `data_collection` inputs, map-over / reduction shape changes, sub-collection mapping, `paired_or_unpaired`, or `sample_sheet`. Each example's `tests:` block pins concrete Galaxy test names — useful when writing tests around collection semantics. Not user docs.
+
+This document describes the semantics around working with Galaxy dataset collections.
+In particular it describes how they operate within Galaxy tools and workflows.
+
+:::{admonition} You Probably Don't Need to Read This
+:class: caution
+
+Any significantly sophisticated workflow language will have ways to collect data
+into arrays or vectors or dictionaries and apply operations across this data (mapping)
+or reduce the dimensionality of this data (reductions). Typically, this is explicitly
+annotated with map functions or for loops. Galaxy however is designed to be a point
+and click interface for connecting steps and running tools. It is important that steps
+just connect and just do the most natural thing - and this is what Galaxy does.
+This document just provides a mathematical formalism to that "what should just
+intuitively work" that can be used to document test cases and help with implementation.
+This is reference documentation not user documentation, Galaxy should just work.
+:::
+
+## Mapping
+
+If a tool consumes a simple dataset parameter and produces a simple dataset parameter,
+then any collection type may be "mapped over" the data input to that tool. The result of
+that is the tool being applied to each element of the collection and "implicit collections"
+being created from the outputs that are produced from those operations. Those implicit
+collections have the same element identifiers in the same order as the input collection that is
+mapped over. Each element of the implicit collections correspond to their own job and
+Galaxy very naturally and intuitively parallelizes jobs without extra work from the user
+and without any knowledge of the tool.
+
+### Example: `BASIC_MAPPING_PAIRED`
+
+```yaml
+label: BASIC_MAPPING_PAIRED
+assumptions:
+- datasets:
+  - d_f
+  - d_r
+- tool:
+    in:
+      i: dataset
+    out:
+      o: dataset
+- collections:
+    C:
+    - paired
+    - forward: d_f
+      reverse: d_r
+then:
+  type: map_over
+  invocation:
+    inputs:
+      i:
+        type: map_over
+        collection: C
+  produces:
+    o:
+      type: collection
+      collection_type: paired
+      elements:
+        forward:
+          type: tool_output_ref
+          invocation:
+            inputs:
+              i:
+                type: dataset
+                ref: d_f
+          output: o
+        reverse:
+          type: tool_output_ref
+          invocation:
+            inputs:
+              i:
+                type: dataset
+                ref: d_r
+          output: o
+tests:
+  tool_runtime:
+    api_test: test_tool_execute.py::test_map_over_collection
+  workflow_runtime:
+    framework_test: collection_semantics_cat_0
+  workflow_editor: accepts paired data -> data connection
+```
+
+### Example: `BASIC_MAPPING_PAIRED_OR_UNPAIRED_PAIRED`
+
+```yaml
+label: BASIC_MAPPING_PAIRED_OR_UNPAIRED_PAIRED
+assumptions:
+- datasets:
+  - d_f
+  - d_r
+- tool:
+    in:
+      i: dataset
+    out:
+      o: dataset
+- collections:
+    C:
+    - paired_or_unpaired
+    - forward: d_f
+      reverse: d_r
+then:
+  type: map_over
+  invocation:
+    inputs:
+      i:
+        type: map_over
+        collection: C
+  produces:
+    o:
+      type: collection
+      collection_type: paired_or_unpaired
+      elements:
+        forward:
+          type: tool_output_ref
+          invocation:
+            inputs:
+              i:
+                type: dataset
+                ref: d_f
+          output: o
+        reverse:
+          type: tool_output_ref
+          invocation:
+            inputs:
+              i:
+                type: dataset
+                ref: d_r
+          output: o
+tests:
+  tool_runtime:
+    api_test: test_tool_execute.py::test_map_over_data_with_paired_or_unpaired_paired
+  workflow_runtime:
+    framework_test: collection_semantics_cat_1
+  workflow_editor: accepts paired_or_unpaired data -> data connection
+```
+
+### Example: `BASIC_MAPPING_PAIRED_OR_UNPAIRED_UNPAIRED`
+
+```yaml
+label: BASIC_MAPPING_PAIRED_OR_UNPAIRED_UNPAIRED
+assumptions:
+- datasets:
+  - d_u
+- tool:
+    in:
+      i: dataset
+    out:
+      o: dataset
+- collections:
+    C:
+    - paired_or_unpaired
+    - unpaired: d_u
+then:
+  type: map_over
+  invocation:
+    inputs:
+      i:
+        type: map_over
+        collection: C
+  produces:
+    o:
+      type: collection
+      collection_type: paired_or_unpaired
+      elements:
+        unpaired:
+          type: tool_output_ref
+          invocation:
+            inputs:
+              i:
+                type: dataset
+                ref: d_u
+          output: o
+tests:
+  tool_runtime:
+    api_test: test_tool_execute.py::test_map_over_data_with_paired_or_unpaired_unpaired
+  workflow_runtime:
+    framework_test: collection_semantics_cat_2
+  workflow_editor: accepts paired_or_unpaired data -> data connection
+```
+
+### Example: `BASIC_MAPPING_LIST`
+
+```yaml
+label: BASIC_MAPPING_LIST
+assumptions:
+- datasets:
+  - d_1,...,d_n
+- tool:
+    in:
+      i: dataset
+    out:
+      o: dataset
+- collections:
+    C:
+    - list
+    - i1: d_1
+      '...': null
+      in: d_n
+then:
+  type: map_over
+  invocation:
+    inputs:
+      i:
+        type: map_over
+        collection: C
+  produces:
+    o:
+      type: collection
+      collection_type: list
+      elements:
+        i1:
+          type: tool_output_ref
+          invocation:
+            inputs:
+              i:
+                type: dataset
+                ref: d_1
+          output: o
+        '...':
+          type: ellipsis
+        in:
+          type: tool_output_ref
+          invocation:
+            inputs:
+              i:
+                type: dataset
+                ref: d_n
+          output: o
+tests:
+  workflow_editor: accepts collection data -> data connection
+```
+
+The above description of mapping over inputs works naturally and as expected for
+nested collections.
+
+### Example: `NESTED_LIST_MAPPING`
+
+```yaml
+label: NESTED_LIST_MAPPING
+assumptions:
+- datasets:
+  - d_1,...,d_n
+- tool:
+    in:
+      i: dataset
+    out:
+      o: dataset
+- collections:
+    C:
+    - list:list
+    - o1:
+        inner: d_1
+      '...': null
+      'on':
+        inner: d_n
+then:
+  type: map_over
+  invocation:
+    inputs:
+      i:
+        type: map_over
+        collection: C
+  produces:
+    o:
+      type: collection
+      collection_type: list:list
+      elements:
+        o1:
+          type: nested_elements
+          elements:
+            inner:
+              type: tool_output_ref
+              invocation:
+                inputs:
+                  i:
+                    type: dataset
+                    ref: d_1
+              output: o
+        '...':
+          type: ellipsis
+        'on':
+          type: nested_elements
+          elements:
+            inner:
+              type: tool_output_ref
+              invocation:
+                inputs:
+                  i:
+                    type: dataset
+                    ref: d_n
+              output: o
+tests:
+  tool_runtime:
+    api_test: test_tools.py::TestToolsApi::test_map_over_nested_collections
+  workflow_editor: accepts list:list data -> data connection
+```
+
+### Example: `BASIC_MAPPING_LIST_PAIRED_OR_UNPAIRED`
+
+```yaml
+label: BASIC_MAPPING_LIST_PAIRED_OR_UNPAIRED
+assumptions:
+- datasets:
+  - d_f
+  - d_r
+- tool:
+    in:
+      i: dataset
+    out:
+      o: dataset
+- collections:
+    C:
+    - list:paired_or_unpaired
+    - el1:
+        forward: d_f
+        reverse: d_r
+then:
+  type: map_over
+  invocation:
+    inputs:
+      i:
+        type: map_over
+        collection: C
+  produces:
+    o:
+      type: collection
+      collection_type: list:paired_or_unpaired
+      elements:
+        el1:
+          type: nested_elements
+          elements:
+            forward:
+              type: tool_output_ref
+              invocation:
+                inputs:
+                  i:
+                    type: dataset
+                    ref: d_f
+              output: o
+            reverse:
+              type: tool_output_ref
+              invocation:
+                inputs:
+                  i:
+                    type: dataset
+                    ref: d_r
+              output: o
+tests:
+  tool_runtime:
+    api_test: test_tool_execute.py::test_map_over_data_with_list_paired_or_unpaired
+  workflow_runtime:
+    framework_test: collection_semantics_cat_3
+  workflow_editor: accepts list:paired_or_unpaired data -> data connection
+```
+
+
+For tools with multiple data inputs, the tool can be executed with individual
+datasets for the non-mapped over input and each tool execution will just be executed
+with that dataset. The dataset not mapped over serves as the input for each execution.
+
+### Example: `BASIC_MAPPING_INCLUDING_SINGLE_DATASET`
+
+```yaml
+label: BASIC_MAPPING_INCLUDING_SINGLE_DATASET
+assumptions:
+- datasets:
+  - d_1,...,d_n
+  - d_o
+- tool:
+    in:
+      i: dataset
+      i2: dataset
+    out:
+      o: dataset
+- collections:
+    C:
+    - list
+    - i1: d_1
+      '...': null
+      in: d_n
+then:
+  type: map_over
+  invocation:
+    inputs:
+      i:
+        type: map_over
+        collection: C
+      i2:
+        type: dataset
+        ref: d_o
+  produces:
+    o:
+      type: collection
+      collection_type: list
+      elements:
+        i1:
+          type: tool_output_ref
+          invocation:
+            inputs:
+              i:
+                type: dataset
+                ref: d_1
+              i2:
+                type: dataset
+                ref: d_o
+          output: o
+        '...':
+          type: ellipsis
+        in:
+          type: tool_output_ref
+          invocation:
+            inputs:
+              i:
+                type: dataset
+                ref: d_n
+              i2:
+                type: dataset
+                ref: d_o
+          output: o
+tests:
+  tool_runtime:
+    api_test: test_tools.py::TestToolsApi::test_map_over_collected_and_individual_datasets
+  workflow_runtime:
+    framework_test: collection_semantics_cat_two_inputs_0
+```
+
+If a tool consumes two input datasets and produces one output dataset, you can map two
+collections with identical structure (same element identifiers in the same order) over
+the respective inputs and the result is an implicit collection with the same structure
+as the inputs and where each output in the implicit collection corresponds to the tool
+being executed with the two inputs corresponding to that position in the input
+collections.
+
+The default behavior here is the collections are linked and the act of mapping over
+inputs to the tool are sort of a flat map or a dot product. No extra dimensionality
+in the resulting collections.
+
+From a user perspective this means if you start with a collection and apply a bunch
+of map over operations on tools - the results will all continue to match and work together
+very naturally - again without extra work by the user and without extra knowledge
+by the tool author.
+
+### Example: `BASIC_MAPPING_TWO_INPUTS_WITH_IDENTICAL_STRUCTURE`
+
+```yaml
+label: BASIC_MAPPING_TWO_INPUTS_WITH_IDENTICAL_STRUCTURE
+assumptions:
+- datasets:
+  - d1_1,...,d1_n
+  - d2_1,...,d2_n
+- tool:
+    in:
+      i: dataset
+      i2: dataset
+    out:
+      o: dataset
+- collections:
+    C1:
+    - list
+    - i1: d1_1
+      '...': null
+      in: d1_n
+    C2:
+    - list
+    - i1: d2_1
+      '...': null
+      in: d2_n
+then:
+  type: map_over
+  invocation:
+    inputs:
+      i:
+        type: map_over
+        collection: C1
+      i2:
+        type: map_over
+        collection: C2
+  produces:
+    o:
+      type: collection
+      collection_type: list
+      elements:
+        i1:
+          type: tool_output_ref
+          invocation:
+            inputs:
+              i:
+                type: dataset
+                ref: d1_1
+              i2:
+                type: dataset
+                ref: d2_1
+          output: o
+        '...':
+          type: ellipsis
+        in:
+          type: tool_output_ref
+          invocation:
+            inputs:
+              i:
+                type: dataset
+                ref: d1_n
+              i2:
+                type: dataset
+                ref: d2_n
+          output: o
+tests:
+  tool_runtime:
+    api_test: test_tools.py::TestToolsApi::test_map_over_two_collections
+  workflow_runtime:
+    framework_test: collection_semantics_cat_two_inputs_1
+```
+
+## Reduction
+
+Not all tool executions result in implicit collections and mapping
+over inputs. Tool inputs of ``type`` ``data_collection`` can consume
+collections directly and do not necessarily result in mapping over.
+
+Tools that consume collections and output datasets effectively
+reduce the dimension of the Galaxy data structure. When used at runtime
+this is often referred to as a "reduction" in the code.
+
+### Example: `COLLECTION_INPUT_PAIRED`
+
+```yaml
+label: COLLECTION_INPUT_PAIRED
+assumptions:
+- datasets:
+  - d_f
+  - d_r
+- tool:
+    in:
+      i: collection<paired>
+    out:
+      o: dataset
+- collections:
+    C:
+    - paired
+    - forward: d_f
+      reverse: d_r
+then:
+  type: reduction
+  invocation:
+    inputs:
+      i:
+        type: collection
+        ref: C
+  produces:
+    o:
+      type: dataset
+tests:
+  tool_runtime:
+    tool: collection_paired_test
+  workflow_editor: accepts paired -> paired connection
+```
+
+### Example: `COLLECTION_INPUT_LIST`
+
+```yaml
+label: COLLECTION_INPUT_LIST
+assumptions:
+- datasets:
+  - d_1,...,d_n
+- tool:
+    in:
+      i: collection<list>
+    out:
+      o: dataset
+- collections:
+    C:
+    - list
+    - el1: d_1
+      '...': null
+      eln: d_n
+then:
+  type: reduction
+  invocation:
+    inputs:
+      i:
+        type: collection
+        ref: C
+  produces:
+    o:
+      type: dataset
+tests:
+  workflow_runtime:
+    framework_test: collection_semantics_cat_collection_0
+  workflow_editor: accepts list -> list connection
+```
+
+### Example: `COLLECTION_INPUT_PAIRED_OR_UNPAIRED`
+
+```yaml
+label: COLLECTION_INPUT_PAIRED_OR_UNPAIRED
+assumptions:
+- datasets:
+  - d_f
+  - d_r
+- tool:
+    in:
+      i: collection<paired_or_unpaired>
+    out:
+      o: dataset
+- collections:
+    C:
+    - paired_or_unpaired
+    - forward: d_f
+      reverse: d_r
+then:
+  type: reduction
+  invocation:
+    inputs:
+      i:
+        type: collection
+        ref: C
+  produces:
+    o:
+      type: dataset
+tests:
+  tool_runtime:
+    tool: collection_paired_or_unpaired
+  workflow_runtime:
+    framework_test: collection_semantics_paired_or_unpaired_0
+  workflow_editor: accepts paired_or_unpaired data -> paired_or_unpaired connection
+```
+
+### Example: `COLLECTION_INPUT_LIST_PAIRED_OR_UNPAIRED`
+
+```yaml
+label: COLLECTION_INPUT_LIST_PAIRED_OR_UNPAIRED
+assumptions:
+- datasets:
+  - d_f
+  - d_r
+- tool:
+    in:
+      i: collection<list:paired_or_unpaired>
+    out:
+      o: dataset
+- collections:
+    C:
+    - list:paired_or_unpaired
+    - el1:
+        forward: d_f
+        reverse: d_r
+then:
+  type: reduction
+  invocation:
+    inputs:
+      i:
+        type: collection
+        ref: C
+  produces:
+    o:
+      type: dataset
+tests:
+  tool_runtime:
+    tool: collection_list_paired_or_unpaired
+  workflow_runtime:
+    framework_test: collection_semantics_list_paired_or_unpaired_0
+  workflow_editor: accepts list:paired_or_unpaired data -> list:paired_or_unpaired connection
+```
+
+For nested collections where each rank is a ``list`` or a ``paired`` collection,
+then collection inputs must match every part of the collection type input definition.
+
+### Example: `COLLECTION_INPUT_LIST_NOT_CONSUMES_PAIRS`
+
+```yaml
+label: COLLECTION_INPUT_LIST_NOT_CONSUMES_PAIRS
+assumptions:
+- datasets:
+  - d_f
+  - d_r
+- tool:
+    in:
+      i: collection<list>
+    out:
+      o: dataset
+- collections:
+    C:
+    - paired
+    - forward: d_f
+      reverse: d_r
+then:
+  type: invalid
+  invocation:
+    inputs:
+      i:
+        type: collection
+        ref: C
+is_valid: false
+tests:
+  workflow_editor: rejects connecting paired -> list
+```
+
+### Example: `COLLECTION_INPUT_PAIRED_NOT_CONSUMES_LIST`
+
+```yaml
+label: COLLECTION_INPUT_PAIRED_NOT_CONSUMES_LIST
+assumptions:
+- datasets:
+  - d_1,...,d_n
+- tool:
+    in:
+      i: collection<paired>
+    out:
+      o: dataset
+- collections:
+    C:
+    - list
+    - i1: d_1
+      '...': null
+      in: d_n
+then:
+  type: invalid
+  invocation:
+    inputs:
+      i:
+        type: collection
+        ref: C
+is_valid: false
+tests:
+  workflow_editor: rejects connecting list -> paired
+```
+
+### Example: `COLLECTION_INPUT_LIST_PAIRED_NOT_CONSUMES_PAIRED_PAIRED`
+
+```yaml
+label: COLLECTION_INPUT_LIST_PAIRED_NOT_CONSUMES_PAIRED_PAIRED
+assumptions:
+- datasets:
+  - d_f
+  - d_r
+- tool:
+    in:
+      i: collection<list:paired>
+    out:
+      o: dataset
+- collections:
+    C:
+    - paired:paired
+    - forward:
+        forward: d_f
+        reverse: d_r
+      reverse:
+        forward: d_f
+        reverse: d_r
+then:
+  type: invalid
+  invocation:
+    inputs:
+      i:
+        type: collection
+        ref: C
+is_valid: false
+tests:
+  workflow_editor: rejects paired:paired -> list:paired connection
+```
+
+### Example: `COLLECTION_INPUT_LIST_PAIRED_OR_NOT_PAIRED_NOT_CONSUMES_PAIRED_PAIRED`
+
+```yaml
+label: COLLECTION_INPUT_LIST_PAIRED_OR_NOT_PAIRED_NOT_CONSUMES_PAIRED_PAIRED
+assumptions:
+- datasets:
+  - d_f
+  - d_r
+- tool:
+    in:
+      i: collection<list:paired_or_unpaired>
+    out:
+      o: dataset
+- collections:
+    C:
+    - paired:paired
+    - forward:
+        forward: d_f
+        reverse: d_r
+      reverse:
+        forward: d_f
+        reverse: d_r
+then:
+  type: invalid
+  invocation:
+    inputs:
+      i:
+        type: collection
+        ref: C
+is_valid: false
+tests:
+  workflow_editor: rejects paired:paired -> list:paired_or_unpaired connection
+```
+
+In addition to explicit collection inputs, tool inputs of ``type`` ``data``
+where ``multiple="true"`` can consume lists directly. This is likewise a
+"reduction" and does not result in implicit collection creation.
+
+### Example: `LIST_REDUCTION`
+
+```yaml
+label: LIST_REDUCTION
+assumptions:
+- datasets:
+  - d_1,...,d_n
+- tool:
+    in:
+      i: dataset<multiple=true>
+    out:
+      o: dataset
+- collections:
+    C:
+    - list
+    - i1: d_1
+      '...': null
+      in: d_n
+then:
+  type: equivalence
+  left:
+    inputs:
+      i:
+        type: collection
+        ref: C
+  right:
+    inputs:
+      i:
+        type: dataset_list
+        refs:
+        - d_1
+        - '...'
+        - d_n
+tests:
+  tool_runtime:
+    api_test: test_tools.py::TestToolsApi::test_reduce_collections
+  workflow_runtime:
+    framework_test: collection_semantics_multi_data_optional_0
+  workflow_editor: treats multi data input as list input
+```
+
+Paired collections cannot be reduced this way. ``paired`` is not meant
+to represent a list/array/vector data structure - it is more like a tuple.
+
+### Example: `PAIRED_REDUCTION_INVALID`
+
+```yaml
+label: PAIRED_REDUCTION_INVALID
+assumptions:
+- datasets:
+  - d_f
+  - d_r
+- tool:
+    in:
+      i: dataset<multiple=true>
+    out:
+      o: dataset
+- collections:
+    C:
+    - paired
+    - forward: d_f
+      reverse: d_r
+then:
+  type: invalid
+  invocation:
+    inputs:
+      i:
+        type: collection
+        ref: C
+is_valid: false
+tests:
+  workflow_editor: rejects paired input on multi-data input
+```
+
+### Example: `PAIRED_OR_UNPAIRED_REDUCTION_INVALID`
+
+```yaml
+label: PAIRED_OR_UNPAIRED_REDUCTION_INVALID
+assumptions:
+- datasets:
+  - d_f
+  - d_r
+- tool:
+    in:
+      i: dataset<multiple=true>
+    out:
+      o: dataset
+- collections:
+    C:
+    - paired_or_unpaired
+    - forward: d_f
+      reverse: d_r
+then:
+  type: invalid
+  invocation:
+    inputs:
+      i:
+        type: collection
+        ref: C
+is_valid: false
+tests:
+  workflow_editor: rejects paired_or_unpaired input on multi-data input
+```
+
+## Sub-collection Mapping
+
+![](https://planemo.readthedocs.io/en/master/_images/subcollection_mapping_identifiers.svg)
+
+### Example: `MAPPING_LIST_PAIRED_OVER_PAIRED`
+
+```yaml
+label: MAPPING_LIST_PAIRED_OVER_PAIRED
+assumptions:
+- datasets:
+  - d_f
+  - d_r
+- tool:
+    in:
+      i: collection<paired>
+    out:
+      o: dataset
+- collections:
+    C:
+    - list:paired
+    - el1:
+        forward: d_f
+        reverse: d_r
+    C\_PAIRED:
+    - paired
+    - forward: d_f
+      reverse: d_r
+then:
+  type: map_over
+  invocation:
+    inputs:
+      i:
+        type: map_over
+        collection: C
+        sub_collection_type: paired
+  produces:
+    o:
+      type: collection
+      collection_type: list
+      elements:
+        el1:
+          type: tool_output_ref
+          invocation:
+            inputs:
+              i:
+                type: collection
+                ref: C\_PAIRED
+          output: o
+tests:
+  tool_runtime:
+    api_test: test_tool_execute.py::test_simple_subcollection_mapping
+  workflow_editor: accepts list:paired -> paired connection
+```
+
+The natural extension of multiple data input parameters consuming list collections as described
+above when discussing reductions is that nested lists of lists (``list:list``) can be mapped
+over a multiple data input parameter. Each nested list will be reduced by this operation but the
+results will be mapped over. The result will be a list with the same structure as the outer list
+of the input collection.
+
+### Example: `NESTED_LIST_REDUCTION`
+
+```yaml
+label: NESTED_LIST_REDUCTION
+assumptions:
+- datasets:
+  - d_1,...,d_n
+- tool:
+    in:
+      i: dataset<multiple=true>
+    out:
+      o: dataset
+- collections:
+    C:
+    - list:list
+    - o1:
+        inner: d_1
+      '...': null
+      'on':
+        inner: d_n
+then:
+  type: map_over
+  invocation:
+    inputs:
+      i:
+        type: map_over
+        collection: C
+        sub_collection_type: list
+  produces:
+    o:
+      type: collection
+      collection_type: list
+      elements:
+        o1:
+          type: tool_output_ref
+          invocation:
+            inputs:
+              i:
+                type: dataset_list
+                refs:
+                - d_1
+          output: o
+        '...':
+          type: ellipsis
+        'on':
+          type: tool_output_ref
+          invocation:
+            inputs:
+              i:
+                type: dataset_list
+                refs:
+                - d_n
+          output: o
+tests:
+  workflow_editor: maps list:list over multi data input
+```
+
+Just as a paired collection won't be reduced by a multiple data input, any sort of nested
+collection ending in a paired collection cannot be mapped over such an input. So a multiple
+data input parameter cannot be mapped over by a list of pairs (``list:paired``) for instance.
+
+### Example: `LIST_PAIRED_REDUCTION_INVALID`
+
+```yaml
+label: LIST_PAIRED_REDUCTION_INVALID
+assumptions:
+- datasets:
+  - d_f
+  - d_r
+- tool:
+    in:
+      i: dataset<multiple=true>
+    out:
+      o: dataset
+- collections:
+    C:
+    - list:paired
+    - el1:
+        forward: d_f
+        reverse: d_r
+then:
+  type: invalid
+  invocation:
+    inputs:
+      i:
+        type: map_over
+        collection: C
+        sub_collection_type: paired
+is_valid: false
+tests:
+  workflow_editor: rejects list:paired input on multi-data input
+```
+
+### Example: `LIST_PAIRED_OR_UNPAIRED_REDUCTION_INVALID`
+
+```yaml
+label: LIST_PAIRED_OR_UNPAIRED_REDUCTION_INVALID
+assumptions:
+- datasets:
+  - d_f
+  - d_r
+- tool:
+    in:
+      i: dataset<multiple=true>
+    out:
+      o: dataset
+- collections:
+    C:
+    - list:paired_or_unpaired
+    - el1:
+        forward: d_f
+        reverse: d_r
+then:
+  type: invalid
+  invocation:
+    inputs:
+      i:
+        type: map_over
+        collection: C
+        sub_collection_type: paired_or_unpaired
+is_valid: false
+tests:
+  workflow_editor: rejects list:paired_or_unpaired input on multi-data input
+```
+
+## paired_or_unpaired Collections
+
+The collection type ``paired_or_unpaired`` is meant to serve as a stand-in for
+an entity that can be either a single dataset or what is effectively a ``paired``
+dataset collection. These collections either have one element with identifier
+``unpaired`` or two elements with identifiers ``forward`` and ``reverse``.
+
+Tools can declare a data_collection input with collection type ``paired_or_unpaired``
+and that input will consume either an explicit ``paired_or_unpaired`` collection
+normally or can consume a ``paired`` input.
+
+### Example: `PAIRED_OR_UNPAIRED_CONSUMES_PAIRED`
+
+```yaml
+label: PAIRED_OR_UNPAIRED_CONSUMES_PAIRED
+assumptions:
+- datasets:
+  - d_f
+  - d_r
+- tool:
+    in:
+      i: collection<paired_or_unpaired>
+    out:
+      o: dataset
+- collections:
+    C:
+    - paired
+    - forward: d_f
+      reverse: d_r
+- 'C_AS_MIXED = CollectionInstance<paired_or_unpaired, {forward: d_f, reverse: d_r}>'
+then:
+  type: equivalence
+  left:
+    inputs:
+      i:
+        type: collection
+        ref: C
+  right:
+    inputs:
+      i:
+        type: collection
+        ref: C_AS_MIXED
+tests:
+  tool_runtime:
+    tool: collection_paired_or_unpaired
+  workflow_runtime:
+    framework_test: collection_semantics_paired_or_unpaired_1
+  workflow_editor: accepts paired -> paired_or_unpaired connection
+```
+
+
+The inverse of this doesn't work intentionally. In some ways a ``paired`` collection
+acts as a ``paired_or_unpaired`` collection but a ``paired_or_unpaired`` is not a paired
+collection. This makes a lot of sense in terms of tools - a tool consuming a ``paired``
+dataset expects to find both a ``forward`` and ``reverse`` element but these may not exist
+in ``paired_or_unpaired`` collection.
+
+### Example: `PAIRED_OR_UNPAIRED_NOT_CONSUMED_BY_PAIRED`
+
+```yaml
+label: PAIRED_OR_UNPAIRED_NOT_CONSUMED_BY_PAIRED
+assumptions:
+- datasets:
+  - d_f
+  - d_r
+- tool:
+    in:
+      i: collection<paired>
+    out:
+      o: dataset
+- collections:
+    C:
+    - paired_or_unpaired
+    - forward: d_f
+      reverse: d_r
+then:
+  type: invalid
+  invocation:
+    inputs:
+      i:
+        type: collection
+        ref: C
+is_valid: false
+tests:
+  workflow_editor: rejects paired_or_unpaired -> paired connection
+```
+
+
+The same logic holds for mapping, lists of paired datasets (``list:paired``) can be mapped over these
+``paired_or_unpaired`` inputs and mixed lists of pairs (``list:paired_or_unpaired``) cannot
+be mapped over a ``paired`` input. Following the same logic, ``list:paired_or_unpaired`` cannot
+be mapped over a ``list`` input or multiple data input.
+
+### Example: `MAPPING_LIST_PAIRED_OVER_PAIRED_OR_UNPAIRED`
+
+```yaml
+label: MAPPING_LIST_PAIRED_OVER_PAIRED_OR_UNPAIRED
+assumptions:
+- datasets:
+  - d_f
+  - d_r
+- tool:
+    in:
+      i: collection<paired_or_unpaired>
+    out:
+      o: dataset
+- collections:
+    C:
+    - list:paired
+    - el:
+        forward: d_f
+        reverse: d_r
+    C_AS_MIXED:
+    - list:paired_or_unpaired
+    - el:
+        forward: d_f
+        reverse: d_r
+then:
+  type: equivalence
+  left:
+    inputs:
+      i:
+        type: map_over
+        collection: C
+  right:
+    inputs:
+      i:
+        type: map_over
+        collection: C_AS_MIXED
+tests:
+  workflow_runtime:
+    framework_test: collection_semantics_paired_or_unpaired_2
+  workflow_editor: accepts list:paired -> paired_or_unpaired connection
+```
+
+### Example: `PAIRED_OR_UNPAIRED_NOT_CONSUMED_BY_PAIRED_WHEN_MAPPING`
+
+```yaml
+label: PAIRED_OR_UNPAIRED_NOT_CONSUMED_BY_PAIRED_WHEN_MAPPING
+assumptions:
+- datasets:
+  - d_f
+  - d_r
+- tool:
+    in:
+      i: collection<paired>
+    out:
+      o: dataset
+- collections:
+    C:
+    - list:paired_or_unpaired
+    - el:
+        forward: d_f
+        reverse: d_r
+then:
+  type: invalid
+  invocation:
+    inputs:
+      i:
+        type: map_over
+        collection: C
+is_valid: false
+tests:
+  tool_runtime:
+    api_test: test_tool_execute.py::test_paired_or_unpaired_not_consumed_by_paired_when_mapping
+  workflow_editor: rejects list:paired_or_unpaired -> paired connection
+```
+
+### Example: `PAIRED_OR_UNPAIRED_NOT_CONSUMED_BY_LIST_WHEN_MAPPING`
+
+```yaml
+label: PAIRED_OR_UNPAIRED_NOT_CONSUMED_BY_LIST_WHEN_MAPPING
+assumptions:
+- datasets:
+  - d_f
+  - d_r
+- tool:
+    in:
+      i: collection<list>
+    out:
+      o: dataset
+- collections:
+    C:
+    - list:paired_or_unpaired
+    - el:
+        forward: d_f
+        reverse: d_r
+then:
+  type: invalid
+  invocation:
+    inputs:
+      i:
+        type: map_over
+        collection: C
+is_valid: false
+tests:
+  workflow_editor: rejects list:paired_or_unpaired -> list connection
+```
+
+This logic extends naturally into higher dimensional collections. A ``list:list:paired``
+can be mapped over either a ``paired_or_unpaired`` input to produce a nested list (``list:list``)
+or a ``list:paired_or_unpaired`` input to produce a flat list (``list``).
+
+### Example: `MAPPING_LIST_LIST_PAIRED_OVER_PAIRED_OR_UNPAIRED`
+
+```yaml
+label: MAPPING_LIST_LIST_PAIRED_OVER_PAIRED_OR_UNPAIRED
+assumptions:
+- datasets:
+  - d_f
+  - d_r
+- tool:
+    in:
+      i: collection<paired_or_unpaired>
+    out:
+      o: dataset
+- collections:
+    C:
+    - list:list:paired
+    - o1:
+        el1:
+          forward: d_f
+          reverse: d_r
+    C_AS_MIXED:
+    - list:list:paired_or_unpaired
+    - o1:
+        el1:
+          forward: d_f
+          reverse: d_r
+then:
+  type: equivalence
+  left:
+    inputs:
+      i:
+        type: map_over
+        collection: C
+  right:
+    inputs:
+      i:
+        type: map_over
+        collection: C_AS_MIXED
+tests:
+  workflow_runtime:
+    framework_test: collection_semantics_paired_or_unpaired_3
+  workflow_editor: accepts list:list:paired -> paired_or_unpaired connection
+```
+
+
+In order for ``paired_or_unpaired`` collections to also act as a single dataset,
+a flat list can be mapped over a such an input with a special sub collection mapping
+type of 'single_datasets'.
+
+### Example: `MAPPING_LIST_OVER_PAIRED_OR_UNPAIRED`
+
+```yaml
+label: MAPPING_LIST_OVER_PAIRED_OR_UNPAIRED
+assumptions:
+- datasets:
+  - d_1,...,d_n
+- tool:
+    in:
+      i: collection<paired_or_unpaired>
+    out:
+      o: dataset
+- collections:
+    C:
+    - list
+    - i1: d_1
+      '...': null
+      in: d_n
+- C_AS_UNPAIRED_i = CollectionInstance<paired_or_unpaired,{unpaired=di}> for i from 1...n
+then:
+  type: map_over
+  invocation:
+    inputs:
+      i:
+        type: map_over
+        collection: C
+        sub_collection_type: single_datasets
+  produces:
+    o:
+      type: collection
+      collection_type: list
+      elements:
+        i1:
+          type: tool_output_ref
+          invocation:
+            inputs:
+              i:
+                type: collection
+                ref: C_AS_UNPAIRED_1
+          output: o
+        '...':
+          type: ellipsis
+        in:
+          type: tool_output_ref
+          invocation:
+            inputs:
+              i:
+                type: collection
+                ref: C_AS_UNPAIRED_n
+          output: o
+tests:
+  tool_runtime:
+    api_test: test_tool_execute.py::test_map_over_paired_or_unpaired_with_list
+  workflow_runtime:
+    framework_test: collection_semantics_paired_or_unpaired_7
+  workflow_editor: accepts list -> paired_or_unpaired connection
+```
+
+This treatment of lists without pairing extends to nested structures naturally.
+For instance, a list of list of datasets (``list:list``) can be mapped over a
+``paired_or_unpaired`` input to produce a nested list of lists (``list:list``)
+with a structure matching the input. Likewise, the nested list can be mapped over
+a ``list:paired_or_unpaired`` input to produce a flat list with the same structure
+as the outer list of the input.
+
+### Example: `MAPPING_LIST_LIST_OVER_PAIRED_OR_UNPAIRED`
+
+```yaml
+label: MAPPING_LIST_LIST_OVER_PAIRED_OR_UNPAIRED
+assumptions:
+- datasets:
+  - d_1,...,d_n
+- tool:
+    in:
+      i: collection<paired_or_unpaired>
+    out:
+      o: dataset
+- collections:
+    C:
+    - list:list
+    - o1:
+        inner: d_1
+      '...': null
+      'on':
+        inner: d_n
+- C_AS_UNPAIRED_j = CollectionInstance<paired_or_unpaired,{unpaired=dj}> for each dataset dj in C
+then:
+  type: map_over
+  invocation:
+    inputs:
+      i:
+        type: map_over
+        collection: C
+        sub_collection_type: single_datasets
+  produces:
+    o:
+      type: collection
+      collection_type: list:list
+      elements:
+        o1:
+          type: nested_elements
+          elements:
+            inner:
+              type: tool_output_ref
+              invocation:
+                inputs:
+                  i:
+                    type: collection
+                    ref: C_AS_UNPAIRED_1
+              output: o
+        '...':
+          type: ellipsis
+        'on':
+          type: nested_elements
+          elements:
+            inner:
+              type: tool_output_ref
+              invocation:
+                inputs:
+                  i:
+                    type: collection
+                    ref: C_AS_UNPAIRED_n
+              output: o
+tests:
+  workflow_editor: accepts list:list -> paired_or_unpaired connection
+```
+
+### Example: `MAPPING_LIST_LIST_OVER_LIST_PAIRED_OR_UNPAIRED`
+
+```yaml
+label: MAPPING_LIST_LIST_OVER_LIST_PAIRED_OR_UNPAIRED
+assumptions:
+- datasets:
+  - d_1,...,d_n
+- tool:
+    in:
+      i: collection<list:paired_or_unpaired>
+    out:
+      o: dataset
+- collections:
+    C:
+    - list:list
+    - o1:
+        inner: d_1
+      '...': null
+      'on':
+        inner: d_n
+- C_AS_LPU_i = inner list of C at position i, treated as list:paired_or_unpaired via single_datasets
+then:
+  type: map_over
+  invocation:
+    inputs:
+      i:
+        type: map_over
+        collection: C
+        sub_collection_type: list:paired_or_unpaired
+  produces:
+    o:
+      type: collection
+      collection_type: list
+      elements:
+        o1:
+          type: tool_output_ref
+          invocation:
+            inputs:
+              i:
+                type: collection
+                ref: C_AS_LPU_1
+          output: o
+        '...':
+          type: ellipsis
+        'on':
+          type: tool_output_ref
+          invocation:
+            inputs:
+              i:
+                type: collection
+                ref: C_AS_LPU_n
+          output: o
+tests:
+  tool_runtime:
+    api_test: test_tool_execute.py::test_map_over_list_paired_or_unpaired_with_list_of_lists
+  workflow_runtime:
+    framework_test: collection_semantics_list_paired_or_unpaired_2
+  workflow_editor: accepts list:list -> list:paired_or_unpaired connection
+```
+
+Due only to implementation time, the special casing of allowing paired_or_unpaired
+act as both datasets and paired collections only works when it is the deepest
+collection type. So while list:paired can be consumed by a list:paired_or_unpaired
+input, a paired:list cannot be consumed by a paired_or_unpaired:list input though
+it should be able to for consistency. We have focused our time on data structures
+more likely to be used in actual Galaxy analyses given current and guessed future
+usage.
+
+## sample_sheet Collections
+
+The collection type ``sample_sheet`` attaches typed, columnar metadata to each
+element of a dataset collection. For mapping and type matching purposes,
+``sample_sheet`` behaves identically to ``list`` - it can be mapped over tool
+inputs, matched against ``list`` collection inputs, and composed with inner types
+(``sample_sheet:paired``, ``sample_sheet:paired_or_unpaired``). The key asymmetry
+is that while a ``sample_sheet`` output can satisfy a ``list`` input, a ``list``
+output cannot satisfy a ``sample_sheet`` input - sample sheets carry metadata
+that plain lists do not.
+
+### Example: `SAMPLE_SHEET_MAPPING`
+
+```yaml
+label: SAMPLE_SHEET_MAPPING
+assumptions:
+- datasets:
+  - d_1,...,d_n
+- tool:
+    in:
+      i: dataset
+    out:
+      o: dataset
+- collections:
+    C:
+    - sample_sheet
+    - i1: d_1
+      '...': null
+      in: d_n
+then:
+  type: map_over
+  invocation:
+    inputs:
+      i:
+        type: map_over
+        collection: C
+  produces:
+    o:
+      type: collection
+      collection_type: sample_sheet
+      elements:
+        i1:
+          type: tool_output_ref
+          invocation:
+            inputs:
+              i:
+                type: dataset
+                ref: d_1
+          output: o
+        '...':
+          type: ellipsis
+        in:
+          type: tool_output_ref
+          invocation:
+            inputs:
+              i:
+                type: dataset
+                ref: d_n
+          output: o
+tests:
+  workflow_runtime:
+    framework_test: collection_semantics_cat_4
+  workflow_editor: accepts sample_sheet data -> data connection (maps like list)
+```
+
+### Example: `SAMPLE_SHEET_MATCHES_LIST`
+
+```yaml
+label: SAMPLE_SHEET_MATCHES_LIST
+assumptions:
+- datasets:
+  - d_1,...,d_n
+- tool:
+    in:
+      i: collection<list>
+    out:
+      o: dataset
+- collections:
+    C:
+    - sample_sheet
+    - i1: d_1
+      '...': null
+      in: d_n
+then:
+  type: reduction
+  invocation:
+    inputs:
+      i:
+        type: collection
+        ref: C
+  produces:
+    o:
+      type: dataset
+tests:
+  workflow_runtime:
+    framework_test: collection_semantics_cat_collection_1
+  workflow_editor: accepts sample_sheet -> list connection (accepts)
+```
+
+Sub-collection mapping works the same as for ``list`` composites. A
+``sample_sheet:paired`` can be mapped over a ``paired`` collection input,
+extracting each inner pair and producing a ``sample_sheet`` implicit output.
+
+### Example: `SAMPLE_SHEET_PAIRED_MAPPING_OVER_PAIRED`
+
+```yaml
+label: SAMPLE_SHEET_PAIRED_MAPPING_OVER_PAIRED
+assumptions:
+- datasets:
+  - d_f
+  - d_r
+- tool:
+    in:
+      i: collection<paired>
+    out:
+      o: dataset
+- collections:
+    C:
+    - sample_sheet:paired
+    - el1:
+        forward: d_f
+        reverse: d_r
+    C\_PAIRED:
+    - paired
+    - forward: d_f
+      reverse: d_r
+then:
+  type: map_over
+  invocation:
+    inputs:
+      i:
+        type: map_over
+        collection: C
+        sub_collection_type: paired
+  produces:
+    o:
+      type: collection
+      collection_type: sample_sheet
+      elements:
+        el1:
+          type: tool_output_ref
+          invocation:
+            inputs:
+              i:
+                type: collection
+                ref: C\_PAIRED
+          output: o
+tests:
+  workflow_runtime:
+    framework_test: collection_semantics_paired_or_unpaired_5
+  workflow_editor: accepts sample_sheet:paired -> paired connection (maps over like list:paired)
+```
+
+### Example: `SAMPLE_SHEET_PAIRED_MATCHES_LIST_PAIRED`
+
+```yaml
+label: SAMPLE_SHEET_PAIRED_MATCHES_LIST_PAIRED
+assumptions:
+- datasets:
+  - d_f
+  - d_r
+- tool:
+    in:
+      i: collection<list:paired>
+    out:
+      o: dataset
+- collections:
+    C:
+    - sample_sheet:paired
+    - el1:
+        forward: d_f
+        reverse: d_r
+then:
+  type: reduction
+  invocation:
+    inputs:
+      i:
+        type: collection
+        ref: C
+  produces:
+    o:
+      type: dataset
+tests:
+  workflow_runtime:
+    framework_test: collection_semantics_list_paired_0
+  workflow_editor: accepts sample_sheet:paired -> list:paired connection (accepts)
+```
+
+The ``paired_or_unpaired`` integration rules carry over from ``list`` to
+``sample_sheet``. A flat ``sample_sheet`` can be mapped over a
+``paired_or_unpaired`` input via ``single_datasets`` sub-collection mapping,
+and ``sample_sheet:paired`` can be mapped over ``paired_or_unpaired`` just as
+``list:paired`` can.
+
+### Example: `SAMPLE_SHEET_MAPPING_OVER_PAIRED_OR_UNPAIRED`
+
+```yaml
+label: SAMPLE_SHEET_MAPPING_OVER_PAIRED_OR_UNPAIRED
+assumptions:
+- datasets:
+  - d_1,...,d_n
+- tool:
+    in:
+      i: collection<paired_or_unpaired>
+    out:
+      o: dataset
+- collections:
+    C:
+    - sample_sheet
+    - i1: d_1
+      '...': null
+      in: d_n
+- C_AS_UNPAIRED_i = CollectionInstance<paired_or_unpaired,{unpaired=di}> for i from 1...n
+then:
+  type: map_over
+  invocation:
+    inputs:
+      i:
+        type: map_over
+        collection: C
+        sub_collection_type: single_datasets
+  produces:
+    o:
+      type: collection
+      collection_type: sample_sheet
+      elements:
+        i1:
+          type: tool_output_ref
+          invocation:
+            inputs:
+              i:
+                type: collection
+                ref: C_AS_UNPAIRED_1
+          output: o
+        '...':
+          type: ellipsis
+        in:
+          type: tool_output_ref
+          invocation:
+            inputs:
+              i:
+                type: collection
+                ref: C_AS_UNPAIRED_n
+          output: o
+tests:
+  tool_runtime:
+    api_test: test_tool_execute.py::test_map_over_paired_or_unpaired_with_sample_sheet
+  workflow_runtime:
+    framework_test: collection_semantics_paired_or_unpaired_8
+  workflow_editor: accepts sample_sheet -> paired_or_unpaired connection
+```
+
+### Example: `SAMPLE_SHEET_PAIRED_MAPPING_OVER_PAIRED_OR_UNPAIRED`
+
+```yaml
+label: SAMPLE_SHEET_PAIRED_MAPPING_OVER_PAIRED_OR_UNPAIRED
+assumptions:
+- datasets:
+  - d_f
+  - d_r
+- tool:
+    in:
+      i: collection<paired_or_unpaired>
+    out:
+      o: dataset
+- collections:
+    C:
+    - sample_sheet:paired
+    - el1:
+        forward: d_f
+        reverse: d_r
+    C_AS_MIXED:
+    - sample_sheet:paired_or_unpaired
+    - el1:
+        forward: d_f
+        reverse: d_r
+then:
+  type: equivalence
+  left:
+    inputs:
+      i:
+        type: map_over
+        collection: C
+  right:
+    inputs:
+      i:
+        type: map_over
+        collection: C_AS_MIXED
+tests:
+  workflow_runtime:
+    framework_test: collection_semantics_paired_or_unpaired_6
+  workflow_editor: accepts sample_sheet:paired -> paired_or_unpaired connection
+```
+
+### Example: `SAMPLE_SHEET_PAIRED_OR_UNPAIRED_MATCHES_LIST_PAIRED_OR_UNPAIRED`
+
+```yaml
+label: SAMPLE_SHEET_PAIRED_OR_UNPAIRED_MATCHES_LIST_PAIRED_OR_UNPAIRED
+assumptions:
+- datasets:
+  - d_f
+  - d_r
+- tool:
+    in:
+      i: collection<list:paired_or_unpaired>
+    out:
+      o: dataset
+- collections:
+    C:
+    - sample_sheet:paired_or_unpaired
+    - el1:
+        forward: d_f
+        reverse: d_r
+then:
+  type: reduction
+  invocation:
+    inputs:
+      i:
+        type: collection
+        ref: C
+  produces:
+    o:
+      type: dataset
+tests:
+  workflow_runtime:
+    framework_test: collection_semantics_list_paired_or_unpaired_1
+  workflow_editor: accepts sample_sheet:paired_or_unpaired -> list:paired_or_unpaired connection (accepts)
+```
+
+The type matching is asymmetric: a ``sample_sheet`` output can satisfy a ``list``
+input because sample sheets carry all the structural information lists have (plus
+metadata). However, a ``list`` output cannot satisfy a ``sample_sheet`` input because
+lists lack the ``column_definitions`` and per-element ``columns`` metadata that
+sample sheet consumers expect.
+
+### Example: `LIST_NOT_MATCHES_SAMPLE_SHEET`
+
+```yaml
+label: LIST_NOT_MATCHES_SAMPLE_SHEET
+assumptions:
+- datasets:
+  - d_1,...,d_n
+- tool:
+    in:
+      i: collection<sample_sheet>
+    out:
+      o: dataset
+- collections:
+    C:
+    - list
+    - i1: d_1
+      '...': null
+      in: d_n
+then:
+  type: invalid
+  invocation:
+    inputs:
+      i:
+        type: collection
+        ref: C
+is_valid: false
+tests:
+  workflow_editor: rejects list -> sample_sheet connection (asymmetry)
+```
+
+### Example: `LIST_PAIRED_NOT_MATCHES_SAMPLE_SHEET_PAIRED`
+
+```yaml
+label: LIST_PAIRED_NOT_MATCHES_SAMPLE_SHEET_PAIRED
+assumptions:
+- datasets:
+  - d_f
+  - d_r
+- tool:
+    in:
+      i: collection<sample_sheet:paired>
+    out:
+      o: dataset
+- collections:
+    C:
+    - list:paired
+    - el1:
+        forward: d_f
+        reverse: d_r
+then:
+  type: invalid
+  invocation:
+    inputs:
+      i:
+        type: collection
+        ref: C
+is_valid: false
+tests:
+  workflow_editor: rejects list:paired -> sample_sheet:paired connection (asymmetry)
+```
+
+### Example: `SAMPLE_SHEET_MATCHES_SAMPLE_SHEET`
+
+```yaml
+label: SAMPLE_SHEET_MATCHES_SAMPLE_SHEET
+assumptions:
+- datasets:
+  - d_1,...,d_n
+- tool:
+    in:
+      i: collection<sample_sheet>
+    out:
+      o: dataset
+- collections:
+    C:
+    - sample_sheet
+    - i1: d_1
+      '...': null
+      in: d_n
+then:
+  type: reduction
+  invocation:
+    inputs:
+      i:
+        type: collection
+        ref: C
+  produces:
+    o:
+      type: dataset
+tests:
+  workflow_runtime:
+    framework_test: collection_semantics_cat_sample_sheet_0
+  workflow_editor: accepts sample_sheet -> sample_sheet connection
+```
+
+## Type Compatibility Algebra
+
+This section is for implementers. It describes the three operations that
+answer "do these collection types fit together?" — used at workflow
+editor connection time and at runtime when sibling inputs are matched
+under a common map-over.
+
+### The lattice
+
+The base types form a small subtype lattice:
+
+```
+list                paired_or_unpaired
+ |                    |
+sample_sheet         paired
+```
+
+Edges are subtype relations. A `sample_sheet` value carries column
+metadata that a `list` does not, so it can be substituted where a
+`list` is required (information is preserved); the reverse is not safe.
+A `paired` value always has two elements; `paired_or_unpaired` admits
+1 or 2, so a `paired` can be substituted where `paired_or_unpaired` is
+required, but not the reverse.
+
+Nesting composes. `list:paired_or_unpaired` is a supertype of both
+`list:paired` and `list` (the latter via the "single-dataset wrapped
+as unpaired" interpretation), so it has two incomparable subtypes.
+
+### Three operations
+
+| Operation | Symmetry | Question | Used at |
+|---|---|---|---|
+| `accepts(other)` | Asymmetric | Does an input slot of type `self` accept an output of type `other`? | Workflow-editor edge validation |
+| `compatible(other)` | Symmetric | Do `self` and `other` match such that they could drive a common map-over over sibling inputs of one tool? | Sibling-matching: matching sibling HDCAs / sibling map-over states under a common mapping |
+| `can_map_over(other)` | Asymmetric | Does `self` have proper subcollections of type `other` — i.e. can `self` be mapped over to feed an `other` slot? | Connection-time map-over decisions; runtime `effective_collection_type` arithmetic |
+
+Conventions: `input_type.accepts(output_type)` for direct edges;
+`output_type.can_map_over(input_type)` for map-over. `accepts` and
+`can_map_over` differ in that `accepts` is the direct-edge case
+where ranks already align, while `can_map_over` is the strict nesting
+case where the output has *more* rank than the input. `compatible`
+is symmetric and either side may go first.
+
+`compatible(a, b)` is implemented as `a.accepts(b) or b.accepts(a)`.
+
+### Where each is used
+
+- `accepts` is called at single-edge validation: connecting one output
+  to one input. The asymmetry between input and output sides matters
+  here. Examples: `connection_types.can_match`,
+  `query.HistoryQuery.direct_match`, and the workflow-editor input
+  attachment paths in `terminals.ts`.
+
+- `compatible` is called when two collections must drive a common
+  map-over as siblings. Neither side is the input slot; both are
+  concrete shapes (observed HDCA shapes at runtime, sibling map-over
+  states at connection time). Order of arrival must not change the
+  answer. Examples: Python `Tree.compatible_shape` (matching.py,
+  execute.py) and the `mappingConstraints` checks in `terminals.ts`.
+
+- `can_map_over` is called when deciding whether an output of higher
+  rank can drive a map-over into a lower-rank input — for instance, a
+  `list:paired` output feeding a `paired` input by iterating the outer
+  list. The Python and TypeScript names match
+  (`can_map_over` / `canMapOver`) because it is the same operational
+  question in both layers.
+
+Routing a sibling-matching question through `accepts` instead of
+`compatible` produces order-dependent behavior — which sibling input
+arrived first changes whether the workflow validates. This was a real
+bug in earlier revisions of both the Python and TypeScript code.
+
+### Worked examples
+
+- `paired.accepts(paired_or_unpaired)` is `False`. A 1-element
+  paired_or_unpaired output cannot be connected to an input slot
+  that strictly requires a pair. Test: `test_paired_accepts_relation`.
+
+- `paired.compatible(paired_or_unpaired)` is `True`. If both observed
+  sibling collections happen to align in cardinality, they match for
+  sibling iteration; cardinality checking happens later at the
+  children level. Test:
+  `test_paired_and_paired_or_unpaired_match_symmetric`.
+
+- `sample_sheet.accepts(list)` is `False`; `list.accepts(sample_sheet)`
+  is `True`. Tests:
+  `test_sample_sheet_accepts_relation`, workflow editor
+  `"rejects list -> sample_sheet connection (asymmetry)"`.
+
+- `sample_sheet.compatible(list)` and `list.compatible(sample_sheet)`
+  are both `True`. Tests: `test_compatible`,
+  `test_tree_compatible_shape_sample_sheet_list_symmetric`.
+
+### Cross-language synchronization
+
+The Python implementation lives in
+`lib/galaxy/model/dataset_collections/type_description.py`. The
+TypeScript implementation lives in
+`client/src/components/Workflow/Editor/modules/collectionTypeDescription.ts`.
+Both must stay in sync; method names and conventions are identical.

--- a/content/research/galaxy-collection-semantics.md
+++ b/content/research/galaxy-collection-semantics.md
@@ -10,6 +10,9 @@ created: 2026-04-30
 revised: 2026-04-30
 revision: 1
 ai_generated: false
+related_notes:
+  - "[[galaxy-collection-tools]]"
+  - "[[galaxy-apply-rules-dsl]]"
 sources:
   - "https://github.com/galaxyproject/galaxy/blob/0683385f5da57c6065c5408f033fdcafd66a27b6/lib/galaxy/model/dataset_collections/types/collection_semantics.yml"
 summary: "Vendored formal spec of Galaxy dataset-collection mapping/reduction semantics, with labeled examples and pinned test references."

--- a/content/research/galaxy-collection-semantics.yml
+++ b/content/research/galaxy-collection-semantics.yml
@@ -1,0 +1,1351 @@
+- doc: |
+    # Collection Semantics
+
+    This document describes the semantics around working with Galaxy dataset collections.
+    In particular it describes how they operate within Galaxy tools and workflows.
+
+    :::{admonition} You Probably Don't Need to Read This
+    :class: caution
+
+    Any significantly sophisticated workflow language will have ways to collect data
+    into arrays or vectors or dictionaries and apply operations across this data (mapping)
+    or reduce the dimensionality of this data (reductions). Typically, this is explicitly
+    annotated with map functions or for loops. Galaxy however is designed to be a point
+    and click interface for connecting steps and running tools. It is important that steps
+    just connect and just do the most natural thing - and this is what Galaxy does.
+    This document just provides a mathematical formalism to that "what should just
+    intuitively work" that can be used to document test cases and help with implementation.
+    This is reference documentation not user documentation, Galaxy should just work.
+    :::
+
+    ## Mapping
+
+    If a tool consumes a simple dataset parameter and produces a simple dataset parameter,
+    then any collection type may be "mapped over" the data input to that tool. The result of
+    that is the tool being applied to each element of the collection and "implicit collections"
+    being created from the outputs that are produced from those operations. Those implicit
+    collections have the same element identifiers in the same order as the input collection that is
+    mapped over. Each element of the implicit collections correspond to their own job and
+    Galaxy very naturally and intuitively parallelizes jobs without extra work from the user
+    and without any knowledge of the tool.
+
+- example:
+    label: BASIC_MAPPING_PAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: dataset}
+        out: {o: dataset}
+    - collections:
+        C: [paired, {forward: d_f, reverse: d_r}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C}
+        produces:
+            o:
+                type: collection
+                collection_type: paired
+                elements:
+                    forward:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d_f}}}
+                        output: o
+                    reverse:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d_r}}}
+                        output: o
+    tests:
+        tool_runtime:
+            api_test: "test_tool_execute.py::test_map_over_collection"
+        workflow_runtime:
+            framework_test: "collection_semantics_cat_0"
+        workflow_editor: "accepts paired data -> data connection"
+
+- example:
+    label: BASIC_MAPPING_PAIRED_OR_UNPAIRED_PAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: dataset}
+        out: {o: dataset}
+    - collections:
+        C: [paired_or_unpaired, {forward: d_f, reverse: d_r}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C}
+        produces:
+            o:
+                type: collection
+                collection_type: paired_or_unpaired
+                elements:
+                    forward:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d_f}}}
+                        output: o
+                    reverse:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d_r}}}
+                        output: o
+    tests:
+        tool_runtime:
+            api_test: "test_tool_execute.py::test_map_over_data_with_paired_or_unpaired_paired"
+        workflow_runtime:
+            framework_test: "collection_semantics_cat_1"
+        workflow_editor: "accepts paired_or_unpaired data -> data connection"
+
+- example:
+    label: BASIC_MAPPING_PAIRED_OR_UNPAIRED_UNPAIRED
+    assumptions:
+    - datasets: [d_u]
+    - tool:
+        in: {i: dataset}
+        out: {o: dataset}
+    - collections:
+        C: [paired_or_unpaired, {unpaired: d_u}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C}
+        produces:
+            o:
+                type: collection
+                collection_type: paired_or_unpaired
+                elements:
+                    unpaired:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d_u}}}
+                        output: o
+    tests:
+        tool_runtime:
+            api_test: "test_tool_execute.py::test_map_over_data_with_paired_or_unpaired_unpaired"
+        workflow_runtime:
+            framework_test: "collection_semantics_cat_2"
+        workflow_editor: "accepts paired_or_unpaired data -> data connection"
+
+- example:
+    label: BASIC_MAPPING_LIST
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: dataset}
+        out: {o: dataset}
+    - collections:
+        C: [list, {i1: "d_1", ..., in: "d_n"}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C}
+        produces:
+            o:
+                type: collection
+                collection_type: list
+                elements:
+                    i1:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d_1}}}
+                        output: o
+                    "...": {type: ellipsis}
+                    in:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d_n}}}
+                        output: o
+    tests:
+        workflow_editor: "accepts collection data -> data connection"
+
+- doc: |
+    The above description of mapping over inputs works naturally and as expected for
+    nested collections.
+
+- example:
+    label: NESTED_LIST_MAPPING
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: dataset}
+        out: {o: dataset}
+    - collections:
+        C: ["list:list", {o1: {inner: d_1}, ..., "on": {inner: d_n}}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C}
+        produces:
+            o:
+                type: collection
+                collection_type: "list:list"
+                elements:
+                    o1:
+                        type: nested_elements
+                        elements:
+                            inner:
+                                type: tool_output_ref
+                                invocation: {inputs: {i: {type: dataset, ref: d_1}}}
+                                output: o
+                    "...": {type: ellipsis}
+                    "on":
+                        type: nested_elements
+                        elements:
+                            inner:
+                                type: tool_output_ref
+                                invocation: {inputs: {i: {type: dataset, ref: d_n}}}
+                                output: o
+    tests:
+        tool_runtime:
+            api_test: "test_tools.py::TestToolsApi::test_map_over_nested_collections"
+        workflow_editor: "accepts list:list data -> data connection"
+
+- example:
+    label: BASIC_MAPPING_LIST_PAIRED_OR_UNPAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: dataset}
+        out: {o: dataset}
+    - collections:
+        C: ["list:paired_or_unpaired", {el1: {forward: d_f, reverse: d_r}}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C}
+        produces:
+            o:
+                type: collection
+                collection_type: "list:paired_or_unpaired"
+                elements:
+                    el1:
+                        type: nested_elements
+                        elements:
+                            forward:
+                                type: tool_output_ref
+                                invocation: {inputs: {i: {type: dataset, ref: d_f}}}
+                                output: o
+                            reverse:
+                                type: tool_output_ref
+                                invocation: {inputs: {i: {type: dataset, ref: d_r}}}
+                                output: o
+    tests:
+        tool_runtime:
+            api_test: "test_tool_execute.py::test_map_over_data_with_list_paired_or_unpaired"
+        workflow_runtime:
+            framework_test: "collection_semantics_cat_3"
+        workflow_editor: "accepts list:paired_or_unpaired data -> data connection"
+
+- doc: |
+
+    For tools with multiple data inputs, the tool can be executed with individual
+    datasets for the non-mapped over input and each tool execution will just be executed
+    with that dataset. The dataset not mapped over serves as the input for each execution.
+
+- example:
+    label: BASIC_MAPPING_INCLUDING_SINGLE_DATASET
+    assumptions:
+    - datasets: ["d_1,...,d_n", "d_o"]
+    - tool:
+        in: {i: dataset, i2: dataset}
+        out: {o: dataset}
+    - collections:
+        C: ["list", {i1: d_1, ..., in: d_n}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C}
+                i2: {type: dataset, ref: d_o}
+        produces:
+            o:
+                type: collection
+                collection_type: list
+                elements:
+                    i1:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d_1}, i2: {type: dataset, ref: d_o}}}
+                        output: o
+                    "...": {type: ellipsis}
+                    in:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d_n}, i2: {type: dataset, ref: d_o}}}
+                        output: o
+    tests:
+        tool_runtime:
+            api_test: "test_tools.py::TestToolsApi::test_map_over_collected_and_individual_datasets"
+        workflow_runtime:
+            framework_test: "collection_semantics_cat_two_inputs_0"
+
+- doc: |
+    If a tool consumes two input datasets and produces one output dataset, you can map two
+    collections with identical structure (same element identifiers in the same order) over
+    the respective inputs and the result is an implicit collection with the same structure
+    as the inputs and where each output in the implicit collection corresponds to the tool
+    being executed with the two inputs corresponding to that position in the input
+    collections.
+
+    The default behavior here is the collections are linked and the act of mapping over
+    inputs to the tool are sort of a flat map or a dot product. No extra dimensionality
+    in the resulting collections.
+
+    From a user perspective this means if you start with a collection and apply a bunch
+    of map over operations on tools - the results will all continue to match and work together
+    very naturally - again without extra work by the user and without extra knowledge
+    by the tool author.
+
+- example:
+    label: BASIC_MAPPING_TWO_INPUTS_WITH_IDENTICAL_STRUCTURE
+    assumptions:
+    - datasets: ["d1_1,...,d1_n", "d2_1,...,d2_n"]
+    - tool:
+        in: {i: dataset, i2: dataset}
+        out: {o: dataset}
+    - collections:
+        C1: ["list", {i1: d1_1, ..., in: d1_n}]
+        C2: ["list", {i1: d2_1, ..., in: d2_n}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C1}
+                i2: {type: map_over, collection: C2}
+        produces:
+            o:
+                type: collection
+                collection_type: list
+                elements:
+                    i1:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d1_1}, i2: {type: dataset, ref: d2_1}}}
+                        output: o
+                    "...": {type: ellipsis}
+                    in:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d1_n}, i2: {type: dataset, ref: d2_n}}}
+                        output: o
+    tests:
+        tool_runtime:
+            api_test: test_tools.py::TestToolsApi::test_map_over_two_collections
+        workflow_runtime:
+            framework_test: "collection_semantics_cat_two_inputs_1"
+
+- doc: "## Reduction"
+- doc: |
+    Not all tool executions result in implicit collections and mapping
+    over inputs. Tool inputs of ``type`` ``data_collection`` can consume
+    collections directly and do not necessarily result in mapping over.
+
+    Tools that consume collections and output datasets effectively
+    reduce the dimension of the Galaxy data structure. When used at runtime
+    this is often referred to as a "reduction" in the code.
+
+- example:
+    label: COLLECTION_INPUT_PAIRED
+    assumptions:
+    - datasets: ["d_f", "d_r"]
+    - tool:
+        in: {i: "collection<paired>"}
+        out: {o: dataset}
+    - collections:
+        C: [paired, {forward: d_f, reverse: d_r}]
+    then:
+        type: reduction
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+        produces:
+            o: {type: dataset}
+    tests:
+        tool_runtime:
+            tool: collection_paired_test
+        workflow_editor: "accepts paired -> paired connection"
+
+- example:
+    label: COLLECTION_INPUT_LIST
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: "collection<list>"}
+        out: {o: dataset}
+    - collections:
+        C: [list, {el1: d_1, ..., eln: d_n}]
+    then:
+        type: reduction
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+        produces:
+            o: {type: dataset}
+    tests:
+        workflow_runtime:
+            framework_test: "collection_semantics_cat_collection_0"
+        workflow_editor: "accepts list -> list connection"
+
+- example:
+    label: COLLECTION_INPUT_PAIRED_OR_UNPAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: [paired_or_unpaired, {forward: d_f, reverse: d_r}]
+    then:
+        type: reduction
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+        produces:
+            o: {type: dataset}
+    tests:
+        tool_runtime:
+            tool: collection_paired_or_unpaired
+        workflow_runtime:
+            framework_test: "collection_semantics_paired_or_unpaired_0"
+        workflow_editor: "accepts paired_or_unpaired data -> paired_or_unpaired connection"
+
+- example:
+    label: COLLECTION_INPUT_LIST_PAIRED_OR_UNPAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<list:paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:paired_or_unpaired", {el1: {forward: d_f, reverse: d_r}}]
+    then:
+        type: reduction
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+        produces:
+            o: {type: dataset}
+    tests:
+        tool_runtime:
+            tool: collection_list_paired_or_unpaired
+        workflow_runtime:
+            framework_test: "collection_semantics_list_paired_or_unpaired_0"
+        workflow_editor: "accepts list:paired_or_unpaired data -> list:paired_or_unpaired connection"
+
+- doc: |
+    For nested collections where each rank is a ``list`` or a ``paired`` collection,
+    then collection inputs must match every part of the collection type input definition.
+
+- example:
+    label: COLLECTION_INPUT_LIST_NOT_CONSUMES_PAIRS
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<list>"}
+        out: {o: dataset}
+    - collections:
+        C: [paired, {forward: d_f, reverse: d_r}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects connecting paired -> list"
+
+- example:
+    label: COLLECTION_INPUT_PAIRED_NOT_CONSUMES_LIST
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: "collection<paired>"}
+        out: {o: dataset}
+    - collections:
+        C: [list, {i1: d_1, ..., in: d_n}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects connecting list -> paired"
+
+- example:
+    label: COLLECTION_INPUT_LIST_PAIRED_NOT_CONSUMES_PAIRED_PAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<list:paired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["paired:paired", {forward: {forward: d_f, reverse: d_r}, reverse: {forward: d_f, reverse: d_r}}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects paired:paired -> list:paired connection"
+
+- example:
+    label: COLLECTION_INPUT_LIST_PAIRED_OR_NOT_PAIRED_NOT_CONSUMES_PAIRED_PAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<list:paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["paired:paired", {forward: {forward: d_f, reverse: d_r}, reverse: {forward: d_f, reverse: d_r}}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects paired:paired -> list:paired_or_unpaired connection"
+
+- doc: |
+    In addition to explicit collection inputs, tool inputs of ``type`` ``data``
+    where ``multiple="true"`` can consume lists directly. This is likewise a
+    "reduction" and does not result in implicit collection creation.
+
+- example:
+    label: LIST_REDUCTION
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: "dataset<multiple=true>"}
+        out: {o: dataset}
+    - collections:
+        C: [list, {i1: d_1, ..., in: d_n}]
+    then:
+        type: equivalence
+        left:
+            inputs:
+                i: {type: collection, ref: C}
+        right:
+            inputs:
+                i: {type: dataset_list, refs: ["d_1", "...", "d_n"]}
+    tests:
+        tool_runtime:
+            api_test: "test_tools.py::TestToolsApi::test_reduce_collections"
+        workflow_runtime:
+            framework_test: "collection_semantics_multi_data_optional_0"
+        workflow_editor: "treats multi data input as list input"
+
+- doc: |
+    Paired collections cannot be reduced this way. ``paired`` is not meant
+    to represent a list/array/vector data structure - it is more like a tuple.
+
+- example:
+    label: PAIRED_REDUCTION_INVALID
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "dataset<multiple=true>"}
+        out: {o: dataset}
+    - collections:
+        C: [paired, {forward: d_f, reverse: d_r}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects paired input on multi-data input"
+
+- example:
+    label: PAIRED_OR_UNPAIRED_REDUCTION_INVALID
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "dataset<multiple=true>"}
+        out: {o: dataset}
+    - collections:
+        C: [paired_or_unpaired, {forward: d_f, reverse: d_r}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects paired_or_unpaired input on multi-data input"
+
+- doc: "## Sub-collection Mapping"
+- doc: |
+    ![](https://planemo.readthedocs.io/en/master/_images/subcollection_mapping_identifiers.svg)
+
+- example:
+    label: MAPPING_LIST_PAIRED_OVER_PAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<paired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:paired", {el1: {forward: d_f, reverse: d_r}}]
+        "C\\_PAIRED": [paired, {forward: d_f,reverse: d_r}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C, sub_collection_type: paired}
+        produces:
+            o:
+                type: collection
+                collection_type: list
+                elements:
+                    el1:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: collection, ref: "C\\_PAIRED"}}}
+                        output: o
+    tests:
+        tool_runtime:
+            api_test: "test_tool_execute.py::test_simple_subcollection_mapping"
+        workflow_editor: "accepts list:paired -> paired connection"
+
+- doc: |
+    The natural extension of multiple data input parameters consuming list collections as described
+    above when discussing reductions is that nested lists of lists (``list:list``) can be mapped
+    over a multiple data input parameter. Each nested list will be reduced by this operation but the
+    results will be mapped over. The result will be a list with the same structure as the outer list
+    of the input collection.
+
+- example:
+    label: NESTED_LIST_REDUCTION
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: "dataset<multiple=true>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:list", {o1: {inner: d_1}, ..., "on": {inner: d_n}}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C, sub_collection_type: list}
+        produces:
+            o:
+                type: collection
+                collection_type: list
+                elements:
+                    o1:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset_list, refs: ["d_1"]}}}
+                        output: o
+                    "...": {type: ellipsis}
+                    "on":
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset_list, refs: ["d_n"]}}}
+                        output: o
+    tests:
+        workflow_editor: "maps list:list over multi data input"
+
+- doc: |
+    Just as a paired collection won't be reduced by a multiple data input, any sort of nested
+    collection ending in a paired collection cannot be mapped over such an input. So a multiple
+    data input parameter cannot be mapped over by a list of pairs (``list:paired``) for instance.
+
+- example:
+    label: LIST_PAIRED_REDUCTION_INVALID
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "dataset<multiple=true>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:paired", {el1: {forward: d_f, reverse: d_r}}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C, sub_collection_type: paired}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects list:paired input on multi-data input"
+
+- example:
+    label: LIST_PAIRED_OR_UNPAIRED_REDUCTION_INVALID
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "dataset<multiple=true>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:paired_or_unpaired", {el1: {forward: d_f, reverse: d_r}}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C, sub_collection_type: paired_or_unpaired}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects list:paired_or_unpaired input on multi-data input"
+
+- doc: "## paired_or_unpaired Collections"
+- doc: |
+    The collection type ``paired_or_unpaired`` is meant to serve as a stand-in for
+    an entity that can be either a single dataset or what is effectively a ``paired``
+    dataset collection. These collections either have one element with identifier
+    ``unpaired`` or two elements with identifiers ``forward`` and ``reverse``.
+
+    Tools can declare a data_collection input with collection type ``paired_or_unpaired``
+    and that input will consume either an explicit ``paired_or_unpaired`` collection
+    normally or can consume a ``paired`` input.
+
+- example:
+    label: PAIRED_OR_UNPAIRED_CONSUMES_PAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: [paired, {forward: d_f, reverse: d_r}]
+    - "C_AS_MIXED = CollectionInstance<paired_or_unpaired, {forward: d_f, reverse: d_r}>"
+    then:
+        type: equivalence
+        left:
+            inputs:
+                i: {type: collection, ref: C}
+        right:
+            inputs:
+                i: {type: collection, ref: C_AS_MIXED}
+    tests:
+        tool_runtime:
+            tool: collection_paired_or_unpaired
+        workflow_runtime:
+            framework_test: "collection_semantics_paired_or_unpaired_1"
+        workflow_editor: "accepts paired -> paired_or_unpaired connection"
+
+- doc: |
+
+    The inverse of this doesn't work intentionally. In some ways a ``paired`` collection
+    acts as a ``paired_or_unpaired`` collection but a ``paired_or_unpaired`` is not a paired
+    collection. This makes a lot of sense in terms of tools - a tool consuming a ``paired``
+    dataset expects to find both a ``forward`` and ``reverse`` element but these may not exist
+    in ``paired_or_unpaired`` collection.
+
+- example:
+    label: PAIRED_OR_UNPAIRED_NOT_CONSUMED_BY_PAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<paired>"}
+        out: {o: dataset}
+    - collections:
+        C: [paired_or_unpaired, {forward: d_f, reverse: d_r}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects paired_or_unpaired -> paired connection"
+
+- doc: |
+
+    The same logic holds for mapping, lists of paired datasets (``list:paired``) can be mapped over these
+    ``paired_or_unpaired`` inputs and mixed lists of pairs (``list:paired_or_unpaired``) cannot
+    be mapped over a ``paired`` input. Following the same logic, ``list:paired_or_unpaired`` cannot
+    be mapped over a ``list`` input or multiple data input.
+
+- example:
+    label: MAPPING_LIST_PAIRED_OVER_PAIRED_OR_UNPAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:paired", {el: {forward: d_f, reverse: d_r}}]
+        C_AS_MIXED: ["list:paired_or_unpaired", {el: {forward: d_f, reverse: d_r}}]
+    then:
+        type: equivalence
+        left:
+            inputs:
+                i: {type: map_over, collection: C}
+        right:
+            inputs:
+                i: {type: map_over, collection: C_AS_MIXED}
+    tests:
+        workflow_runtime:
+            framework_test: "collection_semantics_paired_or_unpaired_2"
+        workflow_editor: "accepts list:paired -> paired_or_unpaired connection"
+
+- example:
+    label: PAIRED_OR_UNPAIRED_NOT_CONSUMED_BY_PAIRED_WHEN_MAPPING
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<paired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:paired_or_unpaired", {el: {forward: d_f, reverse: d_r}}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C}
+    is_valid: false
+    tests:
+        tool_runtime:
+            api_test: "test_tool_execute.py::test_paired_or_unpaired_not_consumed_by_paired_when_mapping"
+        workflow_editor: "rejects list:paired_or_unpaired -> paired connection"
+
+- example:
+    label: PAIRED_OR_UNPAIRED_NOT_CONSUMED_BY_LIST_WHEN_MAPPING
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<list>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:paired_or_unpaired", {el: {forward: d_f, reverse: d_r}}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects list:paired_or_unpaired -> list connection"
+
+- doc: |
+    This logic extends naturally into higher dimensional collections. A ``list:list:paired``
+    can be mapped over either a ``paired_or_unpaired`` input to produce a nested list (``list:list``)
+    or a ``list:paired_or_unpaired`` input to produce a flat list (``list``).
+
+- example:
+    label: MAPPING_LIST_LIST_PAIRED_OVER_PAIRED_OR_UNPAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:list:paired", {o1: {el1: {forward: d_f, reverse: d_r}}}]
+        C_AS_MIXED: ["list:list:paired_or_unpaired", {o1: {el1: {forward: d_f, reverse: d_r}}}]
+    then:
+        type: equivalence
+        left:
+            inputs:
+                i: {type: map_over, collection: C}
+        right:
+            inputs:
+                i: {type: map_over, collection: C_AS_MIXED}
+    tests:
+        workflow_runtime:
+            framework_test: "collection_semantics_paired_or_unpaired_3"
+        workflow_editor: "accepts list:list:paired -> paired_or_unpaired connection"
+
+- doc: |
+
+    In order for ``paired_or_unpaired`` collections to also act as a single dataset,
+    a flat list can be mapped over a such an input with a special sub collection mapping
+    type of 'single_datasets'.
+
+- example:
+    label: MAPPING_LIST_OVER_PAIRED_OR_UNPAIRED
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: "collection<paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: [list, {i1: d_1, ..., in: d_n}]
+    - "C_AS_UNPAIRED_i = CollectionInstance<paired_or_unpaired,{unpaired=di}> for i from 1...n"
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C, sub_collection_type: single_datasets}
+        produces:
+            o:
+                type: collection
+                collection_type: list
+                elements:
+                    i1:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: collection, ref: C_AS_UNPAIRED_1}}}
+                        output: o
+                    "...": {type: ellipsis}
+                    in:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: collection, ref: C_AS_UNPAIRED_n}}}
+                        output: o
+    tests:
+        tool_runtime:
+            api_test: "test_tool_execute.py::test_map_over_paired_or_unpaired_with_list"
+        workflow_runtime:
+            framework_test: "collection_semantics_paired_or_unpaired_7"
+        workflow_editor: "accepts list -> paired_or_unpaired connection"
+
+- doc: |
+    This treatment of lists without pairing extends to nested structures naturally.
+    For instance, a list of list of datasets (``list:list``) can be mapped over a
+    ``paired_or_unpaired`` input to produce a nested list of lists (``list:list``)
+    with a structure matching the input. Likewise, the nested list can be mapped over
+    a ``list:paired_or_unpaired`` input to produce a flat list with the same structure
+    as the outer list of the input.
+
+- example:
+    label: MAPPING_LIST_LIST_OVER_PAIRED_OR_UNPAIRED
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: "collection<paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:list", {o1: {inner: d_1}, ..., "on": {inner: d_n}}]
+    - "C_AS_UNPAIRED_j = CollectionInstance<paired_or_unpaired,{unpaired=dj}> for each dataset dj in C"
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C, sub_collection_type: single_datasets}
+        produces:
+            o:
+                type: collection
+                collection_type: "list:list"
+                elements:
+                    o1:
+                        type: nested_elements
+                        elements:
+                            inner:
+                                type: tool_output_ref
+                                invocation: {inputs: {i: {type: collection, ref: C_AS_UNPAIRED_1}}}
+                                output: o
+                    "...": {type: ellipsis}
+                    "on":
+                        type: nested_elements
+                        elements:
+                            inner:
+                                type: tool_output_ref
+                                invocation: {inputs: {i: {type: collection, ref: C_AS_UNPAIRED_n}}}
+                                output: o
+    tests:
+        workflow_editor: "accepts list:list -> paired_or_unpaired connection"
+
+- example:
+    label: MAPPING_LIST_LIST_OVER_LIST_PAIRED_OR_UNPAIRED
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: "collection<list:paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:list", {o1: {inner: d_1}, ..., "on": {inner: d_n}}]
+    - "C_AS_LPU_i = inner list of C at position i, treated as list:paired_or_unpaired via single_datasets"
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C, sub_collection_type: "list:paired_or_unpaired"}
+        produces:
+            o:
+                type: collection
+                collection_type: list
+                elements:
+                    o1:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: collection, ref: C_AS_LPU_1}}}
+                        output: o
+                    "...": {type: ellipsis}
+                    "on":
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: collection, ref: C_AS_LPU_n}}}
+                        output: o
+    tests:
+        tool_runtime:
+            api_test: "test_tool_execute.py::test_map_over_list_paired_or_unpaired_with_list_of_lists"
+        workflow_runtime:
+            framework_test: "collection_semantics_list_paired_or_unpaired_2"
+        workflow_editor: "accepts list:list -> list:paired_or_unpaired connection"
+
+- doc: |
+    Due only to implementation time, the special casing of allowing paired_or_unpaired
+    act as both datasets and paired collections only works when it is the deepest
+    collection type. So while list:paired can be consumed by a list:paired_or_unpaired
+    input, a paired:list cannot be consumed by a paired_or_unpaired:list input though
+    it should be able to for consistency. We have focused our time on data structures
+    more likely to be used in actual Galaxy analyses given current and guessed future
+    usage.
+
+- doc: "## sample_sheet Collections"
+- doc: |
+    The collection type ``sample_sheet`` attaches typed, columnar metadata to each
+    element of a dataset collection. For mapping and type matching purposes,
+    ``sample_sheet`` behaves identically to ``list`` - it can be mapped over tool
+    inputs, matched against ``list`` collection inputs, and composed with inner types
+    (``sample_sheet:paired``, ``sample_sheet:paired_or_unpaired``). The key asymmetry
+    is that while a ``sample_sheet`` output can satisfy a ``list`` input, a ``list``
+    output cannot satisfy a ``sample_sheet`` input - sample sheets carry metadata
+    that plain lists do not.
+
+- example:
+    label: SAMPLE_SHEET_MAPPING
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: dataset}
+        out: {o: dataset}
+    - collections:
+        C: [sample_sheet, {i1: "d_1", ..., in: "d_n"}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C}
+        produces:
+            o:
+                type: collection
+                collection_type: sample_sheet
+                elements:
+                    i1:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d_1}}}
+                        output: o
+                    "...": {type: ellipsis}
+                    in:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d_n}}}
+                        output: o
+    tests:
+        workflow_runtime:
+            framework_test: "collection_semantics_cat_4"
+        workflow_editor: "accepts sample_sheet data -> data connection (maps like list)"
+
+- example:
+    label: SAMPLE_SHEET_MATCHES_LIST
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: "collection<list>"}
+        out: {o: dataset}
+    - collections:
+        C: [sample_sheet, {i1: d_1, ..., in: d_n}]
+    then:
+        type: reduction
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+        produces:
+            o: {type: dataset}
+    tests:
+        workflow_runtime:
+            framework_test: "collection_semantics_cat_collection_1"
+        workflow_editor: "accepts sample_sheet -> list connection (accepts)"
+
+- doc: |
+    Sub-collection mapping works the same as for ``list`` composites. A
+    ``sample_sheet:paired`` can be mapped over a ``paired`` collection input,
+    extracting each inner pair and producing a ``sample_sheet`` implicit output.
+
+- example:
+    label: SAMPLE_SHEET_PAIRED_MAPPING_OVER_PAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<paired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["sample_sheet:paired", {el1: {forward: d_f, reverse: d_r}}]
+        "C\\_PAIRED": [paired, {forward: d_f, reverse: d_r}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C, sub_collection_type: paired}
+        produces:
+            o:
+                type: collection
+                collection_type: sample_sheet
+                elements:
+                    el1:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: collection, ref: "C\\_PAIRED"}}}
+                        output: o
+    tests:
+        workflow_runtime:
+            framework_test: "collection_semantics_paired_or_unpaired_5"
+        workflow_editor: "accepts sample_sheet:paired -> paired connection (maps over like list:paired)"
+
+- example:
+    label: SAMPLE_SHEET_PAIRED_MATCHES_LIST_PAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<list:paired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["sample_sheet:paired", {el1: {forward: d_f, reverse: d_r}}]
+    then:
+        type: reduction
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+        produces:
+            o: {type: dataset}
+    tests:
+        workflow_runtime:
+            framework_test: "collection_semantics_list_paired_0"
+        workflow_editor: "accepts sample_sheet:paired -> list:paired connection (accepts)"
+
+- doc: |
+    The ``paired_or_unpaired`` integration rules carry over from ``list`` to
+    ``sample_sheet``. A flat ``sample_sheet`` can be mapped over a
+    ``paired_or_unpaired`` input via ``single_datasets`` sub-collection mapping,
+    and ``sample_sheet:paired`` can be mapped over ``paired_or_unpaired`` just as
+    ``list:paired`` can.
+
+- example:
+    label: SAMPLE_SHEET_MAPPING_OVER_PAIRED_OR_UNPAIRED
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: "collection<paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: [sample_sheet, {i1: d_1, ..., in: d_n}]
+    - "C_AS_UNPAIRED_i = CollectionInstance<paired_or_unpaired,{unpaired=di}> for i from 1...n"
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C, sub_collection_type: single_datasets}
+        produces:
+            o:
+                type: collection
+                collection_type: sample_sheet
+                elements:
+                    i1:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: collection, ref: C_AS_UNPAIRED_1}}}
+                        output: o
+                    "...": {type: ellipsis}
+                    in:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: collection, ref: C_AS_UNPAIRED_n}}}
+                        output: o
+    tests:
+        tool_runtime:
+            api_test: "test_tool_execute.py::test_map_over_paired_or_unpaired_with_sample_sheet"
+        workflow_runtime:
+            framework_test: "collection_semantics_paired_or_unpaired_8"
+        workflow_editor: "accepts sample_sheet -> paired_or_unpaired connection"
+
+- example:
+    label: SAMPLE_SHEET_PAIRED_MAPPING_OVER_PAIRED_OR_UNPAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["sample_sheet:paired", {el1: {forward: d_f, reverse: d_r}}]
+        C_AS_MIXED: ["sample_sheet:paired_or_unpaired", {el1: {forward: d_f, reverse: d_r}}]
+    then:
+        type: equivalence
+        left:
+            inputs:
+                i: {type: map_over, collection: C}
+        right:
+            inputs:
+                i: {type: map_over, collection: C_AS_MIXED}
+    tests:
+        workflow_runtime:
+            framework_test: "collection_semantics_paired_or_unpaired_6"
+        workflow_editor: "accepts sample_sheet:paired -> paired_or_unpaired connection"
+
+- example:
+    label: SAMPLE_SHEET_PAIRED_OR_UNPAIRED_MATCHES_LIST_PAIRED_OR_UNPAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<list:paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["sample_sheet:paired_or_unpaired", {el1: {forward: d_f, reverse: d_r}}]
+    then:
+        type: reduction
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+        produces:
+            o: {type: dataset}
+    tests:
+        workflow_runtime:
+            framework_test: "collection_semantics_list_paired_or_unpaired_1"
+        workflow_editor: "accepts sample_sheet:paired_or_unpaired -> list:paired_or_unpaired connection (accepts)"
+
+- doc: |
+    The type matching is asymmetric: a ``sample_sheet`` output can satisfy a ``list``
+    input because sample sheets carry all the structural information lists have (plus
+    metadata). However, a ``list`` output cannot satisfy a ``sample_sheet`` input because
+    lists lack the ``column_definitions`` and per-element ``columns`` metadata that
+    sample sheet consumers expect.
+
+- example:
+    label: LIST_NOT_MATCHES_SAMPLE_SHEET
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: "collection<sample_sheet>"}
+        out: {o: dataset}
+    - collections:
+        C: [list, {i1: d_1, ..., in: d_n}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects list -> sample_sheet connection (asymmetry)"
+
+- example:
+    label: LIST_PAIRED_NOT_MATCHES_SAMPLE_SHEET_PAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<sample_sheet:paired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:paired", {el1: {forward: d_f, reverse: d_r}}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects list:paired -> sample_sheet:paired connection (asymmetry)"
+
+- example:
+    label: SAMPLE_SHEET_MATCHES_SAMPLE_SHEET
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: "collection<sample_sheet>"}
+        out: {o: dataset}
+    - collections:
+        C: [sample_sheet, {i1: d_1, ..., in: d_n}]
+    then:
+        type: reduction
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+        produces:
+            o: {type: dataset}
+    tests:
+        workflow_runtime:
+            framework_test: "collection_semantics_cat_sample_sheet_0"
+        workflow_editor: "accepts sample_sheet -> sample_sheet connection"
+
+- doc: "## Type Compatibility Algebra"
+- doc: |
+    This section is for implementers. It describes the three operations that
+    answer "do these collection types fit together?" — used at workflow
+    editor connection time and at runtime when sibling inputs are matched
+    under a common map-over.
+
+    ### The lattice
+
+    The base types form a small subtype lattice:
+
+    ```
+    list                paired_or_unpaired
+     |                    |
+    sample_sheet         paired
+    ```
+
+    Edges are subtype relations. A `sample_sheet` value carries column
+    metadata that a `list` does not, so it can be substituted where a
+    `list` is required (information is preserved); the reverse is not safe.
+    A `paired` value always has two elements; `paired_or_unpaired` admits
+    1 or 2, so a `paired` can be substituted where `paired_or_unpaired` is
+    required, but not the reverse.
+
+    Nesting composes. `list:paired_or_unpaired` is a supertype of both
+    `list:paired` and `list` (the latter via the "single-dataset wrapped
+    as unpaired" interpretation), so it has two incomparable subtypes.
+
+    ### Three operations
+
+    | Operation | Symmetry | Question | Used at |
+    |---|---|---|---|
+    | `accepts(other)` | Asymmetric | Does an input slot of type `self` accept an output of type `other`? | Workflow-editor edge validation |
+    | `compatible(other)` | Symmetric | Do `self` and `other` match such that they could drive a common map-over over sibling inputs of one tool? | Sibling-matching: matching sibling HDCAs / sibling map-over states under a common mapping |
+    | `can_map_over(other)` | Asymmetric | Does `self` have proper subcollections of type `other` — i.e. can `self` be mapped over to feed an `other` slot? | Connection-time map-over decisions; runtime `effective_collection_type` arithmetic |
+
+    Conventions: `input_type.accepts(output_type)` for direct edges;
+    `output_type.can_map_over(input_type)` for map-over. `accepts` and
+    `can_map_over` differ in that `accepts` is the direct-edge case
+    where ranks already align, while `can_map_over` is the strict nesting
+    case where the output has *more* rank than the input. `compatible`
+    is symmetric and either side may go first.
+
+    `compatible(a, b)` is implemented as `a.accepts(b) or b.accepts(a)`.
+
+    ### Where each is used
+
+    - `accepts` is called at single-edge validation: connecting one output
+      to one input. The asymmetry between input and output sides matters
+      here. Examples: `connection_types.can_match`,
+      `query.HistoryQuery.direct_match`, and the workflow-editor input
+      attachment paths in `terminals.ts`.
+
+    - `compatible` is called when two collections must drive a common
+      map-over as siblings. Neither side is the input slot; both are
+      concrete shapes (observed HDCA shapes at runtime, sibling map-over
+      states at connection time). Order of arrival must not change the
+      answer. Examples: Python `Tree.compatible_shape` (matching.py,
+      execute.py) and the `mappingConstraints` checks in `terminals.ts`.
+
+    - `can_map_over` is called when deciding whether an output of higher
+      rank can drive a map-over into a lower-rank input — for instance, a
+      `list:paired` output feeding a `paired` input by iterating the outer
+      list. The Python and TypeScript names match
+      (`can_map_over` / `canMapOver`) because it is the same operational
+      question in both layers.
+
+    Routing a sibling-matching question through `accepts` instead of
+    `compatible` produces order-dependent behavior — which sibling input
+    arrived first changes whether the workflow validates. This was a real
+    bug in earlier revisions of both the Python and TypeScript code.
+
+    ### Worked examples
+
+    - `paired.accepts(paired_or_unpaired)` is `False`. A 1-element
+      paired_or_unpaired output cannot be connected to an input slot
+      that strictly requires a pair. Test: `test_paired_accepts_relation`.
+
+    - `paired.compatible(paired_or_unpaired)` is `True`. If both observed
+      sibling collections happen to align in cardinality, they match for
+      sibling iteration; cardinality checking happens later at the
+      children level. Test:
+      `test_paired_and_paired_or_unpaired_match_symmetric`.
+
+    - `sample_sheet.accepts(list)` is `False`; `list.accepts(sample_sheet)`
+      is `True`. Tests:
+      `test_sample_sheet_accepts_relation`, workflow editor
+      `"rejects list -> sample_sheet connection (asymmetry)"`.
+
+    - `sample_sheet.compatible(list)` and `list.compatible(sample_sheet)`
+      are both `True`. Tests: `test_compatible`,
+      `test_tree_compatible_shape_sample_sheet_list_symmetric`.
+
+    ### Cross-language synchronization
+
+    The Python implementation lives in
+    `lib/galaxy/model/dataset_collections/type_description.py`. The
+    TypeScript implementation lives in
+    `client/src/components/Workflow/Editor/modules/collectionTypeDescription.ts`.
+    Both must stay in sync; method names and conventions are identical.

--- a/content/research/galaxy-collection-tools.md
+++ b/content/research/galaxy-collection-tools.md
@@ -1,0 +1,437 @@
+---
+type: research
+subtype: component
+title: "Galaxy collection-operation tools"
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-04-30
+revised: 2026-04-30
+revision: 1
+ai_generated: true
+related_notes:
+  - "[[galaxy-collection-semantics]]"
+  - "[[galaxy-apply-rules-dsl]]"
+sources:
+  - "https://github.com/jmchilton/galaxy-agentic-collection-transform (initial research seed)"
+  - "https://github.com/galaxyproject/galaxy/tree/main/lib/galaxy/tools (XML wrappers; source of truth)"
+summary: "Catalog of Galaxy's collection-operation tools — purpose, IO, parameters, selection guide. Companion to galaxy-collection-semantics."
+---
+
+Catalog of Galaxy's built-in collection-operation tools (the `__BUILD_LIST__`, `__FILTER_FROM_FILE__`, `__APPLY_RULES__`, … family) — what each tool does, its inputs and outputs, and when to reach for it. Source of truth is the Galaxy XML wrappers under `lib/galaxy/tools/`; this is the high-level catalog. Pairs with [[galaxy-collection-semantics]], which describes the underlying mapping and reduction semantics rather than the user-facing tools.
+
+These are **model operations** — they manipulate collection structure without processing file contents, so they're fast and don't grow storage.
+
+## Tool Categories
+
+### 1. Collection Creation Tools
+
+#### Build List (`__BUILD_LIST__`)
+**Version:** 1.2.0
+
+**Purpose:** Build a new list collection from individual datasets or collections.
+
+**Inputs:**
+- `datasets` (repeat): Input datasets or collections
+  - `input`: Data input (optional)
+  - `id_cond/id_select`: Label selection method
+    - `idx`: Use index (0, 1, 2...)
+    - `identifier`: Use dataset's existing identifier
+    - `manual`: Specify custom identifier
+
+**Output:** `list` collection
+
+**Use Cases:**
+- A: Build collection from individual datasets
+- B: Merge collection with individual dataset(s) → nested collection
+- C: Merge collections → nested collection (requires equal element counts)
+
+---
+
+#### Duplicate File to Collection (`__DUPLICATE_FILE_TO_COLLECTION__`)
+**Version:** 1.0.0
+
+**Purpose:** Create collection of arbitrary size by duplicating an input dataset N times.
+
+**Inputs:**
+- `input`: Dataset to duplicate
+- `number`: Integer - number of copies
+- `element_identifier`: Base name for identifiers (e.g., "test" → "test 1", "test 2", etc.)
+
+**Output:** `list` collection
+
+**Use Case:** Create test collections, broadcasting single dataset to match collection size.
+
+---
+
+### 2. Element Extraction Tools
+
+#### Extract Dataset (`__EXTRACT_DATASET__`)
+**Version:** 1.0.2
+
+**Purpose:** Extract a single dataset from a collection.
+
+**Inputs:**
+- `input`: Collection (`list`, `paired`, `paired_or_unpaired`, `record`)
+- `which`: Selection method
+  - `first`: First dataset
+  - `by_identifier`: Match element identifier (string)
+  - `by_index`: Select by 0-based index (integer)
+
+**Output:** Single dataset
+
+**Note:** For nested collections, collapses inner-most collection into dataset, creating new list at that level.
+
+---
+
+### 3. Filter Tools
+
+#### Filter Empty Datasets (`__FILTER_EMPTY_DATASETS__`)
+**Version:** 1.1.0
+
+**Purpose:** Remove empty elements from a collection.
+
+**Inputs:**
+- `input`: Collection (`list`, `list:paired`)
+- `replacement` (optional): Dataset to replace empty elements instead of removing
+
+**Output:** Filtered collection (same type)
+
+**Use Case:** Continue multi-sample analysis when downstream tools require content.
+
+---
+
+#### Filter Failed Datasets (`__FILTER_FAILED_DATASETS__`)
+**Version:** 1.0.0
+
+**Purpose:** Remove datasets in error (red) state from a collection.
+
+**Inputs:**
+- `input`: Collection (`list`, `list:paired`)
+- `replacement` (optional): Dataset to replace failed elements
+
+**Output:** Filtered collection (same type)
+
+**Use Case:** Continue analysis when some samples fail.
+
+---
+
+#### Filter Null Elements (`__FILTER_NULL__`)
+**Version:** 1.1.0
+
+**Purpose:** Remove null elements (from conditional workflow execution) from a collection.
+
+**Inputs:**
+- `input`: Collection (`list`, `list:paired`)
+- `replacement` (optional): Dataset to replace null elements
+
+**Output:** Filtered collection (same type)
+
+**Use Case:** Clean up collections after conditional workflow branches.
+
+---
+
+#### Keep Success (`__KEEP_SUCCESS_DATASETS__`)
+**Version:** 1.1.0
+
+**Purpose:** Keep only datasets in success (green) state.
+
+**Inputs:**
+- `input`: Collection (`list`, `list:paired`)
+- `replacement` (optional): Dataset to replace unsuccessful elements
+
+**Output:** Filtered collection (same type)
+
+**Use Case:** Similar to Filter Failed but positive selection approach.
+
+---
+
+#### Filter Collection (`__FILTER_FROM_FILE__`)
+**Version:** 1.1.0
+
+**Purpose:** Filter elements using identifier list from a file.
+
+**Inputs:**
+- `input`: Any collection
+- `how/how_filter`: Filter mode
+  - `remove_if_absent`: Keep only elements in file
+  - `remove_if_present`: Remove elements in file
+- `filter_source`: Text file with identifiers (one per line)
+
+**Outputs:**
+- `output_filtered`: Elements passing filter
+- `output_discarded`: Elements removed by filter
+
+**Use Case:** Subset collections based on sample lists, exclusion lists.
+
+---
+
+### 4. Structure Transformation Tools
+
+#### Flatten Collection (`__FLATTEN__`)
+**Version:** 1.0.0
+
+**Purpose:** Convert nested collection to flat list by merging identifiers.
+
+**Inputs:**
+- `input`: Any nested collection
+- `join_identifier`: Separator for merging identifiers (`_`, `:`, `-`)
+
+**Output:** `list` collection
+
+**Example:** `list:paired` with element `i1` containing `forward`/`reverse` → flat list with `i1_forward`, `i1_reverse`
+
+---
+
+#### Nest Collection (`__NEST__`)
+**Version:** 1.0.0
+
+**Purpose:** Add nesting level to a collection.
+
+**Inputs:**
+- `input`: Collection (`list`, `paired`)
+
+**Output:** `list:list` collection
+
+**Behavior:** Each element becomes a single-element inner list.
+
+**Use Case:** Enable mapping over elements that are themselves lists (Galaxy maps over outer level).
+
+---
+
+#### Zip Collections (`__ZIP_COLLECTION__`)
+**Version:** 1.0.0
+
+**Purpose:** Create paired collection from two inputs.
+
+**Inputs:**
+- `input_forward`: Dataset or collection for forward
+- `input_reverse`: Dataset or collection for reverse
+
+**Output:** `paired` collection
+
+**Use Case:** Combine separate forward/reverse read files/collections into paired structure.
+
+---
+
+#### Unzip Collection (`__UNZIP_COLLECTION__`)
+**Version:** 1.0.0
+
+**Purpose:** Split paired collection into separate datasets.
+
+**Inputs:**
+- `input`: `paired` collection
+
+**Outputs:**
+- `forward`: Forward dataset
+- `reverse`: Reverse dataset
+
+**Use Case:** Separate paired reads for tools requiring individual files.
+
+---
+
+#### Split Paired and Unpaired (`__SPLIT_PAIRED_AND_UNPAIRED__`)
+**Version:** 1.0.0
+
+**Purpose:** Separate mixed paired/unpaired collection into two typed collections.
+
+**Inputs:**
+- `input`: Collection (`list:paired`, `list`, `list:paired_or_unpaired`)
+
+**Outputs:**
+- `output_unpaired`: `list` of unpaired datasets
+- `output_paired`: `list:paired` collection
+
+**Use Case:** Handle mixed sequencing outputs, separate for different downstream tools.
+
+---
+
+### 5. Collection Combination Tools
+
+#### Merge Collections (`__MERGE_COLLECTION__`)
+**Version:** 1.0.0
+
+**Purpose:** Combine two or more collections into one.
+
+**Inputs:**
+- `inputs` (repeat, min 2): Collections to merge
+- `advanced/conflict/duplicate_options`: Conflict handling
+  - `keep_first` (default): Keep first occurrence
+  - `keep_last`: Keep last occurrence
+  - `suffix_conflict`: Add suffix to all conflicting identifiers
+  - `suffix_conflict_rest`: Add suffix to conflicts after first
+  - `suffix_every`: Add suffix to every identifier
+  - `fail`: Error on conflict
+- `suffix_pattern`: Pattern for suffixes (default `_#`)
+
+**Output:** Merged collection (same type as inputs)
+
+---
+
+#### Harmonize Two Collections (`__HARMONIZELISTS__`)
+**Version:** 1.0.0
+
+**Purpose:** Make two collections have same identifiers in same order.
+
+**Inputs:**
+- `input1`: Reference collection with desired order
+- `input2`: Collection to reorder
+
+**Outputs:**
+- `output1`: Filtered/ordered version of input1
+- `output2`: Filtered/ordered version of input2
+
+**Behavior:** Keeps only identifiers present in BOTH collections, orders by input1.
+
+**Use Case:** Prepare two collections for element-wise processing.
+
+---
+
+### 6. Cross Product Tools
+
+#### Flat Cross Product (`__CROSS_PRODUCT_FLAT__`)
+**Version:** 1.0.0
+
+**Purpose:** Create flat lists enabling all-vs-all comparison between two collections.
+
+**Inputs:**
+- `input_a`: List collection A (length n)
+- `input_b`: List collection B (length m)
+- `join_identifier`: Separator for combined identifiers
+
+**Outputs:**
+- `output_a`: Flat list (n*m elements) - A elements repeated
+- `output_b`: Flat list (n*m elements) - B elements repeated
+
+**Use Case:** Run comparison tool on every combination of elements. Element-wise processing of outputs produces all pairwise comparisons.
+
+---
+
+#### Nested Cross Product (`__CROSS_PRODUCT_NESTED__`)
+**Version:** 1.0.0
+
+**Purpose:** Create nested lists for all-vs-all comparison with hierarchical output.
+
+**Inputs:**
+- `input_a`: List collection A
+- `input_b`: List collection B
+
+**Outputs:**
+- `output_a`: `list:list` - nested structure of A elements
+- `output_b`: `list:list` - nested structure of B elements
+
+**Use Case:** All-vs-all comparison preserving hierarchical structure in results (outer list = A elements, inner list = B comparisons).
+
+---
+
+### 7. Metadata Manipulation Tools
+
+#### Relabel Identifiers (`__RELABEL_FROM_FILE__`)
+**Version:** 1.1.0
+
+**Purpose:** Change element identifiers using mapping file.
+
+**Inputs:**
+- `input`: Any collection
+- `how/how_select`: Mapping method
+  - `txt`: Simple text file (line N = new name for element N)
+  - `tabular`: Two-column mapping (old → new)
+  - `tabular_extended`: Any two columns from tabular file
+- `labels`: Mapping file
+- `strict`: Require exact match count
+
+**Output:** Collection with new identifiers
+
+**Valid Characters:** a-z, A-Z, 0-9, dash, underscore, dot, space, comma
+
+---
+
+#### Sort Collection (`__SORTLIST__`)
+**Version:** 1.0.0
+
+**Purpose:** Reorder collection elements.
+
+**Inputs:**
+- `input`: Collection (`list`, `list:paired`)
+- `sort_type`: Method
+  - `alpha`: Alphabetical
+  - `numeric`: Numeric (ignores non-numeric chars)
+  - `file`: Custom order from text file
+
+**Output:** Sorted collection (same type)
+
+---
+
+#### Tag Elements (`__TAG_FROM_FILE__`)
+**Version:** 1.0.0
+
+**Purpose:** Add/modify Galaxy tags on collection elements.
+
+**Inputs:**
+- `input`: Any collection
+- `tags`: Tabular file (col1: identifier, col2+: tags)
+- `how`: Update mode
+  - `add`: Add new tags, keep existing
+  - `set`: Replace all tags
+  - `remove`: Remove specified tags
+
+**Output:** Tagged collection
+
+**Tag Types:**
+- Simple tags: Plain labels
+- Name tags: Prefix with `#` or `name:` - inherited by derived datasets
+- Group tags: Prefix with `group:` - for grouping (e.g., treatment vs control)
+
+---
+
+### 8. Apply Rules Tool (`__APPLY_RULES__`)
+**Version:** 1.1.0
+
+**Purpose:** Most powerful/flexible collection manipulation tool. Process collection metadata as tabular data using rule-based transformations.
+
+**Inputs:**
+- `input`: Any collection
+- `rules`: Rule definition (JSON-based transformation rules)
+
+**Output:** Transformed collection (type determined by rules)
+
+**Capabilities:**
+- Filter elements (rows)
+- Add/remove/reorder identifier levels (columns)
+- Regular expression transformations
+- Complex nesting/flattening
+- Arbitrary reorganization
+
+**Use Cases:**
+- Restructure collections between hierarchies
+- Filter based on identifier patterns
+- Split/merge identifier components
+- Any operation not covered by simpler tools
+
+**Note:** Interactive form provides live preview. Can be used in workflows with static rules.
+
+---
+
+## Tool Selection Guide
+
+| Goal | Recommended Tool |
+|------|------------------|
+| Build collection from datasets | Build List |
+| Extract single element | Extract Dataset |
+| Remove empty/failed/null elements | Filter Empty/Failed/Null |
+| Subset by identifier list | Filter Collection |
+| Convert nested → flat | Flatten Collection |
+| Add nesting level | Nest Collection |
+| Combine forward/reverse | Zip Collections |
+| Separate paired collection | Unzip Collection |
+| Concatenate collections | Merge Collections |
+| Match two collections | Harmonize Two Collections |
+| All-vs-all comparison | Cross Product (Flat or Nested) |
+| Rename elements | Relabel Identifiers |
+| Reorder elements | Sort Collection |
+| Add metadata tags | Tag Elements |
+| Complex restructuring | Apply Rules |
+| Duplicate single dataset | Duplicate File to Collection |
+
+---


### PR DESCRIPTION
## Summary

- Vendors `lib/galaxy/model/dataset_collections/types/collection_semantics.yml` from galaxyproject/galaxy@`0683385` as a `research/component` note in `content/research/`.
- Markdown body transforms the upstream `doc:` / `example:` structure into prose + fenced YAML so Astro renders the spec inline; raw YAML lives next to the note as `galaxy-collection-semantics.yml`.
- Sync of vendored upstream files deferred to #12 — manual copy for now.

## Why a `research/component` (not a `schema`)

`type: schema` notes today render JSON Schemas via `$defs` (`tests-format`, `summary-nextflow`). `collection_semantics.yml` is a prose+example spec, not a JSON Schema, so it doesn't fit that renderer. Lands as `research/component` (precedent: `planemo-asserts-idioms`, `component-tool-shed-search`) without renderer changes. If a second non-JSON-Schema spec import shows up, that's the moment to consider generalizing `type: schema` or coining `type: spec`.

## Test plan

- [x] `npm run validate` clean (no new warnings; 7 pre-existing)
- [x] `npm --prefix site run build` succeeds; `/foundry/research/galaxy-collection-semantics/` renders with framing blockquote, prose, and per-example YAML blocks
- [ ] Spot-check rendered page in dev for headings/anchors

🤖 Generated with [Claude Code](https://claude.com/claude-code)