### PR TITLE
Add tabular pattern pages

### DIFF
--- a/.claude/commands/iwc-survey-pattern.md
+++ b/.claude/commands/iwc-survey-pattern.md
@@ -1,0 +1,87 @@
+---
+description: Draft one Foundry pattern page from an IWC survey candidate without turning the survey into a rigid template.
+argument-hint: "<survey-path> <operation-slug>  e.g. content/research/iwc-tabular-operations-survey.md tabular-sql-query"
+---
+
+# Draft one pattern page from a survey: `$1` `$2`
+
+Write or refine exactly one pattern page under `content/patterns/` from a surveyed candidate. Keep the page operation-first, corpus-grounded, and useful to a cast skill. Do not author a batch unless the user asks.
+
+## Load context first
+
+1. **`content/glossary.md`** — pinned Foundry vocabulary.
+2. **`CLAUDE.md`** — local authoring rules.
+3. **`docs/PATTERNS.md`** — operation-anchored naming, corpus-first rule, legacy-tool posture.
+4. **`docs/ARCHITECTURE.md`** §3, §5, §6 — note types, frontmatter, validation.
+5. **`meta_schema.yml`** + **`meta_tags.yml`** — frontmatter contract and tags.
+6. **`common_paths.yml.sample`** — citation prefix vocabulary; use `$IWC_FORMAT2/path:line` citations.
+7. **The survey at `$1`** — especially the candidate boundary, decisions, and open-question resolution relevant to `$2`.
+
+## Find style comparators without loading everything
+
+Do not read every `content/patterns/*.md` file by default.
+
+1. Use `Glob` for `content/patterns/*.md` to see names.
+2. Pick the 1-2 closest comparators by operation name, shared tool family, or known decision boundary.
+3. If no obvious comparator exists, load one high-signal pattern from the same broad family and one general mature page.
+4. If comparator choice is ambiguous or could bias the page, ask one short clarification question before drafting.
+
+Examples:
+- A SQL tabular page should compare against nearby tabular pages such as `tabular-compute-new-column` or `tabular-join-on-key`.
+- An awk recipe should compare against another operation-named awk recipe if one exists, not every awk-related page.
+- A collection-tabular bridge should compare against the closest bridge page and one ordinary tabular page.
+
+## Decide the page identity
+
+- Filename and title are operation-anchored. Tool names belong in `## Tool`, not the slug, unless the operation is inseparable from one named Galaxy primitive.
+- Use `aliases` for old survey candidate names, tool-anchored names, or terms users are likely to search for.
+- If `$2` looks like a typo or an outlier against `docs/PATTERNS.md`, the survey, or nearby slugs, stop and ask. Recommend the correction.
+
+## Page shape
+
+Use these sections as a flexible house style, not a hard template:
+
+- `## Tool` — recommended tool or recipe mechanism; include version posture only when it matters.
+- `## When to reach for it` — scope and 1-3 nearby “do not use this when...” boundaries.
+- `## Parameters` — authoring-relevant fields and sharp YAML shape facts, not full tool documentation.
+- `## Idiomatic shapes` — corpus-shaped YAML or compact snippets.
+- `## Pitfalls` — concrete silent failures and correctness traps.
+- `## Exemplars (IWC)` — `$IWC_FORMAT2/path:line` citations with why each exemplar matters.
+- `## Legacy alternative` — optional. Include only when there is a real legacy/read-support/migration point.
+- `## See also` — related survey, close sibling pages, and decision-boundary pages.
+
+Drop sections that do not earn their space. A thin “None surfaced” legacy section is worse than no section.
+
+## Frontmatter guidance
+
+- Required fields must conform to `meta_schema.yml`; do not add ad-hoc fields.
+- `summary` is a compressed “what to do and when” line, not a mini abstract.
+- `related_notes` should name primary source notes only, usually the survey. Put secondary context notes in body or `See also` unless they are essential source material.
+- `related_patterns` should be focused: pages that decide against this one, close siblings, or immediate follow-ups. Do not list the whole neighborhood.
+- `related_molds` usually includes `[[implement-galaxy-tool-step]]` when the page guides Galaxy step authoring.
+
+## Evidence and tone
+
+- The survey is the audit trail; the pattern page is the actionable reference.
+- Preserve pinned decisions from the survey. If a decision looks wrong, surface it as a question; do not silently override it.
+- Cite corpus examples tightly. Prefer 2-4 exemplars that teach distinct shapes over citation density.
+- Prefer concrete prescriptive language where the corpus justifies it: “set `one_header: true` when...” not “consider headers.”
+- Avoid speculative capabilities. No IWC exemplar means no pattern page.
+
+## Validation
+
+After writing or editing the page:
+
+1. Run `npm run validate`.
+2. Fix schema, tag, and broken-link errors. Do not weaken the schema to pass.
+3. Warnings can remain if they are known backlink advisories; report them explicitly.
+
+## Report back
+
+Summarize:
+
+- Page written/refined.
+- Main operation boundary.
+- Comparator pages used.
+- Validation result.
+- Any unresolved naming or evidence questions.

