### PR TITLE
Add summarize-nextflow casting groundwork

### DIFF
--- a/content/molds/summarize-nextflow/index.md
+++ b/content/molds/summarize-nextflow/index.md
@@ -13,6 +13,34 @@ revision: 4
 ai_generated: true
 output_schemas:
   - "content/schemas/summary-nextflow.schema.json"
+references:
+  - kind: schema
+    ref: "content/schemas/summary-nextflow.schema.json"
+    used_at: both
+    load: upfront
+    mode: verbatim
+    purpose: "Validate the emitted Nextflow summary JSON and provide downstream consumers the output contract."
+  - kind: research
+    ref: "[[component-nextflow-pipeline-anatomy]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    purpose: "Interpret DSL2 layout, includes, workflow/subworkflow/module boundaries, and channel/process topology."
+    trigger: "When walking pipeline structure or resolving process aliases and channel flow."
+  - kind: research
+    ref: "[[component-nextflow-containers-and-envs]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    purpose: "Resolve container, conda, Wave, and Bioconda/Biocontainers environment evidence."
+    trigger: "When extracting tools, versions, containers, conda directives, or environment equivalences."
+  - kind: research
+    ref: "[[component-nextflow-testing]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    purpose: "Extract nf-test files, snapshot fixtures, test profiles, and Nextflow test-data conventions."
+    trigger: "When filling test_fixtures or nf_tests sections of the summary."
 related_notes:
   - "[[summary-nextflow]]"
 summary: "Read a Nextflow pipeline source tree and emit a structured per-source summary downstream Molds bind to."

