### PR TITLE
Link Galaxy mold references

### DIFF
--- a/content/molds/author-galaxy-tool-wrapper/index.md
+++ b/content/molds/author-galaxy-tool-wrapper/index.md
@@ -12,6 +12,23 @@ revised: 2026-04-30
 revision: 1
 ai_generated: true
 summary: "Author a new Galaxy tool wrapper (XML) when discovery yields nothing acceptable."
+references:
+  - kind: schema
+    ref: "content/schemas/summary-nextflow.schema.json"
+    used_at: runtime
+    load: upfront
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Read process tool, container, conda, inputs, outputs, script summary, and test fixture evidence from the source pipeline summary."
+  - kind: research
+    ref: "[[component-nextflow-containers-and-envs]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    evidence: hypothesis
+    purpose: "Map Nextflow container/conda evidence to Galaxy tool requirements and wrapper provenance."
+    trigger: "When a missing Galaxy wrapper must be authored from a Nextflow process with container or conda directives."
+    verification: "Author one wrapper from nf-core/bacass or nf-core/rnaseq process evidence and confirm the note improves requirements/container extraction."
 ---
 # author-galaxy-tool-wrapper
 

--- a/content/molds/author-galaxy-tool-wrapper/index.md
+++ b/content/molds/author-galaxy-tool-wrapper/index.md
@@ -24,7 +24,7 @@ references:
     ref: "[[component-nextflow-containers-and-envs]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: hypothesis
     purpose: "Map Nextflow container/conda evidence to Galaxy tool requirements and wrapper provenance."
     trigger: "When a missing Galaxy wrapper must be authored from a Nextflow process with container or conda directives."

--- a/content/molds/compare-against-iwc-exemplar/index.md
+++ b/content/molds/compare-against-iwc-exemplar/index.md
@@ -17,7 +17,7 @@ references:
     ref: "[[iwc-transformations-survey]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Compare draft collection-shape recipes against corpus-observed IWC examples."
     trigger: "When the draft workflow contains collection reshape, cleanup, relabel, or synchronization sections."
@@ -25,7 +25,7 @@ references:
     ref: "[[iwc-tabular-operations-survey]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Compare draft tabular/text-processing sections against corpus-observed IWC examples."
     trigger: "When the draft workflow contains tabular filtering, projection, join, aggregation, or free-form text-processing sections."
@@ -33,7 +33,7 @@ references:
     ref: "[[iwc-test-data-conventions]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Compare test-data placement and fixture shapes against IWC conventions."
     trigger: "When exemplar comparison includes workflow tests or input fixture organization."
@@ -41,7 +41,7 @@ references:
     ref: "[[iwc-shortcuts-anti-patterns]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Flag draft shortcuts that are accepted in IWC versus shortcuts that should be treated as smells."
     trigger: "When reviewing draft tests, assertions, labels, or expected-output comparisons."

--- a/content/molds/compare-against-iwc-exemplar/index.md
+++ b/content/molds/compare-against-iwc-exemplar/index.md
@@ -12,6 +12,39 @@ revised: 2026-04-30
 revision: 1
 ai_generated: true
 summary: "Find nearest IWC exemplar(s) and surface a structural diff against a draft."
+references:
+  - kind: research
+    ref: "[[iwc-transformations-survey]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    evidence: corpus-observed
+    purpose: "Compare draft collection-shape recipes against corpus-observed IWC examples."
+    trigger: "When the draft workflow contains collection reshape, cleanup, relabel, or synchronization sections."
+  - kind: research
+    ref: "[[iwc-tabular-operations-survey]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    evidence: corpus-observed
+    purpose: "Compare draft tabular/text-processing sections against corpus-observed IWC examples."
+    trigger: "When the draft workflow contains tabular filtering, projection, join, aggregation, or free-form text-processing sections."
+  - kind: research
+    ref: "[[iwc-test-data-conventions]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    evidence: corpus-observed
+    purpose: "Compare test-data placement and fixture shapes against IWC conventions."
+    trigger: "When exemplar comparison includes workflow tests or input fixture organization."
+  - kind: research
+    ref: "[[iwc-shortcuts-anti-patterns]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    evidence: corpus-observed
+    purpose: "Flag draft shortcuts that are accepted in IWC versus shortcuts that should be treated as smells."
+    trigger: "When reviewing draft tests, assertions, labels, or expected-output comparisons."
 ---
 # compare-against-iwc-exemplar
 

