### PR TITLE
Surface pattern library in site UI

### DIFF
--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -5,6 +5,7 @@ const pathname = Astro.url.pathname.replace(/\/$/, '') || '/';
 const navLinks = [
   { href: `${base}/dashboard/`, label: 'Dashboard', match: (p: string) => p.startsWith(`${base}/dashboard`) },
   { href: `${base}/molds/`, label: 'Molds', match: (p: string) => p.startsWith(`${base}/molds`) },
+  { href: `${base}/patterns/`, label: 'Patterns', match: (p: string) => p.startsWith(`${base}/patterns`) },
   { href: `${base}/pipelines/`, label: 'Pipelines', match: (p: string) => p.startsWith(`${base}/pipelines`) && !p.includes('/molds') },
   { href: `${base}/index/`, label: 'Index', match: (p: string) => p.startsWith(`${base}/index`) },
   { href: `${base}/tags/`, label: 'Tags', match: (p: string) => p.startsWith(`${base}/tags`) },

--- a/site/src/components/PatternSpotlight.astro
+++ b/site/src/components/PatternSpotlight.astro
@@ -1,0 +1,121 @@
+---
+import { getCollection } from 'astro:content';
+
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+const all = await getCollection('content');
+const patterns = all
+  .filter(n => n.data.type === 'pattern' && n.data.status !== 'archived')
+  .sort((a, b) => {
+    const revised = b.data.revised.getTime() - a.data.revised.getTime();
+    if (revised !== 0) return revised;
+    return (a.data as any).title.localeCompare((b.data as any).title);
+  });
+
+const visible = patterns.slice(0, 4);
+
+function shortTitle(title: string): string {
+  return title.replace(/^Tabular:\s*/, '');
+}
+---
+{patterns.length > 0 && (
+  <section aria-labelledby="pattern-spotlight-heading" class="pattern-spotlight">
+    <div class="section-rule">
+      <h2 id="pattern-spotlight-heading">Patterns</h2>
+      <span class="section-tail">/ corpus-backed recipes</span>
+      <a href={`${base}/patterns/`} class="spotlight-all">View all {patterns.length}</a>
+    </div>
+
+    <div class="spotlight-grid">
+      {visible.map((pattern, index) => {
+        const data = pattern.data as any;
+        return (
+          <a href={`${base}/${pattern.id}/`} class="spotlight-card no-underline tinted-shadow tinted-shadow-hover">
+            <span class="spotlight-index font-mono">{String(index + 1).padStart(2, '0')}</span>
+            <span class="spotlight-title">{shortTitle(data.title)}</span>
+            <span class="spotlight-summary">{data.summary}</span>
+            <span class="spotlight-foot">
+              <span class={`badge badge-${data.status}`}>{data.status}</span>
+              <span class="font-mono">pattern</span>
+            </span>
+          </a>
+        );
+      })}
+    </div>
+  </section>
+)}
+
+<style>
+  .pattern-spotlight {
+    margin-top: 1.5rem;
+  }
+  .spotlight-all {
+    margin-left: auto;
+    color: var(--color-link);
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-decoration: none;
+    border-bottom: 1px solid color-mix(in srgb, var(--color-link) 30%, transparent);
+  }
+  .spotlight-all:hover {
+    color: var(--color-link-hover);
+    border-color: var(--color-accent);
+  }
+  .spotlight-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0.75rem;
+  }
+  .spotlight-card {
+    display: grid;
+    grid-template-rows: auto auto 1fr auto;
+    gap: 0.55rem;
+    min-height: 14rem;
+    padding: 1rem;
+    border: 1px solid var(--color-border-subtle);
+    border-radius: 0.6rem;
+    background:
+      linear-gradient(135deg, color-mix(in srgb, var(--color-accent) 10%, transparent), transparent 40%),
+      var(--color-surface-raised);
+    color: inherit;
+    transition: border-color 0.18s ease, transform 0.18s ease, box-shadow 0.18s ease;
+  }
+  .spotlight-card:hover {
+    border-color: var(--color-accent);
+    transform: translateY(-2px);
+  }
+  .spotlight-index {
+    color: var(--color-accent);
+    font-size: 0.78rem;
+    letter-spacing: 0.12em;
+  }
+  .spotlight-title {
+    color: var(--color-text-primary);
+    font-size: 1.05rem;
+    font-weight: 700;
+    line-height: 1.2;
+    letter-spacing: -0.01em;
+  }
+  .spotlight-summary {
+    color: var(--color-text-secondary);
+    font-size: 0.86rem;
+    line-height: 1.5;
+  }
+  .spotlight-foot {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    color: var(--color-text-muted);
+    font-size: 0.75rem;
+  }
+  @media (max-width: 900px) {
+    .spotlight-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+  @media (max-width: 560px) {
+    .spotlight-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import Base from '../layouts/Base.astro';
 import PipelineMatrix from '../components/PipelineMatrix.astro';
+import PatternSpotlight from '../components/PatternSpotlight.astro';
 import GlossaryPrimer from '../components/GlossaryPrimer.astro';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
@@ -8,6 +9,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const navCards = [
   { href: `${base}/dashboard/`, label: 'Dashboard', desc: 'Sectioned tables of every active note.', kbd: 'D' },
   { href: `${base}/molds/`, label: 'Molds', desc: 'Abstract templates grouped by axis.', kbd: 'M' },
+  { href: `${base}/patterns/`, label: 'Patterns', desc: 'Corpus-grounded Galaxy authoring recipes.', kbd: 'R' },
   { href: `${base}/pipelines/`, label: 'Pipelines', desc: 'Flat list of all pipelines.', kbd: 'P' },
   { href: `${base}/glossary/`, label: 'Glossary', desc: 'Pinned definitions for Foundry terminology.', kbd: 'G' },
   { href: `${base}/log/`, label: 'Log', desc: 'Append-only project log.', kbd: 'L' },
@@ -42,6 +44,7 @@ const navCards = [
   </section>
 
   <PipelineMatrix />
+  <PatternSpotlight />
   <GlossaryPrimer />
 
   <section aria-labelledby="nav-cards-heading">

--- a/site/src/pages/patterns/index.astro
+++ b/site/src/pages/patterns/index.astro
@@ -1,0 +1,209 @@
+---
+import { getCollection } from 'astro:content';
+import Base from '../../layouts/Base.astro';
+
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+const all = await getCollection('content');
+const patterns = all
+  .filter(n => n.data.type === 'pattern' && n.data.status !== 'archived')
+  .sort((a, b) => (a.data as any).title.localeCompare((b.data as any).title));
+
+const groups = new Map<string, typeof patterns>();
+for (const pattern of patterns) {
+  const title = (pattern.data as any).title as string;
+  const group = title.includes(':') ? title.split(':')[0] : 'General';
+  const list = groups.get(group) ?? [];
+  list.push(pattern);
+  groups.set(group, list);
+}
+
+const groupedPatterns = [...groups.entries()].sort(([a], [b]) => a.localeCompare(b));
+
+function formatDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+---
+<Base title="Patterns">
+  <section class="patterns-hero bg-grain" aria-labelledby="patterns-heading">
+    <span class="eyebrow mb-3">Pattern Library</span>
+    <div class="patterns-hero-grid">
+      <div>
+        <h1 id="patterns-heading" class="patterns-title text-balance">
+          IWC-grounded workflow construction recipes.
+        </h1>
+        <p class="patterns-lede text-pretty">
+          Pattern pages capture reusable Galaxy authoring moves that Molds can reference and casts can condense.
+          They are operation-anchored, corpus-backed, and separate from action Molds.
+        </p>
+      </div>
+      <dl class="patterns-stats" aria-label="Pattern library stats">
+        <div>
+          <dt>Total</dt>
+          <dd>{patterns.length}</dd>
+        </div>
+        <div>
+          <dt>Groups</dt>
+          <dd>{groupedPatterns.length}</dd>
+        </div>
+      </dl>
+    </div>
+  </section>
+
+  {groupedPatterns.map(([group, list]) => (
+    <section class="pattern-group" aria-labelledby={`patterns-${group.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`}>
+      <div class="section-rule">
+        <h2 id={`patterns-${group.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`}>{group}</h2>
+        <span class="section-tail">/ {list.length} {list.length === 1 ? 'pattern' : 'patterns'}</span>
+      </div>
+      <div class="pattern-grid">
+        {list.map(pattern => {
+          const data = pattern.data as any;
+          const subjectTags = (data.tags as string[]).filter(t => t !== 'pattern');
+          return (
+            <article class="pattern-card tinted-shadow tinted-shadow-hover">
+              <div class="pattern-card-top">
+                <span class={`badge badge-${data.status}`}>{data.status}</span>
+                <span class="pattern-date font-mono">rev {data.revision} · {formatDate(data.revised)}</span>
+              </div>
+              <h3 class="pattern-card-title">
+                <a href={`${base}/${pattern.id}/`}>{data.title}</a>
+              </h3>
+              <p class="pattern-summary">{data.summary}</p>
+              {subjectTags.length > 0 && (
+                <div class="pattern-tags" aria-label="Tags">
+                  {subjectTags.map(tag => <span class="tag">{tag}</span>)}
+                </div>
+              )}
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  ))}
+</Base>
+
+<style>
+  .patterns-hero {
+    padding: 1.25rem 0 1.75rem;
+    margin-bottom: 1rem;
+  }
+  .patterns-hero-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 1.5rem;
+    align-items: end;
+  }
+  .patterns-title {
+    margin: 0 0 0.9rem;
+    color: var(--color-text-primary);
+    font-size: clamp(2rem, 4vw + 0.25rem, 3.25rem);
+    font-weight: 700;
+    line-height: 1.05;
+    letter-spacing: -0.025em;
+  }
+  .patterns-lede {
+    max-width: 48rem;
+    margin: 0;
+    color: var(--color-text-secondary);
+    font-size: 1rem;
+    line-height: 1.65;
+  }
+  .patterns-stats {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(5.5rem, auto));
+    gap: 0.75rem;
+    margin: 0;
+  }
+  .patterns-stats div {
+    padding: 0.75rem 0.9rem;
+    border: 1px solid var(--color-border-subtle);
+    border-radius: 0.5rem;
+    background: var(--color-surface-raised);
+  }
+  .patterns-stats dt {
+    margin: 0 0 0.2rem;
+    color: var(--color-text-muted);
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+  .patterns-stats dd {
+    margin: 0;
+    color: var(--color-galaxy-primary);
+    font-size: 1.65rem;
+    font-weight: 700;
+    line-height: 1;
+  }
+  .dark .patterns-stats dd {
+    color: var(--color-link);
+  }
+  .pattern-group {
+    margin-bottom: 2rem;
+  }
+  .pattern-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+    gap: 1rem;
+  }
+  .pattern-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    min-height: 13rem;
+    padding: 1rem;
+    border: 1px solid var(--color-border-subtle);
+    border-radius: 0.65rem;
+    background: var(--color-surface-raised);
+    transition: border-color 0.18s ease, transform 0.18s ease, box-shadow 0.18s ease;
+  }
+  .pattern-card:hover {
+    border-color: var(--color-accent);
+    transform: translateY(-2px);
+  }
+  .pattern-card-top {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+  .pattern-date {
+    color: var(--color-text-muted);
+    font-size: 0.72rem;
+    white-space: nowrap;
+  }
+  .pattern-card-title {
+    margin: 0;
+    font-size: 1.15rem;
+    line-height: 1.25;
+    letter-spacing: -0.01em;
+  }
+  .pattern-card-title a {
+    color: var(--color-link);
+    text-decoration: none;
+  }
+  .pattern-card-title a:hover {
+    color: var(--color-link-hover);
+    text-decoration: underline;
+  }
+  .pattern-summary {
+    flex: 1;
+    margin: 0;
+    color: var(--color-text-secondary);
+    font-size: 0.9rem;
+    line-height: 1.55;
+  }
+  .pattern-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+  }
+  @media (max-width: 700px) {
+    .patterns-hero-grid {
+      grid-template-columns: 1fr;
+    }
+    .patterns-stats {
+      width: 100%;
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary
- Add a first-class Patterns route with grouped pattern cards and library stats.
- Surface pattern work in the main nav, landing browse list, and homepage spotlight.

## Verification
- npm run validate
- npm run test
- npm run build from site/

## Notes
- Root npm run typecheck still fails on pre-existing merged-main TypeScript issues unrelated to this UI change.