### PR TITLE
IWC survey commands + PATTERNS.md policy (and collection-semantics vendoring)

### DIFF
--- a/.claude/commands/iwc-survey-act.md
+++ b/.claude/commands/iwc-survey-act.md
@@ -1,0 +1,118 @@
+---
+description: Walk an IWC survey's findings interactively, land anti-pattern calls inline, and open GitHub issues for new/refined pattern pages. Does not author the pages.
+argument-hint: "<path-to-survey-note>  e.g. content/research/iwc-collections-survey.md"
+---
+
+# Act on an IWC survey: `$1`
+
+Read survey `$1` and walk its findings with the user via `AskUserQuestion`. Land "don't endorse" calls **inline** in the anti-pattern note as you go. Open GitHub issues for new pattern pages to write and existing pages to refine. **Do not author or edit pattern pages here** — that's a separate task with fresh eyes.
+
+## Load context first (in order)
+
+1. **`content/glossary.md`** — pinned vocabulary.
+2. **`docs/PATTERNS.md`** — authorship policy. Operation-anchored naming is mandatory; corpus-first is mandatory; legacy-tool footnote convention is mandatory.
+3. **`docs/ARCHITECTURE.md`** §3 (note types).
+4. **`common_paths.yml.sample`** — citation prefix vocabulary for any new entries you write.
+5. **`content/research/iwc-shortcuts-anti-patterns.md`** — the live anti-pattern note. You will edit this inline. Read its full current state so additions match its shape and tone.
+6. **All existing pattern pages** under `content/patterns/` — title, scope, related links. Anything already covered by an existing page is *not* a "create new" candidate; at most a "refine existing" candidate.
+7. **The survey at `$1`** — full read.
+8. **The survey's `related_notes`** — for cross-cutting context.
+
+## Pre-flight: dedupe against prior knowledge
+
+Before asking the user anything, suppress questions covered by prior answers:
+
+- Any candidate pattern whose scope overlaps an existing `content/patterns/*.md` page → reclassify as "refine existing," not "create new."
+- Any idiom or tool already called out in `iwc-shortcuts-anti-patterns.md` → do not re-surface as a recommendation candidate; cite the existing entry instead.
+- Any naming-axis question (operation vs tool vs shape) → do not ask; `docs/PATTERNS.md` decides. Use operation-anchored names.
+- Any "should we write a speculative page for this gap" question → do not ask; corpus-first decides. Document the gap, no page.
+
+If the dedupe pass empties the candidate list, post a debrief saying so and stop.
+
+## Walk the findings
+
+Use `AskUserQuestion` for each decision point, **batched in groups of 3-5 questions per round** to keep the user in flow. Group by kind:
+
+### Round 1 — Open questions from the survey
+
+The survey ends at numbered open questions. Walk them. Each question's answer either:
+
+- Resolves a redundancy / posture / scope call → record the answer for issue-body context (no file edits yet).
+- Names something as an anti-pattern → **edit `iwc-shortcuts-anti-patterns.md` inline now**, before moving on. Add a short entry: tool/idiom name, the call ("don't endorse" / "legacy alternative only" / "deprecated"), the reason in one sentence, and a corpus citation from the survey. Match the existing note's shape.
+
+### Round 2 — Candidate pattern pages (new)
+
+For each surveyed candidate the user marked **keep**, ask:
+
+- Confirm operation-anchored name (propose one based on the survey; let the user rename).
+- Confirm scope sketch and the 2-3 anchor citations.
+- Anything to flag for the eventual author (prescriptive rules surfaced in the survey, foot-guns, recommended-default tuples).
+
+Collect into an issue draft per pattern. Do not open issues yet.
+
+### Round 3 — Existing pattern refinements
+
+For each existing pattern page the survey turned up new evidence for:
+
+- What changed (new idiom, new corpus citation, deprecated parameter, version-pin sprawl, …).
+- Whether the change is "add a section" or "rework the recommendation."
+
+Collect into a single refinements issue or one issue per page — your judgment based on coupling. Do not open issues yet.
+
+### Round 4 — Anti-pattern note review
+
+Show the user the diff of edits you made to `iwc-shortcuts-anti-patterns.md` during the walk. Confirm or revise. This is the only writeback you do during the interview.
+
+## Open the issues
+
+After the walk is complete and the anti-pattern diff is confirmed:
+
+1. **Per new pattern** — `gh issue create` with title `Pattern: <operation-anchored-name>`, body containing scope, anchor citations, prescriptive-rule notes, and a link to the survey section that motivated it.
+2. **Per refinement** — `gh issue create` with title `Refine pattern: <existing-name>`, body containing what to change, evidence, and survey section link.
+3. Use `gh` directly via Bash. Pass bodies via `--body-file` or HEREDOC. Label appropriately if labels exist (`gh label list` to check).
+
+Issue-body skeleton (adapt per topic; this is a starting shape, not a template to follow rigidly):
+
+```
+## Source
+Survey: <path>#<section-anchor>
+
+## Scope
+<one paragraph>
+
+## Anchor citations
+- `$IWC_FORMAT2/path:line`
+- ...
+
+## Prescriptive rules surfaced
+<bullets, or "none surfaced">
+
+## Notes for the author
+<anything the user flagged in the walk>
+```
+
+## Commit the anti-pattern note
+
+After issues are open:
+
+- `git add content/research/iwc-shortcuts-anti-patterns.md`
+- Commit with a message naming the survey and listing the additions in one line each.
+- Do **not** push; let the user review and push.
+
+## Debrief
+
+Post a final summary:
+
+- Anti-pattern entries landed inline (count + one-line each).
+- Issues opened (count + URLs).
+- Open questions from the survey that were resolved without a file change (briefly).
+- Anything you suppressed in the dedupe pass (count, with brief reasons).
+
+## What this command does **not** do
+
+- Author or edit pattern pages under `content/patterns/`.
+- Decide naming axis, corpus-first stance, or any policy already pinned in `docs/PATTERNS.md`.
+- Push commits.
+- Re-run the survey or update its citations.
+
+The split is deliberate: surveying, deciding, and authoring are three different tasks with three different optimal contexts.