--- a/content/molds/debug-galaxy-workflow-output/index.md
+++ b/content/molds/debug-galaxy-workflow-output/index.md
@@ -12,6 +12,31 @@ revised: 2026-04-30
 revision: 1
 ai_generated: true
 summary: "Triage failing Galaxy run outputs; classify failure modes; propose fixes."
+references:
+  - kind: research
+    ref: "[[planemo-asserts-idioms]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    evidence: corpus-observed
+    purpose: "Classify whether a failure is an assertion-choice problem, tolerance problem, or real workflow-output regression."
+    trigger: "When Planemo reports output assertion failures or generated tests are too strict/too weak."
+  - kind: research
+    ref: "[[iwc-shortcuts-anti-patterns]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    evidence: corpus-observed
+    purpose: "Decide whether a proposed debug fix aligns with accepted IWC testing shortcuts or masks a real failure."
+    trigger: "When debugging suggests weakening assertions, widening deltas, switching to existence checks, or changing output labels."
+  - kind: research
+    ref: "[[galaxy-collection-semantics]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    evidence: corpus-observed
+    purpose: "Diagnose collection shape, mapping, reduction, and element-identifier mismatches in failed Galaxy runs."
+    trigger: "When a failing output is a collection, a mapped output, or an unexpectedly nested/flattened structure."
 ---
 # debug-galaxy-workflow-output
 

--- a/content/molds/debug-galaxy-workflow-output/index.md
+++ b/content/molds/debug-galaxy-workflow-output/index.md
@@ -17,7 +17,7 @@ references:
     ref: "[[planemo-asserts-idioms]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Classify whether a failure is an assertion-choice problem, tolerance problem, or real workflow-output regression."
     trigger: "When Planemo reports output assertion failures or generated tests are too strict/too weak."
@@ -25,7 +25,7 @@ references:
     ref: "[[iwc-shortcuts-anti-patterns]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Decide whether a proposed debug fix aligns with accepted IWC testing shortcuts or masks a real failure."
     trigger: "When debugging suggests weakening assertions, widening deltas, switching to existence checks, or changing output labels."
@@ -33,7 +33,7 @@ references:
     ref: "[[galaxy-collection-semantics]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Diagnose collection shape, mapping, reduction, and element-identifier mismatches in failed Galaxy runs."
     trigger: "When a failing output is a collection, a mapped output, or an unexpectedly nested/flattened structure."

--- a/content/molds/discover-shed-tool/index.md
+++ b/content/molds/discover-shed-tool/index.md
@@ -47,7 +47,7 @@ references:
     ref: "[[component-tool-shed-search]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Explain Tool Shed search/indexing limitations that affect hit scoring and fallthrough decisions."
     trigger: "When results are missing, weak, duplicated across owners, stale, or ambiguous."

--- a/content/molds/discover-shed-tool/index.md
+++ b/content/molds/discover-shed-tool/index.md
@@ -18,6 +18,39 @@ cli_commands:
   - "[[tool-revisions]]"
 related_notes:
   - "[[component-tool-shed-search]]"