--- a/content/patterns/tabular-concatenate-collection-to-table.md
+++ b/content/patterns/tabular-concatenate-collection-to-table.md
@@ -1,0 +1,124 @@
+---
+type: pattern
+title: "Tabular: concatenate collection to table"
+aliases:
+  - "collection-to-single-tabular-with-collapse_dataset"
+  - "collapse_dataset collection to tabular"
+  - "collection-to-tabular bridge"
+tags:
+  - pattern
+  - target/galaxy
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+summary: "Use collapse_dataset to row-bind a collection of tabulars into one table, with optional element IDs and header dedupe."
+related_notes:
+  - "[[iwc-tabular-operations-survey]]"
+related_patterns:
+  - "[[tabular-pivot-collection-to-wide]]"
+  - "[[tabular-cut-and-reorder-columns]]"
+  - "[[tabular-group-and-aggregate-with-datamash]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+---
+
+# Tabular: concatenate collection to table
+
+## Tool
+
+`toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0`. The tabular survey found 44 step instances, making this the dominant collection-to-tabular bridge for row-binding per-element tabular outputs into one dataset.
+
+## When to reach for it
+
+Use this when a Galaxy dataset collection of tabular-like files must become one tabular dataset for downstream `Cut1`, `Filter1`, `datamash_ops`, `tp_find_and_replace`, or reporting steps.
+
+Do not use this for plain two-file concatenation; use `tp_cat` or legacy `cat1` only when the input is not a collection. Do not use this when each collection element should become a column; use [[tabular-pivot-collection-to-wide]]. For grouped collapse within one table, use [[tabular-group-and-aggregate-with-datamash]].
+
+## Parameters
+
+- `input_list`: connected collection input.
+- `filename.add_name`: whether to inject the collection element identifier into output rows.
+- `filename.place_name`: where/how to place the element identifier when `add_name: true`.
+- `one_header`: whether to keep only one header row across all collection elements.
+
+The canonical headered-table shape is:
+
+```yaml
+tool_id: toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0
+tool_state:
+  filename:
+    add_name: true
+    place_name: same_multiple
+  input_list: { __class__: ConnectedValue }
+  one_header: true
+```
+
+## Idiomatic shapes
+
+Per-sample tabulars to one annotated table:
+
+```yaml
+tool_state:
+  filename:
+    add_name: true
+    place_name: same_multiple
+  input_list: { __class__: ConnectedValue }
+  one_header: true
+```
+
+Cited at `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:414-433`.
+
+Collection concat with no element identifier:
+
+```yaml
+tool_state:
+  filename:
+    add_name: false
+  input_list: { __class__: ConnectedValue }
+  one_header: false
+```
+
+Cited at `$IWC_FORMAT2/amplicon/amplicon-mgnify/mapseq-to-ampvis2/mapseq-to-ampvis2.gxwf.yml:178-198`.
+
+Headerless outputs with row provenance:
+
+```yaml
+tool_state:
+  filename:
+    add_name: true
+    place_name: same_multiple
+  input_list: { __class__: ConnectedValue }
+  one_header: false
+```
+
+Cited at `$IWC_FORMAT2/virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping.gxwf.yml:715-734`.
+
+## Pitfalls
+
+- **`add_name: false` loses provenance.** This is silent if downstream needs sample or element identity.
+- **`one_header: false` duplicates headers** when each collection element has its own header row.
+- **`one_header: true` on headerless data may drop a real first row.** Only enable it when inputs have headers.
+- **`place_name: same_multiple` is the row-provenance idiom.** It repeats the element name so each output row carries identity.
+- **`same_once` is a different shape.** Use it only when downstream expects block labels, not per-row identity.
+- **This is row-bind, not wide pivot.** If each collection element should become a column, use [[tabular-pivot-collection-to-wide]].
+
+## Exemplars (IWC)
+
+- `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:414-433` — canonical triad: `add_name: true`, `place_name: same_multiple`, `one_header: true`.
+- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mapseq-to-ampvis2/mapseq-to-ampvis2.gxwf.yml:178-198` — concat without name/header handling: `add_name: false`, `one_header: false`.
+- `$IWC_FORMAT2/virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping.gxwf.yml:715-734` — `add_name: true`, `same_multiple`, `one_header: false`.
+- `$IWC_FORMAT2/virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping.gxwf.yml:1195-1240` — repeated bridge pattern before tabular filtering.
+- `$IWC_FORMAT2/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation.gxwf.yml:509-548` — collection bridge in a pathogen workflow.
+
+## Legacy alternative
+
+For non-collection two-file concatenation, older workflows may use `tp_cat` or legacy core `cat1`. Those are not replacements for this pattern because they do not carry collection element identity.
+
+## See also
+
+- [[iwc-tabular-operations-survey]] — candidate 9 evidence.
+- [[iwc-transformations-survey]] — collection-side cross-reference for the same bridge.
+- [[tabular-pivot-collection-to-wide]] — collection elements become columns instead of rows.
+- [[tabular-cut-and-reorder-columns]] — common cleanup after concatenation.

--- a/content/patterns/tabular-filter-by-column-value.md
+++ b/content/patterns/tabular-filter-by-column-value.md
@@ -78,10 +78,6 @@ Cited at `$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-atac-cutandru
 
 All three corpus filters are equality / disjunction over a string column, or a `ConnectedValue` rule. Numeric-range predicates are unattested — if you reach for `cN > X`, you're slightly off the corpus path; verify behavior on a sample.
 
