### PR TITLE
Add vendored upstream sync

### DIFF
--- a/content/research/galaxy-collection-semantics.md
+++ b/content/research/galaxy-collection-semantics.md
@@ -7,18 +7,18 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-04-30
+revised: 2026-05-02
 revision: 1
 ai_generated: false
 related_notes:
   - "[[galaxy-collection-tools]]"
   - "[[galaxy-apply-rules-dsl]]"
 sources:
-  - "https://github.com/galaxyproject/galaxy/blob/0683385f5da57c6065c5408f033fdcafd66a27b6/lib/galaxy/model/dataset_collections/types/collection_semantics.yml"
+  - "https://github.com/galaxyproject/galaxy/blob/7765fae934fbfdee77e3be5f5b235e43735273ae/lib/galaxy/model/dataset_collections/types/collection_semantics.yml"
 summary: "Vendored formal spec of Galaxy dataset-collection mapping/reduction semantics, with labeled examples and pinned test references."
 ---
 
-> **Vendored from upstream**, pinned at SHA `0683385`. Two files live next to this note:
+> **Vendored from upstream**, pinned at SHA `7765fae`. Two files live next to this note:
 >
 > - `galaxy-collection-semantics.yml` — the structured source. **Agents and casting should consume this.** It carries the `tests:` blocks that pin concrete Galaxy test names; the rendered upstream view drops them.
 > - `galaxy-collection-semantics.upstream.myst` — Galaxy's auto-generated MyST/LaTeX rendering of the YAML, vendored only so the human view below has something to render. Sync is manual.
@@ -27,6 +27,6 @@ summary: "Vendored formal spec of Galaxy dataset-collection mapping/reduction se
 
 ```vendored-myst
 file: galaxy-collection-semantics.upstream.myst
-source: https://github.com/galaxyproject/galaxy/blob/0683385f5da57c6065c5408f033fdcafd66a27b6/doc/source/dev/collection_semantics.md
-sha: 0683385
+source: https://github.com/galaxyproject/galaxy/blob/7765fae934fbfdee77e3be5f5b235e43735273ae/doc/source/dev/collection_semantics.md
+sha: 7765fae
 ```

--- a/content/research/galaxy-collection-semantics.yml
+++ b/content/research/galaxy-collection-semantics.yml
@@ -1041,7 +1041,7 @@
     tests:
         workflow_runtime:
             framework_test: "collection_semantics_cat_collection_1"
-        workflow_editor: "accepts sample_sheet -> list connection (accepts)"
+        workflow_editor: "accepts sample_sheet -> list connection (canMatch)"
 
 - doc: |
     Sub-collection mapping works the same as for ``list`` composites. A
@@ -1096,7 +1096,7 @@
     tests:
         workflow_runtime:
             framework_test: "collection_semantics_list_paired_0"
-        workflow_editor: "accepts sample_sheet:paired -> list:paired connection (accepts)"
+        workflow_editor: "accepts sample_sheet:paired -> list:paired connection (canMatch)"
 
 - doc: |
     The ``paired_or_unpaired`` integration rules carry over from ``list`` to
@@ -1183,7 +1183,7 @@
     tests:
         workflow_runtime:
             framework_test: "collection_semantics_list_paired_or_unpaired_1"
-        workflow_editor: "accepts sample_sheet:paired_or_unpaired -> list:paired_or_unpaired connection (accepts)"
+        workflow_editor: "accepts sample_sheet:paired_or_unpaired -> list:paired_or_unpaired connection (canMatch)"
 
 - doc: |
     The type matching is asymmetric: a ``sample_sheet`` output can satisfy a ``list``
@@ -1248,104 +1248,3 @@
         workflow_runtime:
             framework_test: "collection_semantics_cat_sample_sheet_0"
         workflow_editor: "accepts sample_sheet -> sample_sheet connection"