+references:
+  - kind: cli-command
+    ref: "[[tool-search]]"
+    used_at: runtime
+    load: on-demand
+    mode: sidecar
+    evidence: corpus-observed
+    purpose: "Search the Tool Shed for candidate wrappers matching a step's tool need."
+    trigger: "When resolving a workflow step to an installable Galaxy tool wrapper."
+  - kind: cli-command
+    ref: "[[tool-versions]]"
+    used_at: runtime
+    load: on-demand
+    mode: sidecar
+    evidence: corpus-observed
+    purpose: "List available Tool Shed versions for a selected candidate."
+    trigger: "After a Tool Shed search candidate is selected and before pinning a version."
+  - kind: cli-command
+    ref: "[[tool-revisions]]"
+    used_at: runtime
+    load: on-demand
+    mode: sidecar
+    evidence: corpus-observed
+    purpose: "Resolve a Tool Shed tool version to an installable changeset revision."
+    trigger: "After selecting a candidate version that needs a reproducible changeset pin."
+  - kind: research
+    ref: "[[component-tool-shed-search]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    evidence: corpus-observed
+    purpose: "Explain Tool Shed search/indexing limitations that affect hit scoring and fallthrough decisions."
+    trigger: "When results are missing, weak, duplicated across owners, stale, or ambiguous."
 ---
 
 # discover-shed-tool

--- a/content/molds/implement-galaxy-tool-step/index.md
+++ b/content/molds/implement-galaxy-tool-step/index.md
@@ -12,6 +12,47 @@ revised: 2026-04-30
 revision: 1
 ai_generated: true
 summary: "Convert an abstract step into a concrete gxformat2 step using a tool summary."
+references:
+  - kind: research
+    ref: "[[galaxy-collection-semantics]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    evidence: corpus-observed
+    purpose: "Connect concrete Galaxy tool inputs/outputs while preserving collection mapping and reduction semantics."
+    trigger: "When implementing a step with data_collection inputs, mapped outputs, reductions, or nested collection wiring."
+  - kind: research
+    ref: "[[galaxy-collection-tools]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    evidence: corpus-observed
+    purpose: "Insert built-in Galaxy collection-operation steps when a direct tool connection cannot express the needed shape."
+    trigger: "When a step needs collection construction, filtering, extraction, zipping, unzipping, flattening, merging, or relabeling."
+  - kind: research
+    ref: "[[galaxy-apply-rules-dsl]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    evidence: corpus-observed
+    purpose: "Implement identifier-derived collection reshaping via Apply Rules."
+    trigger: "When collection element identifiers need regex parsing, nesting-level swaps, regrouping, or paired identifier assignment."
+  - kind: research
+    ref: "[[iwc-transformations-survey]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    evidence: corpus-observed
+    purpose: "Choose corpus-attested collection recipes when implementing concrete Galaxy steps."
+    trigger: "When the implementation needs cleanup-after-fanout, sync-by-identifier, singleton unboxing, relabeling, or collection-to-tabular bridges."
+  - kind: research
+    ref: "[[iwc-tabular-operations-survey]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    evidence: corpus-observed
+    purpose: "Choose corpus-attested tabular/text-processing recipes when implementing concrete Galaxy steps."
+    trigger: "When the implementation needs row filtering, column projection, computed columns, joins, grouping, awk, or text-processing wrappers."
 ---
 # implement-galaxy-tool-step
 

--- a/content/molds/implement-galaxy-tool-step/index.md
+++ b/content/molds/implement-galaxy-tool-step/index.md
@@ -17,7 +17,7 @@ references:
     ref: "[[galaxy-collection-semantics]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Connect concrete Galaxy tool inputs/outputs while preserving collection mapping and reduction semantics."
     trigger: "When implementing a step with data_collection inputs, mapped outputs, reductions, or nested collection wiring."
@@ -25,7 +25,7 @@ references:
     ref: "[[galaxy-collection-tools]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Insert built-in Galaxy collection-operation steps when a direct tool connection cannot express the needed shape."
     trigger: "When a step needs collection construction, filtering, extraction, zipping, unzipping, flattening, merging, or relabeling."
@@ -33,7 +33,7 @@ references:
     ref: "[[galaxy-apply-rules-dsl]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Implement identifier-derived collection reshaping via Apply Rules."
     trigger: "When collection element identifiers need regex parsing, nesting-level swaps, regrouping, or paired identifier assignment."
@@ -41,7 +41,7 @@ references:
     ref: "[[iwc-transformations-survey]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Choose corpus-attested collection recipes when implementing concrete Galaxy steps."
     trigger: "When the implementation needs cleanup-after-fanout, sync-by-identifier, singleton unboxing, relabeling, or collection-to-tabular bridges."