--- a/.claude/commands/iwc-survey.md
+++ b/.claude/commands/iwc-survey.md
@@ -1,0 +1,98 @@
+---
+description: Run (or refresh) an IWC corpus survey for a topic — operation family, single tool, domain, or workflow-shape concern. Produces a research note; does not make pattern decisions.
+argument-hint: "<topic>  e.g. collections, conditionals, awk, apply_rules, genomic_conversion"
+---
+
+# IWC corpus survey: `$1`
+
+Produce or refresh `content/research/iwc-$1-survey.md`. The survey **proposes candidate patterns** (with keep / drop / merge calls and corpus evidence) and surfaces open questions — that's its main deliverable. What it does *not* do is **decide** which candidates graduate to pattern pages, edit policy docs, or land anti-pattern calls. Those decisions happen out of band via `/iwc-survey-act`, with fresh eyes on the proposals.
+
+## Load context first (in order)
+
+1. **`content/glossary.md`** — pinned vocabulary.
+2. **`CLAUDE.md`** — authoring rules.
+3. **`docs/PATTERNS.md`** — pattern-authorship policy. **Operation-anchored naming** is mandatory in candidate-pattern proposals; do not surface tool-anchored names. Corpus-first applies — no speculative candidates.
+4. **`docs/ARCHITECTURE.md`** §3 (note types), §5 (frontmatter), §6 (validation).
+5. **`meta_schema.yml`** + **`meta_tags.yml`**.
+6. **`common_paths.yml.sample`** — `$IWC_FORMAT2` is the cleaned `gxformat2` corpus root for grep work; `$IWC` is the upstream `.ga` source for permalinks. Write every citation as `` `$IWC_FORMAT2/path:line` `` so the renderer can resolve it.
+7. **`content/research/iwc-shortcuts-anti-patterns.md`** — already-pinned "don't endorse" calls. Do not re-surface anything covered here as a recommendation.
+8. **Existing surveys** under `content/research/iwc-*-survey.md` — for shape and tone, and to detect topic overlap.
+9. **If `content/research/iwc-$1-survey.md` already exists** — load it. You are in **refresh mode** (see §Refresh mode below).
+
+## Step 1 — Scope out loud, then pause
+
+Before any heavy mining, post a short scoping plan (~2 minutes of work):
+
+- What kind of topic this is (operation family / single tool / workflow concern / domain) and what that implies for the survey shape.
+- **Evidence techniques you'll use, and roughly how much of each.** Grep is one technique; whole-workflow reading is another; step-pair / step-sequence scanning is another. Different topics need different mixes:
+    - Single-tool topics (`awk`, `apply_rules`) lean grep-heavy plus structured-block extraction.
+    - Operation-family topics (`tabular`) need grep for inventory **plus** workflow-level reading on the highest-density files to find multi-tool recipes.
+    - Workflow-shape topics (`conditionals`, `collections`) lean **workflow-level reading** as the primary technique; grep is supporting.
+- **How much workflow reading.** Be explicit and let the user gate the cost: "the 5 highest-density workflows," "every workflow that calls `__APPLY_RULES__`," "all 120 — yes I know it's expensive." This number is the main token-cost lever; surface it.
+- The rough section skeleton you'll write (titles only — section *layout* is per-topic, not pre-specified; see §Required moves).
+- What you are deliberately **not** covering (out-of-scope adjacencies, deferred follow-ups).
+- Anything in `iwc-shortcuts-anti-patterns.md` or existing pattern pages that already constrains the surface.
+
+**Stop and wait for redirect.** Do not start mining until the user confirms or course-corrects. This is the highest-leverage step in the whole flow — getting the framing right here saves a 20-minute wrong direction.
+
+## Step 2 — Gather evidence
+
+Once scope is confirmed, work through the techniques you committed to:
+
+- **Grep / counts** for tool inventory and ranking.
+- **Structured-block extraction** for tools whose idioms live inside parameter blobs (`__APPLY_RULES__` rule sequences, `tp_awk_tool` `code:` programs, `column_maker` `expressions:` lists). Pull the blocks, not just counts.
+- **Whole-workflow reading** when the patterns of interest are step-pairs, step-sequences, or topology-shaped (one tool's output feeding another in a recurring shape). Grep cannot see these. For each workflow read, take notes on multi-step recipes — an `__APPLY_RULES__` followed by `__FILTER_EMPTY_DATASETS__` to clean up after restructuring is a *recipe*, not a single-tool idiom, and it deserves to be surfaced as such.
+- **Connection / shape inspection** when the topic touches map-over, reduction, or collection-type transitions — those are visible at the workflow connection level, not in any single step.
+
+## Step 3 — Write the survey
+
+Write `content/research/iwc-$1-survey.md` with frontmatter matching the existing surveys (`type: research`, `subtype: component`, `tags: [research/component, target/galaxy]`, `ai_generated: true`, `status: draft`, `created`/`revised` set, `summary` line).
+
+### Required moves (rubric, not section layout)
+
+The survey *must* support these moves; section titles and ordering are your call:
+
+1. **Inventory** — what exists in the corpus on this topic. Counts are **supporting evidence in tables**, not the lead. Do not write a "Tool inventory" section as the first thing the reader hits.
+2. **Redundancy / decision-points** — where the corpus shows multiple tools or shapes competing for the same job. This is where pattern boundaries get decided.
+3. **Recurring idioms** — split into two kinds, both with file:line citations:
+    - **Single-tool parameter idioms** — recurring parameter shapes within one tool (the `BEGIN{OFS="\t"}` awk ritual; the `add_name + one_header + place_name` `collapse_dataset` triad; `auto_col_types: true` for raw-`cN` arithmetic).
+    - **Multi-step recipes** — sequences or topologies that span tools or workflow connections (`datamash collapse → tp_find_and_replace` to emulate "argmax"; `__APPLY_RULES__ → __FILTER_EMPTY_DATASETS__` cleanup; `__HARMONIZELISTS__ → __ZIP_COLLECTION__` for paired-end alignment). These are often the highest-value patterns and are invisible to grep — they only surface from workflow-level reading. Treat them as first-class.
+4. **Candidate pattern boundaries** — operation-anchored names (per `docs/PATTERNS.md`). Each candidate carries: scope sketch, 2-3 corpus citations, and an explicit **keep / drop / merge** call with a reason. Drops and merges are equal in importance to keeps. **Candidates can be recipes**, not just single-tool patterns — a `multi-step:harmonize-then-zip-paired` pattern is as valid as a `tabular-filter-by-regex` pattern if the corpus shows the recipe recurring.
+5. **Open questions** — things only the user can decide: prescriptive rules, redundancy tie-breaks, scope calls, deferral choices. Numbered, with the evidence each question needs to be answered.
+
+### What the survey does **not** include
+
+- **No `## Decisions` section.** Decisions migrate to `/iwc-survey-act`. The survey ends at open questions.
+- **No speculative pattern proposals.** If the corpus shows zero uptake of a capability, document the gap inline and move on. Do not propose a candidate pattern for it.
+- **No tool-anchored candidate names.** `tp_grep_tool-page` is wrong; `tabular-filter-by-regex` is right.
+
+### Style rules
+
+- **Demote numbers.** Counts live inside operation/idiom sections as evidence, not as standalone inventories at the top.
+- **Cite or strike.** Every claim about idiom shape or distribution carries a `$IWC_FORMAT2/path:line` citation. Unverifiable claims get cut.
+- **No "Considerations" / "Trade-offs" prose.** Surface concrete idioms with citations, not abstract pros-and-cons.
+- **Operation-anchored everywhere.** Even when an idiom is implemented via one tool, the framing is "this *operation* is done via this tool," not "this tool does these things."
+
+## Refresh mode
+
+If the survey note already exists:
+
+- Re-run greps. Update inventory tables and citation file:line ranges (corpus drifts).
+- **Preserve everything below the open-questions section** — the act-command may have written into the anti-pattern note based on this survey's prior open Qs. Do not delete or rewrite §Open questions; *append* new questions surfaced this run.
+- New idioms or new candidate patterns surfaced by the refresh go in their respective sections, marked with the revision date.
+- Bump `revision:` and `revised:` in frontmatter.
+
+## On finishing
+
+1. `npm run validate` — schema + cross-file checks must pass.
+2. Post a one-paragraph debrief summarizing: scope decided, candidate count (keep / drop / merge), idiom count, open-question count, anything that surprised you.
+3. Suggest the user run `/iwc-survey-act content/research/iwc-$1-survey.md` next — but do not run it yourself. Fresh eyes on the act phase is the point.
+
+## What this command does **not** do
+
+- Decide which pattern pages to write or refine.
+- Edit `iwc-shortcuts-anti-patterns.md`.
+- Open GitHub issues.
+- Write or edit pattern pages.
+
+All of those belong to `/iwc-survey-act`. Surveying and acting are deliberately separated so the same agent isn't both the proposer and the decider.

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -1,0 +1,34 @@
+# Pattern authorship policy
+
+Project-level conventions for `content/patterns/` notes. Read by the IWC survey commands and by anyone hand-authoring a pattern page. Pattern-specific prescriptive rules (e.g. when to set `auto_col_types: true`) belong on the pattern page itself, not here.
+
+## Naming: operation-anchored
+
+Leaf pattern pages are named after the **operation** they describe, not the tool that implements it. Tool-anchored content is fine *inside* an operation-named page.
+
+- ✅ `tabular-filter-by-regex.md` — operation; lists `tp_grep_tool` as the recommended tool, `Grep1` as a legacy footnote.
+- ✅ `tabular-prepend-header.md` — operation; recipe is awk, but awk isn't in the title.
+- ❌ `tp_grep_tool.md` — tool name in title.
+- ❌ `awk-in-galaxy.md` — tool name in title; split into operation-named sub-pages instead.
+
+Decided 2026-04-30 in the tabular survey (`content/research/iwc-tabular-operations-survey.md` §7). Applies to every pattern hierarchy going forward.
+
+## Corpus-first
+
+No exemplar in IWC, no pattern page. If the survey turns up an interesting capability with zero corpus uptake, document the gap as a one-line note in the survey — do not write a speculative pattern page.
+
+This is what stops the foundry from accreting tool documentation that nobody actually reaches for in the wild.
+
+## Legacy tools as footnotes
+
+When the corpus shows a modern tool *and* a legacy alternative for the same operation (e.g. `datamash_ops` modern vs `Grouping1` legacy), the pattern page leads with the modern tool and footnotes the legacy with a "Legacy alternative" pointer. Reading old IWC workflows must stay possible; recommending old tools to new authors must not.
+
+## Three places where authorship rules live
+
+| Layer | What lives there | Example |
+|---|---|---|
+| `docs/PATTERNS.md` (this file) | Project-level authorship policy | "Operation-anchored naming" |
+| `content/research/iwc-shortcuts-anti-patterns.md` | Corpus-grounded "don't do this" calls | "Don't reach for `Grep1` when `tp_grep_tool` is available" |
+| The pattern page itself | Prescriptive per-pattern rules | `auto_col_types` per-expression-kind table on `tabular-compute-new-column` |
+
+The IWC survey commands read all three before asking the user a question, so already-decided calls don't get re-litigated.


### PR DESCRIPTION
## Summary

Two threads on this branch:

### 1. IWC survey tooling (this session)

- **`.claude/commands/iwc-survey.md`** — runs (or refreshes) a corpus survey for a topic. Produces a research note with candidate pattern boundaries (keep/drop/merge calls), idioms, and open questions. Bakes in: scope-out-loud-then-pause as Step 1; rubric of required moves over fixed section layout; demote-numbers; operation-anchored candidate names; multi-step recipes as first-class candidates alongside single-tool idioms; refresh mode that preserves prior open questions.
- **`.claude/commands/iwc-survey-act.md`** — interview command. Reads survey + `PATTERNS.md` + `iwc-shortcuts-anti-patterns.md` + existing pattern pages, dedupes against prior decisions, walks findings via `AskUserQuestion` in batched rounds, **lands anti-pattern calls inline** in `iwc-shortcuts-anti-patterns.md`, opens GH issues for new/refine pattern pages, commits the anti-pattern diff (no push). Does not author pattern pages.
- **`docs/PATTERNS.md`** — pattern-authorship policy. Operation-anchored naming, corpus-first stance, legacy-tool footnote convention, and the three-layers table (this doc / anti-pattern note / pattern page) so future authorship rules have a known home.

The split is **propose vs decide**: surveys propose with evidence; the act-command decides with fresh eyes; pattern pages get authored as a third out-of-band task. Designed to prevent re-litigation of decisions and keep token-cost gated by an explicit scope step.

Skeleton corpus tier (workflow files stripped to tool-ids + connections, for cheap multi-step recipe mining) filed as **#20** — deferred from this PR.

### 2. Collection-semantics vendoring (prior commit on branch)

- **`006976c`** vendors the upstream Galaxy `collection_semantics.md` MyST source pinned at SHA `0683385` and renders it via a new `remark-vendored-myst` Astro plugin. Site-only changes plus a structured-source companion (`galaxy-collection-semantics.yml`) the casting pipeline can consume.

Independent thread; happy to split into two PRs if preferred.

## Test plan
- [x] `npm run validate` clean (no new content notes; only commands + policy doc).
- [ ] First real run of `/iwc-survey collections` exercises the new flow end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)