-
-- doc: "## Type Compatibility Algebra"
-- doc: |
-    This section is for implementers. It describes the three operations that
-    answer "do these collection types fit together?" — used at workflow
-    editor connection time and at runtime when sibling inputs are matched
-    under a common map-over.
-
-    ### The lattice
-
-    The base types form a small subtype lattice:
-
-    ```
-    list                paired_or_unpaired
-     |                    |
-    sample_sheet         paired
-    ```
-
-    Edges are subtype relations. A `sample_sheet` value carries column
-    metadata that a `list` does not, so it can be substituted where a
-    `list` is required (information is preserved); the reverse is not safe.
-    A `paired` value always has two elements; `paired_or_unpaired` admits
-    1 or 2, so a `paired` can be substituted where `paired_or_unpaired` is
-    required, but not the reverse.
-
-    Nesting composes. `list:paired_or_unpaired` is a supertype of both
-    `list:paired` and `list` (the latter via the "single-dataset wrapped
-    as unpaired" interpretation), so it has two incomparable subtypes.
-
-    ### Three operations
-
-    | Operation | Symmetry | Question | Used at |
-    |---|---|---|---|
-    | `accepts(other)` | Asymmetric | Does an input slot of type `self` accept an output of type `other`? | Workflow-editor edge validation |
-    | `compatible(other)` | Symmetric | Do `self` and `other` match such that they could drive a common map-over over sibling inputs of one tool? | Sibling-matching: matching sibling HDCAs / sibling map-over states under a common mapping |
-    | `can_map_over(other)` | Asymmetric | Does `self` have proper subcollections of type `other` — i.e. can `self` be mapped over to feed an `other` slot? | Connection-time map-over decisions; runtime `effective_collection_type` arithmetic |
-
-    Conventions: `input_type.accepts(output_type)` for direct edges;
-    `output_type.can_map_over(input_type)` for map-over. `accepts` and
-    `can_map_over` differ in that `accepts` is the direct-edge case
-    where ranks already align, while `can_map_over` is the strict nesting
-    case where the output has *more* rank than the input. `compatible`
-    is symmetric and either side may go first.
-
-    `compatible(a, b)` is implemented as `a.accepts(b) or b.accepts(a)`.
-
-    ### Where each is used
-
-    - `accepts` is called at single-edge validation: connecting one output
-      to one input. The asymmetry between input and output sides matters
-      here. Examples: `connection_types.can_match`,
-      `query.HistoryQuery.direct_match`, and the workflow-editor input
-      attachment paths in `terminals.ts`.
-
-    - `compatible` is called when two collections must drive a common
-      map-over as siblings. Neither side is the input slot; both are
-      concrete shapes (observed HDCA shapes at runtime, sibling map-over
-      states at connection time). Order of arrival must not change the
-      answer. Examples: Python `Tree.compatible_shape` (matching.py,
-      execute.py) and the `mappingConstraints` checks in `terminals.ts`.
-
-    - `can_map_over` is called when deciding whether an output of higher
-      rank can drive a map-over into a lower-rank input — for instance, a
-      `list:paired` output feeding a `paired` input by iterating the outer
-      list. The Python and TypeScript names match
-      (`can_map_over` / `canMapOver`) because it is the same operational
-      question in both layers.
-
-    Routing a sibling-matching question through `accepts` instead of
-    `compatible` produces order-dependent behavior — which sibling input
-    arrived first changes whether the workflow validates. This was a real
-    bug in earlier revisions of both the Python and TypeScript code.
-
-    ### Worked examples
-
-    - `paired.accepts(paired_or_unpaired)` is `False`. A 1-element
-      paired_or_unpaired output cannot be connected to an input slot
-      that strictly requires a pair. Test: `test_paired_accepts_relation`.
-
-    - `paired.compatible(paired_or_unpaired)` is `True`. If both observed
-      sibling collections happen to align in cardinality, they match for
-      sibling iteration; cardinality checking happens later at the
-      children level. Test:
-      `test_paired_and_paired_or_unpaired_match_symmetric`.
-
-    - `sample_sheet.accepts(list)` is `False`; `list.accepts(sample_sheet)`
-      is `True`. Tests:
-      `test_sample_sheet_accepts_relation`, workflow editor
-      `"rejects list -> sample_sheet connection (asymmetry)"`.
-
-    - `sample_sheet.compatible(list)` and `list.compatible(sample_sheet)`
-      are both `True`. Tests: `test_compatible`,
-      `test_tree_compatible_shape_sample_sheet_list_symmetric`.
-
-    ### Cross-language synchronization
-
-    The Python implementation lives in
-    `lib/galaxy/model/dataset_collections/type_description.py`. The
-    TypeScript implementation lives in
-    `client/src/components/Workflow/Editor/modules/collectionTypeDescription.ts`.
-    Both must stay in sync; method names and conventions are identical.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "check:index": "tsx scripts/generate-index.ts --check",
     "iwc-overview": "tsx scripts/generate-iwc-overview.ts",
     "check:iwc-overview": "tsx scripts/generate-iwc-overview.ts --check",
+    "check:vendored": "tsx scripts/sync-vendored-upstreams.ts --check",
+    "sync:vendored": "tsx scripts/sync-vendored-upstreams.ts --update",
     "cast": "tsx scripts/cast-mold.ts",
     "packages-build": "pnpm -r build",
     "packages-test": "pnpm -r test",

--- a/scripts/lib/vendored-upstreams.ts
+++ b/scripts/lib/vendored-upstreams.ts
@@ -1,0 +1,123 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import yaml from "js-yaml";
+import { citationLocalPath, loadCommonPaths, parseCitation } from "./common-paths";
+
+export interface VendoredUpstreamEntry {
+  local: string;
+  source: string;
+  pinned_ref: string;
+  framing?: string;
+}
+
+export interface VendoredDrift {
+  entry: VendoredUpstreamEntry;
+  sourcePath: string;
+  currentRef: string;
+}
+
+export function loadVendoredUpstreams(
+  repoRoot: string,
+  manifestPath = path.join(repoRoot, "vendored_upstreams.yml"),
+): VendoredUpstreamEntry[] {
+  if (!fs.existsSync(manifestPath)) return [];
+  const raw = yaml.load(fs.readFileSync(manifestPath, "utf-8"));
+  if (!Array.isArray(raw)) throw new Error(`${manifestPath} must contain an array`);
+  return raw.map((entry, i) => {
+    if (!entry || typeof entry !== "object")
+      throw new Error(`vendored entry ${i + 1} must be an object`);
+    const value = entry as Partial<VendoredUpstreamEntry>;
+    if (!value.local || !value.source || !value.pinned_ref) {
+      throw new Error(`vendored entry ${i + 1} requires local, source, and pinned_ref`);
+    }
+    return {
+      local: value.local,
+      source: value.source,
+      pinned_ref: value.pinned_ref,
+      framing: value.framing,
+    };
+  });
+}
+
+export function currentRepoRef(repoPath: string): string {
+  return execFileSync("git", ["-C", repoPath, "rev-parse", "HEAD"], { encoding: "utf-8" }).trim();
+}
+
+export function resolveSource(
+  repoRoot: string,
+  source: string,
+): { sourcePath: string; repoPath: string; currentRef: string } {
+  const paths = loadCommonPaths(repoRoot);
+  const citation = parseCitation(source, paths);
+  if (!citation) throw new Error(`Cannot resolve source citation ${source}`);
+  return {
+    sourcePath: citationLocalPath(citation),
+    repoPath: citation.entry.path,
+    currentRef: currentRepoRef(citation.entry.path),
+  };
+}
+
+export function findVendoredDrift(
+  repoRoot: string,
+  entries = loadVendoredUpstreams(repoRoot),
+): VendoredDrift[] {
+  const drift: VendoredDrift[] = [];
+  for (const entry of entries) {
+    const localPath = path.join(repoRoot, entry.local);
+    const source = resolveSource(repoRoot, entry.source);
+    if (!fs.existsSync(localPath)) throw new Error(`Missing vendored file ${entry.local}`);
+    if (!fs.existsSync(source.sourcePath)) throw new Error(`Missing source file ${entry.source}`);
+    if (fs.readFileSync(localPath, "utf-8") !== fs.readFileSync(source.sourcePath, "utf-8")) {
+      drift.push({ entry, sourcePath: source.sourcePath, currentRef: source.currentRef });
+    }
+  }
+  return drift;
+}
+
+export function syncVendoredUpstreams(
+  repoRoot: string,
+  entries = loadVendoredUpstreams(repoRoot),
+): VendoredDrift[] {
+  const updated: VendoredDrift[] = [];
+  const framingRefs = new Map<string, string>();
+  for (const entry of entries) {
+    const localPath = path.join(repoRoot, entry.local);
+    const source = resolveSource(repoRoot, entry.source);
+    if (!fs.existsSync(source.sourcePath)) throw new Error(`Missing source file ${entry.source}`);
+    fs.copyFileSync(source.sourcePath, localPath);
+    updated.push({ entry, sourcePath: source.sourcePath, currentRef: source.currentRef });
+    if (entry.framing) framingRefs.set(entry.framing, source.currentRef);
+  }
+  for (const [framing, ref] of framingRefs) updateFramingRef(path.join(repoRoot, framing), ref);
+  return updated;
+}
+
+export function updateVendoredManifestRefs(
+  manifestPath: string,
+  updates: Map<string, string>,
+): void {
+  let currentLocal: string | null = null;
+  const lines = fs.readFileSync(manifestPath, "utf-8").split("\n");
+  const next = lines.map((line) => {
+    const localMatch = /^-\s+local:\s*(\S+)\s*$/.exec(line);
+    if (localMatch) currentLocal = localMatch[1] ?? null;
+    if (currentLocal && updates.has(currentLocal)) {
+      const pinMatch = /^(\s*pinned_ref:\s*).+$/.exec(line);
+      if (pinMatch) return `${pinMatch[1]}${updates.get(currentLocal)}`;
+    }
+    return line;
+  });
+  fs.writeFileSync(manifestPath, next.join("\n"));
+}
+
+export function updateFramingRef(filePath: string, ref: string): void {
+  const shortRef = ref.slice(0, 7);
+  const text = fs.readFileSync(filePath, "utf-8");
+  const next = text
+    .replace(/pinned at SHA `[^`]+`/g, `pinned at SHA \`${shortRef}\``)
+    .replace(/blob\/[0-9a-f]{7,40}\//g, `blob/${ref}/`)
+    .replace(/^sha: [0-9a-f]{7,40}$/gm, `sha: ${shortRef}`)
+    .replace(/revised: \d{4}-\d{2}-\d{2}/, `revised: ${new Date().toISOString().slice(0, 10)}`);
+  fs.writeFileSync(filePath, next);
+}

--- a/scripts/sync-vendored-upstreams.ts
+++ b/scripts/sync-vendored-upstreams.ts
@@ -1,0 +1,43 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  findVendoredDrift,
+  loadVendoredUpstreams,
+  syncVendoredUpstreams,
+  updateVendoredManifestRefs,
+} from "./lib/vendored-upstreams";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const manifestPath = path.join(repoRoot, "vendored_upstreams.yml");
+const args = new Set(process.argv.slice(2));
+
+function usage(): never {
+  console.error("Usage: pnpm sync:vendored [--check|--update]");
+  process.exit(2);
+}
+
+if (args.size !== 1 || (!args.has("--check") && !args.has("--update"))) usage();
+
+const entries = loadVendoredUpstreams(repoRoot);
+
+if (args.has("--check")) {
+  const drift = findVendoredDrift(repoRoot, entries);
+  for (const item of drift) {
+    console.warn(
+      `${item.entry.local} differs from ${item.entry.source} at ${item.currentRef.slice(0, 12)}`,
+    );
+  }
+  if (drift.length) process.exit(1);
+  console.log(`Checked ${entries.length} vendored upstream files; no drift.`);
+} else {
+  const updated = syncVendoredUpstreams(repoRoot, entries);
+  updateVendoredManifestRefs(
+    manifestPath,
+    new Map(updated.map((item) => [item.entry.local, item.currentRef])),
+  );
+  for (const item of updated) {
+    console.log(
+      `Synced ${item.entry.local} from ${item.entry.source} at ${item.currentRef.slice(0, 12)}`,
+    );
+  }
+}