@@ -49,7 +49,7 @@ references:
     ref: "[[iwc-tabular-operations-survey]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Choose corpus-attested tabular/text-processing recipes when implementing concrete Galaxy steps."
     trigger: "When the implementation needs row filtering, column projection, computed columns, joins, grouping, awk, or text-processing wrappers."

--- a/content/molds/implement-galaxy-workflow-test/index.md
+++ b/content/molds/implement-galaxy-workflow-test/index.md
@@ -22,7 +22,7 @@ references:
     ref: "[[iwc-test-data-conventions]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Assemble job input fixtures, remote URLs, hashes, collection shapes, and test-data layout in IWC style."
     trigger: "When writing or revising the job/input side of a Galaxy workflow test file."
@@ -30,7 +30,7 @@ references:
     ref: "[[planemo-asserts-idioms]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Choose assertion families, tolerance magnitudes, and the static/Planemo validation loop."
     trigger: "When writing or revising output assertions for a Galaxy workflow test file."
@@ -38,7 +38,7 @@ references:
     ref: "[[iwc-shortcuts-anti-patterns]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Flag assertion shortcuts that are acceptable in IWC versus shortcuts that should be avoided."
     trigger: "When considering existence-only, size-only, image-only, checksum, output-label, or negative-test patterns."

--- a/content/molds/implement-galaxy-workflow-test/index.md
+++ b/content/molds/implement-galaxy-workflow-test/index.md
@@ -17,6 +17,31 @@ related_notes:
   - "[[planemo-asserts-idioms]]"
   - "[[tests-format]]"
 summary: "Assemble Galaxy workflow test fixtures and assertions."
+references:
+  - kind: research
+    ref: "[[iwc-test-data-conventions]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    evidence: corpus-observed
+    purpose: "Assemble job input fixtures, remote URLs, hashes, collection shapes, and test-data layout in IWC style."
+    trigger: "When writing or revising the job/input side of a Galaxy workflow test file."
+  - kind: research
+    ref: "[[planemo-asserts-idioms]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    evidence: corpus-observed
+    purpose: "Choose assertion families, tolerance magnitudes, and the static/Planemo validation loop."
+    trigger: "When writing or revising output assertions for a Galaxy workflow test file."
+  - kind: research
+    ref: "[[iwc-shortcuts-anti-patterns]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    evidence: corpus-observed
+    purpose: "Flag assertion shortcuts that are acceptable in IWC versus shortcuts that should be avoided."
+    trigger: "When considering existence-only, size-only, image-only, checksum, output-label, or negative-test patterns."
 ---
 # implement-galaxy-workflow-test
 

--- a/content/molds/nextflow-test-to-target-tests/index.md
+++ b/content/molds/nextflow-test-to-target-tests/index.md
@@ -12,6 +12,49 @@ revised: 2026-04-30
 revision: 1
 ai_generated: true
 summary: "Translate NF test fixtures into a target workflow's test format."
+references:
+  - kind: schema
+    ref: "content/schemas/summary-nextflow.schema.json"
+    used_at: runtime
+    load: upfront
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Read summarized nf-test profiles, snapshot fixtures, selected test data, params, and expected outputs."
+  - kind: research
+    ref: "[[component-nextflow-testing]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    evidence: hypothesis
+    purpose: "Interpret nf-test profiles, snapshot assertions, and Nextflow fixture conventions before translating them."
+    trigger: "When converting nf_tests, snapshot fixtures, test profiles, or source test-data references into target test plans."
+    verification: "Translate nf-core/bacass nf-test snapshots into Galaxy tests and confirm this note improves profile/snapshot extraction."
+  - kind: research
+    ref: "[[iwc-test-data-conventions]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    evidence: corpus-observed
+    purpose: "Emit Galaxy/IWC-style job input fixtures, remote locations, hashes, and collection input shapes."
+    trigger: "When writing job inputs or deciding whether fixtures belong in test-data, Zenodo, ENA/SRA, or CVMFS."
+  - kind: research
+    ref: "[[planemo-asserts-idioms]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    evidence: corpus-observed
+    purpose: "Choose Galaxy workflow-test assertion families and tolerances for translated expected outputs."
+    trigger: "When turning Nextflow expected outputs or snapshots into Planemo assertions."
+  - kind: research
+    ref: "[[iwc-shortcuts-anti-patterns]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    evidence: corpus-observed
+    purpose: "Distinguish accepted IWC-style test shortcuts from assertion smells while translating tests."
+    trigger: "When deciding whether to use existence-only, size-only, image-dimension, or tolerant output checks."
+related_notes:
+  - "[[tests-format]]"
 ---
 # nextflow-test-to-target-tests
 