-## Legacy alternative
-
-None — `Filter1` is the modern tool. (Don't confuse with `__FILTER_FROM_FILE__` and `__FILTER_EMPTY_DATASETS__`, which are collection-level filters, not tabular row filters.)
-
 ## See also
 
 - [[iwc-tabular-operations-survey]] — corpus survey and decision record.

--- a/content/patterns/tabular-group-and-aggregate-with-datamash.md
+++ b/content/patterns/tabular-group-and-aggregate-with-datamash.md
@@ -1,0 +1,140 @@
+---
+type: pattern
+title: "Tabular: group and aggregate"
+tags:
+  - pattern
+  - target/galaxy
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+summary: "Use datamash_ops for grouped tabular aggregation: multi-column grouping, collapse, countunique, min/max, and reductions."
+related_notes:
+  - "[[iwc-tabular-operations-survey]]"
+related_patterns:
+  - "[[tabular-compute-new-column]]"
+  - "[[tabular-sql-query]]"
+  - "[[tabular-join-on-key]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+---
+
+# Tabular: group and aggregate
+
+## Tool
+
+`toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops` ("Datamash"). 73 step occurrences in the surveyed IWC corpus across pins including `1.1.0`, `1.8+galaxy0`, and `1.9+galaxy0`. This is the canonical grouped aggregation path; `Grouping1` is the legacy alternative.
+
+## When to reach for it
+
+Use `datamash_ops` when rows need to be grouped by one or more columns and summarized with aggregate operations such as `collapse`, `countunique`, `min`, `max`, or whole-file reductions.
+
+For SQL windows or joins, use [[tabular-sql-query]]. For simple row filtering, use [[tabular-filter-by-column-value]] or [[tabular-filter-by-regex]]. For simple computed columns, use [[tabular-compute-new-column]].
+
+## Parameters
+
+- `grouping`: comma-separated string of 1-indexed key columns, e.g. `"3"` or `1,2,3,4,5`. Empty string means whole-file aggregate.
+- `operations`: repeat list of `{ op_name, op_column }` entries. Corpus operations include `collapse`, `countunique`, `min`, `max`, and `absmax`.
+- `header_in`: whether the input has a header row.
+- `header_out`: whether the output includes aggregate headers.
+- `need_sort`: whether datamash should sort/group by the key before aggregating. Correctness-significant when upstream order is not guaranteed.
+- `narm`: ignore/remove NA values when true.
+- `ignore_case`: case-insensitive grouping when true.
+- `print_full_line`: false in the corpus examples surveyed.
+- `in_file`: connected tabular input.
+
+## Idiomatic shapes
+
+Collapse many value columns by many key columns:
+
+```yaml
+tool_id: toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.8+galaxy0
+tool_state:
+  grouping: 1,2,3,4,5,6,7,8,9,10
+  header_in: true
+  header_out: true
+  ignore_case: false
+  in_file: { __class__: ConnectedValue }
+  narm: false
+  need_sort: false
+  operations:
+    - op_name: collapse
+      op_column: "11"
+    - op_name: collapse
+      op_column: "12"
+    - op_name: collapse
+      op_column: "13"
+    - op_name: collapse
+      op_column: "14"
+    - op_name: collapse
+      op_column: "15"
+    - op_name: collapse
+      op_column: "16"
+    - op_name: collapse
+      op_column: "17"
+  print_full_line: false
+```
+
+Cited at `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:333-373`.
+
+Grouped multi-stat summary in one pass:
+
+```yaml
+tool_id: toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.8+galaxy0
+tool_state:
+  grouping: "3"
+  header_in: true
+  header_out: true
+  ignore_case: false
+  in_file: { __class__: ConnectedValue }
+  narm: false
+  need_sort: true
+  operations:
+    - op_name: countunique
+      op_column: "1"
+    - op_name: min
+      op_column: "8"
+    - op_name: max
+      op_column: "8"
+    - op_name: countunique
+      op_column: "19"
+    - op_name: countunique
+      op_column: "13"
+  print_full_line: false
+```
+
+Cited at `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:562-596`.
+
+## Pitfalls
+
+- **`grouping` is a string, not a YAML list.** Multi-column grouping is `1,2,3`, not `[1, 2, 3]`.
+- **`need_sort` matters.** Grouped datamash requires grouped/sorted input unless upstream already guarantees key order. Corpus examples use both `true` and `false`; choose deliberately.
+- **Header toggles are independent.** `header_in: true` consumes a header; `header_out: true` emits aggregate labels. Wrong settings shift data/header expectations downstream.
+- **`collapse` is not `first`.** The SARS-CoV-2 workflow collapses values, then uses `tp_find_and_replace` to keep the first comma-delimited member. That regex group count must match the collapsed column count.
+- **Datamash-generated headers may need cleanup.** Surveyed workflows strip labels such as `GroupBy(...)` and `collapse(...)` downstream.
+- **Empty `grouping: ""` is a whole-file aggregate.** Valid, but a different operation than grouped summary.
+- **Version pins vary.** Prefer the newest available pin in the workflow context; do not downgrade just to match an old exemplar.
+
+## Exemplars (IWC)
+
+- `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:333-373` — 10-column grouping with 7 `collapse` operations.
+- `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:375-407` — regex cleanup after collapsed datamash output.
+- `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:562-596` — `countunique`, `min`, and `max` in one grouped step.
+- `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:632-657` — single `countunique` operation.
+- `$IWC_FORMAT2/VGP-assembly-v2/Purge-duplicates-one-haplotype-VGP6b/Purging-duplicates-one-haplotype-VGP6b.gxwf.yml:601-626` — `1.9+galaxy0`, whole-file `absmax` reduction with no grouping.
+
+## Legacy alternative
+
+`Grouping1` (Galaxy core; display name "Group data by a column") survives in older microbiome workflows. Preserve it when reading old workflows, but prefer `datamash_ops` for new authoring.
+
+Distinguishing fields: `groupcol`, `ignorecase`, `ignorelines`, `operations[].optype`, `operations[].opcol`, `operations[].opround`, and `operations[].opdefault`. Do not translate `Grouping1.operations[].optype` directly into datamash without checking names; datamash uses `op_name`.
+
+Cited at `$IWC_FORMAT2/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation.gxwf.yml:324-340` and `:1087-1103`.
+
+## See also
+
+- [[iwc-tabular-operations-survey]] — corpus survey and §7 legacy-tool decision.
+- [[tabular-sql-query]] — SQL windows, joins, and anti-joins.
+- [[tabular-join-on-key]] — ordinary key joins before/after aggregation.
+- [[tabular-compute-new-column]] — per-row computations before aggregation.

--- a/content/patterns/tabular-join-on-key.md
+++ b/content/patterns/tabular-join-on-key.md
@@ -1,0 +1,147 @@
+---
+type: pattern
+title: "Tabular: join on key"
+tags:
+  - pattern
+  - target/galaxy
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+summary: "Use tp_easyjoin_tool for two-tabular key joins; use tp_multijoin_tool for many files and query_tabular for SQL joins."
+related_notes:
+  - "[[iwc-tabular-operations-survey]]"
+related_patterns:
+  - "[[tabular-group-and-aggregate-with-datamash]]"
+  - "[[tabular-sql-query]]"
+  - "[[tabular-pivot-collection-to-wide]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+---
+
+# Tabular: join on key
+
+## Tool
+
+`toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool` is the primary corpus path for ordinary two-file key joins. Use `tp_multijoin_tool` when many files share the same key/value shape. Use [[tabular-sql-query]] when the join condition, projection, anti-join, named columns, or indexes are the point.
+
+## When to reach for it
+
+Use this pattern when two or more tabular datasets share an identifier column and need row-wise alignment.
+
+Do not use this for collection-to-wide pivots; that is [[tabular-pivot-collection-to-wide]]. Do not use it for side-by-side paste with no key, row-bind/concat, or grouping. For aggregation around a join, see [[tabular-group-and-aggregate-with-datamash]].
+
+## Parameters
+
+For `tp_easyjoin_tool`:
+
+- `column1`: 1-indexed key column in `infile1`, quoted as a string.
+- `column2`: 1-indexed key column in `infile2`, quoted as a string.
+- `empty_string_filler`: fill value for missing-side cells. Corpus values include `"0"` and `"."`.
+- `header`: boolean; whether inputs have headers.
+- `ignore_case`: boolean key matching option.
+- `jointype`: join mode. Corpus default outer-style shape uses a literal single-space string: `" "`.
+- `infile1`, `infile2`: connected tabular inputs.
+
+For `tp_multijoin_tool`:
+
+- `first_file`: first connected tabular input.
+- `files`: remaining connected tabular inputs.
+- `key_column`: shared key column.
+- `value_columns`: value columns to carry through from each file.
+- `filler`: fill value for missing cells.
+- `input_header`, `output_header`: independent header toggles.
+- `ignore_dups`: duplicate-key behavior.
+
+## Idiomatic shapes
+
+Two-file key join, fill missing with zero:
+
+```yaml
+tool_id: toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/9.3+galaxy1
+tool_state:
+  column1: "20"
+  column2: "1"
+  empty_string_filler: "0"
+  header: true
+  ignore_case: false
+  infile1: { __class__: ConnectedValue }
+  infile2: { __class__: ConnectedValue }
+  jointype: " "
+```
+
+Cited at `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:601-627`.
+
+Many two-column files joined by a shared key:
+
+```yaml
+tool_id: toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_multijoin_tool/9.3+galaxy1
+tool_state:
+  first_file: { __class__: ConnectedValue }
+  files: { __class__: ConnectedValue }
+  key_column: "1"
+  value_columns: "2"
+  filler: "0"
+  input_header: false
+  output_header: true
+  ignore_dups: false
+```
+
+Cited at `$IWC_FORMAT2/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation.gxwf.yml:796-819`.
+
+SQL join when SQL semantics matter:
+
+```yaml
+tool_id: toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/query_tabular/3.3.2
+tool_state:
+  query_result:
+    header: yes
+    header_prefix: ""
+  sqlquery: |-
+    SELECT pep.mpep, prot.prot
+    FROM pep
+    INNER JOIN prot on pep.mpep=prot.pep
+  tables:
+    - table: { __class__: ConnectedValue }
+      tbl_opts:
+        table_name: pep
+        col_names: mpep
+    - table: { __class__: ConnectedValue }
+      tbl_opts:
+        table_name: prot
+        col_names: pep,prot
+```
+
+Cited at `$IWC_FORMAT2/proteomics/clinicalmp/clinicalmp-verification/clinicalmp-verification.gxwf.yml:359-415`.
+
+## Pitfalls
+
+- **`jointype: " "` is intentional.** The surveyed easyjoin shape uses a literal single-space string. Do not clean it up to an empty string or `--outer` without wrapper verification.
+- **Key columns are 1-indexed strings.** Use `"1"`, `"20"`, etc. Do not use `c1` here.
+- **Header flag must match input.** Wrong `header` settings shift matching and can duplicate or garble headers.
+- **Fill value is semantic.** `"0"` means absent is zero; `"."` means absent is unknown/missing. Pick based on downstream interpretation.
+- **`tp_easyjoin_tool` is not SQL.** Compound predicates, anti-joins, named-column projection, or indexed joins belong in [[tabular-sql-query]].
+- **`tp_multijoin_tool` assumes uniform shape.** It fits many same-shaped key/value files, not arbitrary heterogeneous tables.
+- **Do not substitute collection joins.** `collection_column_join` is for the collection-to-wide-table idiom, not ordinary two-file joins.
+
+## Exemplars (IWC)
+
+- `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:601-627` — canonical `tp_easyjoin_tool` with `column1: "20"`, `column2: "1"`, `empty_string_filler: "0"`, `header: true`, `jointype: " "`.
+- `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:722-747`, `:752-777`, `:799-825` — repeated fan-in joins with the same easyjoin shape.
+- `$IWC_FORMAT2/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8.gxwf.yml:3452-3477` — newer `tp_easyjoin_tool/9.5+galaxy3`, key `1` to `1`, filler `"."`.
+- `$IWC_FORMAT2/microbiome/metagenomic-genes-catalogue/metagenomic-genes-catalogue.gxwf.yml:1013-1041` — headerless easyjoin, labeled "Join Prodigal to AMR".
+- `$IWC_FORMAT2/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation.gxwf.yml:796-819` — `tp_multijoin_tool`, key column `"1"`, value column `"2"`, filler `"0"`.
+- `$IWC_FORMAT2/proteomics/clinicalmp/clinicalmp-verification/clinicalmp-verification.gxwf.yml:359-415` — `query_tabular` `INNER JOIN`.
+- `$IWC_FORMAT2/proteomics/clinicalmp/clinicalmp-discovery/iwc-clinicalmp-discovery-workflow.gxwf.yml:724-814` — SQL anti-join using `WHERE ... NOT IN (SELECT ... JOIN ...)`.
+
+## Legacy alternative
+
+Older core join tools may appear in inherited workflows, but the tabular survey's recommended path is `tp_easyjoin_tool` for ordinary two-file joins and `tp_multijoin_tool` for many same-shaped files. Preserve legacy steps when reading old workflows; do not introduce them in new authoring.
+
+## See also
+
+- [[iwc-tabular-operations-survey]] — corpus survey and candidate 6 evidence.
+- [[tabular-sql-query]] — SQL joins and anti-joins.
+- [[tabular-group-and-aggregate-with-datamash]] — grouped summaries before/after joins.
+- [[tabular-pivot-collection-to-wide]] — collection of two-column tables to wide table.

--- a/content/patterns/tabular-pivot-collection-to-wide.md
+++ b/content/patterns/tabular-pivot-collection-to-wide.md
@@ -1,0 +1,103 @@
+---
+type: pattern
+title: "Tabular: pivot collection to wide"
+aliases:
+  - "collection-to-wide-table-with-collection_column_join"
+tags:
+  - pattern
+  - target/galaxy
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+summary: "Use collection_column_join to outer-join a collection of 2-column id/value tables into one wide table."
+related_notes:
+  - "[[iwc-tabular-operations-survey]]"
+related_patterns:
+  - "[[tabular-join-on-key]]"
+  - "[[tabular-concatenate-collection-to-table]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+---
+
+# Tabular: pivot collection to wide
+
+## Tool
+
+`toolshed.g2.bx.psu.edu/repos/iuc/collection_column_join/collection_column_join/0.0.3`. The tabular survey identifies this as the dominant IWC wide-pivot idiom: a collection of per-element `(identifier, value)` tables becomes one wide table with one row per identifier and one column per collection element.
+
+## When to reach for it
+
+Use this when each collection element is a two-column tabular keyed by the same identifier column, and the desired output is one wide tabular matrix.
+
+Do not use this for ordinary two-file joins; use [[tabular-join-on-key]]. Do not frame it as a generic transpose or pivot-table operation; the survey found no broad `datamash_transpose`-style pattern in IWC.
+
+## Parameters
+
+- `input_tabular`: connected collection of tabular datasets.
+- `identifier_column`: 1-indexed key column in each per-element table. Corpus examples usually use `"1"`.
+- `fill_char`: value for missing element/key cells. Corpus examples use `"0"` and `.`.
+- `has_header`: string toggle, `"0"` / `"1"`, not a boolean.
+- `old_col_in_header`: whether collection element / original column identity appears in output headers.
+- `include_outputs`: usually `null` in corpus examples.
+
+## Idiomatic shapes
+
+Headerless abundance/count pivot:
+
+```yaml
+tool_id: toolshed.g2.bx.psu.edu/repos/iuc/collection_column_join/collection_column_join/0.0.3
+tool_state:
+  fill_char: "0"
+  has_header: "0"
+  identifier_column: "1"
+  include_outputs: null
+  input_tabular: { __class__: ConnectedValue }
+  old_col_in_header: true
+```
+
+Cited at `$IWC_FORMAT2/amplicon/amplicon-mgnify/mapseq-to-ampvis2/mapseq-to-ampvis2.gxwf.yml:202-222`.
+
+Headered metric-table pivot:
+
+```yaml
+tool_id: toolshed.g2.bx.psu.edu/repos/iuc/collection_column_join/collection_column_join/0.0.3
+tool_state:
+  fill_char: .
+  has_header: "1"
+  identifier_column: "1"
+  include_outputs: null
+  input_tabular: { __class__: ConnectedValue }
+  old_col_in_header: false
+```
+
+Cited at `$IWC_FORMAT2/microbiome/mags-building/MAGs-generation.gxwf.yml:1483-1505`, `:1544-1565`, and `:1656-1677`.
+
+## Pitfalls
+
+- **Input shape is strict.** This works because upstream emits one `(id, value)` table per collection element. It is not a generic wide/long pivot.
+- **Do not substitute ordinary joins.** `collection_column_join` is collection-shaped; use [[tabular-join-on-key]] for two-file key joins.
+- **`has_header` is a string.** Corpus YAML uses `"0"` / `"1"`, not booleans.
+- **Fill value has meaning.** `"0"` means absent is zero; `.` means missing/unknown. Match downstream semantics.
+- **Header semantics matter.** `old_col_in_header: true` preserves element identity in headers; `false` appears in MAG metric pivots.
+- **Guard empties when plausible.** The transformations survey flags upstream `__FILTER_EMPTY_DATASETS__` as a defensive guard when per-element outputs may be empty, especially small-N or filter-heavy paths. Do not apply it as universal boilerplate; several IWC pivots do not filter first.
+
+## Exemplars (IWC)
+
+- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mapseq-to-ampvis2/mapseq-to-ampvis2.gxwf.yml:202-222` — headerless id/value collection to wide table, `fill_char: "0"`, `old_col_in_header: true`.
+- `$IWC_FORMAT2/microbiome/mags-building/MAGs-generation.gxwf.yml:1483-1505`, `:1544-1565`, `:1656-1677` — three metric pivots in one workflow, headered inputs, `fill_char: .`.
+- `$IWC_FORMAT2/microbiome/mag-genome-annotation-parallel/MAG-Genome-Annotation-Parallel.gxwf.yml:811-833` — "Merge Bakta Output", headered input, `old_col_in_header: true`.
+- `$IWC_FORMAT2/microbiome/pathogen-identification/nanopore-pre-processing/Nanopore-Pre-Processing.gxwf.yml:823-843` — upstream tabular sources joined into wide output.
+- `$IWC_FORMAT2/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation.gxwf.yml:444-455`, `:552-571` — defensive `__FILTER_EMPTY_DATASETS__` upstream of `collection_column_join`.
+
+## Legacy alternative
+
+None. This page exists because the corpus has one dominant operation-shaped path. Awk or SQL rewrites would be custom transformations, not the IWC pattern.
+
+## See also
+
+- [[iwc-tabular-operations-survey]] — candidate 8 and §7 operation-anchored naming decision.
+- [[iwc-transformations-survey]] — collection-side cross-reference and empty-element guard note.
+- [[tabular-join-on-key]] — ordinary two-file key joins.
+- [[tabular-concatenate-collection-to-table]] — row-bind a collection into one long table.

--- a/content/patterns/tabular-prepend-header.md
+++ b/content/patterns/tabular-prepend-header.md
@@ -1,0 +1,100 @@
+---
+type: pattern
+title: "Tabular: prepend header"
+tags:
+  - pattern
+  - target/galaxy
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+summary: "Use tp_awk_tool to prepend a constant header line, optionally skipping or reformatting an existing first row."
+related_notes:
+  - "[[iwc-tabular-operations-survey]]"
+related_patterns:
+  - "[[tabular-compute-new-column]]"
+  - "[[tabular-concatenate-collection-to-table]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+---
+
+# Tabular: prepend header
+
+## Tool
+
+`toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool`. The survey split awk into operation-named recipe pages; this page covers the recurring `BEGIN { print "header" }` idiom, not awk in general.
+
+`tp_text_file_with_recurring_lines` plus concatenation can build constant prefixes, but IWC reaches for awk more often for this header-prepend operation.
+
+## When to reach for it
+
+Use this when a tabular or text-like output needs a fixed first line inside the workflow. Common shapes include prepending a header and passing rows unchanged, prepending a header while skipping an old first row, and prepending a header while normalizing a few fields.
+
+Do not use this for header stripping alone; that is usually `Remove beginning1`. Do not use it for collection header dedupe; use [[tabular-concatenate-collection-to-table]] with `one_header: true`.
+
+## Parameters
+
+- `code`: awk program. Corpus uses both quoted one-liners and multiline `|-` blocks.
+- `infile`: connected input.
+- `variables`: usually `[]` in the cited examples.
+
+Version pins vary (`9.3+galaxy1`, `9.5+galaxy0`, `9.5+galaxy2`, `9.5+galaxy3`) with stable parameter shape. Prefer the newest/current pin already used in the workflow; do not change pins solely for cleanup.
+
+## Idiomatic shapes
+
+Prepend a simple header, pass rows unchanged:
+
+```yaml
+tool_id: toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/9.3+galaxy1
+tool_state:
+  code: 'BEGIN{print "Metric\tAlternate"}; {print}; '
+  infile: { __class__: ConnectedValue }
+  variables: []
+```
+
+Cited at `$IWC_FORMAT2/VGP-assembly-v2/Purge-duplicates-one-haplotype-VGP6b/Purging-duplicates-one-haplotype-VGP6b.gxwf.yml:846-858`.
+
+Prepend a header, skip the old first row, and normalize rows:
+
+```yaml
+tool_id: toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/9.5+galaxy2
+tool_state:
+  code: |-
+    BEGIN {OFS="\t"; print "genome\tcompleteness\tcontamination"}
+    NR > 1 {
+        if ($1 !~ /\.fasta$/)
+            $1 = $1 ".fasta"
+        print $1, $2, $3
+    }
+  infile: { __class__: ConnectedValue }
+  variables: []
+```
+
+Cited at `$IWC_FORMAT2/microbiome/mags-building/MAGs-generation.gxwf.yml:1078-1099`.
+
+## Pitfalls
+
+- **Duplicate headers.** If input already has a header, use `NR > 1`; plain `{print}` preserves the old header under the new one.
+- **Set `OFS` when printing fields.** `print $1, $2, $3` uses `OFS`; without `BEGIN {OFS="\t"}`, awk emits spaces.
+- **Quoted and multiline `code` both occur.** Use one-line quoted strings only for simple pass-through. Use multiline `|-` for `NR > 1`, conditionals, or field rewriting.
+- **Do not name this awk.** The page is operation-named per the survey decision. Sibling awk recipes get their own operation pages.
+- **Header injection is not collection header dedupe.** Collection-wide header dedupe belongs to [[tabular-concatenate-collection-to-table]].
+
+## Exemplars (IWC)
+
+- `$IWC_FORMAT2/microbiome/mags-building/MAGs-generation.gxwf.yml:1078-1099` — multiline awk, prepends `genome\tcompleteness\tcontamination`, skips existing first row, appends `.fasta` when missing.
+- `$IWC_FORMAT2/VGP-assembly-v2/Purge-duplicates-one-haplotype-VGP6b/Purging-duplicates-one-haplotype-VGP6b.gxwf.yml:846-858` — one-liner `Metric\tAlternate`.
+- `$IWC_FORMAT2/VGP-assembly-v2/Purge-duplicates-one-haplotype-VGP6b/Purging-duplicates-one-haplotype-VGP6b.gxwf.yml:1622-1634` — sibling one-liner `Metric\tPrimary`.
+- `$IWC_FORMAT2/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8.gxwf.yml:2150-2161` — one-liner `Metric\tContigs\tNotes`.
+
+## Legacy alternative
+
+`tp_text_file_with_recurring_lines` plus `tp_cat` can prepend constant text, but it is not the lead recommendation for this corpus pattern. Use it only when a separate reusable text file is already part of the workflow design.
+
+## See also
+
+- [[iwc-tabular-operations-survey]] — §2g, §5, and §7 awk split decision.
+- [[tabular-concatenate-collection-to-table]] — collection header dedupe via `one_header`.
+- [[tabular-compute-new-column]] — simple per-row expressions without awk.
+- [[tabular-filter-by-regex]] — line-level regex filtering without header injection.

--- a/content/patterns/tabular-relabel-by-row-counter.md
+++ b/content/patterns/tabular-relabel-by-row-counter.md
@@ -1,0 +1,105 @@
+---
+type: pattern
+title: "Tabular: relabel by row counter"
+aliases:
+  - "sample_N relabel"
+  - "inline relabel"
+tags:
+  - pattern
+  - target/galaxy
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+summary: "Use tp_awk_tool to replace each row or label with deterministic sample_N values from awk NR."
+related_notes:
+  - "[[iwc-tabular-operations-survey]]"
+related_patterns:
+  - "[[tabular-prepend-header]]"
+  - "[[tabular-compute-new-column]]"
+  - "[[tabular-concatenate-collection-to-table]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+---
+
+# Tabular: relabel by row counter
+
+## Tool
+
+`toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool`. This is the operation-named awk recipe for replacing row content with deterministic labels derived from `NR`.
+
+## When to reach for it
+
+Use this when a workflow needs synthetic row labels like `sample_0`, `sample_1`, ... or `sample_1`, `sample_2`, ... based only on input row order.
+
+Do not use this for simple computed columns; use [[tabular-compute-new-column]]. Do not use this when labels should come from collection element identifiers; use collection-aware provenance such as [[tabular-concatenate-collection-to-table]].
+
+## Parameters
+
+- `code`: awk program. A one-line quoted string is enough for this operation.
+- `infile`: connected input.
+- `variables`: usually `[]` in awk examples.
+
+The corpus exemplar uses `toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/9.5+galaxy3`.
+
+## Idiomatic shapes
+
+Corpus-observed `sample_0` first row:
+
+```yaml
+tool_id: toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/9.5+galaxy3
+tool_state:
+  code: '{gsub( $0 ,"sample_" (NR-1)); print}'
+  infile: { __class__: ConnectedValue }
+  variables: []
+```
+
+Cited at `$IWC_FORMAT2/microbiome/binning-evaluation/MAGs-binning-evaluation.gxwf.yml:420-436`.
+
+Clearer equivalent for new whole-row replacement:
+
+```yaml
+tool_state:
+  code: '{print "sample_" (NR-1)}'
+  infile: { __class__: ConnectedValue }
+  variables: []
+```
+
+One-based labels:
+
+```yaml
+tool_state:
+  code: '{print "sample_" NR}'
+  infile: { __class__: ConnectedValue }
+  variables: []
+```
+
+Keep a header and relabel only data rows:
+
+```yaml
+tool_state:
+  code: 'NR==1 {print; next} {print "sample_" (NR-1)}'
+  infile: { __class__: ConnectedValue }
+  variables: []
+```
+
+## Pitfalls
+
+- **Zero-based vs one-based labels.** Corpus emits `sample_0` first because it uses `NR-1`. Use `NR` for `sample_1`.
+- **Headers shift counters.** Decide whether the first line is preserved, dropped, or counted before picking `NR` vs `NR-1`.
+- **Avoid `gsub($0, ...)` for new work.** It works in the exemplar, but treats the current row as a regex pattern. `print "sample_" ...` is clearer when replacing the whole row.
+- **Whole-row replacement destroys original columns.** Only use when downstream wants labels only.
+- **Row order becomes semantic.** Any upstream sort or filter changes assigned sample numbers.
+- **No collection provenance.** If labels should come from element identifiers, do not synthesize them from row order.
+
+## Exemplars (IWC)
+
+- `$IWC_FORMAT2/microbiome/binning-evaluation/MAGs-binning-evaluation.gxwf.yml:420-436` — `tp_awk_tool/9.5+galaxy3`, `code: '{gsub( $0 ,"sample_" (NR-1)); print}'`.
+
+## See also
+
+- [[iwc-tabular-operations-survey]] — §2g and §7 awk split decision.
+- [[tabular-prepend-header]] — header-preserving variants.
+- [[tabular-compute-new-column]] — preserve rows while adding/replacing columns.
+- [[tabular-concatenate-collection-to-table]] — preserve collection element identity instead of synthesizing row labels.

--- a/content/patterns/tabular-split-taxonomy-string.md
+++ b/content/patterns/tabular-split-taxonomy-string.md
@@ -1,0 +1,111 @@
+---
+type: pattern
+title: "Tabular: split taxonomy string"
+tags:
+  - pattern
+  - target/galaxy
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+summary: "Use tp_awk_tool to split semicolon-delimited taxonomy strings into explicit rank columns with missing-rank handling."
+related_notes:
+  - "[[iwc-tabular-operations-survey]]"
+related_patterns:
+  - "[[tabular-prepend-header]]"
+  - "[[tabular-compute-new-column]]"
+  - "[[tabular-cut-and-reorder-columns]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+---
+
+# Tabular: split taxonomy string
+
+## Tool
+
+`toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool`. This page covers the taxonomy-lineage awk recipe from [[iwc-tabular-operations-survey]] §2g and §7.
+
+## When to reach for it
+
+Use this when a tabular column contains semicolon-delimited taxonomic lineage and downstream tools need explicit rank columns such as superkingdom, kingdom, phylum, class, order, family, genus, and species.
+
+Do not use this as a generic pivot or transpose; see [[tabular-pivot-collection-to-wide]] for the collection-wide pivot pattern. Use [[tabular-compute-new-column]] for simple one-expression columns and [[tabular-cut-and-reorder-columns]] for post-split projection.
+
+## Parameters
+
+- `code`: awk program. Corpus examples use multiline code for `split`, prefix dispatch, and missing-rank handling.
+- `infile`: connected tabular input.
+- `variables`: usually `[]` in awk examples.
+
+Set `FS = OFS = "\t"` when reading and writing tabular rows.
+
+## Idiomatic shapes
+
+Prefix-dispatch split, robust to missing or reordered ranks:
+
+```yaml
+tool_id: toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/9.5+galaxy0
+tool_state:
+  code: |-
+    BEGIN { FS = OFS = "\t" }
+    NR > 2 {
+      otu_id = "OTU_" $1
+      superkingdom = kingdom = phylum = tax_class = order = family = genus = species = ""
+
+      split($3, taxonomy, ";")
+
+      for (i in taxonomy) {
+        if (taxonomy[i] ~ /^sk__/) superkingdom = taxonomy[i]
+        else if (taxonomy[i] ~ /^k__/) kingdom = taxonomy[i]
+        else if (taxonomy[i] ~ /^p__/) phylum = taxonomy[i]
+        else if (taxonomy[i] ~ /^c__/) tax_class = taxonomy[i]
+        else if (taxonomy[i] ~ /^o__/) order = taxonomy[i]
+        else if (taxonomy[i] ~ /^f__/) family = taxonomy[i]
+        else if (taxonomy[i] ~ /^g__/) genus = taxonomy[i]
+        else if (taxonomy[i] ~ /^s__/) species = taxonomy[i]
+      }
+
+      print otu_id, superkingdom, kingdom, phylum, tax_class, order, family, genus, species
+    }
+  infile: { __class__: ConnectedValue }
+  variables: []
+```
+
+Cited at `$IWC_FORMAT2/amplicon/amplicon-mgnify/mapseq-to-ampvis2/mapseq-to-ampvis2.gxwf.yml:101-135`.
+
+Fixed-depth split when upstream guarantees positional ranks:
+
+```awk
+BEGIN { FS = OFS = "\t" }
+NR > 1 {
+  split($1, taxa_parts, ";")
+  superkingdom = (taxa_parts[1] != "" ? taxa_parts[1] : "unassigned")
+  kingdom = (taxa_parts[2] != "" ? taxa_parts[2] : "unassigned")
+  phylum = (taxa_parts[3] != "" ? taxa_parts[3] : "unassigned")
+  print superkingdom, kingdom, phylum
+}
+```
+
+## Pitfalls
+
+- **Set `FS = OFS = "\t"`.** Without it, `print a, b, c` emits spaces.
+- **Header skipping is source-specific.** MAPseq examples use `NR > 2`; other table-reshaping examples use `NR > 1`.
+- **Choose prefix behavior deliberately.** Decide whether downstream wants values like `p__Firmicutes` or stripped names like `Firmicutes`.
+- **Handle missing ranks explicitly.** Corpus examples use empty strings or `unassigned` depending on downstream contract.
+- **`for (i in array)` order is undefined.** It is fine for prefix dispatch, not for positional rank emission.
+- **Avoid `class` as a new example variable.** Corpus-style awk may use it, but `tax_class` avoids confusing readers.
+
+## Exemplars (IWC)
+
+- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mapseq-to-ampvis2/mapseq-to-ampvis2.gxwf.yml:101-135` — canonical 8-rank prefix dispatch from `$3`, emits OTU id plus rank columns.
+- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-taxonomic-summary-tables/mgnify-amplicon-summary-tables.gxwf.yml:101-120` — fixed-depth merge of first three ranks, strips `__`, fills `unassigned`.
+- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-taxonomic-summary-tables/mgnify-amplicon-summary-tables.gxwf.yml:336-367` — splits first column into superkingdom/kingdom/phylum and preserves abundance columns.
+- `$IWC_FORMAT2/amplicon/amplicon-mgnify/taxonomic-rank-abundance-summary-table/taxonomic-rank-abundance-summary-table.gxwf.yml:97-111` — rank-depth variants from superkingdom through species.
+
+## See also
+
+- [[iwc-tabular-operations-survey]] — §2g, §2l, and §7 awk split decision.
+- [[tabular-prepend-header]] — header manipulation before/after awk transforms.
+- [[tabular-cut-and-reorder-columns]] — projection after rank expansion.
+- [[tabular-pivot-collection-to-wide]] — collection-to-wide pivot, not taxonomy parsing.

--- a/content/patterns/tabular-sql-query.md
+++ b/content/patterns/tabular-sql-query.md
@@ -1,0 +1,143 @@
+---
+type: pattern
+title: "Tabular: SQL query"
+tags:
+  - pattern
+  - target/galaxy
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+summary: "Use query_tabular when SQL semantics justify it: windows, joins, anti-joins, or fused project+compute over tabulars."
+related_notes:
+  - "[[iwc-tabular-operations-survey]]"
+related_patterns:
+  - "[[tabular-filter-by-column-value]]"
+  - "[[tabular-filter-by-regex]]"
+  - "[[tabular-cut-and-reorder-columns]]"
+  - "[[tabular-compute-new-column]]"
+  - "[[tabular-join-on-key]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+---
+
+# Tabular: SQL query
+
+## Tool
+
+`toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/query_tabular/3.3.2` ("Query Tabular"). 16 step occurrences in the surveyed IWC corpus. This is the SQL leaf in the tabular hierarchy: powerful, but deliberately narrow.
+
+## When to reach for it
+
+Use `query_tabular` when the operation is genuinely SQL-shaped: window functions, multi-table joins, anti-joins, or fused project + compute + filter over one or more tabular inputs.
+
+For a one-table Python predicate, use [[tabular-filter-by-column-value]]. For whole-line regex filtering, use [[tabular-filter-by-regex]]. For pure projection, use [[tabular-cut-and-reorder-columns]]. For a simple computed column, use [[tabular-compute-new-column]].
+
+## Parameters
+
+- `sqlquery`: main SQL query. Tables are named `t1`, `t2`, ... unless `tables[].tbl_opts.table_name` sets explicit names.
+- `query_result.header`: `yes` / `no`; controls whether the main output has a header.
+- `tables`: repeat list of inputs to load into SQLite.
+- `tables[].table`: connected tabular input.
+- `tables[].input_opts.linefilters`: load-time preprocessing before SQLite import. Corpus filters include `comment`, `skip`, `prepend_dataset_name`, `prepend_line_num`, and `normalize`.
+- `tables[].tbl_opts.table_name`: optional SQL table name. Blank means default `t1`, `t2`, ...
+- `tables[].tbl_opts.column_names_from_first_line`: whether the first row supplies column names.
+- `tables[].tbl_opts.col_names`: comma-separated named columns for SQL.
+- `tables[].tbl_opts.load_named_columns`: whether to load named columns rather than positional `cN` columns.
+- `tables[].tbl_opts.indexes`: optional SQLite indexes for join-heavy queries.
+- `addqueries.queries`: optional extra SQL outputs. Check this before assuming `sqlquery` is the only result.
+- `workdb`: usually `workdb.sqlite`.
+
+## Idiomatic shapes
+
+Single-table project + compute with a window function:
+
+```yaml
+tool_id: toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/query_tabular/3.3.2
+tool_state:
+  query_result:
+    header: no
+  sqlquery: |-
+    SELECT c1, c2, c3, c3 * 100 / SUM(c3) OVER() AS relative_abundance
+    FROM t1;
+  tables:
+    - table: { __class__: ConnectedValue }
+      input_opts:
+        linefilters:
+          - filter:
+              filter_type: comment
+              comment_char: "35"
+          - filter:
+              filter_type: prepend_dataset_name
+      tbl_opts:
+        table_name: ""
+        column_names_from_first_line: false
+        col_names: ""
+        load_named_columns: false
+        indexes: []
+  workdb: workdb.sqlite
+```
+
+Cited at `$IWC_FORMAT2/amplicon/amplicon-mgnify/mapseq-to-ampvis2/mapseq-to-ampvis2.gxwf.yml:33-82`.
+
+Multi-table SQL join with named tables:
+
+```yaml
+tool_id: toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/query_tabular/3.3.2
+tool_state:
+  query_result:
+    header: yes
+    header_prefix: ""
+  sqlquery: |-
+    SELECT pep.mpep, prot.prot
+    FROM pep
+    INNER JOIN prot on pep.mpep=prot.pep
+  tables:
+    - table: { __class__: ConnectedValue }
+      input_opts:
+        linefilters: []
+      tbl_opts:
+        table_name: pep
+        column_names_from_first_line: false
+        col_names: mpep
+        load_named_columns: false
+        indexes: []
+    - table: { __class__: ConnectedValue }
+      input_opts:
+        linefilters: []
+      tbl_opts:
+        table_name: prot
+        column_names_from_first_line: false
+        col_names: pep,prot
+        load_named_columns: false
+        indexes: []
+  workdb: workdb.sqlite
+```
+
+Cited at `$IWC_FORMAT2/proteomics/clinicalmp/clinicalmp-verification/clinicalmp-verification.gxwf.yml:359-415`.
+
+## Pitfalls
+
+- **Do not use SQL for simple filters or cuts.** The survey decision keeps this page narrow; simple row predicates and projections have clearer leaf pages.
+- **Header handling is split across fields.** `query_result.header`, `tables[].tbl_opts.column_names_from_first_line`, and load filters like `skip` are independent.
+- **Line filters run before SQL.** `prepend_dataset_name`, `prepend_line_num`, and `normalize` change column positions before the query sees the table.
+- **Blank `table_name` is meaningful.** Blank means default `t1`; named joins need explicit table names.
+- **`comment_char: "35"` means `#`.** The corpus YAML uses the ASCII code string, not the literal `#`.
+- **Extra outputs can hide in `addqueries`.** Some workflows emit multiple query results from one step.
+- **Version pins vary.** `3.3.0` and `3.3.2` appear in corpus. Prefer the newest available pin unless preserving an existing workflow.
+
+## Exemplars (IWC)
+
+- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mapseq-to-ampvis2/mapseq-to-ampvis2.gxwf.yml:33-82` — single-table relative abundance with `SUM(c3) OVER()`.
+- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction.gxwf.yml:137-201` — one input, main query plus three `addqueries` outputs.
+- `$IWC_FORMAT2/proteomics/clinicalmp/clinicalmp-verification/clinicalmp-verification.gxwf.yml:359-415` — two-table `INNER JOIN` with named tables.
+- `$IWC_FORMAT2/proteomics/clinicalmp/clinicalmp-discovery/iwc-clinicalmp-discovery-workflow.gxwf.yml:724-814` — three-table anti-join with load filters and indexes.
+
+## See also
+
+- [[iwc-tabular-operations-survey]] — corpus survey and §7 decision record for SQL as a narrow tabular leaf.
+- [[tabular-filter-by-column-value]] — one-table row predicates.
+- [[tabular-cut-and-reorder-columns]] — pure projection.
+- [[tabular-compute-new-column]] — simple computed columns.
+- [[tabular-join-on-key]] — ordinary key joins without SQL-specific semantics.

--- a/content/patterns/tabular-synthesize-bed-from-3col.md
+++ b/content/patterns/tabular-synthesize-bed-from-3col.md
@@ -1,0 +1,100 @@
+---
+type: pattern
+title: "Tabular: synthesize BED from 3-column input"
+tags:
+  - pattern
+  - target/galaxy
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+summary: "Use tp_awk_tool to convert chrom/start/end rows into 6-column BED, subtracting 1 from start and setting constants."
+related_notes:
+  - "[[iwc-tabular-operations-survey]]"
+related_patterns:
+  - "[[tabular-prepend-header]]"
+  - "[[tabular-compute-new-column]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+---
+
+# Tabular: synthesize BED from 3-column input
+
+## Tool
+
+`toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool`. This is one of the operation-named awk recipe pages from [[iwc-tabular-operations-survey]] §7.
+
+## When to reach for it
+
+Use this when a three-column interval-like table needs to become BED-like six-column rows:
+
+```text
+chrom_or_seqid<TAB>start<TAB>end
+```
+
+to:
+
+```text
+chrom_or_seqid<TAB>start0<TAB>end<TAB>name<TAB>score<TAB>strand
+```
+
+The corpus-attested use is MGnify rRNA prediction: separate SSU/LSU forward/reverse interval outputs become hidden BED datasets, then forward and reverse files are concatenated per target. This is not a general tabular format-conversion page.
+
+## Parameters
+
+- `code`: awk program. Corpus uses a quoted one-liner.
+- `infile`: connected three-column input.
+- Output metadata: corpus examples set `change_datatype: bed` and `hide: true` on the output.
+
+Version pins differ (`9.5+galaxy0` and `9.3+galaxy1`) with stable parameter shape. Prefer the newest/current pin already used in the workflow.
+
+## Idiomatic shapes
+
+Forward-strand BED:
+
+```yaml
+tool_id: toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/9.5+galaxy0
+tool_state:
+  code: 'BEGIN {OFS="\t"} {print $1, $2 - 1, $3, "forward", "1", "+"}'
+  infile: { __class__: ConnectedValue }
+out:
+  - id: outfile
+    change_datatype: bed
+    hide: true
+```
+
+Reverse-strand BED:
+
+```yaml
+tool_id: toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/9.5+galaxy0
+tool_state:
+  code: 'BEGIN {OFS="\t"} {print $1, $2 - 1, $3, "reverse", "1", "-"}'
+  infile: { __class__: ConnectedValue }
+out:
+  - id: outfile
+    change_datatype: bed
+    hide: true
+```
+
+## Pitfalls
+
+- **Start coordinate off-by-one.** BED start is 0-based; corpus subtracts 1 from `$2`.
+- **Do not subtract from end.** BED end stays `$3` in the corpus shape.
+- **Set `OFS="\t"`.** Without it, `print $1, ...` emits spaces.
+- **No header handling is shown.** Corpus inputs are treated as data-only. If input has a header, add `NR > 1` deliberately.
+- **BED datatype matters.** Corpus sets `change_datatype: bed`; do not leave the output as generic tabular if downstream expects BED.
+- **Name and score are constants.** This pattern does not derive BED name or score from input columns.
+- **Forward and reverse are separate steps.** Do not emit both strands from one row unless downstream expects duplicate intervals in one file.
+
+## Exemplars (IWC)
+
+- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction.gxwf.yml:205-245` — SSU forward/reverse BED.
+- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction.gxwf.yml:251-291` — LSU forward/reverse BED.
+- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/mgnify-amplicon-pipeline-v5-complete.gxwf.yml:2084-2170` — same idiom embedded in the complete workflow with older `9.3+galaxy1` pin.
+
+## See also
+
+- [[iwc-tabular-operations-survey]] — §2g and §7 awk split decision.
+- [[tabular-prepend-header]] — another operation-named awk recipe.
+- [[tabular-compute-new-column]] — simple per-row arithmetic when the output remains tabular, not BED.


### PR DESCRIPTION
## Summary
- Add nine corpus-grounded tabular pattern pages from the IWC tabular operations survey.
- Add `/iwc-survey-pattern` for drafting one pattern page from a survey without loading every existing pattern page.
- Tighten existing pattern page cohesion by removing an empty legacy section.

## Validation
- `npm run validate` passes with 0 errors and existing backlink warnings.