### PR TITLE
Add tabular and collection pattern pages

### DIFF
--- a/.claude/commands/iwc-survey-act.md
+++ b/.claude/commands/iwc-survey-act.md
@@ -45,8 +45,11 @@ The survey ends at numbered open questions. Walk them. Each question's answer ei
 For each surveyed candidate the user marked **keep**, ask:
 
 - Confirm operation-anchored name (propose one based on the survey; let the user rename).
+- Confirm title family / MOC bucket (`Tabular:`, `Collection:`, bridge, Apply Rules cluster, etc.) so later pages browse coherently.
 - Confirm scope sketch and the 2-3 anchor citations.
 - Anything to flag for the eventual author (prescriptive rules surfaced in the survey, foot-guns, recommended-default tuples).
+
+Before issue creation, assemble a compact candidate manifest: final slug, title prefix, keep/drop/merge call, nearest sibling pages, MOC bucket, anchor workflow paths plus step labels/tool names, and unresolved evidence questions.
 
 Collect into an issue draft per pattern. Do not open issues yet.
 

--- a/.claude/commands/iwc-survey-pattern.md
+++ b/.claude/commands/iwc-survey-pattern.md
@@ -34,6 +34,7 @@ Examples:
 ## Decide the page identity
 
 - Filename and title are operation-anchored. Tool names belong in `## Tool`, not the slug, unless the operation is inseparable from one named Galaxy primitive.
+- Keep title prefixes coherent within a family (`Tabular: ...`, `Collection: ...`) even when slugs reflect bridge operations or survey wording.
 - Use `aliases` for old survey candidate names, tool-anchored names, or terms users are likely to search for.
 - If `$2` looks like a typo or an outlier against `docs/PATTERNS.md`, the survey, or nearby slugs, stop and ask. Recommend the correction.
 
@@ -65,8 +66,18 @@ Drop sections that do not earn their space. A thin “None surfaced” legacy se
 - The survey is the audit trail; the pattern page is the actionable reference.
 - Preserve pinned decisions from the survey. If a decision looks wrong, surface it as a question; do not silently override it.
 - Cite corpus examples tightly. Prefer 2-4 exemplars that teach distinct shapes over citation density.
+- Prefer workflow-path citations plus step label/tool name when line numbers are brittle because cleaning/conversion output changes. Use exact line ranges only when they clarify a stable snippet.
 - Prefer concrete prescriptive language where the corpus justifies it: “set `one_header: true` when...” not “consider headers.”
 - Avoid speculative capabilities. No IWC exemplar means no pattern page.
+
+## Cohesion pass
+
+Before reporting back, reread the drafted page against its 1-3 nearest siblings and fix drift:
+
+- Title prefix and slug family should feel intentional.
+- State the boundary against close siblings in the body, not only `See also`.
+- For conceptual workflow shapes, label snippets as conceptual. For observed gxformat2, cite the exemplar and avoid simplifying silently.
+- Keep membership sync, order sync, relabeling, and structural reshape pages distinct when working with collection identifiers.
 
 ## Validation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@
 - **Frontmatter is contract.** `meta_schema.yml` is JSON Schema Draft 07 with `additionalProperties: false`. Unknown fields are rejected. Add a property declaration in the schema before adding a frontmatter field anywhere.
 - **Tags must be registered.** Every tag a note uses lives in `meta_tags.yml`. Vocabulary changes touch one file.
 - **Wiki-link fields use `[[Target]]`.** Single-value fields (`parent_pattern`) and array fields (`related_notes`, `related_patterns`, `related_molds`, `patterns`, `cli_commands`, `prompts`).
+- **IWC citations should survive corpus churn.** Prefer workflow-path citations plus step label/tool name over brittle line precision when cleaned/converted workflow files are likely to move. Use line ranges only when they clarify a stable local snippet.
 - **Validate before commit.** `npm run validate` checks schema + cross-file resolution. Errors block; warnings are advisory.
 - **Don't edit generated files by hand.** `Dashboard.md`, `Index.md`, `iwc-overview.md` are produced by `scripts/generate-*.ts`. `glossary.md` is hand-curated and skipped by the validator. `log.md` is append-only.
 