--- a/content/molds/nextflow-test-to-target-tests/index.md
+++ b/content/molds/nextflow-test-to-target-tests/index.md
@@ -24,7 +24,7 @@ references:
     ref: "[[component-nextflow-testing]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: hypothesis
     purpose: "Interpret nf-test profiles, snapshot assertions, and Nextflow fixture conventions before translating them."
     trigger: "When converting nf_tests, snapshot fixtures, test profiles, or source test-data references into target test plans."
@@ -33,7 +33,7 @@ references:
     ref: "[[iwc-test-data-conventions]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Emit Galaxy/IWC-style job input fixtures, remote locations, hashes, and collection input shapes."
     trigger: "When writing job inputs or deciding whether fixtures belong in test-data, Zenodo, ENA/SRA, or CVMFS."
@@ -41,7 +41,7 @@ references:
     ref: "[[planemo-asserts-idioms]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Choose Galaxy workflow-test assertion families and tolerances for translated expected outputs."
     trigger: "When turning Nextflow expected outputs or snapshots into Planemo assertions."
@@ -49,7 +49,7 @@ references:
     ref: "[[iwc-shortcuts-anti-patterns]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Distinguish accepted IWC-style test shortcuts from assertion smells while translating tests."
     trigger: "When deciding whether to use existence-only, size-only, image-dimension, or tolerant output checks."

--- a/content/molds/run-workflow-test/index.md
+++ b/content/molds/run-workflow-test/index.md
@@ -10,6 +10,15 @@ revised: 2026-04-30
 revision: 1
 ai_generated: true
 summary: "Execute a workflow's tests via Planemo; emit structured pass/fail and outputs."
+references:
+  - kind: research
+    ref: "[[planemo-asserts-idioms]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    evidence: corpus-observed
+    purpose: "Interpret assertion failures and choose the right fast inner-loop command before full reruns."
+    trigger: "When a workflow test file exists and the task is to run, iterate, or classify its test assertions."
 ---
 # run-workflow-test
 

--- a/content/molds/run-workflow-test/index.md
+++ b/content/molds/run-workflow-test/index.md
@@ -15,7 +15,7 @@ references:
     ref: "[[planemo-asserts-idioms]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Interpret assertion failures and choose the right fast inner-loop command before full reruns."
     trigger: "When a workflow test file exists and the task is to run, iterate, or classify its test assertions."

--- a/content/molds/summarize-galaxy-tool/index.md
+++ b/content/molds/summarize-galaxy-tool/index.md
@@ -12,6 +12,15 @@ revised: 2026-04-30
 revision: 1
 ai_generated: true
 summary: "Pull JSON schema, container, source, inputs/outputs for a Galaxy tool."
+references:
+  - kind: research
+    ref: "[[component-tool-shed-search]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    evidence: corpus-observed
+    purpose: "Resolve Galaxy tool identity, Tool Shed versioning, and changeset context before summarizing a wrapper."
+    trigger: "When a tool summary starts from a Tool Shed hit rather than an installed Galaxy tool object."
 ---
 # summarize-galaxy-tool
 