--- a/docs/COMPILATION_PIPELINE.md
+++ b/docs/COMPILATION_PIPELINE.md
@@ -4,7 +4,7 @@ Initial sketch of how Molds become cast skills. Anchored to the file layout in `
 
 ## What casting is
 
-Casting takes a Mold (a typed reference manifest plus a procedural body) and its declared references — pattern pages, CLI manual pages, IO schemas, prompt fragments, examples — and produces a target-specific skill artifact. The cast is **condensed and isolated** — no links back to the Foundry, no runtime dependency on it.
+Casting takes a Mold (a typed reference manifest plus a procedural body) and its declared references — pattern pages, CLI manual pages, IO schemas, prompt fragments, examples, and operational research notes — and produces a target-specific skill artifact. The cast is **condensed and isolated** — no links back to the Foundry, no runtime dependency on it.
 
 Casting operates as **per-kind dispatch** over the manifest, not a single resolve-and-inline pass. Different reference kinds get different transformations:
 
@@ -15,10 +15,43 @@ Casting operates as **per-kind dispatch** over the manifest, not a single resolv
 | `schema` | `content/schemas/<name>.schema.json` (Foundry-authored, paired with a `<name>.md` schema note) **or** vendored from an upstream npm/PyPI package and registered in `site/src/lib/schema-registry.ts` (canonical case: `@galaxy-tool-util/schema` for the workflow test-format) | Verbatim copy | `references/schemas/<name>.schema.json` |
 | `prompt` | `content/prompts/*.md` | Inlined verbatim, no LLM rewrite | inlined into `SKILL.md` or `references/prompts/` |
 | `example` | `content/molds/<slug>/examples/`, shared `content/examples/` | Verbatim copy | `references/examples/` |
+| `research` | `content/research/*.md` or paired structured sources under `content/research/` | Verbatim copy or LLM condensation, controlled by the reference `mode` | `references/notes/` or inlined excerpt |
 | `eval` | `content/molds/<slug>/eval.md` | **Never packaged** | — (Foundry-only) |
 | `mold` (smell) | another Mold | Discouraged; see Open questions | — |
 
-Verbatim-copy paths are deterministic; LLM-driven condensation is reserved for kinds where it adds value (patterns, partial manpage extracts when only a slice is referenced).
+Verbatim-copy paths are deterministic; LLM-driven condensation is reserved for kinds where it adds value (patterns, research notes, partial manpage extracts when only a slice is referenced). `mode: condense` is part of the manifest schema now, but the generic condensation handler is not implemented yet; casting is incomplete until it can honor that mode for every kind that allows it.
+
+### Typed reference manifest
+
+Molds may declare the new object-shaped `references` manifest. It is additive during migration and will replace `patterns`, `cli_commands`, `prompts`, and `examples` once enough Molds have moved. `input_schemas` and `output_schemas` remain explicit Mold IO fields for now because they describe the Mold contract as well as cast packaging.
+
+```yaml
+references:
+  - kind: schema
+    ref: "content/schemas/summary-nextflow.schema.json"
+    used_at: both
+    load: upfront
+    mode: verbatim
+    purpose: "Validate emitted summary JSON."
+  - kind: research
+    ref: "[[component-nextflow-testing]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    purpose: "Extract nf-test fixtures and snapshots."
+    trigger: "When filling test_fixtures or nf_tests."
+```
+
+Field contract:
+
+- `kind` selects the resolver and transformation handler: `pattern`, `cli-command`, `schema`, `prompt`, `example`, or `research`.
+- `ref` is a wiki link for note-backed kinds (`pattern`, `cli-command`, `prompt`, `research`) and a path for file-backed kinds (`schema`, `example`).
+- `used_at` is `cast-time`, `runtime`, or `both`; it says whether the reference is consumed while building the cast, consulted by the cast skill at runtime, or both.
+- `load` is `upfront` or `on-demand`; it is the progressive-disclosure contract and should be honored by generated skill instructions and sidecar layout.
+- `mode` is `verbatim`, `condense`, `sidecar`, or `copy`; it declares the transformation, even when that transformation is not fully implemented yet.
+- `purpose` and `trigger` are optional prose for maintainers and cast-skill instructions. `trigger` is especially important for `load: on-demand` references.
+
+`load: never` is deliberately omitted. Non-operational graph links stay in `related_notes`; once a reference appears in `references`, casting and validation should treat it as operational.
 
 ### Agent-facing vs. human-facing vendored artifacts
 
@@ -49,11 +82,12 @@ To cast a Mold, the casting process consumes:
 
 - **The Mold directory** — `index.md` (frontmatter manifest + procedural body) plus, if the schema permits, casting hints. **Not** `eval.md` — evals stay in the Foundry.
 - **All typed references declared in the manifest**, resolved by kind:
-  - `patterns` — wiki links into `content/patterns/`.
-  - `cli_commands` — wiki links into `content/cli/<tool>/<cmd>.md`.
+  - `references` — object-shaped typed references with `kind`, `ref`, `used_at`, `load`, and `mode`; this is the preferred manifest for new operational references.
+  - `patterns` — legacy wiki links into `content/patterns/`.
+  - `cli_commands` — legacy wiki links into `content/cli/<tool>/<cmd>.md`.
   - `input_schemas` / `output_schemas` — paths into `content/schemas/`.
-  - `prompts` — wiki links into `content/prompts/` (when the Mold needs them).
-  - `examples` — paths into `content/molds/<slug>/examples/` or shared `content/examples/`.
+  - `prompts` — legacy wiki links into `content/prompts/` (when the Mold needs them).
+  - `examples` — legacy paths into `content/molds/<slug>/examples/` or shared `content/examples/`.
   - IWC exemplar URLs cited in pattern bodies are resolved by the pattern transformation, not by the casting top-level (URLs stay URLs in pattern bodies; pinning to a SHA is at the pattern author's discretion).
   - Other Molds (`related_molds`) — flagged as a smell; see Open questions.
 - **The cast target spec** — a per-target adapter (prompt templates per kind + output structure) declared in `casts/<target>/_target.yml`.
@@ -62,7 +96,8 @@ To cast a Mold, the casting process consumes:
 Resolution policy is per-kind, not a single rule:
 - `pattern` — verbatim inline if under a size threshold; LLM-summarize otherwise. Casting hints (`inline: true` / `summarize: true`) may override.
 - `cli-command` — always cast to JSON sidecar (deterministic structuring; no token-budget condensation needed because the sidecar is loaded only when the agent needs that command).
-- `schema`, `example`, `prompt` — always verbatim copy. No LLM in the loop.
+- `schema`, `example`, `prompt` — always verbatim copy unless the typed reference declares a future supported transformation.
+- `research` — operational background; copied or condensed according to `mode`, and loaded according to `used_at` / `load`. `mode: condense` is specified but not implemented in v1 tooling yet.
 - `eval` — never packaged.
 
 ## Output contract
@@ -78,6 +113,7 @@ casts/claude/<mold-name>/
 │   ├── cli/                  # JSON sidecars cast from manpages
 │   │   └── <tool>/<cmd>.json
 │   ├── patterns/             # condensed pattern excerpts (when not fully inlined)
+│   ├── notes/                # research notes or condensed operational excerpts
 │   ├── prompts/              # verbatim prompt fragments (when not fully inlined)
 │   └── examples/             # verbatim fixtures
 └── _provenance.json          # required, not part of the skill
@@ -142,7 +178,7 @@ The reference-kind `schema` does not distinguish between Foundry-authored and up
 cast_mold(mold_name, target):
   mold     <- read molds/<mold_name>/index.md
   validate mold against frontmatter schema (incl. typed-reference manifest)
-  refs     <- resolve_manifest(mold)               # by kind: patterns, cli_commands, schemas, prompts, examples
+  refs     <- resolve_manifest(mold)               # by kind: references plus legacy fields
   validate every ref exists and conforms to its kind's contract
   target   <- load_target_adapter(target)
 
@@ -154,6 +190,7 @@ cast_mold(mold_name, target):
       cli-command  -> sidecar = llm.cast_manpage_to_json(ref, target.cli_prompt)
                       write to references/cli/<tool>/<cmd>.json
       schema       -> copy verbatim to references/schemas/
+      research     -> copy verbatim or condense to references/notes/ per mode
       prompt       -> copy verbatim (inlined or to references/prompts/)
       example      -> copy verbatim to references/examples/
       eval         -> skip

--- a/meta_schema.yml
+++ b/meta_schema.yml
@@ -112,6 +112,34 @@ properties:
     type: array
     items:
       type: string
+  references:
+    type: array
+    items:
+      type: object
+      required: [kind, ref, used_at, load, mode]
+      additionalProperties: false
+      properties:
+        kind:
+          type: string
+          enum: [pattern, cli-command, schema, prompt, example, research]
+        ref:
+          type: string
+          minLength: 1
+        used_at:
+          type: string
+          enum: [cast-time, runtime, both]
+        load:
+          type: string
+          enum: [upfront, on-demand]
+        mode:
+          type: string
+          enum: [verbatim, condense, sidecar, copy]
+        purpose:
+          type: string
+          minLength: 1
+        trigger:
+          type: string
+          minLength: 1
 
   # --- CLI command fields ---
   command:

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -107,6 +107,20 @@ function validateWikiLinks(data: Frontmatter): ValidationResult {
       }
     });
   }
+  const refs = data.references;
+  if (Array.isArray(refs)) {
+    refs.forEach((ref, i) => {
+      if (typeof ref !== "object" || ref === null || Array.isArray(ref)) return;
+      const value = (ref as Record<string, unknown>).ref;
+      if (typeof value !== "string") return;
+      const m = WIKI_LINK_RE.exec(value);
+      if (!m) return;
+      const inner = m[1];
+      if (inner !== undefined && inner.trim() === "") {
+        result.errors.push(`references[${i}].ref: wiki link has whitespace-only inner text: '${value}'`);
+      }
+    });
+  }
   return result;
 }
 
@@ -182,6 +196,7 @@ function validateMoldRefs(
   files: FileMeta[],
   slugMap: Map<string, string>,
   metaByPath: Map<string, Frontmatter>,
+  contentRoot: string,
 ): CrossFileFinding[] {
   const findings: CrossFileFinding[] = [];
   const checks: Array<{ field: string; expected: string }> = [
@@ -215,8 +230,117 @@ function validateMoldRefs(
         }
       }
     }
+    const typedRefs = f.meta.references;
+    if (Array.isArray(typedRefs)) {
+      typedRefs.forEach((ref, i) => {
+        validateTypedReference(ref, i, f.path, contentRoot, slugMap, metaByPath, findings);
+      });
+    }
   }
   return findings;
+}
+
+function validateTypedReference(
+  raw: unknown,
+  index: number,
+  filePath: string,
+  contentRoot: string,
+  slugMap: Map<string, string>,
+  metaByPath: Map<string, Frontmatter>,
+  findings: CrossFileFinding[],
+): void {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return;
+  const ref = raw as Record<string, unknown>;
+  if (typeof ref.kind !== "string" || typeof ref.ref !== "string") return;
+
+  const expectedTypes: Record<string, string> = {
+    pattern: "pattern",
+    "cli-command": "cli-command",
+    prompt: "prompt",
+    research: "research",
+  };
+
+  if (ref.kind === "schema") {
+    validatePathReference(ref.ref, index, filePath, contentRoot, findings, "content/schemas/", true);
+    return;
+  }
+  if (ref.kind === "example") {
+    validatePathReference(ref.ref, index, filePath, contentRoot, findings, "content/", false);
+    return;
+  }
+
+  const expected = expectedTypes[ref.kind];
+  if (!expected) return;
+  const tp = resolveWikiLink(ref.ref, slugMap);
+  if (!tp) {
+    findings.push({
+      path: filePath,
+      severity: "error",
+      message: `references[${index}]: ${ref.kind} ref ${ref.ref} did not resolve`,
+    });
+    return;
+  }
+  const targetType = metaByPath.get(tp)?.type;
+  if (targetType !== expected) {
+    findings.push({
+      path: filePath,
+      severity: "error",
+      message: `references[${index}]: ${ref.kind} ref ${ref.ref} resolves to type=${targetType ?? "(none)"}, expected ${expected}`,
+    });
+  }
+}
+
+function validatePathReference(
+  ref: string,
+  index: number,
+  filePath: string,
+  contentRoot: string,
+  findings: CrossFileFinding[],
+  requiredPrefix: string,
+  requireJson: boolean,
+): void {
+  if (WIKI_LINK_RE.test(ref)) {
+    findings.push({
+      path: filePath,
+      severity: "error",
+      message: `references[${index}]: path reference must not be a wiki link: ${ref}`,
+    });
+    return;
+  }
+  if (!ref.startsWith(requiredPrefix)) {
+    findings.push({
+      path: filePath,
+      severity: "error",
+      message: `references[${index}]: path reference must start with ${requiredPrefix}: ${ref}`,
+    });
+    return;
+  }
+  const repoRelativeAbs = path.resolve(process.cwd(), ref);
+  const contentRelativeAbs = path.resolve(contentRoot, ref.replace(/^content\//, ""));
+  const abs = existsSync(repoRelativeAbs) ? repoRelativeAbs : contentRelativeAbs;
+  if (!existsSync(abs)) {
+    findings.push({
+      path: filePath,
+      severity: "error",
+      message: `references[${index}]: path reference does not exist: ${ref}`,
+    });
+    return;
+  }
+  if (!statSync(abs).isFile()) {
+    findings.push({
+      path: filePath,
+      severity: "error",
+      message: `references[${index}]: path reference is not a file: ${ref}`,
+    });
+    return;
+  }
+  if (requireJson && !ref.endsWith(".schema.json")) {
+    findings.push({
+      path: filePath,
+      severity: "error",
+      message: `references[${index}]: schema reference must end with .schema.json: ${ref}`,
+    });
+  }
 }
 
 interface PhaseRefs {
@@ -429,7 +553,7 @@ export function validateDirectory(opts: ValidateOptions): {
 
   const crossFindings: CrossFileFinding[] = [];
   crossFindings.push(...validateBidirectionalRelatedNotes(validFiles, slugMap));
-  crossFindings.push(...validateMoldRefs(validFiles, slugMap, metaByPath));
+  crossFindings.push(...validateMoldRefs(validFiles, slugMap, metaByPath, opts.directory));
   crossFindings.push(...validatePipelinePhases(validFiles, slugMap, metaByPath));
 
   for (const f of crossFindings) {

--- a/site/src/components/MoldBody.astro
+++ b/site/src/components/MoldBody.astro
@@ -1,6 +1,7 @@
 ---
 import type { CollectionEntry } from 'astro:content';
 import { resolveWikiLink, type WikiLinkTarget } from '../lib/wiki-links';
+import ReferenceContract from './ReferenceContract.astro';
 
 interface Props {
   entry: CollectionEntry<'content'>;
@@ -28,6 +29,8 @@ const specifier = data.source ?? data.target ?? data.tool ?? null;
   {specifier && <span class="text-xs px-2 py-1 rounded border border-(--color-border) font-mono">{specifier}</span>}
   <span class="text-xs text-(--color-text-secondary) font-mono">{data.name}</span>
 </div>
+
+<ReferenceContract references={data.references} linkMap={linkMap} />
 
 {(patterns.length + cliCommands.length + prompts.length) > 0 && (
   <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-6">

--- a/site/src/components/ReferenceContract.astro
+++ b/site/src/components/ReferenceContract.astro
@@ -1,0 +1,152 @@
+---
+import { resolveWikiLink, type WikiLinkTarget } from '../lib/wiki-links';
+
+interface TypedReference {
+  kind: string;
+  ref: string;
+  used_at: string;
+  load: string;
+  mode: string;
+  purpose?: string;
+  trigger?: string;
+}
+
+interface Props {
+  references?: TypedReference[];
+  linkMap: Map<string, WikiLinkTarget>;
+}
+
+const { references = [], linkMap } = Astro.props;
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+
+const KIND_HELP: Record<string, string> = {
+  pattern: 'Workflow-construction idiom. Usually condensed during casting.',
+  'cli-command': 'Command reference. Usually cast to a sidecar and loaded only when invoked.',
+  schema: 'Structured contract. Usually copied verbatim for validation or lookup.',
+  prompt: 'Prompt fragment. Usually copied verbatim or inlined by the target adapter.',
+  example: 'Fixture or exemplar. Usually copied verbatim.',
+  research: 'Background synthesis. Loaded by explicit progressive-disclosure metadata.',
+};
+
+function linkFor(ref: string) {
+  if (!/^\[\[.+\]\]$/.test(ref)) return null;
+  return resolveWikiLink(ref, linkMap, base);
+}
+---
+{references.length > 0 && (
+  <section class="reference-contract mb-6">
+    <div class="reference-contract-head">
+      <h2>Reference Loading Contract</h2>
+      <p>Typed Mold references describe what casting consumes and when the cast skill should load each artifact.</p>
+    </div>
+    <div class="reference-grid">
+      {references.map(ref => {
+        const link = linkFor(ref.ref);
+        return (
+          <article class="reference-card">
+            <div class="reference-card-top">
+              <span class="kind">{ref.kind}</span>
+              <span class="ref">
+                {link
+                  ? link.href
+                    ? <a href={link.href} title={link.summary || undefined}>{link.label}</a>
+                    : <span class="dangling">{link.label}</span>
+                  : ref.ref}
+              </span>
+            </div>
+            <p class="kind-help">{KIND_HELP[ref.kind] ?? 'Typed reference consumed by casting.'}</p>
+            <div class="chips" aria-label="loading metadata">
+              <span>{ref.used_at}</span>
+              <span>{ref.load}</span>
+              <span>{ref.mode}</span>
+            </div>
+            {ref.purpose && <p class="detail"><strong>Purpose:</strong> {ref.purpose}</p>}
+            {ref.trigger && <p class="detail"><strong>Trigger:</strong> {ref.trigger}</p>}
+          </article>
+        );
+      })}
+    </div>
+  </section>
+)}
+
+<style>
+  .reference-contract {
+    border: 1px solid var(--color-border);
+    border-radius: 1rem;
+    background: var(--color-surface-raised);
+    padding: 1rem;
+  }
+  .reference-contract-head {
+    margin-bottom: 0.9rem;
+  }
+  .reference-contract h2 {
+    margin: 0 0 0.25rem;
+    font-size: 0.95rem;
+    font-weight: 700;
+  }
+  .reference-contract p {
+    margin: 0;
+  }
+  .reference-contract-head p,
+  .kind-help,
+  .detail {
+    color: var(--color-text-secondary);
+    font-size: 0.82rem;
+  }
+  .reference-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+    gap: 0.75rem;
+  }
+  .reference-card {
+    border: 1px solid var(--color-border);
+    border-radius: 0.75rem;
+    background: var(--color-surface);
+    padding: 0.85rem;
+  }
+  .reference-card-top {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-bottom: 0.4rem;
+  }
+  .kind,
+  .chips span {
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+  .kind {
+    color: var(--color-text-muted);
+  }
+  .ref {
+    font-size: 0.86rem;
+    text-align: right;
+    overflow-wrap: anywhere;
+  }
+  .ref a {
+    color: var(--color-link);
+    text-decoration: none;
+  }
+  .ref a:hover {
+    text-decoration: underline;
+  }
+  .chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    margin: 0.65rem 0;
+  }
+  .chips span {
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+    padding: 0.14rem 0.45rem;
+    color: var(--color-text-secondary);
+    background: var(--color-surface-raised);
+  }
+  .detail + .detail {
+    margin-top: 0.35rem;
+  }
+</style>

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -10,6 +10,16 @@ function slugifyPath(entry: string): string {
 
 const wikiLink = z.string().regex(/^\[\[.+\]\]$/, { message: 'must be a [[wiki-link]]' });
 
+const typedReference = z.object({
+  kind: z.enum(['pattern', 'cli-command', 'schema', 'prompt', 'example', 'research']),
+  ref: z.string().min(1),
+  used_at: z.enum(['cast-time', 'runtime', 'both']),
+  load: z.enum(['upfront', 'on-demand']),
+  mode: z.enum(['verbatim', 'condense', 'sidecar', 'copy']),
+  purpose: z.string().min(1).optional(),
+  trigger: z.string().min(1).optional(),
+}).strict();
+
 const baseFields = {
   tags: z.array(z.string()).min(1),
   status: z.enum(['draft', 'reviewed', 'revised', 'stale', 'archived']),
@@ -64,6 +74,7 @@ const moldSchema = z.object({
   input_schemas: z.array(z.string()).optional(),
   output_schemas: z.array(z.string()).optional(),
   examples: z.array(z.string()).optional(),
+  references: z.array(typedReference).optional(),
   ...baseFields,
 }).strict();
 

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -82,6 +82,53 @@ describe("validateData (per-file)", () => {
     expect(r.errors.some((e) => /source/.test(e))).toBe(true);
   });
 
+  it("accepts typed references metadata", () => {
+    const r = validateData(
+      baseRequired({
+        type: "mold",
+        tags: ["mold"],
+        name: "x",
+        axis: "generic",
+        references: [
+          {
+            kind: "research",
+            ref: "[[component-x]]",
+            used_at: "runtime",
+            load: "on-demand",
+            mode: "condense",
+            purpose: "Explain when to load this reference.",
+            trigger: "When the runtime task needs component details.",
+          },
+        ],
+      }),
+      schema,
+    );
+    expect(r.errors).toEqual([]);
+  });
+
+  it("rejects unknown typed reference fields", () => {
+    const r = validateData(
+      baseRequired({
+        type: "mold",
+        tags: ["mold"],
+        name: "x",
+        axis: "generic",
+        references: [
+          {
+            kind: "research",
+            ref: "[[component-x]]",
+            used_at: "runtime",
+            load: "on-demand",
+            mode: "verbatim",
+            bogus: "x",
+          },
+        ],
+      }),
+      schema,
+    );
+    expect(r.errors.some((e) => /bogus/.test(e))).toBe(true);
+  });
+
   it("rejects bad date format", () => {
     const r = validateData(baseRequired({ created: "not-a-date" }), schema);
     expect(r.errors.length).toBeGreaterThan(0);
@@ -196,5 +243,60 @@ describe("validateDirectory (cross-file)", () => {
       tagsPath: TAGS_PATH,
     });
     expect(r.errors).toBe(0);
+  });
+
+  it("validates typed reference targets", () => {
+    writeFm(path.join(dir, "molds/m/index.md"), {
+      ...baseRequired({
+        type: "mold",
+        tags: ["mold"],
+        name: "m",
+        axis: "generic",
+        references: [
+          { kind: "research", ref: "[[component-x]]", used_at: "runtime", load: "on-demand", mode: "verbatim" },
+          { kind: "pattern", ref: "[[pattern-x]]", used_at: "cast-time", load: "upfront", mode: "condense" },
+          { kind: "schema", ref: "content/schemas/x.schema.json", used_at: "both", load: "upfront", mode: "verbatim" },
+        ],
+      }),
+    });
+    writeFm(path.join(dir, "research/component-x.md"), {
+      ...baseRequired({ type: "research", tags: ["research/component"], subtype: "component" }),
+    });
+    writeFm(path.join(dir, "patterns/pattern-x.md"), {
+      ...baseRequired({ type: "pattern", tags: ["pattern"], title: "Pattern X" }),
+    });
+    mkdirSync(path.join(dir, "schemas"), { recursive: true });
+    writeFileSync(path.join(dir, "schemas/x.schema.json"), "{}");
+
+    const r = validateDirectory({
+      directory: dir,
+      schemaPath: SCHEMA_PATH,
+      tagsPath: TAGS_PATH,
+    });
+    expect(r.errors).toBe(0);
+  });
+
+  it("rejects typed references that resolve to the wrong type", () => {
+    writeFm(path.join(dir, "molds/m/index.md"), {
+      ...baseRequired({
+        type: "mold",
+        tags: ["mold"],
+        name: "m",
+        axis: "generic",
+        references: [
+          { kind: "research", ref: "[[not-research]]", used_at: "runtime", load: "on-demand", mode: "verbatim" },
+        ],
+      }),
+    });
+    writeFm(path.join(dir, "patterns/not-research.md"), {
+      ...baseRequired({ type: "pattern", tags: ["pattern"], title: "Not Research" }),
+    });
+
+    const r = validateDirectory({
+      directory: dir,
+      schemaPath: SCHEMA_PATH,
+      tagsPath: TAGS_PATH,
+    });
+    expect(r.errors).toBeGreaterThanOrEqual(1);
   });
 });


### PR DESCRIPTION
## Summary
- Add typed Mold `references` metadata for cast/runtime loading contracts, with validation, tests, and site rendering.
- Document progressive-disclosure reference handling in the compilation pipeline and apply it to `summarize-nextflow`.
- Include summarize-nextflow casting/schema groundwork and related site/package updates already present on this branch.

## Checks
- npm run test
- npm run validate
- npm run typecheck (fails on existing site type setup issues)