--- a/content/patterns/collection-build-list-paired-with-apply-rules.md
+++ b/content/patterns/collection-build-list-paired-with-apply-rules.md
@@ -1,0 +1,82 @@
+---
+type: pattern
+title: "Collection: build list paired with Apply Rules"
+aliases:
+  - "Apply Rules build list:paired"
+  - "promote paired identifier with Apply Rules"
+tags:
+  - pattern
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+summary: "Use Apply Rules to promote identifier columns into a list:paired collection, with optional cleanup first."
+related_notes:
+  - "[[iwc-transformations-survey]]"
+  - "[[galaxy-apply-rules-dsl]]"
+related_patterns:
+  - "[[collection-swap-nesting-with-apply-rules]]"
+  - "[[collection-split-identifier-via-rules]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+---
+
+# Collection: build list paired with Apply Rules
+
+## Tool
+
+Use `__APPLY_RULES__` to produce a `list:paired` collection by mapping one identifier column to the sample/list level and another to the paired level.
+
+## When to reach for it
+
+Use this when identifiers already encode, or can be cleaned to encode, both the list element identifier and the paired role.
+
+This is not the same as `__ZIP_COLLECTION__`. Use zip only when you already have two sibling collections, one forward and one reverse, with matching order. In IWC, zip is rare; Apply Rules dominates when pairedness is derived from existing identifiers or deeper nesting.
+
+This page is about promoting an identifier into paired-end structure. Use [[collection-split-identifier-via-rules]] when the second derived axis is another list level, not forward/reverse.
+
+## Parameters
+
+Minimal `list:paired` promotion:
+
+Conceptual Apply Rules shape:
+
+```yaml
+tool_id: __APPLY_RULES__
+tool_state:
+  rules:
+    - type: add_column_metadata
+      value: identifier0
+    - type: add_column_metadata
+      value: identifier1
+  mapping:
+    list_identifiers: [0]
+    paired_identifier: [1]
+```
+
+For deeper inputs, add the needed identifier columns and map the innermost paired-role column.
+
+## Pitfalls
+
+- Paired identifiers must normalize to paired roles such as forward/reverse. Do not map arbitrary replicate labels as paired ends.
+- Use `paired_identifier`, not a second list identifier, when the second axis is read direction.
+- Regex rules append new columns; check column numbers after cleanup.
+- Sorting by the wrong column can separate intended pairs.
+
+## Exemplars (IWC)
+
+- `$IWC_FORMAT2/amplicon/dada2/dada2_paired.gxwf.yml` — "Sort samples" uses `identifier0` and `identifier1`, sorts by sample, then maps `list_identifiers: [0]` plus `paired_identifier: [1]`.
+- `$IWC_FORMAT2/data-fetching/parallel-accession-download/parallel-accession-download.gxwf.yml` — flattens deeper download output into `list:paired` by promoting an inner identifier to paired role.
+- `$IWC_FORMAT2/data-fetching/sra-manifest-to-concatenated-fastqs/sra-manifest-to-concatenated-fastqs.gxwf.yml:12-13` — paired-promotion shape with regex cleanup of transient delimiter text before mapping.
+
+## Legacy alternative
+
+`__ZIP_COLLECTION__` is the dedicated two-list pairing tool, but the survey found only two corpus uses. Prefer Apply Rules when pairedness is derived from identifiers or deeper nesting; use zip only when forward and reverse sibling collections are already aligned.
+
+## See also
+
+- [[iwc-transformations-survey]] — Apply Rules Shape C and candidate boundary.
+- [[galaxy-apply-rules-dsl]] — `paired_identifier` mapping rules.
+- [[collection-split-identifier-via-rules]] — split one identifier into two list axes instead of paired role.
+- [[collection-swap-nesting-with-apply-rules]] — swap existing list axes.

--- a/content/patterns/collection-build-named-bundle.md
+++ b/content/patterns/collection-build-named-bundle.md
@@ -1,0 +1,80 @@
+---
+type: pattern
+title: "Collection: build named bundle"
+aliases:
+  - "collection build list named outputs"
+  - "__BUILD_LIST__ named bundle"
+  - "tool-output fan-in collection"
+tags:
+  - pattern
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+summary: "Use BUILD_LIST to assemble named outputs into a collection bundle for publishing or downstream fan-in."
+related_notes:
+  - "[[iwc-transformations-survey]]"
+related_patterns:
+  - "[[collection-flatten-after-fanout]]"
+  - "[[tabular-concatenate-collection-to-table]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+---
+
+# Collection: build named bundle
+
+## Tool
+
+Use Galaxy built-in `__BUILD_LIST__`.
+
+The survey found two useful sub-cases:
+
+- Manual-id output bundle: collect related outputs into a named result collection for organization or publishing.
+- Identifier-id fan-in: assemble tool outputs into one collection for a downstream tool that expects collection input.
+
+`__MERGE_COLLECTION__` is the sibling operation when the inputs are already collections. Current corpus evidence does not justify a standalone merge pattern.
+
+## When to reach for it
+
+Use `__BUILD_LIST__` when you start with individual datasets or individual output connections and need a Galaxy `list`.
+
+Use manual identifiers when element names should be human-authored result labels. Use inherited identifiers when downstream semantics already know those names.
+
+Do not use this to concatenate file contents. Use [[tabular-concatenate-collection-to-table]] when the goal is one combined tabular dataset.
+
+## Parameters
+
+The main knob is the element identifier source:
+
+```yaml
+tool_id: __BUILD_LIST__
+tool_state:
+  elements:
+    - src: { __class__: ConnectedValue }
+      id_cond:
+        id_select: manual
+        identifier: bray_curtis_pcoa_results
+```
+
+- `id_select: manual`: human-authored names for output bundles.
+- `id_select: identifier`: inherit source identifiers for downstream fan-in.
+- `id_select: idx`: positional/default style; avoid when element identity matters.
+
+## Pitfalls
+
+- Manual identifiers become collection element identifiers and may appear in output histories or reports.
+- Manual bundles group outputs; they do not align rows, merge contents, or validate common keys.
+- Use inherited identifiers only when source names are meaningful.
+- Prefer `__MERGE_COLLECTION__` only when inputs are already collections.
+
+## Exemplars (IWC)
+
+- `$IWC_FORMAT2/amplicon/qiime2/qiime2-III-VI-downsteam/QIIME2-VI-diversity-metrics-and-estimations.gxwf.yml:340` — QIIME2 Emperor plots, PCoA results, distance matrices, and richness vectors grouped into named output collections.
+- `$IWC_FORMAT2/microbiome/mags-building/MAGs-generation.gxwf.yml:961` — bin-table outputs from multiple binners assembled into one collection for `binette`.
+
+## See also
+
+- [[iwc-transformations-survey]] — Recipe K and candidate boundary.
+- [[collection-flatten-after-fanout]] — collapse nested outputs before downstream pooling.
+- [[tabular-concatenate-collection-to-table]] — row-bind a collection of tabulars after collection assembly.