--- a/content/molds/summarize-galaxy-tool/index.md
+++ b/content/molds/summarize-galaxy-tool/index.md
@@ -17,7 +17,7 @@ references:
     ref: "[[component-tool-shed-search]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Resolve Galaxy tool identity, Tool Shed versioning, and changeset context before summarizing a wrapper."
     trigger: "When a tool summary starts from a Tool Shed hit rather than an installed Galaxy tool object."

--- a/content/molds/summarize-nextflow/index.md
+++ b/content/molds/summarize-nextflow/index.md
@@ -25,7 +25,7 @@ references:
     ref: "[[component-nextflow-pipeline-anatomy]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: hypothesis
     purpose: "Interpret DSL2 layout, includes, workflow/subworkflow/module boundaries, and channel/process topology."
     trigger: "When walking pipeline structure or resolving process aliases and channel flow."
@@ -34,7 +34,7 @@ references:
     ref: "[[component-nextflow-containers-and-envs]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: hypothesis
     purpose: "Resolve container, conda, Wave, and Bioconda/Biocontainers environment evidence."
     trigger: "When extracting tools, versions, containers, conda directives, or environment equivalences."
@@ -43,7 +43,7 @@ references:
     ref: "[[component-nextflow-testing]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: hypothesis
     purpose: "Extract nf-test files, snapshot fixtures, test profiles, and Nextflow test-data conventions."
     trigger: "When filling test_fixtures or nf_tests sections of the summary."

--- a/content/molds/summary-to-galaxy-data-flow/index.md
+++ b/content/molds/summary-to-galaxy-data-flow/index.md
@@ -24,7 +24,7 @@ references:
     ref: "[[galaxy-collection-semantics]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Map Nextflow fan-out/fan-in shapes onto Galaxy collection mapping and reduction behavior."
     trigger: "When a channel edge involves collection mapping, reduction, nesting, or paired/list shape changes."
@@ -32,7 +32,7 @@ references:
     ref: "[[galaxy-collection-tools]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Choose Galaxy built-in collection-operation tools for shape-only data-flow transformations."
     trigger: "When the Galaxy data-flow draft needs explicit collection construction, filtering, flattening, zipping, or relabeling."
@@ -40,7 +40,7 @@ references:
     ref: "[[galaxy-apply-rules-dsl]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Represent identifier-derived collection reshaping with Apply Rules when simpler collection tools are insufficient."
     trigger: "When channel identifiers need regex extraction, regrouping, nesting-level swaps, or paired identifier construction."
@@ -48,7 +48,7 @@ references:
     ref: "[[iwc-transformations-survey]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Ground collection-shape translation choices in observed IWC transformation recipes."
     trigger: "When selecting between Galaxy collection-operation recipes or checking whether a proposed shape transform is corpus-attested."
@@ -56,7 +56,7 @@ references:
     ref: "[[iwc-tabular-operations-survey]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Ground tabular bridge choices that appear while translating Nextflow channel/data-flow operations."
     trigger: "When data-flow translation leaves collection-land for tabular projection, filtering, joining, aggregation, or pivoting."

--- a/content/molds/summary-to-galaxy-data-flow/index.md
+++ b/content/molds/summary-to-galaxy-data-flow/index.md
@@ -12,6 +12,54 @@ revised: 2026-04-30
 revision: 1
 ai_generated: true
 summary: "Abstract DAG with Galaxy collection / scatter / branching idioms surfaced."
