### PR TITLE
Add workflow-fixtures/ + IWC skeleton corpus tier (#20)

### DIFF
--- a/.claude/commands/iwc-survey.md
+++ b/.claude/commands/iwc-survey.md
@@ -14,7 +14,7 @@ Produce or refresh `content/research/iwc-$1-survey.md`. The survey **proposes ca
 3. **`docs/PATTERNS.md`** — pattern-authorship policy. **Operation-anchored naming** is mandatory in candidate-pattern proposals; do not surface tool-anchored names. Corpus-first applies — no speculative candidates.
 4. **`docs/ARCHITECTURE.md`** §3 (note types), §5 (frontmatter), §6 (validation).
 5. **`meta_schema.yml`** + **`meta_tags.yml`**.
-6. **`common_paths.yml.sample`** — `$IWC_FORMAT2` is the cleaned `gxformat2` corpus root for grep work; `$IWC` is the upstream `.ga` source for permalinks. Write every citation as `` `$IWC_FORMAT2/path:line` `` so the renderer can resolve it.
+6. **`common_paths.yml.sample`** — `$IWC_FORMAT2` is the cleaned `gxformat2` corpus root for grep work and full-workflow reads; `$IWC_SKELETONS` mirrors that tree with non-structural fields stripped (tool_ids + topology + control flow only) — cheap structural scans for step-pair / step-sequence patterns; `$IWC` is the upstream `.ga` source for permalinks. Write citations as `` `$IWC_FORMAT2/path:line` `` (or `` `$IWC_SKELETONS/path:line` `` when the structural view is what's evidenced).
 7. **`content/research/iwc-shortcuts-anti-patterns.md`** — already-pinned "don't endorse" calls. Do not re-surface anything covered here as a recommendation.
 8. **Existing surveys** under `content/research/iwc-*-survey.md` — for shape and tone, and to detect topic overlap.
 9. **If `content/research/iwc-$1-survey.md` already exists** — load it. You are in **refresh mode** (see §Refresh mode below).
@@ -24,11 +24,11 @@ Produce or refresh `content/research/iwc-$1-survey.md`. The survey **proposes ca
 Before any heavy mining, post a short scoping plan (~2 minutes of work):
 
 - What kind of topic this is (operation family / single tool / workflow concern / domain) and what that implies for the survey shape.
-- **Evidence techniques you'll use, and roughly how much of each.** Grep is one technique; whole-workflow reading is another; step-pair / step-sequence scanning is another. Different topics need different mixes:
-    - Single-tool topics (`awk`, `apply_rules`) lean grep-heavy plus structured-block extraction.
-    - Operation-family topics (`tabular`) need grep for inventory **plus** workflow-level reading on the highest-density files to find multi-tool recipes.
-    - Workflow-shape topics (`conditionals`, `collections`) lean **workflow-level reading** as the primary technique; grep is supporting.
-- **How much workflow reading.** Be explicit and let the user gate the cost: "the 5 highest-density workflows," "every workflow that calls `__APPLY_RULES__`," "all 120 — yes I know it's expensive." This number is the main token-cost lever; surface it.
+- **Evidence techniques you'll use, and roughly how much of each.** Three tiers: grep over `$IWC_FORMAT2` (cheap, blind to topology); skeleton scan over `$IWC_SKELETONS` (cheap, sees step-pair / step-sequence shape — all 120 fit in context); whole-workflow reads of `$IWC_FORMAT2` (expensive, parameter-level evidence). Different topics need different mixes:
+    - Single-tool topics (`awk`, `apply_rules`) lean grep-heavy plus structured-block extraction; full reads on a few high-density files.
+    - Operation-family topics (`tabular`) need grep for inventory **plus** skeleton scans for multi-tool recipes, with selective full reads to confirm parameter shapes.
+    - Workflow-shape topics (`conditionals`, `collections`, harness routing) default to **skeleton scan first** to catalog topologies and recipes; full reads only on the few workflows that need parameter-level confirmation.
+- **How much workflow reading.** Distinguish skeleton reads (cheap — feel free to scan dozens) from full `$IWC_FORMAT2` reads (expensive — gate explicitly: "the 5 highest-density," "every workflow that calls `__APPLY_RULES__`," "all 120 — yes I know it's expensive"). Full-read count is the main token-cost lever; surface it.
 - The rough section skeleton you'll write (titles only — section *layout* is per-topic, not pre-specified; see §Required moves).
 - What you are deliberately **not** covering (out-of-scope adjacencies, deferred follow-ups).
 - Anything in `iwc-shortcuts-anti-patterns.md` or existing pattern pages that already constrains the surface.
@@ -39,10 +39,11 @@ Before any heavy mining, post a short scoping plan (~2 minutes of work):
 
 Once scope is confirmed, work through the techniques you committed to:
 
-- **Grep / counts** for tool inventory and ranking.
-- **Structured-block extraction** for tools whose idioms live inside parameter blobs (`__APPLY_RULES__` rule sequences, `tp_awk_tool` `code:` programs, `column_maker` `expressions:` lists). Pull the blocks, not just counts.
-- **Whole-workflow reading** when the patterns of interest are step-pairs, step-sequences, or topology-shaped (one tool's output feeding another in a recurring shape). Grep cannot see these. For each workflow read, take notes on multi-step recipes — an `__APPLY_RULES__` followed by `__FILTER_EMPTY_DATASETS__` to clean up after restructuring is a *recipe*, not a single-tool idiom, and it deserves to be surfaced as such.
-- **Connection / shape inspection** when the topic touches map-over, reduction, or collection-type transitions — those are visible at the workflow connection level, not in any single step.
+- **Grep / counts** over `$IWC_FORMAT2` for tool inventory and ranking.
+- **Skeleton scan** over `$IWC_SKELETONS` to surface step-pair / step-sequence patterns and topology-shaped recipes — one tool's output feeding another in a recurring shape. Cheap enough to read dozens or all 120; the structural-only view is the right tier for "which workflows have a `__FILTER_EMPTY_DATASETS__` whose input is an `__APPLY_RULES__` output?" An `__APPLY_RULES__` followed by `__FILTER_EMPTY_DATASETS__` cleanup is a *recipe*, not a single-tool idiom, and it deserves to surface as such.
+- **Structured-block extraction** from `$IWC_FORMAT2` for tools whose idioms live inside parameter blobs (`__APPLY_RULES__` rule sequences, `tp_awk_tool` `code:` programs, `column_maker` `expressions:` lists). Skeletons strip these; pull from full files.
+- **Whole-workflow reading** of `$IWC_FORMAT2` files reserved for parameter-level confirmation on the recipes the skeleton scan flagged as promising.
+- **Connection / shape inspection** for map-over, reduction, or collection-type transitions — visible at the workflow connection level, scannable from skeletons.
 
 ## Step 3 — Write the survey
 

--- a/common_paths.yml.sample
+++ b/common_paths.yml.sample
@@ -31,13 +31,10 @@ iwc:
   repo: galaxyproject/iwc
   ref: main
 
-iwc_format2:
-  # Local-only authoring aid: cleaned format2 conversions of IWC workflows.
-  # Citations resolve on disk for the validator and authoring agents but
-  # render as plain code on the site (no `repo` set — workflow-fixtures
-  # has no upstream remote). Prefer re-anchoring to `$IWC` when the
-  # upstream `.ga` file is the right pointer.
-  path: ~/projects/repositories/workflow-fixtures/iwc-format2
+# $IWC_FORMAT2 and $IWC_SKELETONS resolve automatically to
+# <foundry-checkout>/workflow-fixtures/{iwc-format2,iwc-skeletons} — built in
+# to scripts/lib/common-paths.ts, no user config needed. Override here if
+# you keep the corpus elsewhere.
 
 galaxy:
   path: ~/projects/repositories/galaxy

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,7 +7,7 @@ These are sketches, not specs. Layouts and component edges will move as we walk 
 ## 1. Component map
 
 External:
-- **IWC corpus** — the canonical Galaxy workflow corpus at `https://github.com/galaxyproject/iwc`. Pattern pages cite IWC workflows by URL (optionally pinned to commit SHA per citation). Not mirrored into the Foundry; not a build-time dependency. `workflow-fixtures/` is an authoring aid in the user's lap, not a Foundry input. See `CORPUS_INGESTION.md`.
+- **IWC corpus** — the canonical Galaxy workflow corpus at `https://github.com/galaxyproject/iwc`. Pattern pages cite IWC workflows by URL (optionally pinned to commit SHA per citation). Not mirrored into the Foundry; not a build-time dependency. `workflow-fixtures/` lives as a top-level directory inside the Foundry checkout — a generated-corpus workspace for authoring/survey evidence, outside `content/`, with gitignored outputs (`pipelines/`, `iwc-src/`, `iwc-cleaned/`, `iwc-format2/`, `iwc-skeletons/`). Not part of the content model; not a runtime/cast dependency. See `CORPUS_INGESTION.md`.
 - **gxwf** — design-time CLI; called by Molds (and by validation tooling) for schema validation, tool search/discovery, conversion. TS and Python implementations with a shared interface. Lives in its own repo(s).
 - **Planemo** — runtime CLI; executes Galaxy and CWL workflows. Used by `run-workflow-test` and `debug-*-workflow-output` Molds at cast skill runtime, not by the Foundry directly.
 

--- a/docs/CORPUS_INGESTION.md
+++ b/docs/CORPUS_INGESTION.md
@@ -10,6 +10,30 @@ Problem: the unique value per exemplar page is the hand-curated `## Patterns dem
 
 `workflow-fixtures` was R&D scratch for pattern-research. Treating it as Foundry-runtime input recreates the "we mirror IWC" problem in lighter clothing. Agents have `gxwf` and can clean / inspect IWC directly. Foundry contributors can use `workflow-fixtures` locally as an authoring aid without the Foundry depending on it.
 
+`workflow-fixtures/` now lives as a top-level directory inside the Foundry checkout (Foundry support infrastructure, not a separate product). Generated corpora — `pipelines/`, `iwc-src/`, `iwc-cleaned/`, `iwc-format2/`, `iwc-skeletons/` — are gitignored. The validator and site-content traversal stay scoped to `content/`; `workflow-fixtures/` is invisible to them. The directory is cited by `$IWC_FORMAT2/...` and `$IWC_SKELETONS/...` from authoring/survey notes; nothing in `casts/` or `content/` reads from it at build time.
+
+## Skeleton tier
+
+Survey-time evidence has three tiers:
+
+1. **Grep** over `$IWC_FORMAT2/**/*.gxwf.yml` — cheap, blind to step-pair / step-sequence patterns.
+2. **Skeleton scan** over `$IWC_SKELETONS/**/*.gxwf.yml` — cheap structural read; sees topology, control flow, and tool sequences. All 120 skeletons fit in agent context (median ~6KB, total ~1MB).
+3. **Whole-workflow reading** of selective `$IWC_FORMAT2` files — expensive; reserved for parameter-level evidence on the recipes that look promising from tier 1 or 2.
+
+A skeleton is the format2 workflow with non-structural fields stripped, leaving:
+
+- `tool_id`, `label`, `doc` per step
+- `in:` (with `source:`) / `out:` (ids only) / `step_inputs` topology
+- `when:` expressions and other control flow
+- `run:` subworkflow descents (recursive)
+- workflow-level `inputs:` / `outputs:` / `tags` / `release` / `license`
+
+Dropped: `tool_state` parameter blobs, step `position:` UI metadata, step-level `comments:` / `uuid` / `tool_shed_repository` / `tool_version` (redundant with `tool_id`), output post-processing fields (`add_tags`, `change_datatype`, `hide`, `rename`, …), and top-level `comments:` (Galaxy sticky-notes, not topology).
+
+Regen: `cd workflow-fixtures && make skeletons` (or `tsx workflow-fixtures/scripts/build-skeletons.ts`). Idempotent — rebuilds `iwc-skeletons/` from the current `iwc-format2/`. Re-run after `make iwc` bumps the IWC pin.
+
+The pattern is **skeletons + selective full reads**, not skeletons replacing full reads. `/iwc-survey` defaults to "skeleton scan first, then drill into `$IWC_FORMAT2`" for workflow-shape topics; tool-level topics still lean grep + structured-block extraction.
+
 ## What the Foundry does instead
 
 1. **Patterns cite IWC by URL, in the page body.** A pattern's `## Exemplars` section lists IWC workflows that demonstrate it, each as a free-form Markdown link (`[bacterial-genomics/...](https://github.com/galaxyproject/iwc/blob/<sha>/workflows/...)`) with one-liner author commentary. Pin to a specific commit SHA when stability matters; pin to `main` when freshness matters. Author choice per citation; no enforced policy.

--- a/scripts/lib/common-paths.ts
+++ b/scripts/lib/common-paths.ts
@@ -46,16 +46,27 @@ function normalizeKeys(raw: Record<string, CommonPathEntry>): CommonPaths {
   return out;
 }
 
+// Built-in entries for corpora that live inside the Foundry checkout —
+// resolved without user configuration so $IWC_FORMAT2 / $IWC_SKELETONS
+// citations work out of the box. User entries with the same key override.
+function builtinPaths(repoRoot: string): CommonPaths {
+  return {
+    iwc_format2: { path: path.join(repoRoot, "workflow-fixtures", "iwc-format2") },
+    iwc_skeletons: { path: path.join(repoRoot, "workflow-fixtures", "iwc-skeletons") },
+  };
+}
+
 export function loadCommonPaths(repoRoot: string): CommonPaths {
+  const builtins = builtinPaths(repoRoot);
   const local = path.join(repoRoot, "common_paths.yml");
   const sample = path.join(repoRoot, "common_paths.yml.sample");
   const file = fs.existsSync(local) ? local : fs.existsSync(sample) ? sample : null;
-  if (!file) return {};
+  if (!file) return builtins;
   try {
     const raw = yaml.load(fs.readFileSync(file, "utf-8")) as Record<string, CommonPathEntry> | null;
-    return raw ? normalizeKeys(raw) : {};
+    return raw ? { ...builtins, ...normalizeKeys(raw) } : builtins;
   } catch {
-    return {};
+    return builtins;
   }
 }
 

--- a/workflow-fixtures/.gitignore
+++ b/workflow-fixtures/.gitignore
@@ -1,0 +1,10 @@
+# Cloned pipeline working trees — materialized by scripts/fetch.sh from fixtures.yaml.
+pipelines/
+
+# IWC working tree + intermediate + final format2 outputs (built by scripts/build-iwc.sh)
+iwc-src/
+iwc-cleaned/
+iwc-format2/
+
+# Skeleton corpus — derived from iwc-format2/ by scripts/build-skeletons.ts.
+iwc-skeletons/

--- a/workflow-fixtures/Makefile
+++ b/workflow-fixtures/Makefile
@@ -1,0 +1,19 @@
+.PHONY: all nextflow iwc skeletons verify clean
+
+all: nextflow iwc skeletons
+
+nextflow:
+	scripts/fetch.sh
+
+iwc:
+	scripts/build-iwc.sh
+
+skeletons:
+	cd .. && npx tsx workflow-fixtures/scripts/build-skeletons.ts
+
+verify:
+	VERIFY=1 scripts/fetch.sh
+	VERIFY=1 scripts/build-iwc.sh
+
+clean:
+	rm -rf pipelines iwc-src iwc-cleaned iwc-format2 iwc-skeletons

--- a/workflow-fixtures/README.md
+++ b/workflow-fixtures/README.md
@@ -1,0 +1,71 @@
+# workflow-fixtures
+
+Local generated-corpus workspace for the Foundry. Materializes:
+
+- IWC `gxformat2` workflows (via `gxwf clean-tree` + `convert-tree`) under `iwc-format2/`.
+- IWC skeletons (structural-only views) under `iwc-skeletons/`.
+- Pinned Nextflow pipeline working trees under `pipelines/` (legacy; for `review-nextflow` research).
+
+Outputs are gitignored — re-materialize from the pinned SHAs in `fixtures.yaml`. Not part of the Foundry content model; not a runtime/cast dependency. Cited from Foundry notes via `$IWC_FORMAT2/...` and `$IWC_SKELETONS/...` (see `../common_paths.yml.sample`).
+
+## Usage
+
+```sh
+make all          # nextflow pipelines + IWC format2 + skeletons
+make nextflow     # nextflow only
+make iwc          # IWC only (clone, clean, convert to format2)
+make skeletons    # iwc-format2/ -> iwc-skeletons/ (strip non-structural fields)
+make verify       # fetch + assert pinned SHAs
+make clean        # rm pipelines/ iwc-src/ iwc-cleaned/ iwc-format2/ iwc-skeletons/
+```
+
+Or call the scripts directly:
+
+```sh
+scripts/fetch.sh                 # fetch/update all nextflow pipelines
+scripts/fetch.sh nf-core/demo    # single pipeline
+VERIFY=1 scripts/fetch.sh        # assert HEAD matches pinned SHA
+scripts/build-iwc.sh             # IWC corpus -> iwc-format2/
+tsx scripts/build-skeletons.ts   # iwc-format2/ -> iwc-skeletons/
+```
+
+Working trees:
+- `pipelines/<org>__<name>/` — nextflow clones at pinned SHA (detached HEAD).
+- `iwc-src/` — IWC clone at pinned SHA.
+- `iwc-cleaned/` — `gxwf clean-tree` output (intermediate `.ga`).
+- `iwc-format2/` — final `.gxwf.yml` corpus, mirrors IWC `workflows/` tree.
+- `iwc-skeletons/` — structural-only views of `iwc-format2/`, mirrors that tree.
+
+The IWC pipeline shells out to `gxwf` via `npx -p @galaxy-tool-util/cli` (no global install needed; cached after first run).
+
+## Skeletons
+
+A skeleton is an `iwc-format2/.../foo.gxwf.yml` workflow with non-structural fields stripped, leaving roughly:
+
+- `tool_id`, `label`, `annotation` per step
+- `in:` / `out:` / `step_inputs` (the topology)
+- `when:` expressions and other control flow
+- workflow-level `inputs:` / `outputs:`
+
+Dropped: `tool_state` parameter blobs, `position:` UI metadata, step-level `comments:`, `uuid` and other non-structural IDs.
+
+Each skeleton is ~5–20KB instead of ~100KB–1MB; all 120 fit in agent context. Used by `/iwc-survey` as a cheap first-pass scan for step-pair / step-sequence patterns before drilling into `$IWC_FORMAT2`. See `../docs/CORPUS_INGESTION.md`.
+
+## Adding a Nextflow fixture
+
+1. Append an entry to `fixtures.yaml` with `name`, `tier`, `repo`, `tag`, `sha`, `notes`.
+2. Resolve the SHA for the tag:
+
+   ```sh
+   gh api repos/<org>/<name>/git/ref/tags/<tag> --jq '.object.sha'
+   # if object.type is "tag" (annotated), dereference:
+   gh api repos/<org>/<name>/git/tags/<sha> --jq '.object.sha'
+   ```
+
+3. Run `scripts/fetch.sh <org>/<name>` to verify.
+
+## Tiers (Nextflow)
+
+- `tiny` — minimal, bootstrap / smoke tests
+- `small` — mostly linear, clean patterns
+- `large` — many profiles, complex config; edge-case stress

--- a/workflow-fixtures/fixtures.yaml
+++ b/workflow-fixtures/fixtures.yaml
@@ -1,0 +1,85 @@
+# Nextflow fixture corpus for review-nextflow / gxwf skill research.
+#
+# Each entry pins a pipeline at a specific commit SHA so research results
+# are reproducible. Update `tag` + `sha` together when bumping.
+#
+# Tiers:
+#   tiny    - minimal, fast to fully review; bootstrap / smoke tests
+#   small   - mostly linear, few branches; clean params/containers/test patterns
+#   large   - many profiles, complex modules.config; stresses edge cases
+
+pipelines:
+  - name: nf-core/demo
+    tier: tiny
+    repo: https://github.com/nf-core/demo.git
+    tag: 1.1.0
+    sha: 45904cb9d12db3d89900e6c479fe604ef71b297b
+    notes: >
+      Minimal nf-core template pipeline (FastQC + MultiQC). Good for
+      bootstrapping the review skill and regression-testing output format.
+
+  - name: nf-core/fetchngs
+    tier: small
+    repo: https://github.com/nf-core/fetchngs.git
+    tag: 1.12.0
+    sha: 8ec2d934f9301c818d961b1e4fdf7fc79610bdc5
+    notes: >
+      SRA/ENA/GEO/DDBJ metadata + FASTQ fetcher. Small, mostly linear,
+      exercises remote data handling and param surface.
+
+  - name: nf-core/rnaseq
+    tier: large
+    repo: https://github.com/nf-core/rnaseq.git
+    tag: 3.24.0
+    sha: 47b3b0d3daad69e99d45c9e2dd8db19ee28307a1
+    notes: >
+      Flagship RNA-seq pipeline. Multiple aligners/quantifiers, heavy
+      modules.config, many profiles. Hard mode for the review skill.
+
+  - name: nf-core/bacass
+    tier: small
+    repo: https://github.com/nf-core/bacass.git
+    tag: 2.5.0
+    sha: 76e4b12cacdc242891ea57e723c5e273f4ac71b4
+    notes: >
+      Bacterial assembly + annotation. Modest size, clean process
+      structure, good mid-tier example between demo and rnaseq.
+
+  - name: nf-core/hlatyping
+    tier: small
+    repo: https://github.com/nf-core/hlatyping.git
+    tag: 2.2.0
+    sha: 3237d20e7e611d8bbf8c37e637202dfe8a23e996
+    notes: >
+      HLA typing (OptiType). Small, focused, single-purpose — useful
+      for exercising param surface + container mapping without branching.
+
+  - name: nf-core/sarek
+    tier: large
+    repo: https://github.com/nf-core/sarek.git
+    tag: 3.8.1
+    sha: 4bd2948f98c5bf7b785c91cf6708fffccab25467
+    notes: >
+      Variant calling (germline/somatic). Many toggleable callers +
+      aligners, heavy config, distinct flavor from rnaseq hard-mode.
+
+  - name: nf-core/taxprofiler
+    tier: large
+    repo: https://github.com/nf-core/taxprofiler.git
+    tag: 2.0.0
+    sha: fa1aab03875c090c0594af7c2bbe22ada6c12391
+    notes: >
+      Metagenomic taxonomic profiling across many profilers. Heavy
+      branching, different domain from rnaseq/sarek — stresses the
+      incompatibility report on parallel-tool patterns.
+
+# IWC corpus — single rolling repo, no tag. Pin SHA from main.
+# Materialized into iwc-src/ then cleaned + converted to format2 under iwc-format2/
+# by scripts/build-iwc.sh (uses gxwf via @galaxy-tool-util/cli).
+iwc:
+  repo: https://github.com/galaxyproject/iwc.git
+  ref: main
+  sha: deafc4876f2c778aaf075e48bd8e95f3604ccc92
+  notes: >
+    galaxyproject/iwc — Intergalactic Workflow Commission curated Galaxy
+    workflows (.ga). Cleaned + converted to format2 for fixture use.

--- a/workflow-fixtures/scripts/build-iwc.sh
+++ b/workflow-fixtures/scripts/build-iwc.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Materialize the IWC corpus and emit cleaned format2 workflows.
+#
+# Steps:
+#   1. Clone/update iwc-src/ at the SHA pinned in fixtures.yaml (iwc: section).
+#   2. gxwf clean-tree  iwc-src/workflows -> iwc-cleaned/
+#   3. gxwf convert-tree iwc-cleaned --to format2 -> iwc-format2/
+#
+# Usage:
+#   scripts/build-iwc.sh
+#   VERIFY=1 scripts/build-iwc.sh   # assert HEAD matches pinned SHA
+#
+# Deps: git, npx (node), python3 (or yq).
+
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+manifest="$root/fixtures.yaml"
+src="$root/iwc-src"
+cleaned="$root/iwc-cleaned"
+out="$root/iwc-format2"
+
+read_iwc() {
+  if command -v yq >/dev/null 2>&1; then
+    yq -r ".iwc.$1" "$manifest"
+  else
+    python3 -c "import sys,yaml; print(yaml.safe_load(open('$manifest'))['iwc']['$1'])"
+  fi
+}
+
+repo="$(read_iwc repo)"
+sha="$(read_iwc sha)"
+
+if [ ! -d "$src/.git" ]; then
+  echo ">> cloning $repo into $src"
+  git clone --quiet "$repo" "$src"
+fi
+echo ">> fetching + checking out $sha"
+git -C "$src" fetch --quiet origin
+git -C "$src" -c advice.detachedHead=false checkout --quiet "$sha"
+if [ "${VERIFY:-0}" = "1" ]; then
+  head=$(git -C "$src" rev-parse HEAD)
+  [ "$head" = "$sha" ] || { echo "!! HEAD $head != pinned $sha" >&2; exit 1; }
+fi
+
+# gxwf via npx (cached after first run). Pin to a major.
+GXWF=(npx --yes -p '@galaxy-tool-util/cli' gxwf)
+
+echo ">> cleaning workflows -> $cleaned"
+rm -rf "$cleaned"
+# clean-tree exits non-zero when any file was changed; that's expected, not an error.
+"${GXWF[@]}" clean-tree "$src/workflows" --output-dir "$cleaned" || true
+in_count=$(find "$src/workflows" -name '*.ga' | wc -l | tr -d ' ')
+clean_count=$(find "$cleaned" -name '*.ga' | wc -l | tr -d ' ')
+[ "$in_count" = "$clean_count" ] || { echo "!! clean-tree wrote $clean_count of $in_count" >&2; exit 1; }
+
+echo ">> converting to format2 -> $out"
+rm -rf "$out"
+"${GXWF[@]}" convert-tree "$cleaned" --to format2 --output-dir "$out"
+
+count=$(find "$out" -name '*.gxwf.yml' | wc -l | tr -d ' ')
+echo "done. $count format2 workflows in $out"

--- a/workflow-fixtures/scripts/build-skeletons.ts
+++ b/workflow-fixtures/scripts/build-skeletons.ts
@@ -1,0 +1,171 @@
+#!/usr/bin/env tsx
+// Build IWC workflow skeletons — structural-only views of iwc-format2/.
+//
+// Strips parameter blobs, UI metadata, and non-structural IDs, leaving
+// tool_id, labels/annotations, the step graph (in/out/source), control flow
+// (when:), workflow-level inputs/outputs, and subworkflow descents. Each
+// skeleton is ~5-20KB instead of ~100KB-1MB.
+//
+// Usage:
+//   tsx scripts/build-skeletons.ts                         # full corpus
+//   tsx scripts/build-skeletons.ts --in DIR --out DIR      # explicit roots
+//   tsx scripts/build-skeletons.ts --check                 # exit nonzero if outputs would change
+
+import { mkdirSync, readFileSync, readdirSync, statSync, writeFileSync, existsSync, rmSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import yaml from "js-yaml";
+
+interface Args {
+  inDir: string;
+  outDir: string;
+  check: boolean;
+}
+
+const TOP_KEEP = new Set(["class", "label", "doc", "tags", "release", "license", "inputs", "outputs", "steps"]);
+const STEP_KEEP = new Set(["id", "label", "doc", "tool_id", "when", "in", "out", "run"]);
+const INPUT_KEEP = new Set(["id", "type", "optional", "default", "format", "collection_type", "doc"]);
+const OUTPUT_KEEP = new Set(["id", "outputSource"]);
+
+type Yaml = unknown;
+type Dict = Record<string, Yaml>;
+
+function isDict(v: Yaml): v is Dict {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function pick(obj: Dict, allowed: Set<string>): Dict {
+  const out: Dict = {};
+  for (const k of Object.keys(obj)) {
+    if (allowed.has(k)) out[k] = obj[k];
+  }
+  return out;
+}
+
+function reduceWorkflow(wf: Dict): Dict {
+  const out: Dict = {};
+  for (const k of Object.keys(wf)) {
+    if (!TOP_KEEP.has(k)) continue;
+    const v = wf[k];
+    if (k === "inputs" && Array.isArray(v)) {
+      out.inputs = v.map((i) => (isDict(i) ? pick(i, INPUT_KEEP) : i));
+    } else if (k === "outputs" && Array.isArray(v)) {
+      out.outputs = v.map((o) => (isDict(o) ? pick(o, OUTPUT_KEEP) : o));
+    } else if (k === "steps" && Array.isArray(v)) {
+      out.steps = v.map((s) => (isDict(s) ? reduceStep(s) : s));
+    } else {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
+function reduceStep(step: Dict): Dict {
+  const out: Dict = {};
+  for (const k of Object.keys(step)) {
+    if (!STEP_KEEP.has(k)) continue;
+    const v = step[k];
+    if (k === "out" && Array.isArray(v)) {
+      // Keep only ids — rename/hide/add_tags/etc. are post-processing, not topology.
+      out.out = v.map((o) => (isDict(o) && typeof o.id === "string" ? { id: o.id } : o));
+    } else if (k === "run" && isDict(v)) {
+      // Embedded subworkflow — descend recursively.
+      out.run = reduceWorkflow(v);
+    } else {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
+function* walkYml(root: string): Generator<string> {
+  if (!existsSync(root)) return;
+  for (const ent of readdirSync(root, { withFileTypes: true })) {
+    const p = path.join(root, ent.name);
+    if (ent.isDirectory()) {
+      yield* walkYml(p);
+    } else if (ent.isFile() && ent.name.endsWith(".gxwf.yml")) {
+      yield p;
+    }
+  }
+}
+
+function parseArgs(argv: string[]): Args {
+  const here = path.dirname(new URL(import.meta.url).pathname);
+  const root = path.dirname(here);
+  const args: Args = {
+    inDir: path.join(root, "iwc-format2"),
+    outDir: path.join(root, "iwc-skeletons"),
+    check: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--in") args.inDir = argv[++i]!;
+    else if (a === "--out") args.outDir = argv[++i]!;
+    else if (a === "--check") args.check = true;
+  }
+  return args;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!existsSync(args.inDir)) {
+    process.stderr.write(`input dir not found: ${args.inDir}\n`);
+    process.stderr.write(`run scripts/build-iwc.sh first to materialize iwc-format2/.\n`);
+    process.exit(1);
+  }
+
+  const files: string[] = [];
+  for (const f of walkYml(args.inDir)) files.push(f);
+  files.sort();
+
+  let drift = 0;
+  let written = 0;
+  let bytesIn = 0;
+  let bytesOut = 0;
+
+  if (!args.check && existsSync(args.outDir)) rmSync(args.outDir, { recursive: true, force: true });
+
+  for (const inPath of files) {
+    const rel = path.relative(args.inDir, inPath);
+    const outPath = path.join(args.outDir, rel);
+    const raw = readFileSync(inPath, "utf8");
+    bytesIn += statSync(inPath).size;
+    let doc: Yaml;
+    try {
+      doc = yaml.load(raw);
+    } catch (e) {
+      process.stderr.write(`!! parse error: ${rel}: ${(e as Error).message}\n`);
+      continue;
+    }
+    if (!isDict(doc)) continue;
+    const reduced = reduceWorkflow(doc);
+    const dumped = yaml.dump(reduced, { lineWidth: -1, noRefs: true });
+
+    if (args.check) {
+      if (!existsSync(outPath) || readFileSync(outPath, "utf8") !== dumped) drift++;
+    } else {
+      mkdirSync(path.dirname(outPath), { recursive: true });
+      writeFileSync(outPath, dumped);
+      written++;
+      bytesOut += Buffer.byteLength(dumped, "utf8");
+    }
+  }
+
+  if (args.check) {
+    if (drift > 0) {
+      process.stderr.write(`!! ${drift} skeleton(s) drift; rerun without --check.\n`);
+      process.exit(1);
+    }
+    process.stdout.write(`ok: ${files.length} skeleton(s) up to date\n`);
+    return;
+  }
+
+  const ratio = bytesIn > 0 ? ((bytesOut / bytesIn) * 100).toFixed(1) : "n/a";
+  process.stdout.write(
+    `wrote ${written} skeleton(s) to ${args.outDir} ` +
+      `(${(bytesIn / 1024).toFixed(0)}KB -> ${(bytesOut / 1024).toFixed(0)}KB, ${ratio}% of source)\n`,
+  );
+}
+
+main();

--- a/workflow-fixtures/scripts/fetch.sh
+++ b/workflow-fixtures/scripts/fetch.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Fetch (or update) pipeline fixtures into ./pipelines/ at SHAs pinned in fixtures.yaml.
+#
+# Usage:
+#   scripts/fetch.sh                 # fetch all
+#   scripts/fetch.sh nf-core/demo    # fetch one
+#   VERIFY=1 scripts/fetch.sh        # also verify HEAD matches pinned SHA
+#
+# Deps: git, yq (https://github.com/mikefarah/yq). Falls back to python3 if yq absent.
+
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+manifest="$root/fixtures.yaml"
+dest_root="$root/pipelines"
+mkdir -p "$dest_root"
+
+parse() {
+  if command -v yq >/dev/null 2>&1; then
+    yq -o=tsv '.pipelines[] | [.name, .repo, .sha, .tag] | @tsv' "$manifest"
+  else
+    python3 - "$manifest" <<'PY'
+import sys, yaml
+m = yaml.safe_load(open(sys.argv[1]))
+for p in m["pipelines"]:
+    print("\t".join([p["name"], p["repo"], p["sha"], p["tag"]]))
+PY
+  fi
+}
+
+want="${1:-}"
+
+parse | while IFS=$'\t' read -r name repo sha tag; do
+  [ -n "$want" ] && [ "$want" != "$name" ] && continue
+  dir="$dest_root/${name//\//__}"
+  if [ ! -d "$dir/.git" ]; then
+    echo ">> cloning $name @ $tag ($sha)"
+    git clone --quiet "$repo" "$dir"
+  fi
+  echo ">> checking out $name @ $sha"
+  git -C "$dir" fetch --quiet --tags origin
+  git -C "$dir" -c advice.detachedHead=false checkout --quiet "$sha"
+  if [ "${VERIFY:-0}" = "1" ]; then
+    head=$(git -C "$dir" rev-parse HEAD)
+    if [ "$head" != "$sha" ]; then
+      echo "!! HEAD $head != pinned $sha for $name" >&2
+      exit 1
+    fi
+  fi
+done
+
+echo "done."


### PR DESCRIPTION
## Summary

Closes #20. Adds `workflow-fixtures/` as a top-level Foundry workspace and a structural-only skeleton tier for `/iwc-survey` evidence.

- **`workflow-fixtures/`** imported flat (prior repo had 3 commits; not preserved). Generated corpora (`pipelines/`, `iwc-src/`, `iwc-cleaned/`, `iwc-format2/`, `iwc-skeletons/`) are gitignored. Outside `content/`, invisible to validator and site.
- **`workflow-fixtures/scripts/build-skeletons.ts`** — TypeScript yaml-walker. Drops `tool_state`, step `position`/`uuid`/`tool_shed_repository`/`tool_version`, output post-processing fields, and top-level `comments:`. Recurses `run:` subworkflows. `--check` mode for idempotent CI use. Output: 120 skeletons, ~1.1MB total, median ~9KB.
- **Round-trip verified**: tool_ids, step graph (`in.source` / `out.id`), `when:` expressions, workflow-level inputs/outputs all match between source and skeleton across all 117 PyYAML-parseable files (3 source files have tab characters PyYAML rejects; `js-yaml` handles them).
- **`$IWC_FORMAT2` / `$IWC_SKELETONS` resolve via built-ins** in `scripts/lib/common-paths.ts` — no user config needed since the corpora live inside the checkout. Users can still override in `common_paths.yml`.
- **Doc updates**: `CORPUS_INGESTION.md` (skeleton tier section), `ARCHITECTURE.md` (component map), `.claude/commands/iwc-survey.md` (skeletons as first-class evidence technique in Steps 1 + 2).

## Out of scope / deferred

- Acceptance bullet 5 — re-run one survey topic with skeletons available and compare against grep-only — left as a follow-up. Suggest `collections` as the topic since it's workflow-shape and an existing survey gives a baseline.
- No automated round-trip vitest yet; verified manually (above). Easy follow-up.

## PR scope note

Branch also carries two earlier unrelated commits (`Vendor upstream collection-semantics MD` 006976c, `Add /iwc-survey + /iwc-survey-act commands` 29edd72). Happy to split if preferred.

## Test plan

- [x] `npm run validate` — 0 errors
- [x] `npm run test` — 24 passed
- [x] `npx tsx workflow-fixtures/scripts/build-skeletons.ts --check` — 120 skeletons up to date
- [x] Topology + tool_id round-trip across the corpus (manual python check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)