### PR TITLE
fix site reference contract dependency

### DIFF
--- a/site/src/components/ReferenceContract.astro
+++ b/site/src/components/ReferenceContract.astro
@@ -1,6 +1,6 @@
 ---
 import { resolveWikiLink, type WikiLinkTarget } from '../lib/wiki-links';
-import { loadReferenceContract, type ReferenceContractTerm } from '../../../scripts/lib/reference-contract';
+import { loadReferenceContract, type ReferenceContractTerm } from '../lib/reference-contract';
 
 interface TypedReference {
   kind: string;

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -1,6 +1,6 @@
 import { defineCollection, z } from 'astro:content';
 import { glob } from 'astro/loaders';
-import { contractKeys, loadReferenceContract } from '../../scripts/lib/reference-contract';
+import { contractKeys, loadReferenceContract } from './lib/reference-contract';
 
 const referenceContract = loadReferenceContract();
 

--- a/site/src/lib/reference-contract.ts
+++ b/site/src/lib/reference-contract.ts
@@ -1,0 +1,39 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import yaml from "js-yaml";
+
+export interface ReferenceContractTerm {
+  label: string;
+  description: string;
+  href: string;
+  ref_shape?: "wiki-link" | "path";
+}
+
+export interface ReferenceContract {
+  kinds: Record<string, ReferenceContractTerm>;
+  used_at: Record<string, ReferenceContractTerm>;
+  load: Record<string, ReferenceContractTerm>;
+  modes: Record<string, ReferenceContractTerm>;
+  evidence: Record<string, ReferenceContractTerm>;
+}
+
+export function findReferenceContractPath(startDir = process.cwd()): string {
+  let dir = path.resolve(startDir);
+  while (true) {
+    const candidate = path.join(dir, "reference_contract.yml");
+    if (existsSync(candidate)) return candidate;
+    const parent = path.dirname(dir);
+    if (parent === dir) throw new Error("reference_contract.yml not found");
+    dir = parent;
+  }
+}
+
+export function loadReferenceContract(contractPath = findReferenceContractPath()): ReferenceContract {
+  const data = yaml.load(readFileSync(contractPath, "utf8")) as ReferenceContract | null;
+  if (!data) throw new Error(`empty reference contract: ${contractPath}`);
+  return data;
+}
+
+export function contractKeys(contract: ReferenceContract, group: keyof ReferenceContract): string[] {
+  return Object.keys(contract[group]);
+}


### PR DESCRIPTION
## Summary
- Add a site-local reference contract loader so Astro resolves `js-yaml` from `site/node_modules`.
- Point content config and reference contract component at the site helper.

## Verification
- `npm run build` from `site` passes.
- `npm run typecheck` from repo root still fails on existing Astro/site type issues unrelated to this fix.