--- a/content/patterns/collection-cleanup-after-mapover-failure.md
+++ b/content/patterns/collection-cleanup-after-mapover-failure.md
@@ -1,0 +1,97 @@
+---
+type: pattern
+title: "Collection: cleanup after map-over failure"
+aliases:
+  - "cleanup after fanout failure"
+  - "FILTER_EMPTY after map-over"
+  - "FILTER_FAILED after map-over"
+tags:
+  - pattern
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+summary: "Use FILTER_EMPTY or FILTER_FAILED after map-over when bad elements would break downstream collection steps."
+related_notes:
+  - "[[iwc-transformations-survey]]"
+related_patterns:
+  - "[[sync-collections-by-identifier]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+---
+
+# Collection: cleanup after map-over failure
+
+## Tool
+
+Use Galaxy built-in collection filters:
+
+- `__FILTER_EMPTY_DATASETS__` drops or replaces elements whose datasets are empty.
+- `__FILTER_FAILED_DATASETS__` drops or replaces elements whose jobs failed.
+
+These are content/state cleanup gates. They are not identifier-list filters; use [[sync-collections-by-identifier]] when the keep/drop set comes from collection element names.
+
+## When to reach for it
+
+Use this immediately after a tool maps over a collection and some elements may be unusable for the next step.
+
+Use `__FILTER_EMPTY_DATASETS__` when a per-element tool succeeds but produces a zero-line or zero-byte dataset. This is common after tabular, awk, BED, or search-style extraction where "no hits" is a valid per-sample result but the downstream tool expects non-empty input.
+
+Use `__FILTER_FAILED_DATASETS__` when a per-element job may fail and downstream processing should continue on the successful elements.
+
+Use the `replacement` form when downstream shape must stay stable. A sentinel dataset keeps an element slot instead of shortening the collection.
+
+## Parameters
+
+- `input`: collection to inspect.
+- `replacement`: optional connected dataset. If omitted, bad elements are removed. If supplied, bad elements are replaced with this dataset.
+
+The simple drop form has no meaningful knobs beyond choosing empty vs failed. The authoring decision is which failure mode you are guarding and whether collection length must be preserved.
+
+## Idiomatic shapes
+
+Drop empty elements before the next collection consumer:
+
+```yaml
+tool_id: __FILTER_EMPTY_DATASETS__
+tool_state:
+  input: { __class__: ConnectedValue }
+```
+
+Drop failed elements before aggregation:
+
+```yaml
+tool_id: __FILTER_FAILED_DATASETS__
+tool_state:
+  input: { __class__: ConnectedValue }
+```
+
+Replace failed elements with a sentinel dataset:
+
+```yaml
+tool_id: __FILTER_FAILED_DATASETS__
+in:
+  - id: input
+    source: argNorm on Groot output
+  - id: replacement
+    source: _unlabeled_step_8/outfile
+```
+
+## Pitfalls
+
+- Empty is not failed. Use `__FILTER_EMPTY_DATASETS__` for successful empty files and `__FILTER_FAILED_DATASETS__` for red elements.
+- Dropping changes collection length. If a downstream zip or sibling comparison assumes one-to-one alignment, resync siblings or use a replacement sentinel.
+- Replacement changes data semantics. The sentinel becomes real downstream input, so choose a value the next tool treats as controlled no-result data.
+- Do not confuse this with `__FILTER_FROM_FILE__`; that tool filters by identifier list and does not inspect dataset state.
+
+## Exemplars (IWC)
+
+- `$IWC_FORMAT2/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation.gxwf.yml:10-14` — five collection inputs pass through `__FILTER_FAILED_DATASETS__` before downstream aggregation.
+- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction.gxwf.yml` — repeated `__FILTER_EMPTY_DATASETS__` uses after awk/search reshapes before the next consumer.
+- `$IWC_FORMAT2/microbiome/metagenomic-raw-reads-amr-analysis/metagenomic-raw-reads-amr-analysis.gxwf.yml:225` — rare replacement form, preserving shape with a sentinel file.
+
+## See also
+
+- [[iwc-transformations-survey]] — Recipe C and candidate boundary.
+- [[sync-collections-by-identifier]] — follow-up when the cleaned collection should drive sibling filtering or relabeling.

--- a/content/patterns/collection-flatten-after-fanout.md
+++ b/content/patterns/collection-flatten-after-fanout.md
@@ -1,0 +1,68 @@
+---
+type: pattern
+title: "Collection: flatten after fan-out"
+aliases:
+  - "collection flatten after fanout"
+  - "flatten list:list to list"
+  - "__FLATTEN__ after fanout"
+tags:
+  - pattern
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+summary: "Use FLATTEN to collapse nested collection outputs to a flat list once the outer axis no longer matters."
+related_notes:
+  - "[[iwc-transformations-survey]]"
+related_patterns:
+  - "[[collection-build-named-bundle]]"
+  - "[[harmonize-by-sortlist-from-identifiers]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+---
+
+# Collection: flatten after fan-out
+
+## Tool
+
+Use Galaxy built-in `__FLATTEN__`.
+
+The corpus-attested operation is simple: collapse a nested collection such as `list:list` or `list:paired` into a flat `list` when the outer grouping axis has served its purpose.
+
+## When to reach for it
+
+Use this after a tool fans out within each sample/group and downstream no longer needs that grouping.
+
+Typical shape: a domain tool maps over a collection and produces nested outputs, the outer axis becomes only organizational, and `__FLATTEN__` produces one flat list for pooling, relabeling, reporting, or MultiQC-style consumption.
+
+Do not flatten if downstream needs to know which outer sample/group produced each element.
+
+## Parameters
+
+```yaml
+tool_id: __FLATTEN__
+tool_state:
+  input: { __class__: ConnectedValue }
+```
+
+The useful authoring decision is input collection type and whether the outer axis is truly no longer meaningful.
+
+## Pitfalls
+
+- Flattening discards structure. Element identifiers may retain hints, but the Galaxy collection type no longer encodes the outer axis.
+- Flatten only after the outer axis is done.
+- If flattened identifiers collide or become unreadable, add an explicit relabel step.
+- Do not use Apply Rules for plain flattening; the survey found `__FLATTEN__` dominates simple cases.
+
+## Exemplars (IWC)
+
+- `$IWC_FORMAT2/microbiome/mags-building/MAGs-generation.gxwf.yml` — "Pool Bins from all samples" flattens a `list:list` of bins for pool-level processing.
+- `$IWC_FORMAT2/transcriptomics/rnaseq-pe/rnaseq-pe.gxwf.yml:11` — flattens a paired collection to a flat list for MultiQC.
+- `$IWC_FORMAT2/microbiome/metagenomic-raw-reads-amr-analysis/metagenomic-raw-reads-amr-analysis.gxwf.yml:15` — flattens `list:list` output from `sylph_profile` before relabeling.
+
+## See also
+
+- [[iwc-transformations-survey]] — Recipe H and candidate boundary.
+- [[collection-build-named-bundle]] — assemble named outputs into a collection.
+- [[harmonize-by-sortlist-from-identifiers]] — order/intersect sibling collections by identifier file.

--- a/content/patterns/collection-split-identifier-via-rules.md
+++ b/content/patterns/collection-split-identifier-via-rules.md
@@ -1,0 +1,79 @@
+---
+type: pattern
+title: "Collection: split identifier via rules"
+aliases:
+  - "Apply Rules split identifier into nesting"
+  - "regex identifier split to list:list"
+tags:
+  - pattern
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+summary: "Use Apply Rules regex columns to split one collection identifier into nested list identifiers."
+related_notes:
+  - "[[iwc-transformations-survey]]"
+  - "[[galaxy-apply-rules-dsl]]"
+related_patterns:
+  - "[[collection-swap-nesting-with-apply-rules]]"
+  - "[[collection-build-list-paired-with-apply-rules]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+---
+
+# Collection: split identifier via rules
+
+## Tool
+
+Use `__APPLY_RULES__` to turn a flat `list` into a nested `list:list` by splitting each element identifier into two parts.
+
+## When to reach for it
+
+Use this when identifiers encode two nesting axes in one string, such as `sampleA_rep1`, and downstream tools need `sampleA -> rep1` nesting.
+
+Do not use this for swapping two existing nesting levels; use [[collection-swap-nesting-with-apply-rules]]. Do not use this to make forward/reverse pairs; use [[collection-build-list-paired-with-apply-rules]] when one parsed axis is a paired-end role.
+
+This page is about deriving list nesting from one identifier. Use [[regex-relabel-via-tabular]] when the collection shape is already right and only labels need cleanup.
+
+## Parameters
+
+The corpus shape uses two parallel `add_column_regex` rules, each with one capture result. Do not encode this as one `group_count: 2` rule when following the IWC exemplar.
+
+Conceptual Apply Rules shape:
+
+```yaml
+tool_id: __APPLY_RULES__
+tool_state:
+  rules:
+    - type: add_column_metadata
+      value: identifier0
+    - type: add_column_regex
+      target_column: 0
+      expression: "^(.*)_([^_]*)$"
+      replacement: "\\1"
+    - type: add_column_regex
+      target_column: 0
+      expression: "^(.*)_([^_]*)$"
+      replacement: "\\2"
+  mapping:
+    list_identifiers: [1, 2]
+```
+
+## Pitfalls
+
+- Use two regex rules, not one `group_count: 2` rule, for corpus parity.
+- Target the original identifier column both times.
+- `^(.*)_([^_]*)$` splits on the last underscore; use a stricter regex if identifiers can contain multiple separators.
+- Validate unmatched behavior instead of silently creating empty nesting keys.
+
+## Exemplars (IWC)
+
+- `$IWC_FORMAT2/epigenetics/average-bigwig-between-replicates/average-bigwig-between-replicates.gxwf.yml` — splits flat bigWig identifiers into sample-prefix and replicate-suffix nesting with two regex-derived columns.
+
+## See also
+
+- [[iwc-transformations-survey]] — Apply Rules Shape B and candidate boundary.
+- [[galaxy-apply-rules-dsl]] — `add_column_regex` and `list_identifiers` details.
+- [[collection-swap-nesting-with-apply-rules]] — regroup existing `list:list` axes.
+- [[collection-build-list-paired-with-apply-rules]] — paired-end variant.

--- a/content/patterns/collection-swap-nesting-with-apply-rules.md
+++ b/content/patterns/collection-swap-nesting-with-apply-rules.md
@@ -1,0 +1,82 @@
+---
+type: pattern
+title: "Collection: swap nesting with Apply Rules"
+aliases:
+  - "regroup list:list by inner identifier"
+  - "Apply Rules swap list nesting"
+tags:
+  - pattern
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+summary: "Use Apply Rules to regroup a list:list collection by swapping outer and inner identifier columns."
+related_notes:
+  - "[[iwc-transformations-survey]]"
+  - "[[galaxy-apply-rules-dsl]]"
+related_patterns:
+  - "[[collection-split-identifier-via-rules]]"
+  - "[[collection-build-list-paired-with-apply-rules]]"
+  - "[[relabel-via-rules-and-find-replace]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+---
+
+# Collection: swap nesting with Apply Rules
+
+## Tool
+
+Use `__APPLY_RULES__` to turn a `list:list` keyed as `sample -> segment` into a `list:list` keyed as `segment -> sample`.
+
+## When to reach for it
+
+Use this when the upstream collection has the right leaf datasets but the wrong nesting axis for downstream map-over.
+
+Do not use this for simple flattening; use [[collection-flatten-after-fanout]] when one axis should disappear. Do not use this to parse one identifier into multiple axes; use [[collection-split-identifier-via-rules]].
+
+This page is about pure axis swap. Use [[relabel-via-rules-and-find-replace]] when noisy identifiers must be cleaned during the reshape.
+
+## Parameters
+
+The rule shape is intentionally small:
+
+1. Add the outer identifier as a column.
+2. Add the inner identifier as a column.
+3. Map list identifiers in reversed order.
+
+Conceptual Apply Rules shape:
+
+```yaml
+tool_id: __APPLY_RULES__
+tool_state:
+  rules:
+    - type: add_column_metadata
+      value: identifier0
+    - type: add_column_metadata
+      value: identifier1
+  mapping:
+    list_identifiers: [1, 0]
+```
+
+Treat this as the logical shape, not a complete serialized workflow API blob.
+
+## Pitfalls
+
+- Reverse the mapping, not the rules. The corpus shape adds `identifier0`, then `identifier1`, then maps `[1, 0]`.
+- Check that the input is actually `list:list`; `identifier1` exists only when there is an inner list level.
+- Keep pure regrouping separate from relabeling unless noisy identifiers force the heavier recipe.
+- Downstream map-over behavior changes after the swap; tools now iterate by the former inner axis.
+
+## Exemplars (IWC)
+
+- `$IWC_FORMAT2/virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping.gxwf.yml` steps 14, 34, 39, 43 — repeated regrouping of influenza BAM collections between sample and segment axes.
+
+Footnote: the same workflow uses `__DUPLICATE_FILE_TO_COLLECTION__` before one Apply Rules step as a broadcast setup. That broadcast is barely attested and should not be treated as the main pattern.
+
+## See also
+
+- [[iwc-transformations-survey]] — Apply Rules Shape A and candidate boundary.
+- [[galaxy-apply-rules-dsl]] — rule and mapping grammar.
+- [[collection-split-identifier-via-rules]] — derive nesting axes from one identifier.
+- [[collection-build-list-paired-with-apply-rules]] — promote a paired identifier into `list:paired`.

--- a/content/patterns/collection-unbox-singleton.md
+++ b/content/patterns/collection-unbox-singleton.md
@@ -1,0 +1,70 @@
+---
+type: pattern
+title: "Collection: unbox singleton"
+aliases:
+  - "extract first dataset"
+  - "__EXTRACT_DATASET__ singleton"
+tags:
+  - pattern
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+summary: "Use __EXTRACT_DATASET__ with which: first when a one-element collection must become a dataset."
+related_notes:
+  - "[[iwc-transformations-survey]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+---
+
+# Collection: unbox singleton
+
+## Tool
+
+Use Galaxy built-in `__EXTRACT_DATASET__` with `which: first`.
+
+This page covers the corpus-dominant shape: an upstream step emits a known one-element collection, but the downstream step or workflow output expects a dataset.
+
+## When to reach for it
+
+Use this when the collection has exactly one meaningful element by construction.
+
+Common IWC context: QC/reporting tools emit images, stats, or HTML outputs as singleton collections after map-over or conditional branching. The workflow immediately extracts the first element so ordinary dataset-consuming steps can use it.
+
+Do not use this to reshape a real multi-element collection. If `N > 1` is meaningful, preserve collection semantics or use a collection-aware operation.
+
+## Parameters
+
+- `input`: connected collection.
+- `which: first`: singleton unboxing.
+
+The same tool supports by-index and by-identifier extraction, but the survey signal is overwhelmingly the singleton case. Prefer by-identifier over by-index if you genuinely need arbitrary element extraction.
+
+## Idiomatic shape
+
+```yaml
+tool_id: __EXTRACT_DATASET__
+tool_state:
+  input: { __class__: ConnectedValue }
+  which: first
+```
+
+Read this as an assertion: this collection has exactly one useful element here.
+
+## Pitfalls
+
+- `which: first` hides bugs if the collection unexpectedly has multiple elements.
+- Do not use it as collection filtering; selecting a named element is a different operation.
+- Check conditional branches. Singleton extraction often follows single-sample vs multi-sample routing.
+- Once unboxed, collection element identifiers are no longer available as collection metadata.
+
+## Exemplars (IWC)
+
+- `$IWC_FORMAT2/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8.gxwf.yml:27,29,48,58,60` — repeated unboxing of singleton QC/report outputs such as alignment scores, alignment stats, and snapshots.
+- `$IWC_FORMAT2/VGP-assembly-v2/Assembly-Hifi-HiC-phasing-VGP4/Assembly-Hifi-HiC-phasing-VGP4.gxwf.yml` — repeated singleton extraction for Merqury and PNG outputs.
+- `$IWC_FORMAT2/VGP-assembly-v2/Purge-duplicates-one-haplotype-VGP6b/Purging-duplicates-one-haplotype-VGP6b.gxwf.yml` — same VGP reporting/QC shape.
+
+## See also
+
+- [[iwc-transformations-survey]] — Recipe E and candidate boundary.

--- a/content/patterns/harmonize-by-sortlist-from-identifiers.md
+++ b/content/patterns/harmonize-by-sortlist-from-identifiers.md
@@ -1,0 +1,73 @@
+---
+type: pattern
+title: "Collection: harmonize by sortlist from identifiers"
+aliases:
+  - "collection harmonize by sortlist from identifiers"
+  - "sort sibling collections by identifier file"
+  - "SORTLIST file-driven harmonization"
+tags:
+  - pattern
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+summary: "Use SORTLIST with sort_type:file to reorder one collection by another collection's identifiers."
+related_notes:
+  - "[[iwc-transformations-survey]]"
+related_patterns:
+  - "[[sync-collections-by-identifier]]"
+  - "[[collection-flatten-after-fanout]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+---
+
+# Collection: harmonize by sortlist from identifiers
+
+## Tool
+
+Use Galaxy built-in `__SORTLIST__` with `sort_type: file`, driven by an identifier list from `collection_element_identifiers`.
+
+This is the corpus-attested harmonization recipe. `__HARMONIZELISTS__` exists in the collection-tools catalog, but the survey found zero corpus uptake.
+
+## When to reach for it
+
+Use this when two sibling collections must line up by element identifier before downstream map-over, zip-like pairing, or parallel per-sample processing.
+
+The usual shape is: extract identifiers from the reference collection, feed that identifier file into `__SORTLIST__`, and sort the sibling collection with `sort_type: file`.
+
+Do not use this if unmatched elements must be preserved; file-driven sort can also filter.
+
+This page is about order harmonization. Use [[sync-collections-by-identifier]] when membership alone is the issue and [[regex-relabel-via-tabular]] when labels need cleanup.
+
+## Parameters
+
+Identifier extraction has no meaningful knobs. For sort:
+
+```yaml
+tool_id: __SORTLIST__
+tool_state:
+  input: { __class__: ConnectedValue }
+  sort_type: file
+  sort_file: { __class__: ConnectedValue }
+```
+
+The `sort_file` must be the identifiers of the collection whose order should be copied.
+
+## Pitfalls
+
+- This can drop elements. Treat `sort_type: file` as reorder-plus-intersect unless you have verified behavior for missing identifiers.
+- The reference collection defines truth. If the identifier file comes from the wrong sibling, downstream pairing silently follows the wrong axis.
+- Extract identifiers after upstream relabel, filter, or flatten operations, not before.
+- Mention `__HARMONIZELISTS__` only as the absent catalog alternative; do not recommend it from corpus evidence.
+
+## Exemplars (IWC)
+
+- `$IWC_FORMAT2/virology/pox-virus-amplicon/pox-virus-half-genome.gxwf.yml:541-562` — identifiers from Pool1 drive `__SORTLIST__` on Pool2.
+- `$IWC_FORMAT2/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8.gxwf.yml` — subworkflow uses multiple file-driven `__SORTLIST__` steps to align sibling collections by identifier order.
+
+## See also
+
+- [[iwc-transformations-survey]] — Recipe I, decision table, and Q7 on sort-as-filter.
+- [[sync-collections-by-identifier]] — membership sync without explicit order harmonization.
+- [[collection-flatten-after-fanout]] — one-step collection-shape cleanup after map-over.

--- a/content/patterns/regex-relabel-via-tabular.md
+++ b/content/patterns/regex-relabel-via-tabular.md
@@ -1,0 +1,92 @@
+---
+type: pattern
+title: "Collection: regex relabel via tabular"
+aliases:
+  - "collection regex relabel via tabular"
+  - "tp_find_and_replace to RELABEL_FROM_FILE"
+  - "collection relabel from identifier table"
+tags:
+  - pattern
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+summary: "Derive collection element identifiers in a tabular mapping, then apply them with RELABEL_FROM_FILE."
+related_notes:
+  - "[[iwc-transformations-survey]]"
+related_patterns:
+  - "[[relabel-via-rules-and-find-replace]]"
+  - "[[sync-collections-by-identifier]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+---
+
+# Collection: regex relabel via tabular
+
+## Tool
+
+Use a tabular mapping source, optionally transform it with `tp_find_and_replace`, then relabel the collection with `__RELABEL_FROM_FILE__`.
+
+Corpus-shaped chain:
+
+1. `collection_element_identifiers` or another mapping source emits identifiers as data.
+2. `tp_find_and_replace` rewrites identifier text.
+3. `__RELABEL_FROM_FILE__` applies the modified labels to the target collection.
+
+## When to reach for it
+
+Use this when the collection structure is right but element identifiers are wrong, noisy, or need a simple regex/string transformation.
+
+Good fits include tool output that lost original sample names, identifiers that need prefix/suffix cleanup, and paired/unpaired outputs that need the same manifest-derived names.
+
+Do not use this when relabeling is coupled to a structural reshape. Use [[relabel-via-rules-and-find-replace]] for the influenza-style restructure, extract identifiers, regex-relabel, restructure again shape.
+
+This page is about label rewrite. Use [[sync-collections-by-identifier]] for membership sync and [[harmonize-by-sortlist-from-identifiers]] for order harmonization.
+
+## Parameters
+
+`collection_element_identifiers` emits one identifier per line and no header.
+
+For `tp_find_and_replace`, set regex mode deliberately. For no-header identifier lists, do not skip the first line.
+
+For `__RELABEL_FROM_FILE__`, choose line-based labels only when row order matches collection order. Use tabular old-to-new mapping when order is uncertain.
+
+## Idiomatic shape
+
+```yaml
+# collection_element_identifiers(input collection)
+# -> optional tp_find_and_replace
+# -> __RELABEL_FROM_FILE__(target collection, labels=modified identifiers)
+```
+
+Regex cleanup before relabel:
+
+```yaml
+tool_id: toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.5+galaxy3
+tool_state:
+  infile: { __class__: ConnectedValue }
+  find_pattern: "^(.*)\\.fastq(\\.gz)?$"
+  replace_pattern: "\\1"
+  is_regex: true
+  skip_first_line: false
+```
+
+## Pitfalls
+
+- Line-based relabeling assumes mapping rows match collection element order.
+- `collection_element_identifiers` has no header; skipping the first line drops a real identifier.
+- Relabeling does not reorder or filter. Use a filter or sort pattern when membership or order changes.
+- Keep regex cleanup narrow enough that distinct elements do not collapse to the same identifier.
+
+## Exemplars (IWC)
+
+- `$IWC_FORMAT2/data-fetching/sra-manifest-to-concatenated-fastqs/sra-manifest-to-concatenated-fastqs.gxwf.yml` — generated relabel table feeds `__RELABEL_FROM_FILE__` for paired and unpaired `fasterq_dump` output collections.
+- `$IWC_FORMAT2/microbiome/metagenomic-raw-reads-amr-analysis/metagenomic-raw-reads-amr-analysis.gxwf.yml:11-19` — original read identifiers drive relabeling of a downstream collection.
+- `$IWC_FORMAT2/virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping.gxwf.yml:35-38` — heavier sibling chain uses identifier extraction plus `tp_find_and_replace` before relabeling.
+
+## See also
+
+- [[iwc-transformations-survey]] — Recipe G and candidate boundary.
+- [[relabel-via-rules-and-find-replace]] — use when relabeling is fused with Apply Rules structural fan-out.
+- [[sync-collections-by-identifier]] — use when identifiers filter or relabel sibling collections without regex cleanup.

--- a/content/patterns/relabel-via-rules-and-find-replace.md
+++ b/content/patterns/relabel-via-rules-and-find-replace.md
@@ -1,0 +1,82 @@
+---
+type: pattern
+title: "Collection: relabel via rules and find/replace"
+aliases:
+  - "collection relabel via rules and find replace"
+  - "structured relabel via Apply Rules"
+  - "influenza collection relabel fan-out"
+tags:
+  - pattern
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+summary: "Use Apply Rules, identifier extraction, find/replace, and relabeling for structural fan-out cleanup."
+related_notes:
+  - "[[iwc-transformations-survey]]"
+  - "[[galaxy-apply-rules-dsl]]"
+related_patterns:
+  - "[[regex-relabel-via-tabular]]"
+  - "[[collection-swap-nesting-with-apply-rules]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+---
+
+# Collection: relabel via rules and find/replace
+
+## Tool
+
+Use this narrow chain when relabeling is embedded in structural collection reshape:
+
+1. A domain tool fans out into a nested collection with noisy identifiers.
+2. `__APPLY_RULES__` swaps or regroups collection nesting.
+3. `collection_element_identifiers` extracts current identifiers.
+4. `tp_find_and_replace` cleans those identifiers.
+5. `__RELABEL_FROM_FILE__` applies the cleaned identifiers.
+6. A second `__APPLY_RULES__` may restore the downstream grouping.
+
+## When to reach for it
+
+Use this when a tool creates machine-generated names, downstream steps need meaningful segment/sample identifiers, and collection nesting must be regrouped around those identifiers.
+
+Do not generalize this page to every Apply Rules relabel. The strong citation is one influenza workflow. Prefer [[regex-relabel-via-tabular]] unless the workflow has this structural fan-out problem.
+
+This page is about relabeling inside a reshape. Use [[collection-swap-nesting-with-apply-rules]] for pure nesting swaps and [[regex-relabel-via-tabular]] for relabel-only cleanup.
+
+## Parameters
+
+For the Apply Rules portions, expose `identifier0` and `identifier1`, then map list identifiers in the required order. The exact persisted `rules` blob is workflow API state; author the logical rule sequence, then validate gxformat2.
+
+Run `collection_element_identifiers` on the reshaped collection level whose labels need cleanup. Use `tp_find_and_replace` only for the identifier cleanup. Apply the cleaned list with `__RELABEL_FROM_FILE__`.
+
+## Idiomatic shape
+
+Conceptual chain:
+
+```yaml
+# domain fan-out tool, e.g. BAM split by reference
+# -> __APPLY_RULES__            # regroup list:list axes
+# -> collection_element_identifiers
+# -> tp_find_and_replace        # clean generated labels
+# -> __RELABEL_FROM_FILE__      # apply cleaned labels
+# -> __APPLY_RULES__            # regroup again if downstream needs it
+```
+
+## Pitfalls
+
+- Do not flatten away the axis you need. The point is preserving both sample and segment/reference axes.
+- Extract identifiers at the right level; extracting before the first Apply Rules step can capture the wrong labels.
+- Rewrite only tool-added noise. A broad regex can merge distinct segment/sample identifiers.
+- `__RELABEL_FROM_FILE__` changes names only. Apply Rules carries the shape change.
+
+## Exemplars (IWC)
+
+- `$IWC_FORMAT2/virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping.gxwf.yml:34-38` — canonical dense segment: `bamtools_split_ref` output goes through Apply Rules, identifier extraction, find/replace, relabeling, then Apply Rules again.
+- `$IWC_FORMAT2/virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping.gxwf.yml:14,39,43` — same workflow repeatedly uses the Apply Rules swap-nesting shape around sample/segment collections.
+
+## See also
+
+- [[iwc-transformations-survey]] — Recipe B and candidate boundary.
+- [[regex-relabel-via-tabular]] — simpler sibling when only labels change.
+- [[collection-swap-nesting-with-apply-rules]] — pure swap-nesting operation without relabeling.

--- a/content/patterns/sync-collections-by-identifier.md
+++ b/content/patterns/sync-collections-by-identifier.md
@@ -1,0 +1,88 @@
+---
+type: pattern
+title: "Collection: sync collections by identifier"
+aliases:
+  - "collection sync by identifier"
+  - "collection_element_identifiers to FILTER_FROM_FILE"
+  - "filter sibling collection by identifiers"
+tags:
+  - pattern
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+summary: "Use collection_element_identifiers with FILTER_FROM_FILE or RELABEL_FROM_FILE to align sibling collections."
+related_notes:
+  - "[[iwc-transformations-survey]]"
+related_patterns:
+  - "[[collection-cleanup-after-mapover-failure]]"
+  - "[[harmonize-by-sortlist-from-identifiers]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+---
+
+# Collection: sync collections by identifier
+
+## Tool
+
+Use `collection_element_identifiers` to turn collection element names into a one-column tabular dataset, then feed that file to a collection operation:
+
+- `__FILTER_FROM_FILE__` keeps or drops elements in a sibling collection by identifier.
+- `__RELABEL_FROM_FILE__` applies labels from a file when a downstream collection preserved order but lost useful names.
+
+## When to reach for it
+
+Use this when two sibling collections must stay aligned after one side was filtered, cleaned, or reshaped.
+
+The common shape is: collection `X` is filtered to useful results, then identifiers from `X` filter collection `Y` to the same element set. This prevents later per-sample steps from pairing a result from one sample with input from another.
+
+Use the relabel variant when a downstream tool preserves collection order but emits generic or noisy identifiers.
+
+This page is about membership sync. Use [[harmonize-by-sortlist-from-identifiers]] when order must match and [[regex-relabel-via-tabular]] when labels need string cleanup.
+
+Do not use this to detect empty or failed datasets. Run [[collection-cleanup-after-mapover-failure]] first, then use the cleaned collection's identifiers as the mask.
+
+## Parameters
+
+`collection_element_identifiers` has no meaningful knobs in the corpus. Its output is one identifier per line, no header.
+
+For `__FILTER_FROM_FILE__`, the key corpus shape is `how_filter: remove_if_absent`: keep elements whose identifiers appear in the file. Wire downstream steps to `output_filtered`, not `output_discarded`.
+
+For `__RELABEL_FROM_FILE__`, the survey examples use a connected labels file and non-strict relabeling. Prefer stricter mapping when the relabel file should cover every element exactly.
+
+## Idiomatic shape
+
+```yaml
+# 1. Extract identifiers from cleaned collection X.
+tool_id: toolshed.g2.bx.psu.edu/repos/iuc/collection_element_identifiers/collection_element_identifiers/0.0.2
+tool_state:
+  input_collection: { __class__: ConnectedValue }
+
+# 2. Keep only matching elements in sibling collection Y.
+tool_id: __FILTER_FROM_FILE__
+tool_state:
+  how:
+    how_filter: remove_if_absent
+    filter_source: { __class__: ConnectedValue }
+  input: { __class__: ConnectedValue }
+```
+
+## Pitfalls
+
+- Identifier sync is not necessarily order sync. If downstream zip-like behavior depends on order, verify order or use [[harmonize-by-sortlist-from-identifiers]].
+- Extract identifiers from the collection that represents truth after cleanup. In MGnify examples, BED hits drive filtering of processed sequences, not the reverse.
+- Relabeling can hide mismatches when strict checks are off. Use only when the upstream shape guarantees correspondence.
+- `__FILTER_FROM_FILE__` filters by names in a file; it does not inspect whether files are empty or failed.
+
+## Exemplars (IWC)
+
+- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction.gxwf.yml:12-18` — cleaned SSU/LSU BED identifiers drive filtering of processed sequence collections.
+- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-its/mgnify-amplicon-pipeline-v5-its.gxwf.yml:2-4` — compact version of the same clean, identify, filter sibling shape.
+- `$IWC_FORMAT2/microbiome/metagenomic-raw-reads-amr-analysis/metagenomic-raw-reads-amr-analysis.gxwf.yml:11,19` — identifier extraction and relabel variant used to restore per-sample identity downstream.
+
+## See also
+
+- [[iwc-transformations-survey]] — Recipe A and candidate boundary.
+- [[collection-cleanup-after-mapover-failure]] — common upstream cleanup step.
+- [[harmonize-by-sortlist-from-identifiers]] — use when sibling order must match, not just membership.

--- a/content/patterns/tabular-to-collection-by-row.md
+++ b/content/patterns/tabular-to-collection-by-row.md
@@ -1,0 +1,76 @@
+---
+type: pattern
+title: "Tabular: to collection by row"
+aliases:
+  - "collection from tabular rows"
+  - "split_file_to_collection by column"
+  - "row fan-out collection"
+tags:
+  - pattern
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+summary: "Use split_file_to_collection split_by:col to fan a tabular into collection elements by row/key."
+related_notes:
+  - "[[iwc-transformations-survey]]"
+related_patterns:
+  - "[[tabular-concatenate-collection-to-table]]"
+  - "[[sync-collections-by-identifier]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+---
+
+# Tabular: to collection by row
+
+## Tool
+
+Use `toolshed.g2.bx.psu.edu/repos/bgruening/split_file_to_collection/split_file_to_collection/0.5.2`.
+
+The IWC-attested shape is `split_by: col`: split a tabular file into a dataset collection, one element per row or key. `id_col` chooses the column that becomes the element identifier. `match_regex` and `sub_regex` clean or extract that identifier.
+
+This is the inverse of [[tabular-concatenate-collection-to-table]], where `collapse_dataset` turns a collection into one tabular dataset.
+
+## When to reach for it
+
+Use this when a single manifest, sample sheet, accession list, or combined results table must become a collection so the next tool can map over each row/key.
+
+Do not use this when the input is already a collection. Do not use this for collection-to-table row-binding; use [[tabular-concatenate-collection-to-table]].
+
+## Parameters
+
+```yaml
+tool_id: toolshed.g2.bx.psu.edu/repos/bgruening/split_file_to_collection/split_file_to_collection/0.5.2
+tool_state:
+  input: { __class__: ConnectedValue }
+  split_parms:
+    split_by: col
+    id_col: "1"
+    match_regex: (.*)
+    sub_regex: \1
+```
+
+- `split_parms.split_by: col`: split by a tabular column.
+- `split_parms.id_col`: 1-indexed column whose value becomes the collection element identifier.
+- `split_parms.match_regex` / `sub_regex`: regex and replacement used to produce the final identifier.
+
+## Pitfalls
+
+- `id_col` is 1-indexed.
+- Pick a stable, unique identifier column; duplicate values produce ambiguous collection elements.
+- Regex cleanup is downstream metadata cleanup, not cosmetic only.
+- Headers matter. Ensure each split element gets the header behavior the downstream tool expects.
+
+## Exemplars (IWC)
+
+- `$IWC_FORMAT2/data-fetching/sra-manifest-to-concatenated-fastqs/sra-manifest-to-concatenated-fastqs.gxwf.yml` — splits one-column SRA accessions so `fasterq_dump` runs once per accession.
+- `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:895` — splits a combined per-clade VCF table into per-clade elements.
+- `$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-chip-sr.gxwf.yml:415` — turns a sample-list tabular into a collection-shaped input.
+- `$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:440` — same row-fan-out shape in the ATAC/CUT&RUN variant.
+
+## See also
+
+- [[iwc-transformations-survey]] — Recipe J and candidate boundary.
+- [[tabular-concatenate-collection-to-table]] — inverse operation using `collapse_dataset`.
+- [[sync-collections-by-identifier]] — downstream collection alignment by element identifiers.


### PR DESCRIPTION
## Summary
- Add corpus-grounded tabular and collection transformation pattern pages.
- Add `/iwc-survey-pattern` guidance and refine `/iwc-survey-act` for pattern candidate manifests and cohesion checks.
- Add authoring guidance for IWC citations that survive workflow cleanup/conversion churn.

## Validation
- `npm run validate` passes with 0 errors and backlink advisory warnings.