+references:
+  - kind: schema
+    ref: "content/schemas/summary-nextflow.schema.json"
+    used_at: runtime
+    load: upfront
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Read the Nextflow summary contract this Mold consumes when translating source data flow."
+  - kind: research
+    ref: "[[galaxy-collection-semantics]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    evidence: corpus-observed
+    purpose: "Map Nextflow fan-out/fan-in shapes onto Galaxy collection mapping and reduction behavior."
+    trigger: "When a channel edge involves collection mapping, reduction, nesting, or paired/list shape changes."
+  - kind: research
+    ref: "[[galaxy-collection-tools]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    evidence: corpus-observed
+    purpose: "Choose Galaxy built-in collection-operation tools for shape-only data-flow transformations."
+    trigger: "When the Galaxy data-flow draft needs explicit collection construction, filtering, flattening, zipping, or relabeling."
+  - kind: research
+    ref: "[[galaxy-apply-rules-dsl]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    evidence: corpus-observed
+    purpose: "Represent identifier-derived collection reshaping with Apply Rules when simpler collection tools are insufficient."
+    trigger: "When channel identifiers need regex extraction, regrouping, nesting-level swaps, or paired identifier construction."
+  - kind: research
+    ref: "[[iwc-transformations-survey]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    evidence: corpus-observed
+    purpose: "Ground collection-shape translation choices in observed IWC transformation recipes."
+    trigger: "When selecting between Galaxy collection-operation recipes or checking whether a proposed shape transform is corpus-attested."
+  - kind: research
+    ref: "[[iwc-tabular-operations-survey]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    evidence: corpus-observed
+    purpose: "Ground tabular bridge choices that appear while translating Nextflow channel/data-flow operations."
+    trigger: "When data-flow translation leaves collection-land for tabular projection, filtering, joining, aggregation, or pivoting."
 ---
 # summary-to-galaxy-data-flow
 

--- a/content/molds/summary-to-galaxy-template/index.md
+++ b/content/molds/summary-to-galaxy-template/index.md
@@ -24,7 +24,7 @@ references:
     ref: "[[galaxy-collection-semantics]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Preserve Galaxy collection typing and map-over/reduction semantics in the gxformat2 skeleton."
     trigger: "When creating workflow inputs, outputs, and placeholder connections involving collections."
@@ -32,7 +32,7 @@ references:
     ref: "[[iwc-transformations-survey]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Use observed IWC collection recipes as style guidance for unresolved skeleton steps."
     trigger: "When adding TODO steps for collection cleanup, reshaping, relabeling, or identifier synchronization."
@@ -40,7 +40,7 @@ references:
     ref: "[[iwc-tabular-operations-survey]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Use observed IWC tabular recipes as style guidance for unresolved skeleton steps."
     trigger: "When adding TODO steps for tabular filtering, projection, joins, aggregation, or text-processing bridges."

--- a/content/molds/summary-to-galaxy-template/index.md
+++ b/content/molds/summary-to-galaxy-template/index.md
@@ -12,6 +12,38 @@ revised: 2026-04-30
 revision: 1
 ai_generated: true
 summary: "gxformat2 skeleton with per-step TODOs from a data-flow summary."
+references:
+  - kind: schema
+    ref: "content/schemas/summary-nextflow.schema.json"
+    used_at: runtime
+    load: upfront
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Read source-level process, channel, tool, and test-fixture structure while drafting a Galaxy workflow skeleton."
+  - kind: research
+    ref: "[[galaxy-collection-semantics]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    evidence: corpus-observed
+    purpose: "Preserve Galaxy collection typing and map-over/reduction semantics in the gxformat2 skeleton."
+    trigger: "When creating workflow inputs, outputs, and placeholder connections involving collections."
+  - kind: research
+    ref: "[[iwc-transformations-survey]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    evidence: corpus-observed
+    purpose: "Use observed IWC collection recipes as style guidance for unresolved skeleton steps."
+    trigger: "When adding TODO steps for collection cleanup, reshaping, relabeling, or identifier synchronization."
+  - kind: research
+    ref: "[[iwc-tabular-operations-survey]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    evidence: corpus-observed
+    purpose: "Use observed IWC tabular recipes as style guidance for unresolved skeleton steps."
+    trigger: "When adding TODO steps for tabular filtering, projection, joins, aggregation, or text-processing bridges."
 ---
 # summary-to-galaxy-template
 


### PR DESCRIPTION
## Summary
- add typed runtime references to Nextflow-to-Galaxy mold stubs
- migrate discover-shed-tool CLI/research refs into the reference contract
- connect test/debug/tool-step molds to existing Galaxy/IWC research notes and summary schema

## Validation
- npm run validate

## Follow-up
- Issues #38-#71 track missing schemas, research notes, and replacing raw survey refs with a pattern MOC.