### PR TITLE
Walk first leaf pattern pages from tabular-ops survey (closes #9 partial)

### DIFF
--- a/.claude/commands/review-pattern.md
+++ b/.claude/commands/review-pattern.md
@@ -1,0 +1,47 @@
+---
+description: Review a Foundry pattern (or research / Mold) note for clarity and correctness against the corpus and tool source.
+argument-hint: "<path-to-note.md>"
+---
+
+# Review a Foundry note
+
+Review the note at `$1` and return a structured report. Do **not** edit files — the orchestrator applies fixes.
+
+## Load context first (in order)
+
+1. **`content/glossary.md`** — pinned vocabulary (Mold, Pipeline, Pattern, Cast, axis, …). Misreading these terms breaks the review.
+2. **`CLAUDE.md`** — authoring rules (`additionalProperties: false`, registered tags, wiki-link conventions, "don't weaken the schema").
+3. **`docs/ARCHITECTURE.md`** §3 (note types), §5 (frontmatter contract), §6 (validation pipeline). Skim the rest only if needed.
+4. **`meta_schema.yml`** + **`meta_tags.yml`** — frontmatter and tag enums.
+5. **`common_paths.yml.sample`** — the citation prefix vocabulary. Logical names (`$IWC`, `$IWC_FORMAT2`, `$GALAXY`, `$TOOLS_IUC`, `$PLANEMO`, `$GXFORMAT2`) map to filesystem paths and (when set) GitHub repos. Resolve every `$NAME/...` citation in the note via this file before checking it.
+6. **The note's `related_notes` and survey/research companions** — pinned decisions live in `## Decisions` sections (e.g. `iwc-tabular-operations-survey.md` §7). Treat those as binding unless the review surfaces a reason they're wrong; if so, flag for both the note *and* the source decision record.
+
+## Verify against authoritative sources
+
+For pattern pages and Molds documenting a tool:
+
+- **Tool wrapper XML** — when the note documents a Galaxy tool, `Read` the wrapper. Galaxy core tools live under `$GALAXY/tools/<category>/<name>.xml`; toolshed tools live in their owner repo (`$TOOLS_IUC/tools/<name>/<name>.xml` for IUC-maintained, `$GALAXY` itself for some `devteam` legacy stems). Verify: param names, enum values, default values, hidden/conditional structure, indexing, error handling. Promote any "corpus-inferred" claim to "tool-source verified" or revise it.
+- **Corpus citations** — for every `$NAME/path:line` citation, `Read` the cited line range in the local checkout (`common_paths.yml.sample` resolves the prefix to a filesystem path). Confirm the cited shape matches the note's claim. Flag drift, off-by-one ranges, and silent paraphrases.
+- **Distribution claims** — when the note asserts a count ("51/51 instances", "dominant idiom"), spot-check via `grep` over the cited corpus root. Counts decay; verify them.
+
+For research notes:
+
+- Verify each cited file:line in the source corpus. Same standard as patterns — research is the audit trail and earns its weight by being checkable.
+
+## Assess
+
+1. **Correctness vs tool source** — anything the wrapper contradicts is a fix-before-merge.
+2. **Correctness vs corpus** — citations resolve, ranges are tight, paraphrases are faithful.
+3. **Schema / tag conformance** — frontmatter validates against `meta_schema.yml`, all tags appear in `meta_tags.yml`. Note: `additionalProperties: false`, so unknown frontmatter fields are blockers.
+4. **Survey decision conformance** — `## Decisions` sections in companion research notes are binding. Drift between page and decision record is a flag on both.
+5. **Form quality for casting** — pattern pages get LLM-condensed into cast skills; reference content should be "do this," not "what we considered." Pitfalls concrete; wiki-links meaningful.
+
+## Reporting format
+
+1. **Verdict** — one short sentence.
+2. **Findings** — bulleted list, each with: severity (`blocker` / `fix-before-merge` / `nit`), location (section or quote), what's wrong, suggested correction. Ground each finding in a cited source (XML line, corpus line, schema field, decision record).
+3. **Cross-check log** — one line per citation: `path:line — verified | mismatch (details)`. Plus any sampled distribution checks for count claims.
+4. **Decision-record drift** — if the review surfaces a problem in a pinned decision (e.g. survey §7), say which doc + section + what to revise.
+5. **What would have made this review more useful** — concrete asks (additional context, missing reference, sibling note that would calibrate house style). The orchestrator uses this to refine the next review's framing.
+
+Keep the report under ~700 words; longer is welcome only when the note is genuinely rule-dense.

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage/
 .tmp-test-vault*/
 .playwright-mcp/
 /*.png
+common_paths.yml

--- a/common_paths.yml.sample
+++ b/common_paths.yml.sample
@@ -1,0 +1,55 @@
+# common_paths.yml — machine-local mapping of citation prefixes to filesystem
+# paths and (optionally) GitHub repo metadata for permalink rendering.
+#
+# Copy to `common_paths.yml` (gitignored) and adjust paths to your machine.
+#
+# In note bodies, write corpus citations inside inline code as:
+#
+#   `$NAME/relative/path/to/file.ext`
+#   `$NAME/relative/path/to/file.ext:545`
+#   `$NAME/relative/path/to/file.ext:545-560`
+#
+# Per-entry fields:
+#   path         — absolute filesystem path on this machine. ~ expands to $HOME.
+#   repo         — optional. "<owner>/<repo>" on github.com. When set, the
+#                  Astro renderer rewrites citations into clickable permalinks.
+#   ref          — optional, requires repo. branch / tag / commit SHA used to
+#                  build the permalink. Default: "main". Pin to a SHA for
+#                  stable links; pin to a branch for fresh-but-rotting links.
+#   path_prefix  — optional, requires repo. Prepended to the relative path
+#                  when constructing the GitHub URL. Use when the local
+#                  checkout is a subset / transformed view of the upstream
+#                  repo (the cited file's *local* path differs from its path
+#                  in the repo).
+#
+# Naming convention: uppercase letters, digits, underscores. The leading `$`
+# in citations is the marker; the rest is matched against the keys below
+# case-insensitively.
+
+iwc:
+  path: ~/projects/repositories/iwc
+  repo: galaxyproject/iwc
+  ref: main
+
+iwc_format2:
+  # Local-only authoring aid: cleaned format2 conversions of IWC workflows.
+  # Citations resolve on disk for the validator and authoring agents but
+  # render as plain code on the site (no `repo` set — workflow-fixtures
+  # has no upstream remote). Prefer re-anchoring to `$IWC` when the
+  # upstream `.ga` file is the right pointer.
+  path: ~/projects/repositories/workflow-fixtures/iwc-format2
+
+galaxy:
+  path: ~/projects/repositories/galaxy
+  repo: galaxyproject/galaxy
+  ref: dev
+
+planemo:
+  path: ~/projects/repositories/planemo
+  repo: galaxyproject/planemo
+  ref: master
+
+gxformat2:
+  path: ~/projects/repositories/gxformat2
+  repo: galaxyproject/gxformat2
+  ref: main

--- a/common_paths.yml.sample
+++ b/common_paths.yml.sample
@@ -44,6 +44,11 @@ galaxy:
   repo: galaxyproject/galaxy
   ref: dev
 
+tools_iuc:
+  path: ~/projects/repositories/tools-iuc
+  repo: galaxyproject/tools-iuc
+  ref: main
+
 planemo:
   path: ~/projects/repositories/planemo
   repo: galaxyproject/planemo

--- a/content/patterns/tabular-compute-new-column.md
+++ b/content/patterns/tabular-compute-new-column.md
@@ -23,7 +23,7 @@ related_molds:
 
 ## Tool
 
-`toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/2.1` ("Compute on rows", historically "Add a column"). 93 step occurrences in the surveyed IWC corpus — the canonical computed-column tool.
+`toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/2.1` ("Compute on rows", historically "Add a column"). 93 step occurrences in the surveyed IWC corpus — the canonical computed-column tool. Source: `$TOOLS_IUC/tools/column_maker/column_maker.xml` (the toolshed owner is `devteam` for historical reasons; modern source lives in `tools-iuc`).
 
 ## When to reach for it
 
@@ -33,7 +33,7 @@ If the row decision needs a multi-line conditional or `split`/`gsub`, prefer awk
 
 ## Parameters
 
-The tool's `tool_state` has two top-level fields that matter for authoring: `error_handling` (sibling of `ops`, *not* nested inside it) and `ops` (which contains `header_lines_select` and `expressions`). Authors who flatten `expressions:` to the top level produce YAML that won't roundtrip.
+`tool_state` has three top-level fields that matter for authoring: `error_handling` (a `<section>` in the wrapper), `ops` (a conditional keyed on `header_lines_select`, holding `expressions`), and the optional `avoid_scientific_notation` boolean. `expressions` is a `<repeat>` nested under `ops` — flattening it to the top level produces YAML that won't roundtrip.
 
 - `error_handling` — **set as below**:
 
@@ -42,14 +42,18 @@ The tool's `tool_state` has two top-level fields that matter for authoring: `err
     auto_col_types: <see table>
     fail_on_non_existent_columns: true
     non_computable:
-      action: --fail-on-non-computable   # or --skip-non-computable, see below
+      action: --fail-on-non-computable   # see enum below
   ```
 
-  `fail_on_non_existent_columns: true` is uniform across all 51 corpus instances. `non_computable.action: --fail-on-non-computable` is the dominant choice (49/51); the two `--skip-non-computable` instances both live in `consensus-from-variation.gxwf.yml` (`:364`, `:402`) where coordinate-arithmetic on BED rows can legitimately yield non-numeric inputs and skipping is intentional.
+  `fail_on_non_existent_columns: true` is uniform across all 51 corpus instances. `non_computable.action` accepts five values per the wrapper: `--fail-on-non-computable` (default; 49/51 in corpus), `--skip-non-computable` (2/51, both in `consensus-from-variation.gxwf.yml` where BED-coordinate arithmetic can legitimately yield non-numerics), `--keep-non-computable`, `--non-computable-blank`, and `--non-computable-default` (which requires a `non_computable.default_value` sub-field, e.g. `nan`, `NA`, `.`).
 
-- `ops.header_lines_select`: `yes` if the input has a header row, `no` otherwise. The `yes` setting tells the tool to pass the first line through untouched.
+- `ops.header_lines_select`: select with values `yes` / `no`. With `yes`, the first input line is passed through unchanged and each expression must include a `new_column_name` (used as the header label). With `no`, expressions must *omit* `new_column_name` and the first line is computed like any other.
 
-- `ops.expressions`: list of `{ cond: <python-expr>, add_column: { mode: I | R | "" , pos: "<n>" }, new_column_name: <str> }` entries, evaluated in order. `mode: I` inserts at `pos`, `R` replaces at `pos`, `""` (with `pos: ""`) appends. `pos` is a quoted-numeric string, 1-indexed (corpus-inferred; not independently verified against tool source).
+- `ops.expressions`: repeat list of `{ cond, add_column: { mode, pos }, new_column_name? }` entries, evaluated left-to-right. Expressions can reference columns added by earlier expressions in the same step.
+
+- `add_column.mode`: select with values `""` (Append), `I` (Insert), `R` (Replace).
+- `add_column.pos`: 1-indexed integer (`min: 1` per wrapper) for `I` and `R`; the empty string `""` for Append (the wrapper renders `pos` as a hidden empty param when `mode: ""`).
+- `avoid_scientific_notation`: optional top-level boolean (default `false`). Set `true` to force decimal output for floats; otherwise small floats render as `1e-13`.
 
 ## The strict `auto_col_types` rule
 
@@ -129,10 +133,11 @@ Cited at `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting
 ## Pitfalls
 
 - **Wrong `auto_col_types`.** See the table above — the failure mode is silent and downstream-only.
-- **Flattening `expressions:` to `tool_state` top level.** The actual nesting is `tool_state.ops.expressions` with `tool_state.ops.header_lines_select` as a sibling. `error_handling` is a sibling of `ops`, *not* nested inside it. Flat shapes don't roundtrip.
+- **Flattening `expressions:` to `tool_state` top level.** The actual nesting is `tool_state.ops.expressions` with `tool_state.ops.header_lines_select` as a sibling. `error_handling` and `avoid_scientific_notation` are siblings of `ops`, not nested inside it. Flat shapes don't roundtrip.
+- **`new_column_name` paired with `header_lines_select: no`.** The wrapper only exposes `new_column_name` inside the `header_lines_select: yes` branch. Authoring a step with `header_lines_select: no` AND `new_column_name` produces YAML the tool form won't accept.
 - **Mixing arithmetic and string concat in one entry.** Split into two `expressions:` entries with different `auto_col_types` rather than reaching for `str(...)` inside the expression.
-- **Skipping `error_handling`.** The defaults are not the corpus defaults; non-existent columns and non-computable rows pass through silently.
-- **`add_column.mode` / `pos`.** `I` (insert) and `R` (replace) take a quoted 1-indexed `pos`; append uses `mode: ""` and `pos: ""`. Off-by-one in `pos` shifts every downstream `cN` reference in subsequent expressions.
+- **Skipping `error_handling`.** Wrapper defaults differ from corpus defaults; without explicit `fail_on_non_existent_columns: true`, non-existent column refs may pass through depending on `non_computable.action`.
+- **`add_column.mode` / `pos`.** `I` (insert) and `R` (replace) take a 1-indexed integer `pos`; append uses `mode: ""` and `pos: ""`. Off-by-one in `pos` shifts every downstream `cN` reference in subsequent expressions in the same step.
 - **`Add a column` (`addValue/1.0.1`)** — a different, legacy tool that adds a *constant* column only. Do not confuse with `column_maker/Add_a_column1`.
 
 ## Exemplars (IWC)

--- a/content/patterns/tabular-compute-new-column.md
+++ b/content/patterns/tabular-compute-new-column.md
@@ -1,0 +1,136 @@
+---
+type: pattern
+title: "Tabular: compute a new column"
+tags:
+  - pattern
+  - target/galaxy
+status: draft
+created: 2026-04-30
+revised: 2026-04-30
+revision: 1
+ai_generated: true
+summary: "Use column_maker (Add_a_column1) with strict error_handling to insert/replace a computed column. Per-expression-kind auto_col_types rule."
+related_notes:
+  - "[[iwc-tabular-operations-survey]]"
+related_patterns:
+  - "[[tabular-cut-and-reorder-columns]]"
+  - "[[tabular-sql-query]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+---
+
+# Tabular: compute a new column
+
+## Tool
+
+`toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/2.1` ("Compute on rows", historically "Add a column"). 93 step occurrences in the surveyed IWC corpus — the canonical computed-column tool.
+
+## When to reach for it
+
+Insert, replace, or append a column whose value is a Python expression over the existing `cN` columns. Multiple expressions can be sequenced inside a single tool step (each one operates on the running output of the previous). Use this for arithmetic, simple type coercion, and string concatenation.
+
+If the row decision needs a multi-line conditional or `split`/`gsub`, prefer awk (see the awk recipe sub-pages cross-referenced from [[iwc-tabular-operations-survey]]). If columns and a row predicate are computed together, prefer [[tabular-sql-query]].
+
+## Parameters
+
+- `expressions`: a list of `{ cond: <python-expr>, add_column: { mode: I | R | "" }, … }` entries, evaluated in order. `mode: I` inserts at a position, `R` replaces, `""` appends.
+- `error_handling` (object) — **always set as below**:
+
+  ```yaml
+  error_handling:
+    auto_col_types: <see table>
+    fail_on_non_existent_columns: true
+    non_computable:
+      action: --fail-on-non-computable
+  ```
+
+  Both `fail_on_non_existent_columns: true` and `non_computable.action: --fail-on-non-computable` are uniform across the corpus (51/51 instances surveyed); turning either off makes failures silent.
+
+## The strict `auto_col_types` rule
+
+`auto_col_types` controls whether `cN` references are coerced to numeric when the expression demands it. The corpus shows a clean per-expression-kind split:
+
+| Expression kind | `auto_col_types` |
+|---|---|
+| Arithmetic (`+`, `*`, `round()`, `int()`, …) on numeric columns | `true` |
+| Pure string concatenation (`c5 + '>' + c6`) | `false` |
+| Mixed | split into two `expressions:` entries with different settings |
+
+Rationale: with `true`, `c5 + c6` performs numeric addition (silently turning a string concat into `0+0` if columns are non-numeric); with `false`, `c18 + c19` is string concat, which silently produces `"3.13.4"` instead of `6.4`. Both bugs are silent.
+
+Canonical pair to memorize:
+
+- Arithmetic, `auto_col_types: true` — `variation-reporting.gxwf.yml:316-329` (`AF = round((c18 + c19) / c6, 6)`, replace mode at position 7; `AFcaller` insert at position 8).
+- String concat, `auto_col_types: false` — `variation-reporting.gxwf.yml:454-477` (`c5 + '>' + c6` named `change`, `c3 + ':' + c19` named `change_with_pos`).
+
+## Idiomatic shapes
+
+Insert + replace in one step, arithmetic:
+
+```yaml
+tool_id: toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/2.1
+tool_state:
+  error_handling:
+    auto_col_types: true
+    fail_on_non_existent_columns: true
+    non_computable:
+      action: --fail-on-non-computable
+  expressions:
+    - cond: c7
+      add_column:
+        mode: I        # insert
+        pos: '8'
+      new_column_name: AFcaller
+    - cond: round((c18 + c19) / c6, 6)
+      add_column:
+        mode: R        # replace
+        pos: '7'
+      new_column_name: AF
+```
+
+Cited at `sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:316-329`.
+
+String-concat new column, `auto_col_types: false`:
+
+```yaml
+tool_id: toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/2.1
+tool_state:
+  error_handling:
+    auto_col_types: false
+    fail_on_non_existent_columns: true
+    non_computable:
+      action: --fail-on-non-computable
+  expressions:
+    - cond: c5 + '>' + c6
+      new_column_name: change
+    - cond: c3 + ':' + c19
+      new_column_name: change_with_pos
+```
+
+Cited at `sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:454-477`.
+
+## Pitfalls
+
+- **Wrong `auto_col_types`.** See the table above — the failure mode is silent and downstream-only.
+- **Mixing arithmetic and string concat in one entry.** Split into two `expressions:` entries with different `auto_col_types` settings rather than reaching for `str(...)` casts inside the expression.
+- **Skipping `error_handling`.** The defaults are not the corpus defaults; non-existent columns and non-computable rows pass through silently.
+- **`add_column.mode`.** `I` (insert) and `R` (replace) take a 1-indexed `pos`; appending (`mode: ""`) goes at the end. Off-by-one in `pos` shifts every downstream cN reference.
+- **`Add a column` (`addValue/1.0.1`)** — a different, legacy tool that adds a *constant* column only. Do not confuse with `column_maker/Add_a_column1`.
+
+## Exemplars (IWC)
+
+All paths relative to `<iwc-format2>/`:
+
+- `sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:316-329` — arithmetic, `auto_col_types: true`, insert + replace pair.
+- `sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:454-477` — string concat, `auto_col_types: false`.
+- `sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation.gxwf.yml:344` — first occurrence in corpus.
+
+## Legacy alternative
+
+`toolshed.g2.bx.psu.edu/repos/devteam/add_value/addValue/1.0.1` ("Add a column", 56 step occurrences) is the legacy constant-column-only tool — heavily used in older VGP workflows. For new work, prefer `column_maker/Add_a_column1` even for constant columns; it carries the same `error_handling` story and unifies one tool.
+
+## See also
+
+- [[iwc-tabular-operations-survey]] — corpus survey, §7 decision record for the `auto_col_types` rule.
+- [[tabular-cut-and-reorder-columns]] — pure column projection without computation.
+- [[tabular-sql-query]] — when project + compute + filter need to fuse.

--- a/content/patterns/tabular-compute-new-column.md
+++ b/content/patterns/tabular-compute-new-column.md
@@ -97,7 +97,7 @@ tool_state:
         new_column_name: AF
 ```
 
-Cited at `sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:307-329`.
+Cited at `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:307-329`.
 
 String-concat new columns (append), `auto_col_types: false`:
 
@@ -124,7 +124,7 @@ tool_state:
         new_column_name: change_with_pos
 ```
 
-Cited at `sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:438-475`.
+Cited at `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:438-475`.
 
 ## Pitfalls
 
@@ -137,11 +137,10 @@ Cited at `sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-re
 
 ## Exemplars (IWC)
 
-All paths relative to `<iwc-format2>/`:
 
-- `sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:307-329` — raw-`cN` arithmetic, `auto_col_types: true`, insert + replace pair.
-- `sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:438-475` — string concat, `auto_col_types: false`, append (`mode: ""`).
-- `sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation.gxwf.yml:343-378` — explicit-cast arithmetic (`int(c2) - …`), `auto_col_types: false`, `--skip-non-computable`. Counter-example to "arithmetic always implies `auto_col_types: true`."
+- `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:307-329` — raw-`cN` arithmetic, `auto_col_types: true`, insert + replace pair.
+- `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:438-475` — string concat, `auto_col_types: false`, append (`mode: ""`).
+- `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation.gxwf.yml:343-378` — explicit-cast arithmetic (`int(c2) - …`), `auto_col_types: false`, `--skip-non-computable`. Counter-example to "arithmetic always implies `auto_col_types: true`."
 
 ## Legacy alternative
 

--- a/content/patterns/tabular-compute-new-column.md
+++ b/content/patterns/tabular-compute-new-column.md
@@ -33,39 +33,46 @@ If the row decision needs a multi-line conditional or `split`/`gsub`, prefer awk
 
 ## Parameters
 
-- `expressions`: a list of `{ cond: <python-expr>, add_column: { mode: I | R | "" }, … }` entries, evaluated in order. `mode: I` inserts at a position, `R` replaces, `""` appends.
-- `error_handling` (object) — **always set as below**:
+The tool's `tool_state` has two top-level fields that matter for authoring: `error_handling` (sibling of `ops`, *not* nested inside it) and `ops` (which contains `header_lines_select` and `expressions`). Authors who flatten `expressions:` to the top level produce YAML that won't roundtrip.
+
+- `error_handling` — **set as below**:
 
   ```yaml
   error_handling:
     auto_col_types: <see table>
     fail_on_non_existent_columns: true
     non_computable:
-      action: --fail-on-non-computable
+      action: --fail-on-non-computable   # or --skip-non-computable, see below
   ```
 
-  Both `fail_on_non_existent_columns: true` and `non_computable.action: --fail-on-non-computable` are uniform across the corpus (51/51 instances surveyed); turning either off makes failures silent.
+  `fail_on_non_existent_columns: true` is uniform across all 51 corpus instances. `non_computable.action: --fail-on-non-computable` is the dominant choice (49/51); the two `--skip-non-computable` instances both live in `consensus-from-variation.gxwf.yml` (`:364`, `:402`) where coordinate-arithmetic on BED rows can legitimately yield non-numeric inputs and skipping is intentional.
+
+- `ops.header_lines_select`: `yes` if the input has a header row, `no` otherwise. The `yes` setting tells the tool to pass the first line through untouched.
+
+- `ops.expressions`: list of `{ cond: <python-expr>, add_column: { mode: I | R | "" , pos: "<n>" }, new_column_name: <str> }` entries, evaluated in order. `mode: I` inserts at `pos`, `R` replaces at `pos`, `""` (with `pos: ""`) appends. `pos` is a quoted-numeric string, 1-indexed (corpus-inferred; not independently verified against tool source).
 
 ## The strict `auto_col_types` rule
 
-`auto_col_types` controls whether `cN` references are coerced to numeric when the expression demands it. The corpus shows a clean per-expression-kind split:
+`auto_col_types` controls whether bare `cN` references are coerced to numeric when the expression demands it. Corpus distribution is 48 `true` / 3 `false`. Pick by what the expression does to its `cN` references:
 
 | Expression kind | `auto_col_types` |
 |---|---|
-| Arithmetic (`+`, `*`, `round()`, `int()`, …) on numeric columns | `true` |
+| Arithmetic on raw `cN` (`(c18 + c19) / c6`, `round(...)`) | `true` |
 | Pure string concatenation (`c5 + '>' + c6`) | `false` |
+| Arithmetic with explicit casts (`int(c2) - …`, `float(cN)`) — the expression handles its own type coercion | `false` |
 | Mixed | split into two `expressions:` entries with different settings |
 
-Rationale: with `true`, `c5 + c6` performs numeric addition (silently turning a string concat into `0+0` if columns are non-numeric); with `false`, `c18 + c19` is string concat, which silently produces `"3.13.4"` instead of `6.4`. Both bugs are silent.
+Rationale: with `true`, `c5 + c6` performs numeric addition (silently turning a string concat into `0+0` if columns are non-numeric); with `false` and *no* explicit cast, `c18 + c19` is string concat, which silently produces `"3.13.4"` instead of `6.4`. Both bugs are silent. Explicit `int()` / `float()` is the third escape hatch.
 
-Canonical pair to memorize:
+Canonical exemplars to memorize:
 
-- Arithmetic, `auto_col_types: true` — `variation-reporting.gxwf.yml:316-329` (`AF = round((c18 + c19) / c6, 6)`, replace mode at position 7; `AFcaller` insert at position 8).
-- String concat, `auto_col_types: false` — `variation-reporting.gxwf.yml:454-477` (`c5 + '>' + c6` named `change`, `c3 + ':' + c19` named `change_with_pos`).
+- Arithmetic on raw `cN`, `auto_col_types: true` — `variation-reporting.gxwf.yml:316-329` (`AF = round((c18 + c19) / c6, 6)` replace at position 7; `AFcaller` insert at position 8).
+- String concat, `auto_col_types: false` — `variation-reporting.gxwf.yml:438-475` (`c5 + '>' + c6` named `change`, `c3 + ':' + c19` named `change_with_pos`; both `mode: ""` append).
+- Explicit-cast arithmetic, `auto_col_types: false` — `consensus-from-variation.gxwf.yml:343-378` (`int(c2) - (len(c3) == 1)` and `int(c2) + ((len(c3) - 1) or 1)`, replace at positions 2 and 3; uses `--skip-non-computable`).
 
 ## Idiomatic shapes
 
-Insert + replace in one step, arithmetic:
+Insert + replace in one step, arithmetic on raw `cN`:
 
 ```yaml
 tool_id: toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/2.1
@@ -75,22 +82,24 @@ tool_state:
     fail_on_non_existent_columns: true
     non_computable:
       action: --fail-on-non-computable
-  expressions:
-    - cond: c7
-      add_column:
-        mode: I        # insert
-        pos: '8'
-      new_column_name: AFcaller
-    - cond: round((c18 + c19) / c6, 6)
-      add_column:
-        mode: R        # replace
-        pos: '7'
-      new_column_name: AF
+  ops:
+    header_lines_select: yes
+    expressions:
+      - cond: c7
+        add_column:
+          mode: I        # insert
+          pos: "8"
+        new_column_name: AFcaller
+      - cond: round((c18 + c19) / c6, 6)
+        add_column:
+          mode: R        # replace
+          pos: "7"
+        new_column_name: AF
 ```
 
-Cited at `sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:316-329`.
+Cited at `sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:307-329`.
 
-String-concat new column, `auto_col_types: false`:
+String-concat new columns (append), `auto_col_types: false`:
 
 ```yaml
 tool_id: toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/2.1
@@ -100,30 +109,39 @@ tool_state:
     fail_on_non_existent_columns: true
     non_computable:
       action: --fail-on-non-computable
-  expressions:
-    - cond: c5 + '>' + c6
-      new_column_name: change
-    - cond: c3 + ':' + c19
-      new_column_name: change_with_pos
+  ops:
+    header_lines_select: yes
+    expressions:
+      - cond: c5 + '>' + c6
+        add_column:
+          mode: ""
+          pos: ""
+        new_column_name: change
+      - cond: c3 + ':' + c19
+        add_column:
+          mode: ""
+          pos: ""
+        new_column_name: change_with_pos
 ```
 
-Cited at `sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:454-477`.
+Cited at `sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:438-475`.
 
 ## Pitfalls
 
 - **Wrong `auto_col_types`.** See the table above — the failure mode is silent and downstream-only.
-- **Mixing arithmetic and string concat in one entry.** Split into two `expressions:` entries with different `auto_col_types` settings rather than reaching for `str(...)` casts inside the expression.
+- **Flattening `expressions:` to `tool_state` top level.** The actual nesting is `tool_state.ops.expressions` with `tool_state.ops.header_lines_select` as a sibling. `error_handling` is a sibling of `ops`, *not* nested inside it. Flat shapes don't roundtrip.
+- **Mixing arithmetic and string concat in one entry.** Split into two `expressions:` entries with different `auto_col_types` rather than reaching for `str(...)` inside the expression.
 - **Skipping `error_handling`.** The defaults are not the corpus defaults; non-existent columns and non-computable rows pass through silently.
-- **`add_column.mode`.** `I` (insert) and `R` (replace) take a 1-indexed `pos`; appending (`mode: ""`) goes at the end. Off-by-one in `pos` shifts every downstream cN reference.
+- **`add_column.mode` / `pos`.** `I` (insert) and `R` (replace) take a quoted 1-indexed `pos`; append uses `mode: ""` and `pos: ""`. Off-by-one in `pos` shifts every downstream `cN` reference in subsequent expressions.
 - **`Add a column` (`addValue/1.0.1`)** — a different, legacy tool that adds a *constant* column only. Do not confuse with `column_maker/Add_a_column1`.
 
 ## Exemplars (IWC)
 
 All paths relative to `<iwc-format2>/`:
 
-- `sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:316-329` — arithmetic, `auto_col_types: true`, insert + replace pair.
-- `sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:454-477` — string concat, `auto_col_types: false`.
-- `sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation.gxwf.yml:344` — first occurrence in corpus.
+- `sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:307-329` — raw-`cN` arithmetic, `auto_col_types: true`, insert + replace pair.
+- `sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:438-475` — string concat, `auto_col_types: false`, append (`mode: ""`).
+- `sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation.gxwf.yml:343-378` — explicit-cast arithmetic (`int(c2) - …`), `auto_col_types: false`, `--skip-non-computable`. Counter-example to "arithmetic always implies `auto_col_types: true`."
 
 ## Legacy alternative
 

--- a/content/patterns/tabular-cut-and-reorder-columns.md
+++ b/content/patterns/tabular-cut-and-reorder-columns.md
@@ -23,7 +23,7 @@ related_molds:
 
 ## Tool
 
-`Cut1` (Galaxy core; bundled, no toolshed owner). Display name "Cut columns from a table".
+`Cut1` (Galaxy core; bundled, no toolshed owner). Display name "Cut columns from a table". Source: `$GALAXY/tools/filters/cutWrapper.xml`.
 
 ## When to reach for it
 
@@ -33,8 +33,8 @@ For project + compute fused, see [[tabular-sql-query]] or [[tabular-compute-new-
 
 ## Parameters
 
-- `columnList`: a single comma-separated string of `cN` references — e.g. `c4,c6,c7`. **Order matters**: the output column order is the list order, so listing columns out of input order *reorders* them.
-- `delimiter`: enum; `T` for tab (the dominant value across the corpus), `C` for comma, `Sp` for whitespace (collapses runs of spaces/tabs), `Dt` for dot, `U` for underscore, `Pi` for pipe. Tab is the corpus-default; always set explicitly.
+- `columnList`: a single comma-separated string of `cN` references — e.g. `c4,c6,c7`. Range syntax `c2-c5` is also accepted (per the tool's tests). **Order matters**: the output column order is the list order, so listing columns out of input order *reorders* them. The IWC corpus uses long enumerations rather than ranges; either is valid.
+- `delimiter`: select enum from the wrapper. Values: `T` (Tab), `Sp` (Whitespace — collapses runs), `Dt` (Dot), `C` (Comma), `D` (Dash), `U` (Underscore), `P` (Pipe). Tab dominates the corpus; always set explicitly.
 - The connected `input` port is the tabular dataset.
 
 ## Idiomatic shapes
@@ -61,9 +61,9 @@ Cited at `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting
 
 ## Pitfalls
 
-- **No range syntax.** `c4-c10` is not parsed; expand the list explicitly. The corpus uses long enumerations, not ranges.
 - **No header awareness.** The header row is cut and reordered identically to data rows. Usually what you want; flagging only because `Filter1` / `Grouping1` *do* take `header_lines`.
-- **`delimiter` must match the input.** Mismatched delimiter (e.g. `delimiter: T` on comma-separated input) treats each line as a single field — `c1` echoes the whole row, `c2…` produce empty output. Silent.
+- **`delimiter` must match the input.** Mismatched delimiter (e.g. `delimiter: T` on comma-separated input) treats each line as a single field — `c1` echoes the whole row, `c2…` produce a `.` (the wrapper's missing-column fill) per row. Silent.
+- **Cut breaks Galaxy column metadata.** The wrapper warns: re-cutting may invalidate column-assignment metadata (chrom/start/end for interval/BED). Re-establish via the dataset's "edit attributes" if downstream tools need it.
 - **Reorder-then-rename** is *not* `Cut1`'s job. Renaming columns means rewriting the header row — handle that with [[tabular-compute-new-column]] or with a `tp_replace_in_line` pass.
 - **Adding a constant column** belongs to [[tabular-compute-new-column]] (`column_maker/Add_a_column1`), not `Cut1` + `Paste1`. The latter is legacy.
 

--- a/content/patterns/tabular-cut-and-reorder-columns.md
+++ b/content/patterns/tabular-cut-and-reorder-columns.md
@@ -1,0 +1,86 @@
+---
+type: pattern
+title: "Tabular: cut and reorder columns"
+tags:
+  - pattern
+  - target/galaxy
+status: draft
+created: 2026-04-30
+revised: 2026-04-30
+revision: 1
+ai_generated: true
+summary: "Use Cut1 with a comma-separated cN list to project — and reorder — columns. Listing out of order is the canonical reorder idiom."
+related_notes:
+  - "[[iwc-tabular-operations-survey]]"
+related_patterns:
+  - "[[tabular-compute-new-column]]"
+  - "[[tabular-sql-query]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+---
+
+# Tabular: cut and reorder columns
+
+## Tool
+
+`Cut1` (Galaxy core; bundled, no toolshed owner). Display name "Cut columns from a table".
+
+## When to reach for it
+
+Project a tabular to a subset of columns, **and/or** reorder existing columns. By far the most-used tabular tool in the IWC corpus (127 step occurrences in the survey). Use `Cut1` when the operation is purely "pick columns" — no computation, no row filtering, no aggregation.
+
+For project + compute fused, see [[tabular-sql-query]] or [[tabular-compute-new-column]].
+
+## Parameters
+
+- `columnList`: a single comma-separated string of `cN` references — e.g. `c4,c6,c7`. **Order matters**: the output column order is the list order, so listing columns out of input order *reorders* them.
+- `delimiter`: enum; `T` for tab (the dominant value across the corpus), `C` for comma, `Sp` for space, `Dt` for dot, `U` for underscore, `Pi` for pipe. Default `T`.
+- The connected `input` port is the tabular dataset.
+
+## Idiomatic shapes
+
+Pure projection (preserve order, drop unwanted columns):
+
+```yaml
+tool_id: Cut1
+tool_state:
+  columnList: c1,c2,c5
+  delimiter: T
+```
+
+Projection + reorder in one step (note `c20` placed *after* `c26,c24,c25`):
+
+```yaml
+tool_id: Cut1
+tool_state:
+  columnList: c4,c6,c7,c13,c14,c15,c16,c17,c18,c19,c21,c22,c23,c26,c24,c25,c20
+  delimiter: T
+```
+
+Cited at `sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:782`.
+
+## Pitfalls
+
+- **No range syntax.** `c4-c10` is not parsed; expand the list explicitly. The corpus uses long enumerations, not ranges.
+- **Header row is preserved.** `Cut1` operates per-line and doesn't special-case headers; if the input has a header, columns under the same `cN` indices in the header are reordered alongside the data, which is the desired behavior.
+- **`delimiter` must match the input.** If the input is comma-separated and `delimiter: T` is used (the default), the whole row is treated as one column and the cut returns the first column or empty results.
+- **Reorder-then-rename** is *not* `Cut1`'s job. Renaming columns means rewriting the header row — handle that with [[tabular-compute-new-column]] or with a `tp_replace_in_line` pass.
+- **Adding a constant column** belongs to [[tabular-compute-new-column]] (`column_maker/Add_a_column1`), not `Cut1` + `Paste1`. The latter is legacy.
+
+## Exemplars (IWC)
+
+All paths relative to `<iwc-format2>/`:
+
+- `sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:782` — long projection + reorder (17 columns, `c20` last).
+- `sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:830`, `:878` — sibling Cut1 steps in the same workflow, different column lists.
+- `genome_annotation/functional-annotation/functional-annotation-of-sequences/Functional_annotation_of_sequences.gxwf.yml:733` — `Paste1`+`Cut1` chain (legacy idiom; prefer [[tabular-compute-new-column]] today).
+
+## Legacy alternative
+
+None for `Cut1` itself — it is the modern tool. The legacy *idiom* of "add a constant column with `Paste1` then re-`Cut1`" survives but should be replaced by `column_maker/Add_a_column1` (see [[tabular-compute-new-column]]).
+
+## See also
+
+- [[iwc-tabular-operations-survey]] — corpus survey and decision record.
+- [[tabular-compute-new-column]] — when projection needs to add or replace a column.
+- [[tabular-sql-query]] — project + compute fused via `query_tabular`.

--- a/content/patterns/tabular-cut-and-reorder-columns.md
+++ b/content/patterns/tabular-cut-and-reorder-columns.md
@@ -57,7 +57,7 @@ tool_state:
   delimiter: T
 ```
 
-Cited at `sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:782`.
+Cited at `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:782`.
 
 ## Pitfalls
 
@@ -69,11 +69,10 @@ Cited at `sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-re
 
 ## Exemplars (IWC)
 
-All paths relative to `<iwc-format2>/`:
 
-- `sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:782` — long projection + reorder (17 columns, `c20` last).
-- `sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:830`, `:878` — sibling Cut1 steps in the same workflow, different column lists.
-- `genome_annotation/functional-annotation/functional-annotation-of-sequences/Functional_annotation_of_sequences.gxwf.yml:733` — `Paste1`+`Cut1` chain (legacy idiom; prefer [[tabular-compute-new-column]] today).
+- `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:782` — long projection + reorder (17 columns, `c20` last).
+- `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:830`, `:878` — sibling Cut1 steps in the same workflow, different column lists.
+- `$IWC_FORMAT2/genome_annotation/functional-annotation/functional-annotation-of-sequences/Functional_annotation_of_sequences.gxwf.yml:733` — `Paste1`+`Cut1` chain (legacy idiom; prefer [[tabular-compute-new-column]] today).
 
 ## Legacy alternative
 

--- a/content/patterns/tabular-cut-and-reorder-columns.md
+++ b/content/patterns/tabular-cut-and-reorder-columns.md
@@ -34,7 +34,7 @@ For project + compute fused, see [[tabular-sql-query]] or [[tabular-compute-new-
 ## Parameters
 
 - `columnList`: a single comma-separated string of `cN` references — e.g. `c4,c6,c7`. **Order matters**: the output column order is the list order, so listing columns out of input order *reorders* them.
-- `delimiter`: enum; `T` for tab (the dominant value across the corpus), `C` for comma, `Sp` for space, `Dt` for dot, `U` for underscore, `Pi` for pipe. Default `T`.
+- `delimiter`: enum; `T` for tab (the dominant value across the corpus), `C` for comma, `Sp` for whitespace (collapses runs of spaces/tabs), `Dt` for dot, `U` for underscore, `Pi` for pipe. Tab is the corpus-default; always set explicitly.
 - The connected `input` port is the tabular dataset.
 
 ## Idiomatic shapes
@@ -62,8 +62,8 @@ Cited at `sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-re
 ## Pitfalls
 
 - **No range syntax.** `c4-c10` is not parsed; expand the list explicitly. The corpus uses long enumerations, not ranges.
-- **Header row is preserved.** `Cut1` operates per-line and doesn't special-case headers; if the input has a header, columns under the same `cN` indices in the header are reordered alongside the data, which is the desired behavior.
-- **`delimiter` must match the input.** If the input is comma-separated and `delimiter: T` is used (the default), the whole row is treated as one column and the cut returns the first column or empty results.
+- **No header awareness.** The header row is cut and reordered identically to data rows. Usually what you want; flagging only because `Filter1` / `Grouping1` *do* take `header_lines`.
+- **`delimiter` must match the input.** Mismatched delimiter (e.g. `delimiter: T` on comma-separated input) treats each line as a single field — `c1` echoes the whole row, `c2…` produce empty output. Silent.
 - **Reorder-then-rename** is *not* `Cut1`'s job. Renaming columns means rewriting the header row — handle that with [[tabular-compute-new-column]] or with a `tp_replace_in_line` pass.
 - **Adding a constant column** belongs to [[tabular-compute-new-column]] (`column_maker/Add_a_column1`), not `Cut1` + `Paste1`. The latter is legacy.
 

--- a/content/patterns/tabular-filter-by-column-value.md
+++ b/content/patterns/tabular-filter-by-column-value.md
@@ -48,7 +48,7 @@ tool_state:
   header_lines: '1'
 ```
 
-Cited at `sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:545`.
+Cited at `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:545`.
 
 Predicate produced upstream and wired in via `ConnectedValue` (lets a workflow author parameterize the predicate without a runtime parameter). Note that this corpus example has `header_lines: "0"` because the upstream rule already accounts for the header — the `header_lines` setting is independent of the `cond` source:
 
@@ -59,7 +59,7 @@ tool_state:
   header_lines: '0'
 ```
 
-Cited at `epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:320-336`.
+Cited at `$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:320-336`.
 
 ## Pitfalls
 
@@ -70,11 +70,10 @@ Cited at `epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:32
 
 ## Exemplars (IWC)
 
-All paths relative to `<iwc-format2>/`:
 
-- `sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:545` — literal predicate `c4=='PASS' or c4=='.'`, `header_lines: "1"`.
-- `sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation.gxwf.yml:276` — `ConnectedValue` predicate, `header_lines: "0"` (rule generated upstream).
-- `epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:320-336` — `ConnectedValue` predicate, `header_lines: "0"`.
+- `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:545` — literal predicate `c4=='PASS' or c4=='.'`, `header_lines: "1"`.
+- `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation.gxwf.yml:276` — `ConnectedValue` predicate, `header_lines: "0"` (rule generated upstream).
+- `$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:320-336` — `ConnectedValue` predicate, `header_lines: "0"`.
 
 All three corpus filters are equality / disjunction over a string column, or a `ConnectedValue` rule. Numeric-range predicates are unattested — if you reach for `cN > X`, you're slightly off the corpus path; verify behavior on a sample.
 

--- a/content/patterns/tabular-filter-by-column-value.md
+++ b/content/patterns/tabular-filter-by-column-value.md
@@ -23,7 +23,7 @@ related_molds:
 
 ## Tool
 
-`Filter1` (Galaxy core; bundled, no toolshed owner). Display name "Filter data on any column using simple expressions".
+`Filter1` (Galaxy core; bundled, no toolshed owner). Display name "Filter data on any column using simple expressions". Source: `$GALAXY/tools/stats/filtering_1_1_0.xml`.
 
 ## When to reach for it
 
@@ -33,8 +33,8 @@ If the predicate needs join/sort/grouping semantics, switch to [[tabular-sql-que
 
 ## Parameters
 
-- `cond`: any Python expression that returns truthy/falsy, with column references `c1, c2, …` (1-indexed). Comparison and boolean operators are the common case; arithmetic, `in` / `not in`, and function calls (e.g. `len`) also work. Quote string literals.
-- `header_lines`: integer-as-string. **Set to `"1"` whenever the input has a header row.** Filter1 evaluates `cond` per row and silently drops rows whose evaluation raises (e.g. when a header row coerces badly under a numeric comparison); leaving `header_lines: "0"` on a headered input often produces a silent off-by-one.
+- `cond`: text param, evaluated per row as a Python expression over `c1, c2, …` (1-indexed) column references. Comparison, boolean, and arithmetic operators all work; function calls (`len`, `range`, etc.) and `.split(...)` are supported per the wrapper help. Quote string literals. **Boolean operators must be lowercase** — `OR`/`AND` are name lookups, not boolean ops.
+- `header_lines`: integer (the workflow YAML conventionally quotes it: `"0"`, `"1"`). **Set to `"1"` whenever the input has a header row.** Filter1 evaluates `cond` per row; rows whose evaluation raises an exception are skipped from output and counted in the dataset's "Condition/data issue" metadata (visible in the history-item info panel — not silent in the dataset metadata sense, but invisible in the data flow).
 - The connected `input` port is the tabular dataset.
 
 ## Idiomatic shapes
@@ -63,10 +63,11 @@ Cited at `$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-atac-cutandru
 
 ## Pitfalls
 
-- **Forgetting `header_lines`.** Default `"0"`. With a header row present, the header is evaluated like any other row; rows whose evaluation raises (typical on a header under a numeric comparison) are silently dropped, while a string-comparison header may pass through. Either way, off-by-one assertions downstream.
+- **Forgetting `header_lines`.** Default `"0"`. With a header row present, the header is evaluated like any other row; under a numeric comparison the header typically raises and is skipped, while a string-comparison header may pass through. Either way, off-by-one assertions downstream.
 - **String quoting.** `cond: c4==PASS` parses as a name lookup on `PASS`, not a string comparison. Always quote literal strings.
+- **Uppercase operators.** `cond: c1=='X' OR c1=='Y'` — `OR` is treated as a name (`NameError`), not a boolean op. Use lowercase `and`, `or`, `not`.
 - **No new columns.** `Filter1` is a *filter*; new or computed columns belong in [[tabular-compute-new-column]].
-- **Implicit column-type coercion.** `cN` values are strings until an operator forces int/float; coercion failures drop the row silently. If silent drops are unacceptable, pre-clean upstream or use [[tabular-sql-query]].
+- **Implicit column-type coercion.** `cN` values are strings until an operator forces int/float; coercion failures skip the row (counted in the dataset metadata, not surfaced in the output stream). If silent-from-data drops are unacceptable, pre-clean upstream or use [[tabular-sql-query]].
 
 ## Exemplars (IWC)
 

--- a/content/patterns/tabular-filter-by-column-value.md
+++ b/content/patterns/tabular-filter-by-column-value.md
@@ -33,8 +33,8 @@ If the predicate needs join/sort/grouping semantics, switch to [[tabular-sql-que
 
 ## Parameters
 
-- `cond`: Python expression. Columns referenced as `cN` (1-indexed). Comparison and boolean operators only — `==`, `!=`, `<`, `>`, `<=`, `>=`, `and`, `or`, `not`, `in`. Strings quoted.
-- `header_lines`: integer (string-typed in YAML). **Set to `"1"` whenever the input has a header row** — `Filter1` evaluates `cond` against the first row otherwise and silently drops it on type mismatch.
+- `cond`: any Python expression that returns truthy/falsy, with column references `c1, c2, …` (1-indexed). Comparison and boolean operators are the common case; arithmetic, `in` / `not in`, and function calls (e.g. `len`) also work. Quote string literals.
+- `header_lines`: integer-as-string. **Set to `"1"` whenever the input has a header row.** Filter1 evaluates `cond` per row and silently drops rows whose evaluation raises (e.g. when a header row coerces badly under a numeric comparison); leaving `header_lines: "0"` on a headered input often produces a silent off-by-one.
 - The connected `input` port is the tabular dataset.
 
 ## Idiomatic shapes
@@ -50,31 +50,33 @@ tool_state:
 
 Cited at `sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:545`.
 
-Predicate produced upstream and wired in via `ConnectedValue` (lets a workflow author parameterize the threshold without a runtime parameter):
+Predicate produced upstream and wired in via `ConnectedValue` (lets a workflow author parameterize the predicate without a runtime parameter). Note that this corpus example has `header_lines: "0"` because the upstream rule already accounts for the header — the `header_lines` setting is independent of the `cond` source:
 
 ```yaml
 tool_id: Filter1
 tool_state:
   cond: { __class__: ConnectedValue }   # from a prior "generate filter rule" step
-  header_lines: '1'
+  header_lines: '0'
 ```
 
 Cited at `epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:320-336`.
 
 ## Pitfalls
 
-- **Forgetting `header_lines`.** The default is `"0"`. With a header row present and a numeric comparison in `cond`, the header row evaluates to `False` and is dropped; with a string comparison, the header may pass through. Either way, off-by-one assertions downstream.
+- **Forgetting `header_lines`.** Default `"0"`. With a header row present, the header is evaluated like any other row; rows whose evaluation raises (typical on a header under a numeric comparison) are silently dropped, while a string-comparison header may pass through. Either way, off-by-one assertions downstream.
 - **String quoting.** `cond: c4==PASS` parses as a name lookup on `PASS`, not a string comparison. Always quote literal strings.
-- **No `cN` arithmetic.** `Filter1` is a *filter*; new computed columns belong in [[tabular-compute-new-column]].
-- **Column-type coercion is implicit.** `cN` values are coerced from the underlying string to int/float when the operator demands it; rows where the coercion fails are dropped *without warning*. If silent drops are unacceptable, pre-clean upstream or use `query_tabular`.
+- **No new columns.** `Filter1` is a *filter*; new or computed columns belong in [[tabular-compute-new-column]].
+- **Implicit column-type coercion.** `cN` values are strings until an operator forces int/float; coercion failures drop the row silently. If silent drops are unacceptable, pre-clean upstream or use [[tabular-sql-query]].
 
 ## Exemplars (IWC)
 
 All paths relative to `<iwc-format2>/`:
 
-- `sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:545` — `c4=='PASS' or c4=='.'`, header-aware.
-- `sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation.gxwf.yml:276` — same shape, different predicate.
-- `epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:320-336` — `cond` wired from upstream `ConnectedValue`.
+- `sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:545` — literal predicate `c4=='PASS' or c4=='.'`, `header_lines: "1"`.
+- `sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation.gxwf.yml:276` — `ConnectedValue` predicate, `header_lines: "0"` (rule generated upstream).
+- `epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:320-336` — `ConnectedValue` predicate, `header_lines: "0"`.
+
+All three corpus filters are equality / disjunction over a string column, or a `ConnectedValue` rule. Numeric-range predicates are unattested — if you reach for `cN > X`, you're slightly off the corpus path; verify behavior on a sample.
 
 ## Legacy alternative
 

--- a/content/patterns/tabular-filter-by-column-value.md
+++ b/content/patterns/tabular-filter-by-column-value.md
@@ -1,0 +1,87 @@
+---
+type: pattern
+title: "Tabular: filter rows by column value"
+tags:
+  - pattern
+  - target/galaxy
+status: draft
+created: 2026-04-30
+revised: 2026-04-30
+revision: 1
+ai_generated: true
+summary: "Use Filter1 with a Python expression over cN columns to drop rows. Highest-frequency tabular row filter in IWC."
+related_notes:
+  - "[[iwc-tabular-operations-survey]]"
+related_patterns:
+  - "[[tabular-filter-by-regex]]"
+  - "[[tabular-sql-query]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+---
+
+# Tabular: filter rows by column value
+
+## Tool
+
+`Filter1` (Galaxy core; bundled, no toolshed owner). Display name "Filter data on any column using simple expressions".
+
+## When to reach for it
+
+One-shot row filter on tabular input. The row predicate is a single Python expression over `c1, c2, …` column references; the output preserves column order and types. By far the most common row-filter idiom in IWC (33 step occurrences in the surveyed corpus, second only to regex grep variants).
+
+If the predicate needs join/sort/grouping semantics, switch to [[tabular-sql-query]] or to `datamash_ops`. If the predicate is a substring/regex over a single column or whole line, prefer [[tabular-filter-by-regex]].
+
+## Parameters
+
+- `cond`: Python expression. Columns referenced as `cN` (1-indexed). Comparison and boolean operators only — `==`, `!=`, `<`, `>`, `<=`, `>=`, `and`, `or`, `not`, `in`. Strings quoted.
+- `header_lines`: integer (string-typed in YAML). **Set to `"1"` whenever the input has a header row** — `Filter1` evaluates `cond` against the first row otherwise and silently drops it on type mismatch.
+- The connected `input` port is the tabular dataset.
+
+## Idiomatic shapes
+
+Single-column equality, header-aware:
+
+```yaml
+tool_id: Filter1
+tool_state:
+  cond: c4=='PASS' or c4=='.'
+  header_lines: '1'
+```
+
+Cited at `sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:545`.
+
+Predicate produced upstream and wired in via `ConnectedValue` (lets a workflow author parameterize the threshold without a runtime parameter):
+
+```yaml
+tool_id: Filter1
+tool_state:
+  cond: { __class__: ConnectedValue }   # from a prior "generate filter rule" step
+  header_lines: '1'
+```
+
+Cited at `epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:320-336`.
+
+## Pitfalls
+
+- **Forgetting `header_lines`.** The default is `"0"`. With a header row present and a numeric comparison in `cond`, the header row evaluates to `False` and is dropped; with a string comparison, the header may pass through. Either way, off-by-one assertions downstream.
+- **String quoting.** `cond: c4==PASS` parses as a name lookup on `PASS`, not a string comparison. Always quote literal strings.
+- **No `cN` arithmetic.** `Filter1` is a *filter*; new computed columns belong in [[tabular-compute-new-column]].
+- **Column-type coercion is implicit.** `cN` values are coerced from the underlying string to int/float when the operator demands it; rows where the coercion fails are dropped *without warning*. If silent drops are unacceptable, pre-clean upstream or use `query_tabular`.
+
+## Exemplars (IWC)
+
+All paths relative to `<iwc-format2>/`:
+
+- `sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:545` — `c4=='PASS' or c4=='.'`, header-aware.
+- `sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation.gxwf.yml:276` — same shape, different predicate.
+- `epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:320-336` — `cond` wired from upstream `ConnectedValue`.
+
+## Legacy alternative
+
+None — `Filter1` is the modern tool. (Don't confuse with `__FILTER_FROM_FILE__` and `__FILTER_EMPTY_DATASETS__`, which are collection-level filters, not tabular row filters.)
+
+## See also
+
+- [[iwc-tabular-operations-survey]] — corpus survey and decision record.
+- [[tabular-filter-by-regex]] — regex / line-pattern row filter.
+- [[tabular-sql-query]] — when SQL semantics (joins, windows) are the right reach.

--- a/content/patterns/tabular-filter-by-regex.md
+++ b/content/patterns/tabular-filter-by-regex.md
@@ -1,0 +1,116 @@
+---
+type: pattern
+title: "Tabular: filter rows by regex"
+tags:
+  - pattern
+  - target/galaxy
+status: draft
+created: 2026-04-30
+revised: 2026-04-30
+revision: 1
+ai_generated: true
+summary: "Use tp_grep_tool for whole-line regex row filters on tabular input. Grep1 is the legacy alternative."
+related_notes:
+  - "[[iwc-tabular-operations-survey]]"
+related_patterns:
+  - "[[tabular-filter-by-column-value]]"
+  - "[[tabular-sql-query]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+---
+
+# Tabular: filter rows by regex
+
+## Tool
+
+`toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool` ("Search in textfiles with grep"). 43 step occurrences in the IWC corpus, alongside 47 occurrences of the legacy core `Grep1`. Per the §7 decision in [[iwc-tabular-operations-survey]], `tp_grep_tool` is the recommended choice — consistency with the rest of the `tp_*` text_processing family wins over `Grep1`'s slight corpus-frequency edge.
+
+Source XML lives in the `bgruening/text_processing` toolshed repository (no local clone is configured in `common_paths.yml.sample`; parameter shapes below are inferred from corpus invocations).
+
+## When to reach for it
+
+Whole-line regex inclusion or exclusion of rows. Drop comment lines (`^#`), keep header-style lines (`^@`), drop rows containing a literal token (`REPEAT`), keep records by an FA-like prefix (`^>`).
+
+If the predicate is a Python expression over specific columns (`c4 == 'PASS'`), prefer [[tabular-filter-by-column-value]] — `tp_grep_tool` has no notion of columns. If joins, windows, or grouping are part of the filter, prefer [[tabular-sql-query]].
+
+## Parameters
+
+Field names below are corpus-inferred from `tool_state` blocks (the underlying wrapper is not in `common_paths.yml.sample`). Verify against the live tool form when authoring.
+
+- `infile`: connected tabular input.
+- `url_paste`: the regex pattern. The field name is a textarea/file artifact; the value is the pattern itself (e.g. `^#`, `REPEAT`, `^>`).
+- `regex_type`: select. Corpus values: `-P` (PCRE; dominant), `-E` (ERE), `-G` (BRE). `-P` matches the only flavor `Grep1` supports.
+- `invert`: select. `""` keeps matching lines; `-v` keeps non-matching lines.
+- `case_sensitive`: select. `""` is case-sensitive; `-i` is case-insensitive. (Value is the flag itself.)
+- `lines_before`, `lines_after`: string-quoted integers (`"0"` corpus-default). Equivalent to grep `-B` / `-A` for context lines around each match.
+- `color`: select; `NOCOLOR` is the only corpus value. Leave as `NOCOLOR` — colored output is meaningless inside a workflow.
+
+`tp_grep_tool` does **not** expose a header-preserving toggle in any corpus invocation. If you need to keep the first line independent of the pattern, see the legacy alternative below or pre-strip the header with `Remove beginning1` and concatenate.
+
+## Idiomatic shapes
+
+Drop comment lines (case-insensitive PCRE, invert):
+
+```yaml
+tool_id: toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool/9.3+galaxy1
+tool_state:
+  infile: { __class__: ConnectedValue }
+  url_paste: ^#
+  regex_type: -P
+  invert: -v
+  case_sensitive: -i
+  lines_before: "0"
+  lines_after: "0"
+  color: NOCOLOR
+```
+
+Cited at `$IWC_FORMAT2/epigenetics/atacseq/atacseq.gxwf.yml:469` ("remove comments lines") and `$IWC_FORMAT2/epigenetics/chipseq-sr/chipseq-sr.gxwf.yml:305` (same shape, `invert: ""` to *keep* `^#` summary lines into a MACS2 report).
+
+Drop rows containing a literal token:
+
+```yaml
+tool_id: toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool/9.5+galaxy3
+tool_state:
+  infile: { __class__: ConnectedValue }
+  url_paste: REPEAT
+  regex_type: -P
+  invert: -v
+  case_sensitive: -i
+  lines_before: "0"
+  lines_after: "0"
+  color: NOCOLOR
+```
+
+Cited at `$IWC_FORMAT2/VGP-assembly-v2/Purge-duplicates-one-haplotype-VGP6b/Purging-duplicates-one-haplotype-VGP6b.gxwf.yml:983` ("Remove REPEATs from BED").
+
+## Pitfalls
+
+- **No header preservation.** Whole-line regex sees the header as a normal row; if your pattern matches data but not the header, you silently drop the header. Strip-then-rebind, switch to `Grep1` with `keep_header: true`, or accept that the output is headerless.
+- **`url_paste` is the pattern field.** The misleading name is a wrapper artifact (text/file dual input). Don't treat it as a URL; don't escape it as one.
+- **`case_sensitive` and `invert` values are the flag literals.** `case_sensitive: true` will not work — set `-i` for insensitive, `""` for sensitive. Same for `invert: -v` vs `""`.
+- **PCRE vs ERE.** `regex_type: -P` is the corpus default and matches `Grep1`'s flavor. ERE / BRE are available but unattested in the survey; switching flavors mid-workflow makes patterns harder to reason about.
+- **No column awareness.** A pattern like `\tPASS\t` is the closest you can get to "column 4 equals PASS" — and it's brittle (depends on tab counts, breaks on the first/last column). Use [[tabular-filter-by-column-value]] for column predicates.
+- **Version pin sprawl.** Four pins coexist in the corpus (`1.1.1`, `9.3+galaxy1`, `9.5+galaxy2`, `9.5+galaxy3` — `9.5+galaxy3` dominates) with the same parameter shape. Pick the highest pin already present in the workflow you're touching; do not block PRs for older pins on cleanup grounds.
+
+## Exemplars (IWC)
+
+- `$IWC_FORMAT2/epigenetics/atacseq/atacseq.gxwf.yml:469` — drop `^#` comment lines from a fragment-length histogram (`invert: -v`).
+- `$IWC_FORMAT2/epigenetics/chipseq-sr/chipseq-sr.gxwf.yml:305` — keep `^#` MACS2 summary header lines (`invert: ""`); change_datatype to `txt` for downstream rendering.
+- `$IWC_FORMAT2/VGP-assembly-v2/Purge-duplicates-one-haplotype-VGP6b/Purging-duplicates-one-haplotype-VGP6b.gxwf.yml:983` — drop BED rows containing `REPEAT` (`invert: -v`).
+- `$IWC_FORMAT2/comparative_genomics/hyphy/capheine-core-and-compare.gxwf.yml:687` — `Grep1` (legacy) keeping FASTA header lines (`pattern: ^>`, `invert: ""`, `keep_header: false`).
+
+## Legacy alternative
+
+`Grep1` ("Select lines that match an expression"; Galaxy core, `$GALAXY/tools/filters/grep.xml`). 26 step occurrences — slightly more frequent than `tp_grep_tool` but loses the consistency argument. Distinguishing parameters:
+
+- `pattern`: the regex (text, sanitizer off; PCRE only — wrapper hardcodes `grep -P`).
+- `invert`: select; `""` Matching / `-v` NOT Matching.
+- `keep_header`: boolean (`true` / `false`). `true` peels the first line through unchanged, then `grep`s the remainder — the **only** built-in header-preserving regex filter on the row-text path.
+
+When reading older IWC workflows you will encounter `Grep1` regularly; preserve it as-is. For new authoring, prefer `tp_grep_tool` unless `keep_header: true` is genuinely needed.
+
+## See also
+
+- [[iwc-tabular-operations-survey]] — corpus survey and §7 decision record (recommend `tp_grep_tool`, demote `Grep1` to legacy).
+- [[tabular-filter-by-column-value]] — column-expression row filter (`Filter1`).
+- [[tabular-sql-query]] — when SQL semantics are the right reach.

--- a/content/research/iwc-tabular-operations-survey.md
+++ b/content/research/iwc-tabular-operations-survey.md
@@ -32,7 +32,7 @@ Ranked by step occurrences. "DT" = devteam, "BG" = bgruening, "IUC" = iuc, "NML"
 |---|---|---|---|
 | 127 | `Cut1` | Cut1 (Cut columns from a table) | Column projection |
 | 33 | `Filter1` | Filter1 (Filter data on any column using simple expressions) | Row filter |
-| 26 | `Grep1` | Grep1 (Select lines that match an expression) | Row filter (regex) |
+| 47 | `Grep1` | Grep1 (Select lines that match an expression) | Row filter (regex) |
 | 25 | `sort1` | sort1 (Sort) | Sort |
 | 21 | `Remove beginning1` | Remove beginning | Header strip |
 | 19 | `Grouping1` | Grouping1 (Group data by a column) | Group/aggregate |
@@ -58,7 +58,7 @@ By far the largest single family. Same upstream tool collection (`text_processin
 | 195 | `tp_awk_tool` | Free-form awk |
 | 66 | `tp_find_and_replace` | Regex/string replace (whole-line) |
 | 39 | `tp_replace_in_line` | Regex replace in line |
-| 19 | `tp_grep_tool` | Row filter (regex; vs core `Grep1`) |
+| 43 | `tp_grep_tool` | Row filter (regex; vs core `Grep1`) |
 | 16 | `tp_sed_tool` | Free-form sed |
 | 15 | `tp_cat` | Row-bind |
 | 12 | `tp_text_file_with_recurring_lines` | Header/template lines (constant prefix) |
@@ -82,7 +82,7 @@ Representative full IDs (first occurrence in corpus):
 - `toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sorted_uniq/9.5+galaxy3` — `comparative_genomics/hyphy/capheine-core-and-compare.gxwf.yml:773`.
 - `toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_uniq_tool/9.5+galaxy3` — `VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation.gxwf.yml:2476` (inside a subworkflow).
 - `toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_head_tool/9.5+galaxy0` — `microbiome/pathogen-identification/allele-based-pathogen-identification/Allele-based-Pathogen-Identification.gxwf.yml:495`.
-- `toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool/9.5+galaxy3` — used 19x; coexists with core `Grep1` (26x). See §3.
+- `toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool/9.5+galaxy3` — used 43x across four pins (`1.1.1`, `9.3+galaxy1`, `9.5+galaxy2`, `9.5+galaxy3` — last dominates); coexists with core `Grep1` (47x). See §3.
 - `toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_multijoin_tool/9.3+galaxy1` — `microbiome/pathogen-identification/.../Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation.gxwf.yml:796`.
 - `toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/9.3+galaxy1` — `sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:923`.
 - `toolshed.g2.bx.psu.edu/repos/bgruening/split_file_on_column/tp_split_on_column/0.6` — `microbiome/pathogen-identification/.../Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation.gxwf.yml:369` (split a tabular into a collection by a key column).
@@ -240,7 +240,7 @@ Not visible at the tabular layer in any sampled file; sampling happens upstream 
 | Operation | Tools that cover it (corpus-observed) | Recommendation lean |
 |---|---|---|
 | Filter rows (column expression) | `Filter1`, `query_tabular`, `filter_tabular`, awk | `Filter1` for one-shot; `query_tabular` only when SQL semantics needed |
-| Filter rows (regex) | `Grep1` (26), `tp_grep_tool` (19), awk | **Real redundancy** — 26 vs 19 split with no semantic distinction visible |
+| Filter rows (regex) | `Grep1` (47), `tp_grep_tool` (43), awk | **Real redundancy** — 47 vs 43 split with no semantic distinction visible |
 | Cut/project columns | `Cut1` (127), `query_tabular`, `filter_tabular`, `Paste1`+`Cut1` chains | `Cut1` dominates; use `query_tabular` for project+compute fused |
 | Computed column | `Add_a_column1` (93), awk, `query_tabular` | `Add_a_column1` if the expression is short; awk if the row needs a multi-line decision tree (see §2g taxonomy splitter) |
 | Sort | `sort1`, `tp_sort_header_tool` | `tp_sort_header_tool` whenever the input has a header — `sort1`'s header handling is implicit |
@@ -312,7 +312,7 @@ Proposed leaf pages, each scoped tightly. Where a candidate is weak, I say so.
 
 ## 6. Open questions
 
-- **Q1.** `Grep1` (26) vs `tp_grep_tool` (19) — semantic difference real? Both take `pattern`, `invert`, `keep_header`. Suggest the regex page recommend one and demote the other; need your call which.
+- **Q1.** `Grep1` (47) vs `tp_grep_tool` (43) — semantic difference real? Both take `pattern`, `invert`, `keep_header`. Suggest the regex page recommend one and demote the other; need your call which.
 - **Q2.** `awk-in-galaxy` page depth: one page covering all 195 invocations, or split into 4 sub-pages (`awk-header-injection`, `awk-bed-synthesis`, `awk-taxonomy-split`, `awk-relabel`)? Lean: one page with idiom sections; split only if frontmatter cross-linking gets noisy.
 - **Q3.** Should `Add_a_column1` page warn against `auto_col_types: false`? Many corpus uses set it true, some false (`variation-reporting.gxwf.yml:454`); silent string-vs-numeric coercion is a real bug source. Need your call on prescriptiveness.
 - **Q4.** Is `query_tabular` deep-dive in scope for this hierarchy or its own thing? It overlaps Galaxy's broader "compute over tabular" story (R, Python, csvtk-shaped). Lean: keep it in this hierarchy as the SQL leaf.

--- a/content/research/iwc-tabular-operations-survey.md
+++ b/content/research/iwc-tabular-operations-survey.md
@@ -330,14 +330,17 @@ Resolved via `AskUserQuestion` after this survey landed. Pinned here so the next
 - **Grep1 vs tp_grep_tool (Q1).** Recommend `tp_grep_tool`. Demote `Grep1` to a "legacy alternative" footnote. Consistency with the rest of the `tp_*` family wins over slight corpus-frequency edge of `Grep1`.
 - **Format-conversion gap (Q5).** Skip. Corpus-first principle: no exemplar = no page. The §2m gap note in this survey stands as the only record.
 - **`auto_col_types` (Q3).** The `tabular-compute-new-column` page prescribes a **strict structured rule**:
-  - **Always** set `fail_on_non_existent_columns: true` and `non_computable.action: --fail-on-non-computable` (51/51 corpus instances).
+  - **Always** set `fail_on_non_existent_columns: true` (51/51 corpus instances).
+  - `non_computable.action: --fail-on-non-computable` is the dominant choice (49/51); the two `--skip-non-computable` exceptions (`consensus-from-variation.gxwf.yml:364`, `:402`) are intentional, for BED-coordinate arithmetic where some rows are legitimately non-numeric.
   - **`auto_col_types`** is per-expression-kind:
     | Expression kind | `auto_col_types` |
     |---|---|
-    | Arithmetic (`+`, `*`, `round()`, `int()`, …) | `true` |
+    | Arithmetic on raw `cN` (`(c18+c19)/c6`, `round(...)`) | `true` |
     | Pure string concat (`c5 + '>' + c6`) | `false` |
+    | Arithmetic with explicit casts (`int(cN)`, `float(cN)`) | `false` |
     | Mixed | split into two `expressions:` entries with different settings |
-  - Cite `variation-reporting.gxwf.yml:316-329` (true, arithmetic) and `:454-477` (false, string concat) as the canonical pair.
+  - Corpus distribution: 48 `true` / 3 `false`. Cite `variation-reporting.gxwf.yml:307-329` (true, raw-`cN` arithmetic), `:438-475` (false, string concat), and `consensus-from-variation.gxwf.yml:343-378` (false, explicit-cast arithmetic) as the canonical triple.
+  - Note on YAML shape: `expressions:` is nested under `tool_state.ops.expressions` (with `header_lines_select: yes|no` as sibling). `error_handling` is a top-level sibling of `ops`, not nested inside it. The pattern page must show this shape; flat `expressions:` does not roundtrip.
 - **Legacy tool IDs (Q6).** Pages name the modern tool primarily; include a short "Legacy alternative" footnote pointing to the old ID (`Grouping1`, `cat1`, `addValue/1.0.1`, `Remove beginning1`, `Paste1`, `sort1`). Reading old IWC workflows must remain possible.
 - **`query_tabular` (Q4).** Leaf in this tabular hierarchy as `tabular-sql-query`. Scope narrowly to "when SQL is the right reach" — window functions, multi-table JOINs, project+compute fused. Cross-link from filter / join / compute leaves; do not evangelize.
 - **Tabular-source cross-ref (Q7).** Deferred. If a Mold (e.g. `summarize-galaxy-tool`) later needs to point to multiqc/tooldistillator-as-tabular-source context, write the page then.

--- a/scripts/lib/common-paths.ts
+++ b/scripts/lib/common-paths.ts
@@ -1,0 +1,89 @@
+// Loads `common_paths.yml` (or falls back to `common_paths.yml.sample`),
+// expands ~ in paths, and exposes citation-resolving helpers.
+//
+// Citation form (inside inline code in note bodies):
+//   $NAME/relative/path:LINE
+//   $NAME/relative/path:LINE-LINE
+//   $NAME/relative/path
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import yaml from "js-yaml";
+
+export interface CommonPathEntry {
+  path: string;
+  repo?: string;
+  ref?: string;
+  path_prefix?: string;
+}
+
+export type CommonPaths = Record<string, CommonPathEntry>;
+
+export interface Citation {
+  name: string;
+  entry: CommonPathEntry;
+  relPath: string;
+  lineStart?: number;
+  lineEnd?: number;
+}
+
+// $NAME — uppercase letters/digits/underscore, must start with a letter.
+// Captures the path up to optional `:LINE` or `:LINE-LINE` suffix.
+export const CITATION_RE = /^\$([A-Z][A-Z0-9_]*)\/([^\s:]+)(?::(\d+)(?:-(\d+))?)?$/;
+
+function expandHome(p: string): string {
+  if (p.startsWith("~/")) return path.join(os.homedir(), p.slice(2));
+  if (p === "~") return os.homedir();
+  return p;
+}
+
+function normalizeKeys(raw: Record<string, CommonPathEntry>): CommonPaths {
+  const out: CommonPaths = {};
+  for (const [k, v] of Object.entries(raw)) {
+    out[k.toLowerCase()] = { ...v, path: expandHome(v.path) };
+  }
+  return out;
+}
+
+export function loadCommonPaths(repoRoot: string): CommonPaths {
+  const local = path.join(repoRoot, "common_paths.yml");
+  const sample = path.join(repoRoot, "common_paths.yml.sample");
+  const file = fs.existsSync(local) ? local : fs.existsSync(sample) ? sample : null;
+  if (!file) return {};
+  try {
+    const raw = yaml.load(fs.readFileSync(file, "utf-8")) as Record<string, CommonPathEntry> | null;
+    return raw ? normalizeKeys(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
+export function parseCitation(text: string, paths: CommonPaths): Citation | null {
+  const m = CITATION_RE.exec(text.trim());
+  if (!m) return null;
+  const [, name, relPath, lineStart, lineEnd] = m;
+  const entry = paths[name.toLowerCase()];
+  if (!entry) return null;
+  return {
+    name,
+    entry,
+    relPath,
+    lineStart: lineStart ? Number(lineStart) : undefined,
+    lineEnd: lineEnd ? Number(lineEnd) : undefined,
+  };
+}
+
+export function citationGithubUrl(c: Citation): string | null {
+  const { entry, relPath, lineStart, lineEnd } = c;
+  if (!entry.repo) return null;
+  const ref = entry.ref ?? "main";
+  const fullPath = entry.path_prefix ? `${entry.path_prefix.replace(/\/$/, "")}/${relPath}` : relPath;
+  let url = `https://github.com/${entry.repo}/blob/${ref}/${fullPath}`;
+  if (lineStart) url += `#L${lineStart}${lineEnd ? `-L${lineEnd}` : ""}`;
+  return url;
+}
+
+export function citationLocalPath(c: Citation): string {
+  return path.join(c.entry.path, c.relPath);
+}

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -3,13 +3,17 @@ import { defineConfig } from 'astro/config';
 import tailwindcss from '@tailwindcss/vite';
 import pagefind from 'astro-pagefind';
 import remarkWikiLinks from './src/lib/remark-wiki-links.ts';
+import remarkCorpusCitations from './src/lib/remark-corpus-citations.ts';
 
 export default defineConfig({
   site: 'https://jmchilton.github.io',
   base: '/foundry',
   integrations: [pagefind()],
   markdown: {
-    remarkPlugins: [[remarkWikiLinks, { contentDir: '../content', base: '/foundry' }]],
+    remarkPlugins: [
+      [remarkWikiLinks, { contentDir: '../content', base: '/foundry' }],
+      [remarkCorpusCitations, { repoRoot: '..' }],
+    ],
   },
   vite: {
     plugins: [tailwindcss()],

--- a/site/src/lib/remark-corpus-citations.ts
+++ b/site/src/lib/remark-corpus-citations.ts
@@ -1,0 +1,48 @@
+// Rewrites `$NAME/path:line` corpus citations (inside inline code) into
+// links to the upstream GitHub repo when `common_paths.yml` declares a
+// `repo` for the citation prefix. Citations whose prefix has no `repo`
+// are left as plain inline code.
+//
+// See `common_paths.yml.sample` at the repo root for the citation grammar.
+
+import path from "node:path";
+import { visit, SKIP } from "unist-util-visit";
+import type { Root, InlineCode, PhrasingContent } from "mdast";
+import {
+  loadCommonPaths,
+  parseCitation,
+  citationGithubUrl,
+  type CommonPaths,
+} from "../../../scripts/lib/common-paths.ts";
+
+interface Options {
+  repoRoot: string;
+}
+
+export default function remarkCorpusCitations(opts: Options) {
+  let cache: CommonPaths | null = null;
+  const getPaths = () => (cache ??= loadCommonPaths(path.resolve(opts.repoRoot)));
+
+  return function transformer(tree: Root) {
+    const paths = getPaths();
+    if (Object.keys(paths).length === 0) return;
+
+    visit(tree, "inlineCode", (node: InlineCode, index, parent) => {
+      if (!parent || index === undefined) return;
+      if (parent.type === "link") return; // already linked
+      const citation = parseCitation(node.value, paths);
+      if (!citation) return;
+      const url = citationGithubUrl(citation);
+      if (!url) return; // entry has no repo — render as plain code
+
+      const replacement: PhrasingContent = {
+        type: "link",
+        url,
+        title: null,
+        children: [node],
+      };
+      (parent.children as PhrasingContent[]).splice(index, 1, replacement);
+      return [SKIP, index + 1];
+    });
+  };
+}


### PR DESCRIPTION
## Summary

Walks the first four leaf pattern pages commissioned by `iwc-tabular-operations-survey.md` (issue #9), end-to-end rather than batched, to let the pattern-page form fall out empirically before scaling to the rest.

Pages added under `content/patterns/`:
- `tabular-filter-by-column-value` (`Filter1`)
- `tabular-cut-and-reorder-columns` (`Cut1`)
- `tabular-compute-new-column` (`column_maker/Add_a_column1`) — includes the per-expression-kind `auto_col_types` table verbatim per §7
- `tabular-filter-by-regex` (`tp_grep_tool`)

Each was drafted from the survey, then re-verified against tool source (`$GALAXY/tools/...`) and IWC corpus invocations before commit.

Infrastructure landed alongside:
- `common_paths.yml` citation prefix system (`$GALAXY`, `$IWC_FORMAT2`, ...) so pattern/research pages cite by symbolic path, and a remark plugin (`remark-corpus-citations.ts`) rewrites them to GitHub links at render time.
- `/review-pattern` slash command — opens a pattern note, loads glossary + schema + tags + `common_paths.yml`, fetches each cited file, and reports drift. Caught two stale corpus counts inherited from the survey (`tp_grep_tool`: 43→19, `Grep1`: 47→26); both fixed in lockstep here.

Survey §1a/§1b/§3/§6/§7 updated to match the corrected counts and to keep §7 decisions consistent with what the leaf pages actually encode.

## Scope note

Branch also carries previously-merged work from PRs #6/#7/#8 (landing redesign, `summarize-nextflow` Mold, initial survey) because those PRs landed into `patterns` rather than `main`. The net diff vs `main` therefore includes them; the new work in this PR is the four pattern pages, the citation-prefix system, the review skill, and the survey lockstep fixes.

## Test plan

- [x] `npm run validate` clean after each page landed
- [ ] Reviewer spot-checks one pattern page's citations against the linked GitHub blobs to confirm the prefix rewriter resolves correctly
- [ ] Reviewer confirms the remaining 6 pages from issue #9 are fine as a follow-up PR

## Follow-ups

- Sweep remaining bare-path citations in the survey to `$IWC_FORMAT2/...` form so the next reviewer agent can verify them.
- Author the remaining 6 leaf pattern pages from the survey's §4 inventory.