--- a/tests/vendored-upstreams.test.ts
+++ b/tests/vendored-upstreams.test.ts
@@ -1,0 +1,78 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  findVendoredDrift,
+  syncVendoredUpstreams,
+  updateVendoredManifestRefs,
+} from "../scripts/lib/vendored-upstreams";
+
+describe("vendored upstream sync", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = path.join(
+      os.tmpdir(),
+      `foundry-vendored-${process.pid}-${Math.random().toString(16).slice(2)}`,
+    );
+    mkdirSync(path.join(dir, "upstream", "docs"), { recursive: true });
+    mkdirSync(path.join(dir, "content"), { recursive: true });
+    execFileSync("git", ["init"], { cwd: path.join(dir, "upstream"), stdio: "ignore" });
+    writeFileSync(path.join(dir, "upstream", "docs", "source.txt"), "new\n");
+    execFileSync("git", ["add", "."], { cwd: path.join(dir, "upstream") });
+    execFileSync("git", ["commit", "-m", "init"], {
+      cwd: path.join(dir, "upstream"),
+      env: {
+        ...process.env,
+        GIT_AUTHOR_NAME: "Test User",
+        GIT_AUTHOR_EMAIL: "test@example.com",
+        GIT_COMMITTER_NAME: "Test User",
+        GIT_COMMITTER_EMAIL: "test@example.com",
+      },
+      stdio: "ignore",
+    });
+    writeFileSync(
+      path.join(dir, "common_paths.yml"),
+      `upstream:\n  path: ${path.join(dir, "upstream")}\n`,
+    );
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("detects and syncs drift from common_paths source", () => {
+    writeFileSync(path.join(dir, "content", "vendored.txt"), "old\n");
+    writeFileSync(
+      path.join(dir, "content", "note.md"),
+      "> pinned at SHA `abcdef0`\nsource/blob/abcdef0123456789/docs/source.txt\nsha: abcdef0\nrevised: 2026-01-01\n",
+    );
+    const entry = {
+      local: "content/vendored.txt",
+      source: "$UPSTREAM/docs/source.txt",
+      pinned_ref: "abcdef0123456789",
+      framing: "content/note.md",
+    };
+
+    expect(findVendoredDrift(dir, [entry])).toHaveLength(1);
+    const synced = syncVendoredUpstreams(dir, [entry]);
+    expect(synced).toHaveLength(1);
+    expect(findVendoredDrift(dir, [entry])).toHaveLength(0);
+  });
+
+  it("updates manifest pins without losing comments", () => {
+    const manifest = path.join(dir, "vendored_upstreams.yml");
+    writeFileSync(
+      manifest,
+      "# keep\n\n- local: content/vendored.txt\n  source: $UPSTREAM/docs/source.txt\n  pinned_ref: old\n",
+    );
+
+    updateVendoredManifestRefs(manifest, new Map([["content/vendored.txt", "newref"]]));
+
+    expect(readFileSync(manifest, "utf-8")).toBe(
+      "# keep\n\n- local: content/vendored.txt\n  source: $UPSTREAM/docs/source.txt\n  pinned_ref: newref\n",
+    );
+  });
+});

--- a/vendored_upstreams.yml
+++ b/vendored_upstreams.yml
@@ -1,0 +1,12 @@
+# Vendored files copied from repositories declared in common_paths.yml.
+# `source` uses the same $NAME/path citation grammar as content notes.
+
+- local: content/research/galaxy-collection-semantics.yml
+  source: $GALAXY/lib/galaxy/model/dataset_collections/types/collection_semantics.yml
+  pinned_ref: 7765fae934fbfdee77e3be5f5b235e43735273ae
+  framing: content/research/galaxy-collection-semantics.md
+
+- local: content/research/galaxy-collection-semantics.upstream.myst
+  source: $GALAXY/doc/source/dev/collection_semantics.md
+  pinned_ref: 7765fae934fbfdee77e3be5f5b235e43735273ae
+  framing: content/research/galaxy-collection-semantics.md


### PR DESCRIPTION
## Summary
- Add `vendored_upstreams.yml` manifest using `common_paths.yml` citation prefixes for upstream sources.
- Add `pnpm check:vendored` and `pnpm sync:vendored` to detect and refresh vendored files.
- Sync Galaxy collection semantics to local Galaxy ref `7765fae934fb` and update note pins.

## Verification
- `pnpm check:vendored`
- `pnpm test`
- `pnpm validate` (0 errors, existing backlink warnings)

Closes #12