### PR TITLE
Add pattern maps

### DIFF
--- a/.claude/commands/iwc-survey-pattern.md
+++ b/.claude/commands/iwc-survey-pattern.md
@@ -56,6 +56,7 @@ Drop sections that do not earn their space. A thin “None surfaced” legacy se
 ## Frontmatter guidance
 
 - Required fields must conform to `meta_schema.yml`; do not add ad-hoc fields.
+- Set `pattern_kind: leaf` for concrete operation pages and `pattern_kind: moc` for map-of-content pages that route readers to leaf patterns.
 - `summary` is a compressed “what to do and when” line, not a mini abstract.
 - `related_notes` should name primary source notes only, usually the survey. Put secondary context notes in body or `See also` unless they are essential source material.
 - `related_patterns` should be focused: pages that decide against this one, close siblings, or immediate follow-ups. Do not list the whole neighborhood.

--- a/content/molds/compare-against-iwc-exemplar/index.md
+++ b/content/molds/compare-against-iwc-exemplar/index.md
@@ -8,27 +8,27 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-04-30
-revision: 1
+revised: 2026-05-02
+revision: 2
 ai_generated: true
 summary: "Find nearest IWC exemplar(s) and surface a structural diff against a draft."
 references:
-  - kind: research
-    ref: "[[iwc-transformations-survey]]"
+  - kind: pattern
+    ref: "[[galaxy-collection-patterns]]"
     used_at: runtime
     load: on-demand
-    mode: verbatim
+    mode: condense
     evidence: corpus-observed
-    purpose: "Compare draft collection-shape recipes against corpus-observed IWC examples."
-    trigger: "When the draft workflow contains collection reshape, cleanup, relabel, or synchronization sections."
-  - kind: research
-    ref: "[[iwc-tabular-operations-survey]]"
+    purpose: "Compare draft collection transformations against curated corpus-observed pattern guidance."
+    trigger: "When the draft workflow contains collection reshape, cleanup, relabel, synchronization, or collection-tabular bridge sections."
+  - kind: pattern
+    ref: "[[galaxy-tabular-patterns]]"
     used_at: runtime
     load: on-demand
-    mode: verbatim
+    mode: condense
     evidence: corpus-observed
-    purpose: "Compare draft tabular/text-processing sections against corpus-observed IWC examples."
-    trigger: "When the draft workflow contains tabular filtering, projection, join, aggregation, or free-form text-processing sections."
+    purpose: "Compare draft tabular transformations against curated corpus-observed pattern guidance."
+    trigger: "When the draft workflow contains tabular filtering, projection, join, aggregation, SQL, or free-form text-processing sections."
   - kind: research
     ref: "[[iwc-test-data-conventions]]"
     used_at: runtime

--- a/content/molds/compare-against-iwc-exemplar/index.md
+++ b/content/molds/compare-against-iwc-exemplar/index.md
@@ -17,7 +17,7 @@ references:
     ref: "[[galaxy-collection-patterns]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Compare draft collection transformations against curated corpus-observed pattern guidance."
     trigger: "When the draft workflow contains collection reshape, cleanup, relabel, synchronization, or collection-tabular bridge sections."
@@ -25,7 +25,7 @@ references:
     ref: "[[galaxy-tabular-patterns]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Compare draft tabular transformations against curated corpus-observed pattern guidance."
     trigger: "When the draft workflow contains tabular filtering, projection, join, aggregation, SQL, or free-form text-processing sections."

--- a/content/molds/implement-galaxy-tool-step/index.md
+++ b/content/molds/implement-galaxy-tool-step/index.md
@@ -8,8 +8,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-04-30
-revision: 1
+revised: 2026-05-02
+revision: 2
 ai_generated: true
 summary: "Convert an abstract step into a concrete gxformat2 step using a tool summary."
 references:
@@ -37,22 +37,22 @@ references:
     evidence: corpus-observed
     purpose: "Implement identifier-derived collection reshaping via Apply Rules."
     trigger: "When collection element identifiers need regex parsing, nesting-level swaps, regrouping, or paired identifier assignment."
-  - kind: research
-    ref: "[[iwc-transformations-survey]]"
+  - kind: pattern
+    ref: "[[galaxy-collection-patterns]]"
     used_at: runtime
     load: on-demand
-    mode: verbatim
+    mode: condense
     evidence: corpus-observed
     purpose: "Choose corpus-attested collection recipes when implementing concrete Galaxy steps."
-    trigger: "When the implementation needs cleanup-after-fanout, sync-by-identifier, singleton unboxing, relabeling, or collection-to-tabular bridges."
-  - kind: research
-    ref: "[[iwc-tabular-operations-survey]]"
+    trigger: "When implementation needs cleanup-after-fanout, sync-by-identifier, singleton unboxing, relabeling, collection reshaping, or collection-tabular bridges."
+  - kind: pattern
+    ref: "[[galaxy-tabular-patterns]]"
     used_at: runtime
     load: on-demand
-    mode: verbatim
+    mode: condense
     evidence: corpus-observed
-    purpose: "Choose corpus-attested tabular/text-processing recipes when implementing concrete Galaxy steps."
-    trigger: "When the implementation needs row filtering, column projection, computed columns, joins, grouping, awk, or text-processing wrappers."
+    purpose: "Choose corpus-attested tabular recipes when implementing concrete Galaxy steps."
+    trigger: "When implementation needs row filtering, column projection, computed columns, joins, grouping, SQL, awk, text-processing wrappers, or tabular-collection bridges."
 ---
 # implement-galaxy-tool-step
 

--- a/content/molds/implement-galaxy-tool-step/index.md
+++ b/content/molds/implement-galaxy-tool-step/index.md
@@ -41,7 +41,7 @@ references:
     ref: "[[galaxy-collection-patterns]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Choose corpus-attested collection recipes when implementing concrete Galaxy steps."
     trigger: "When implementation needs cleanup-after-fanout, sync-by-identifier, singleton unboxing, relabeling, collection reshaping, or collection-tabular bridges."
@@ -49,7 +49,7 @@ references:
     ref: "[[galaxy-tabular-patterns]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Choose corpus-attested tabular recipes when implementing concrete Galaxy steps."
     trigger: "When implementation needs row filtering, column projection, computed columns, joins, grouping, SQL, awk, text-processing wrappers, or tabular-collection bridges."

--- a/content/molds/summary-to-galaxy-data-flow/index.md
+++ b/content/molds/summary-to-galaxy-data-flow/index.md
@@ -48,7 +48,7 @@ references:
     ref: "[[galaxy-collection-patterns]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Ground collection-shape choices in curated, corpus-observed leaf patterns."
     trigger: "When selecting between collection cleanup, reshape, identifier, or collection-tabular bridge patterns."
@@ -56,7 +56,7 @@ references:
     ref: "[[galaxy-tabular-patterns]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Ground tabular bridge and table-operation choices in curated, corpus-observed leaf patterns."
     trigger: "When data-flow translation leaves collection-land for tabular projection, filtering, joining, aggregation, pivoting, or tabular-collection bridges."

--- a/content/molds/summary-to-galaxy-data-flow/index.md
+++ b/content/molds/summary-to-galaxy-data-flow/index.md
@@ -8,8 +8,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-04-30
-revision: 1
+revised: 2026-05-02
+revision: 2
 ai_generated: true
 summary: "Abstract DAG with Galaxy collection / scatter / branching idioms surfaced."
 references:
@@ -44,22 +44,22 @@ references:
     evidence: corpus-observed
     purpose: "Represent identifier-derived collection reshaping with Apply Rules when simpler collection tools are insufficient."
     trigger: "When channel identifiers need regex extraction, regrouping, nesting-level swaps, or paired identifier construction."
-  - kind: research
-    ref: "[[iwc-transformations-survey]]"
+  - kind: pattern
+    ref: "[[galaxy-collection-patterns]]"
     used_at: runtime
     load: on-demand
-    mode: verbatim
+    mode: condense
     evidence: corpus-observed
-    purpose: "Ground collection-shape translation choices in observed IWC transformation recipes."
-    trigger: "When selecting between Galaxy collection-operation recipes or checking whether a proposed shape transform is corpus-attested."
-  - kind: research
-    ref: "[[iwc-tabular-operations-survey]]"
+    purpose: "Ground collection-shape choices in curated, corpus-observed leaf patterns."
+    trigger: "When selecting between collection cleanup, reshape, identifier, or collection-tabular bridge patterns."
+  - kind: pattern
+    ref: "[[galaxy-tabular-patterns]]"
     used_at: runtime
     load: on-demand
-    mode: verbatim
+    mode: condense
     evidence: corpus-observed
-    purpose: "Ground tabular bridge choices that appear while translating Nextflow channel/data-flow operations."
-    trigger: "When data-flow translation leaves collection-land for tabular projection, filtering, joining, aggregation, or pivoting."
+    purpose: "Ground tabular bridge and table-operation choices in curated, corpus-observed leaf patterns."
+    trigger: "When data-flow translation leaves collection-land for tabular projection, filtering, joining, aggregation, pivoting, or tabular-collection bridges."
 ---
 # summary-to-galaxy-data-flow
 

--- a/content/molds/summary-to-galaxy-template/index.md
+++ b/content/molds/summary-to-galaxy-template/index.md
@@ -32,7 +32,7 @@ references:
     ref: "[[galaxy-collection-patterns]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Use corpus-grounded collection pattern guidance for unresolved skeleton steps."
     trigger: "When adding TODO steps for collection cleanup, reshaping, relabeling, identifier synchronization, or collection-tabular bridges."
@@ -40,7 +40,7 @@ references:
     ref: "[[galaxy-tabular-patterns]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Use corpus-grounded tabular pattern guidance for unresolved skeleton steps."
     trigger: "When adding TODO steps for tabular filtering, projection, joins, aggregation, text-processing recipes, or tabular-collection bridges."

--- a/content/molds/summary-to-galaxy-template/index.md
+++ b/content/molds/summary-to-galaxy-template/index.md
@@ -8,8 +8,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-04-30
-revision: 1
+revised: 2026-05-02
+revision: 2
 ai_generated: true
 summary: "gxformat2 skeleton with per-step TODOs from a data-flow summary."
 references:
@@ -28,22 +28,22 @@ references:
     evidence: corpus-observed
     purpose: "Preserve Galaxy collection typing and map-over/reduction semantics in the gxformat2 skeleton."
     trigger: "When creating workflow inputs, outputs, and placeholder connections involving collections."
-  - kind: research
-    ref: "[[iwc-transformations-survey]]"
+  - kind: pattern
+    ref: "[[galaxy-collection-patterns]]"
     used_at: runtime
     load: on-demand
-    mode: verbatim
+    mode: condense
     evidence: corpus-observed
-    purpose: "Use observed IWC collection recipes as style guidance for unresolved skeleton steps."
-    trigger: "When adding TODO steps for collection cleanup, reshaping, relabeling, or identifier synchronization."
-  - kind: research
-    ref: "[[iwc-tabular-operations-survey]]"
+    purpose: "Use corpus-grounded collection pattern guidance for unresolved skeleton steps."
+    trigger: "When adding TODO steps for collection cleanup, reshaping, relabeling, identifier synchronization, or collection-tabular bridges."
+  - kind: pattern
+    ref: "[[galaxy-tabular-patterns]]"
     used_at: runtime
     load: on-demand
-    mode: verbatim
+    mode: condense
     evidence: corpus-observed
-    purpose: "Use observed IWC tabular recipes as style guidance for unresolved skeleton steps."
-    trigger: "When adding TODO steps for tabular filtering, projection, joins, aggregation, or text-processing bridges."
+    purpose: "Use corpus-grounded tabular pattern guidance for unresolved skeleton steps."
+    trigger: "When adding TODO steps for tabular filtering, projection, joins, aggregation, text-processing recipes, or tabular-collection bridges."
 ---
 # summary-to-galaxy-template
 

--- a/content/patterns/collection-build-list-paired-with-apply-rules.md
+++ b/content/patterns/collection-build-list-paired-with-apply-rules.md
@@ -1,5 +1,6 @@
 ---
 type: pattern
+pattern_kind: leaf
 title: "Collection: build list paired with Apply Rules"
 aliases:
   - "Apply Rules build list:paired"

--- a/content/patterns/collection-build-named-bundle.md
+++ b/content/patterns/collection-build-named-bundle.md
@@ -1,5 +1,6 @@
 ---
 type: pattern
+pattern_kind: leaf
 title: "Collection: build named bundle"
 aliases:
   - "collection build list named outputs"

--- a/content/patterns/collection-cleanup-after-mapover-failure.md
+++ b/content/patterns/collection-cleanup-after-mapover-failure.md
@@ -1,5 +1,6 @@
 ---
 type: pattern
+pattern_kind: leaf
 title: "Collection: cleanup after map-over failure"
 aliases:
   - "cleanup after fanout failure"

--- a/content/patterns/collection-flatten-after-fanout.md
+++ b/content/patterns/collection-flatten-after-fanout.md
@@ -1,5 +1,6 @@
 ---
 type: pattern
+pattern_kind: leaf
 title: "Collection: flatten after fan-out"
 aliases:
   - "collection flatten after fanout"

--- a/content/patterns/collection-split-identifier-via-rules.md
+++ b/content/patterns/collection-split-identifier-via-rules.md
@@ -1,5 +1,6 @@
 ---
 type: pattern
+pattern_kind: leaf
 title: "Collection: split identifier via rules"
 aliases:
   - "Apply Rules split identifier into nesting"

--- a/content/patterns/collection-swap-nesting-with-apply-rules.md
+++ b/content/patterns/collection-swap-nesting-with-apply-rules.md
@@ -1,5 +1,6 @@
 ---
 type: pattern
+pattern_kind: leaf
 title: "Collection: swap nesting with Apply Rules"
 aliases:
   - "regroup list:list by inner identifier"

--- a/content/patterns/collection-unbox-singleton.md
+++ b/content/patterns/collection-unbox-singleton.md
@@ -1,5 +1,6 @@
 ---
 type: pattern
+pattern_kind: leaf
 title: "Collection: unbox singleton"
 aliases:
   - "extract first dataset"

--- a/content/patterns/galaxy-collection-patterns.md
+++ b/content/patterns/galaxy-collection-patterns.md
@@ -1,0 +1,74 @@
+---
+type: pattern
+pattern_kind: moc
+title: "Galaxy: collection patterns"
+aliases:
+  - "Galaxy collection pattern MOC"
+  - "collection transformation patterns"
+  - "IWC collection pattern map"
+tags:
+  - pattern
+  - target/galaxy
+  - topic/galaxy-transform
+  - topic/collection-transform
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+summary: "Use this MOC to choose corpus-grounded Galaxy collection transformation patterns."
+related_notes:
+  - "[[iwc-transformations-survey]]"
+related_patterns:
+  - "[[collection-cleanup-after-mapover-failure]]"
+  - "[[sync-collections-by-identifier]]"
+  - "[[harmonize-by-sortlist-from-identifiers]]"
+  - "[[regex-relabel-via-tabular]]"
+  - "[[relabel-via-rules-and-find-replace]]"
+  - "[[collection-swap-nesting-with-apply-rules]]"
+  - "[[collection-split-identifier-via-rules]]"
+  - "[[collection-build-list-paired-with-apply-rules]]"
+  - "[[tabular-to-collection-by-row]]"
+  - "[[tabular-concatenate-collection-to-table]]"
+  - "[[tabular-pivot-collection-to-wide]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+  - "[[summary-to-galaxy-data-flow]]"
+  - "[[summary-to-galaxy-template]]"
+  - "[[compare-against-iwc-exemplar]]"
+---
+
+# Galaxy: collection patterns
+
+This is the runtime-facing map for Galaxy collection transformation choices. Use it before loading raw survey notes. The survey remains evidence backing; the leaf pages are the actionable references.
+
+## Cleanup
+
+- [[collection-cleanup-after-mapover-failure]] — use `__FILTER_EMPTY_DATASETS__` or `__FILTER_FAILED_DATASETS__` after map-over when empty or errored elements would break downstream steps.
+- [[collection-unbox-singleton]] — use `__EXTRACT_DATASET__` with `which: first` when a known one-element collection must become a dataset.
+
+## Identifiers
+
+- [[sync-collections-by-identifier]] — membership sync: extract identifiers from one collection and filter or relabel a sibling collection.
+- [[harmonize-by-sortlist-from-identifiers]] — order sync: sort one sibling collection by another collection's identifier order.
+- [[regex-relabel-via-tabular]] — label rewrite: derive new element identifiers in tabular form and apply them with `__RELABEL_FROM_FILE__`.
+- [[relabel-via-rules-and-find-replace]] — relabel inside a structural reshape, currently grounded in the influenza fan-out pattern.
+
+## Structural Reshape
+
+- [[collection-flatten-after-fanout]] — collapse nested collection output to a flat list when the outer axis no longer matters.
+- [[collection-build-named-bundle]] — assemble individual outputs into a named collection bundle for publishing or downstream fan-in.
+- [[collection-swap-nesting-with-apply-rules]] — use Apply Rules to swap `list:list` axes.
+- [[collection-split-identifier-via-rules]] — use Apply Rules regex columns to derive nested list identifiers from one identifier string.
+- [[collection-build-list-paired-with-apply-rules]] — use Apply Rules to promote identifier columns into `list:paired` structure.
+
+## Bridges
+
+- [[tabular-to-collection-by-row]] — split a tabular manifest/list into collection elements for map-over.
+- [[tabular-concatenate-collection-to-table]] — row-bind a collection of tabular outputs into one table.
+- [[tabular-pivot-collection-to-wide]] — outer-join a collection of id/value tabulars into one wide table.
+
+## See also
+
+- [[iwc-transformations-survey]] — collection-transform survey and evidence trail.
+- [[galaxy-tabular-patterns]] — companion MOC for tabular operations.

--- a/content/patterns/galaxy-tabular-patterns.md
+++ b/content/patterns/galaxy-tabular-patterns.md
@@ -1,0 +1,77 @@
+---
+type: pattern
+pattern_kind: moc
+title: "Galaxy: tabular patterns"
+aliases:
+  - "Galaxy tabular pattern MOC"
+  - "tabular transformation patterns"
+  - "IWC tabular pattern map"
+tags:
+  - pattern
+  - target/galaxy
+  - topic/galaxy-transform
+  - topic/tabular-transform
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+summary: "Use this MOC to choose corpus-grounded Galaxy tabular transformation patterns."
+related_notes:
+  - "[[iwc-tabular-operations-survey]]"
+related_patterns:
+  - "[[tabular-filter-by-column-value]]"
+  - "[[tabular-filter-by-regex]]"
+  - "[[tabular-cut-and-reorder-columns]]"
+  - "[[tabular-compute-new-column]]"
+  - "[[tabular-join-on-key]]"
+  - "[[tabular-group-and-aggregate-with-datamash]]"
+  - "[[tabular-sql-query]]"
+  - "[[tabular-prepend-header]]"
+  - "[[tabular-synthesize-bed-from-3col]]"
+  - "[[tabular-split-taxonomy-string]]"
+  - "[[tabular-relabel-by-row-counter]]"
+  - "[[tabular-to-collection-by-row]]"
+  - "[[tabular-concatenate-collection-to-table]]"
+  - "[[tabular-pivot-collection-to-wide]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+  - "[[summary-to-galaxy-data-flow]]"
+  - "[[summary-to-galaxy-template]]"
+  - "[[compare-against-iwc-exemplar]]"
+---
+
+# Galaxy: tabular patterns
+
+This is the runtime-facing map for Galaxy tabular transformation choices. Use it before loading raw survey notes. The survey remains evidence backing; the leaf pages are the actionable references.
+
+## Row And Column Operations
+
+- [[tabular-filter-by-column-value]] — keep/drop rows by string column value with `Filter1`.
+- [[tabular-filter-by-regex]] — keep/drop rows by regex or pattern matching.
+- [[tabular-cut-and-reorder-columns]] — project and reorder columns with `Cut1`.
+- [[tabular-compute-new-column]] — compute row-wise values into a new column.
+
+## Joins And Aggregation
+
+- [[tabular-join-on-key]] — join two tabular datasets by key columns.
+- [[tabular-group-and-aggregate-with-datamash]] — group and aggregate rows with `datamash_ops`.
+- [[tabular-sql-query]] — use SQL when filtering, joining, and projection are clearer as one query.
+
+## Text-Processing Recipes
+
+- [[tabular-prepend-header]] — add a header row with an awk/text-processing step.
+- [[tabular-synthesize-bed-from-3col]] — build BED from three-column tabular inputs.
+- [[tabular-split-taxonomy-string]] — split taxonomy-like strings into useful columns.
+- [[tabular-relabel-by-row-counter]] — synthesize row labels from row order.
+
+## Bridges
+
+- [[tabular-to-collection-by-row]] — split a tabular manifest/list into collection elements for map-over.
+- [[tabular-concatenate-collection-to-table]] — row-bind a collection of tabular outputs into one table.
+- [[tabular-pivot-collection-to-wide]] — outer-join a collection of id/value tabulars into one wide table.
+
+## See also
+
+- [[iwc-tabular-operations-survey]] — tabular-operation survey and evidence trail.
+- [[galaxy-collection-patterns]] — companion MOC for collection operations.

--- a/content/patterns/harmonize-by-sortlist-from-identifiers.md
+++ b/content/patterns/harmonize-by-sortlist-from-identifiers.md
@@ -1,5 +1,6 @@
 ---
 type: pattern
+pattern_kind: leaf
 title: "Collection: harmonize by sortlist from identifiers"
 aliases:
   - "collection harmonize by sortlist from identifiers"

--- a/content/patterns/regex-relabel-via-tabular.md
+++ b/content/patterns/regex-relabel-via-tabular.md
@@ -1,5 +1,6 @@
 ---
 type: pattern
+pattern_kind: leaf
 title: "Collection: regex relabel via tabular"
 aliases:
   - "collection regex relabel via tabular"

--- a/content/patterns/relabel-via-rules-and-find-replace.md
+++ b/content/patterns/relabel-via-rules-and-find-replace.md
@@ -1,5 +1,6 @@
 ---
 type: pattern
+pattern_kind: leaf
 title: "Collection: relabel via rules and find/replace"
 aliases:
   - "collection relabel via rules and find replace"

--- a/content/patterns/sync-collections-by-identifier.md
+++ b/content/patterns/sync-collections-by-identifier.md
@@ -1,5 +1,6 @@
 ---
 type: pattern
+pattern_kind: leaf
 title: "Collection: sync collections by identifier"
 aliases:
   - "collection sync by identifier"

--- a/content/patterns/tabular-compute-new-column.md
+++ b/content/patterns/tabular-compute-new-column.md
@@ -1,5 +1,6 @@
 ---
 type: pattern
+pattern_kind: leaf
 title: "Tabular: compute a new column"
 tags:
   - pattern

--- a/content/patterns/tabular-concatenate-collection-to-table.md
+++ b/content/patterns/tabular-concatenate-collection-to-table.md
@@ -1,5 +1,6 @@
 ---
 type: pattern
+pattern_kind: leaf
 title: "Tabular: concatenate collection to table"
 aliases:
   - "collection-to-single-tabular-with-collapse_dataset"

--- a/content/patterns/tabular-cut-and-reorder-columns.md
+++ b/content/patterns/tabular-cut-and-reorder-columns.md
@@ -1,5 +1,6 @@
 ---
 type: pattern
+pattern_kind: leaf
 title: "Tabular: cut and reorder columns"
 tags:
   - pattern

--- a/content/patterns/tabular-filter-by-column-value.md
+++ b/content/patterns/tabular-filter-by-column-value.md
@@ -1,5 +1,6 @@
 ---
 type: pattern
+pattern_kind: leaf
 title: "Tabular: filter rows by column value"
 tags:
   - pattern

--- a/content/patterns/tabular-filter-by-regex.md
+++ b/content/patterns/tabular-filter-by-regex.md
@@ -1,5 +1,6 @@
 ---
 type: pattern
+pattern_kind: leaf
 title: "Tabular: filter rows by regex"
 tags:
   - pattern

--- a/content/patterns/tabular-group-and-aggregate-with-datamash.md
+++ b/content/patterns/tabular-group-and-aggregate-with-datamash.md
@@ -1,5 +1,6 @@
 ---
 type: pattern
+pattern_kind: leaf
 title: "Tabular: group and aggregate"
 tags:
   - pattern

--- a/content/patterns/tabular-join-on-key.md
+++ b/content/patterns/tabular-join-on-key.md
@@ -1,5 +1,6 @@
 ---
 type: pattern
+pattern_kind: leaf
 title: "Tabular: join on key"
 tags:
   - pattern

--- a/content/patterns/tabular-pivot-collection-to-wide.md
+++ b/content/patterns/tabular-pivot-collection-to-wide.md
@@ -1,5 +1,6 @@
 ---
 type: pattern
+pattern_kind: leaf
 title: "Tabular: pivot collection to wide"
 aliases:
   - "collection-to-wide-table-with-collection_column_join"

--- a/content/patterns/tabular-prepend-header.md
+++ b/content/patterns/tabular-prepend-header.md
@@ -1,5 +1,6 @@
 ---
 type: pattern
+pattern_kind: leaf
 title: "Tabular: prepend header"
 tags:
   - pattern

--- a/content/patterns/tabular-relabel-by-row-counter.md
+++ b/content/patterns/tabular-relabel-by-row-counter.md
@@ -1,5 +1,6 @@
 ---
 type: pattern
+pattern_kind: leaf
 title: "Tabular: relabel by row counter"
 aliases:
   - "sample_N relabel"

--- a/content/patterns/tabular-split-taxonomy-string.md
+++ b/content/patterns/tabular-split-taxonomy-string.md
@@ -1,5 +1,6 @@
 ---
 type: pattern
+pattern_kind: leaf
 title: "Tabular: split taxonomy string"
 tags:
   - pattern

--- a/content/patterns/tabular-sql-query.md
+++ b/content/patterns/tabular-sql-query.md
@@ -1,5 +1,6 @@
 ---
 type: pattern
+pattern_kind: leaf
 title: "Tabular: SQL query"
 tags:
   - pattern

--- a/content/patterns/tabular-synthesize-bed-from-3col.md
+++ b/content/patterns/tabular-synthesize-bed-from-3col.md
@@ -1,5 +1,6 @@
 ---
 type: pattern
+pattern_kind: leaf
 title: "Tabular: synthesize BED from 3-column input"
 tags:
   - pattern

--- a/content/patterns/tabular-to-collection-by-row.md
+++ b/content/patterns/tabular-to-collection-by-row.md
@@ -1,5 +1,6 @@
 ---
 type: pattern
+pattern_kind: leaf
 title: "Tabular: to collection by row"
 aliases:
   - "collection from tabular rows"

--- a/meta_schema.yml
+++ b/meta_schema.yml
@@ -43,6 +43,9 @@ properties:
     type: array
     items:
       type: string
+  pattern_kind:
+    type: string
+    enum: [leaf, moc]
   sources:
     type: array
     minItems: 1
@@ -213,13 +216,13 @@ allOf:
     then:
       required: [tool]
 
-  # pattern requires title
+  # pattern requires title + pattern_kind
   - if:
       properties:
         type: { const: pattern }
       required: [type]
     then:
-      required: [title]
+      required: [title, pattern_kind]
 
   # cli-command requires tool + command
   - if:

--- a/meta_tags.yml
+++ b/meta_tags.yml
@@ -46,3 +46,11 @@ tool/planemo:
 # Seeded once from top-level dirs of <iwc-clone>/workflows/.
 # See INITIAL_CORPUS_INGESTION.md.
 # Add iwc/<category> entries here as patterns and Molds reference them.
+
+# --- topic/* (Foundry-authored pattern/MOC topics) ---
+topic/galaxy-transform:
+  description: "Galaxy data-shape transformation pattern maps"
+topic/collection-transform:
+  description: "Galaxy collection transformation pattern map"
+topic/tabular-transform:
+  description: "Galaxy tabular transformation pattern map"

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "pnpm -r build && changeset publish",
-    "site:dev": "cd site && astro dev",
-    "site:build": "cd site && astro build",
-    "site:preview": "cd site && astro preview"
+    "site:dev": "npm --prefix site run dev",
+    "site:build": "npm --prefix site run build",
+    "site:preview": "npm --prefix site run preview"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.6.0",

--- a/site/src/components/PatternBody.astro
+++ b/site/src/components/PatternBody.astro
@@ -1,4 +1,99 @@
 ---
-// Pattern body — title is in the header. Parent_pattern shows in NoteMeta.
-// Reserved for future pattern-specific surfaces.
+import type { CollectionEntry } from 'astro:content';
+import { resolveWikiLink, type WikiLinkTarget } from '../lib/wiki-links';
+
+interface Props {
+  entry: CollectionEntry<'content'>;
+  linkMap: Map<string, WikiLinkTarget>;
+}
+
+const { entry, linkMap } = Astro.props;
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+const data = entry.data as any;
+const isMap = data.pattern_kind === 'moc';
+const relatedPatterns = (data.related_patterns ?? [])
+  .map((link: string) => resolveWikiLink(link, linkMap, base))
+  .filter((link: ReturnType<typeof resolveWikiLink>) => link.href);
 ---
+
+{isMap && (
+  <aside class="pattern-map-panel" aria-labelledby="pattern-map-heading">
+    <div class="pattern-map-panel-top">
+      <span class="badge badge-draft">pattern map</span>
+      <span class="pattern-map-count font-mono">{relatedPatterns.length} linked patterns</span>
+    </div>
+    <h2 id="pattern-map-heading">Start Here</h2>
+    <p>
+      This page is a map of content, not a leaf recipe. Use it to choose the right operation page,
+      then follow the linked leaf pattern for concrete Galaxy authoring guidance.
+    </p>
+    {relatedPatterns.length > 0 && (
+      <div class="pattern-map-links">
+        {relatedPatterns.map(link => (
+          <a href={link.href!} class="pattern-map-link no-underline">
+            <span>{link.label}</span>
+            {link.summary && <small>{link.summary}</small>}
+          </a>
+        ))}
+      </div>
+    )}
+  </aside>
+)}
+
+<style>
+  .pattern-map-panel {
+    margin: 0 0 1.25rem;
+    padding: 1rem;
+    border: 1px solid color-mix(in srgb, var(--color-galaxy-primary) 22%, var(--color-border-subtle));
+    border-radius: 0.75rem;
+    background:
+      linear-gradient(135deg, color-mix(in srgb, var(--color-galaxy-primary) 8%, transparent), transparent 45%),
+      var(--color-surface-raised);
+  }
+  .pattern-map-panel-top {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 0.75rem;
+  }
+  .pattern-map-count {
+    color: var(--color-text-muted);
+    font-size: 0.75rem;
+  }
+  .pattern-map-panel h2 {
+    margin: 0 0 0.35rem;
+    color: var(--color-text-primary);
+    font-size: 1.15rem;
+  }
+  .pattern-map-panel p {
+    margin: 0 0 0.9rem;
+    color: var(--color-text-secondary);
+    font-size: 0.92rem;
+    line-height: 1.55;
+  }
+  .pattern-map-links {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+    gap: 0.6rem;
+  }
+  .pattern-map-link {
+    display: grid;
+    gap: 0.25rem;
+    padding: 0.7rem;
+    border: 1px solid var(--color-border-subtle);
+    border-radius: 0.55rem;
+    background: var(--color-surface);
+    color: var(--color-link);
+    transition: border-color 0.15s ease, transform 0.15s ease;
+  }
+  .pattern-map-link:hover {
+    border-color: var(--color-accent);
+    transform: translateY(-1px);
+  }
+  .pattern-map-link small {
+    color: var(--color-text-muted);
+    font-size: 0.78rem;
+    line-height: 1.35;
+  }
+</style>

--- a/site/src/components/PatternSpotlight.astro
+++ b/site/src/components/PatternSpotlight.astro
@@ -11,10 +11,15 @@ const patterns = all
     return (a.data as any).title.localeCompare((b.data as any).title);
   });
 
-const visible = patterns.slice(0, 4);
+const maps = patterns
+  .filter(p => (p.data as any).pattern_kind === 'moc')
+  .sort((a, b) => (a.data as any).title.localeCompare((b.data as any).title));
+const recentLeaves = patterns
+  .filter(p => (p.data as any).pattern_kind === 'leaf')
+  .slice(0, 4);
 
 function shortTitle(title: string): string {
-  return title.replace(/^Tabular:\s*/, '');
+  return title.replace(/^(Tabular|Collection|Galaxy):\s*/, '');
 }
 ---
 {patterns.length > 0 && (
@@ -25,8 +30,27 @@ function shortTitle(title: string): string {
       <a href={`${base}/patterns/`} class="spotlight-all">View all {patterns.length}</a>
     </div>
 
+    {maps.length > 0 && (
+      <div class="map-spotlight-grid">
+        {maps.map((pattern) => {
+          const data = pattern.data as any;
+          return (
+            <a href={`${base}/${pattern.id}/`} class="map-spotlight-card no-underline tinted-shadow tinted-shadow-hover">
+              <span class="spotlight-index font-mono">MAP</span>
+              <span class="spotlight-title">{shortTitle(data.title)}</span>
+              <span class="spotlight-summary">{data.summary}</span>
+              <span class="spotlight-foot">
+                <span class="badge badge-draft">map</span>
+                <span class="font-mono">{data.related_patterns?.length ?? 0} links</span>
+              </span>
+            </a>
+          );
+        })}
+      </div>
+    )}
+
     <div class="spotlight-grid">
-      {visible.map((pattern, index) => {
+      {recentLeaves.map((pattern, index) => {
         const data = pattern.data as any;
         return (
           <a href={`${base}/${pattern.id}/`} class="spotlight-card no-underline tinted-shadow tinted-shadow-hover">
@@ -35,7 +59,7 @@ function shortTitle(title: string): string {
             <span class="spotlight-summary">{data.summary}</span>
             <span class="spotlight-foot">
               <span class={`badge badge-${data.status}`}>{data.status}</span>
-              <span class="font-mono">pattern</span>
+              <span class="font-mono">leaf</span>
             </span>
           </a>
         );
@@ -64,6 +88,30 @@ function shortTitle(title: string): string {
     display: grid;
     grid-template-columns: repeat(4, minmax(0, 1fr));
     gap: 0.75rem;
+  }
+  .map-spotlight-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+  }
+  .map-spotlight-card {
+    display: grid;
+    grid-template-rows: auto auto 1fr auto;
+    gap: 0.55rem;
+    min-height: 12rem;
+    padding: 1.05rem;
+    border: 1px solid color-mix(in srgb, var(--color-galaxy-primary) 22%, var(--color-border-subtle));
+    border-radius: 0.65rem;
+    background:
+      linear-gradient(135deg, color-mix(in srgb, var(--color-galaxy-primary) 12%, transparent), transparent 42%),
+      var(--color-surface-raised);
+    color: inherit;
+    transition: border-color 0.18s ease, transform 0.18s ease, box-shadow 0.18s ease;
+  }
+  .map-spotlight-card:hover {
+    border-color: var(--color-accent);
+    transform: translateY(-2px);
   }
   .spotlight-card {
     display: grid;
@@ -109,11 +157,13 @@ function shortTitle(title: string): string {
     font-size: 0.75rem;
   }
   @media (max-width: 900px) {
+    .map-spotlight-grid,
     .spotlight-grid {
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
   }
   @media (max-width: 560px) {
+    .map-spotlight-grid,
     .spotlight-grid {
       grid-template-columns: 1fr;
     }

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -94,6 +94,7 @@ const moldSchema = z.object({
 
 const patternSchema = z.object({
   type: z.literal('pattern'),
+  pattern_kind: z.enum(['leaf', 'moc']),
   title: z.string(),
   parent_pattern: wikiLink.optional(),
   ...baseFields,

--- a/site/src/pages/[...slug].astro
+++ b/site/src/pages/[...slug].astro
@@ -75,7 +75,7 @@ const metaMode: 'full' | 'related-only' = data.type === 'mold' ? 'related-only' 
 
     {data.type === 'mold' && <MoldBody entry={entry} linkMap={linkMap} />}
     {data.type === 'pipeline' && <PipelineBody entry={entry} linkMap={linkMap} />}
-    {data.type === 'pattern' && <PatternBody />}
+    {data.type === 'pattern' && <PatternBody entry={entry} linkMap={linkMap} />}
     {data.type === 'cli-command' && <CliCommandBody entry={entry} />}
     {data.type === 'research' && <ResearchBody entry={entry} />}
     {data.type === 'schema' && <SchemaBody entry={entry} />}

--- a/site/src/pages/patterns/index.astro
+++ b/site/src/pages/patterns/index.astro
@@ -8,8 +8,13 @@ const patterns = all
   .filter(n => n.data.type === 'pattern' && n.data.status !== 'archived')
   .sort((a, b) => (a.data as any).title.localeCompare((b.data as any).title));
 
-const groups = new Map<string, typeof patterns>();
-for (const pattern of patterns) {
+const maps = patterns.filter(p => (p.data as any).pattern_kind === 'moc');
+const leafPatterns = patterns.filter(p => (p.data as any).pattern_kind === 'leaf');
+const topicTags = [...new Set(patterns.flatMap(p => (p.data.tags as string[]).filter(t => t.startsWith('topic/'))))]
+  .sort((a, b) => a.localeCompare(b));
+
+const groups = new Map<string, typeof leafPatterns>();
+for (const pattern of leafPatterns) {
   const title = (pattern.data as any).title as string;
   const group = title.includes(':') ? title.split(':')[0] : 'General';
   const list = groups.get(group) ?? [];
@@ -32,8 +37,7 @@ function formatDate(d: Date): string {
           IWC-grounded workflow construction recipes.
         </h1>
         <p class="patterns-lede text-pretty">
-          Pattern pages capture reusable Galaxy authoring moves that Molds can reference and casts can condense.
-          They are operation-anchored, corpus-backed, and separate from action Molds.
+          Pattern maps are the entry points; leaf pages are the concrete Galaxy authoring moves that Molds can reference and casts can condense.
         </p>
       </div>
       <dl class="patterns-stats" aria-label="Pattern library stats">
@@ -42,18 +46,59 @@ function formatDate(d: Date): string {
           <dd>{patterns.length}</dd>
         </div>
         <div>
-          <dt>Groups</dt>
-          <dd>{groupedPatterns.length}</dd>
+          <dt>Maps</dt>
+          <dd>{maps.length}</dd>
         </div>
       </dl>
     </div>
   </section>
 
+  {maps.length > 0 && (
+    <section class="pattern-group" aria-labelledby="pattern-maps-heading">
+      <div class="section-rule">
+        <h2 id="pattern-maps-heading">Pattern Maps</h2>
+        <span class="section-tail">/ start here</span>
+      </div>
+      <div class="pattern-map-grid">
+        {maps.map(pattern => {
+          const data = pattern.data as any;
+          const linkedCount = data.related_patterns?.length ?? 0;
+          const subjectTags = (data.tags as string[]).filter(t => t !== 'pattern');
+          return (
+            <article class="pattern-map-card tinted-shadow tinted-shadow-hover">
+              <div class="pattern-card-top">
+                <span class="badge badge-draft">map</span>
+                <span class="pattern-date font-mono">{linkedCount} links</span>
+              </div>
+              <h3 class="pattern-map-title"><a href={`${base}/${pattern.id}/`}>{data.title}</a></h3>
+              <p class="pattern-summary">{data.summary}</p>
+              <div class="pattern-tags" aria-label="Tags">
+                {subjectTags.map(tag => <a href={`${base}/tags/${tag}/`} class="tag no-underline">{tag}</a>)}
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  )}
+
+  {topicTags.length > 0 && (
+    <section class="pattern-group" aria-labelledby="pattern-topics-heading">
+      <div class="section-rule">
+        <h2 id="pattern-topics-heading">Browse By Topic</h2>
+        <span class="section-tail">/ tag rollups</span>
+      </div>
+      <div class="pattern-topic-row">
+        {topicTags.map(tag => <a href={`${base}/tags/${tag}/`} class="topic-chip no-underline">{tag}</a>)}
+      </div>
+    </section>
+  )}
+
   {groupedPatterns.map(([group, list]) => (
     <section class="pattern-group" aria-labelledby={`patterns-${group.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`}>
       <div class="section-rule">
         <h2 id={`patterns-${group.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`}>{group}</h2>
-        <span class="section-tail">/ {list.length} {list.length === 1 ? 'pattern' : 'patterns'}</span>
+        <span class="section-tail">/ {list.length} leaf {list.length === 1 ? 'pattern' : 'patterns'}</span>
       </div>
       <div class="pattern-grid">
         {list.map(pattern => {
@@ -63,7 +108,7 @@ function formatDate(d: Date): string {
             <article class="pattern-card tinted-shadow tinted-shadow-hover">
               <div class="pattern-card-top">
                 <span class={`badge badge-${data.status}`}>{data.status}</span>
-                <span class="pattern-date font-mono">rev {data.revision} · {formatDate(data.revised)}</span>
+                <span class="pattern-date font-mono">leaf · rev {data.revision} · {formatDate(data.revised)}</span>
               </div>
               <h3 class="pattern-card-title">
                 <a href={`${base}/${pattern.id}/`}>{data.title}</a>
@@ -145,6 +190,63 @@ function formatDate(d: Date): string {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
     gap: 1rem;
+  }
+  .pattern-map-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+    gap: 1rem;
+  }
+  .pattern-map-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+    min-height: 12rem;
+    padding: 1.1rem;
+    border: 1px solid color-mix(in srgb, var(--color-galaxy-primary) 22%, var(--color-border-subtle));
+    border-radius: 0.75rem;
+    background:
+      linear-gradient(135deg, color-mix(in srgb, var(--color-galaxy-primary) 9%, transparent), transparent 46%),
+      var(--color-surface-raised);
+    transition: border-color 0.18s ease, transform 0.18s ease, box-shadow 0.18s ease;
+  }
+  .pattern-map-card:hover {
+    border-color: var(--color-accent);
+    transform: translateY(-2px);
+  }
+  .pattern-map-title {
+    margin: 0;
+    font-size: 1.35rem;
+    line-height: 1.2;
+    letter-spacing: -0.015em;
+  }
+  .pattern-map-title a {
+    color: var(--color-link);
+    text-decoration: none;
+  }
+  .pattern-map-title a:hover {
+    color: var(--color-link-hover);
+    text-decoration: underline;
+  }
+  .pattern-topic-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+  }
+  .topic-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.45rem 0.75rem;
+    border: 1px solid var(--color-border-subtle);
+    border-radius: 999px;
+    background: var(--color-surface-raised);
+    color: var(--color-link);
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    transition: border-color 0.15s ease, transform 0.15s ease;
+  }
+  .topic-chip:hover {
+    border-color: var(--color-accent);
+    transform: translateY(-1px);
   }
   .pattern-card {
     display: flex;

--- a/site/src/pages/tags/index.astro
+++ b/site/src/pages/tags/index.astro
@@ -20,14 +20,16 @@ const noteTypeTags = sorted.filter(([t]) =>
 );
 const sourceTags = sorted.filter(([t]) => t.startsWith('source/'));
 const targetTags = sorted.filter(([t]) => t.startsWith('target/'));
+const topicTags = sorted.filter(([t]) => t.startsWith('topic/'));
 const toolTags = sorted.filter(([t]) => t.startsWith('tool/') || t.startsWith('cli/'));
-const seen = new Set([...noteTypeTags, ...sourceTags, ...targetTags, ...toolTags].map(([t]) => t));
+const seen = new Set([...noteTypeTags, ...sourceTags, ...targetTags, ...topicTags, ...toolTags].map(([t]) => t));
 const otherTags = sorted.filter(([t]) => !seen.has(t));
 
 const groups = [
   { label: 'Note Type', tags: noteTypeTags },
   { label: 'Source', tags: sourceTags },
   { label: 'Target', tags: targetTags },
+  { label: 'Topic', tags: topicTags },
   { label: 'Tool / CLI', tags: toolTags },
   { label: 'Other', tags: otherTags },
 ];

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -27,11 +27,16 @@ const baseRequired = (overrides: Record<string, unknown> = {}) => ({
   ...overrides,
 });
 
+const patternRequired = (overrides: Record<string, unknown> = {}) => baseRequired({
+  pattern_kind: "leaf",
+  ...overrides,
+});
+
 describe("validateData (per-file)", () => {
   const schema = loadRealSchema();
 
   it("accepts a minimal pattern", () => {
-    const r = validateData(baseRequired(), schema);
+    const r = validateData(patternRequired(), schema);
     expect(r.errors).toEqual([]);
   });
 
@@ -41,7 +46,7 @@ describe("validateData (per-file)", () => {
   });
 
   it("rejects unknown fields", () => {
-    const r = validateData(baseRequired({ bogus: "x" }), schema);
+    const r = validateData(patternRequired({ bogus: "x" }), schema);
     expect(r.errors.some((e) => /bogus/.test(e))).toBe(true);
   });
 
@@ -155,17 +160,17 @@ describe("validateData (per-file)", () => {
   });
 
   it("rejects bad date format", () => {
-    const r = validateData(baseRequired({ created: "not-a-date" }), schema);
+    const r = validateData(patternRequired({ created: "not-a-date" }), schema);
     expect(r.errors.length).toBeGreaterThan(0);
   });
 
   it("rejects whitespace-only wiki link", () => {
-    const r = validateData(baseRequired({ parent_pattern: "[[   ]]" }), schema);
+    const r = validateData(patternRequired({ parent_pattern: "[[   ]]" }), schema);
     expect(r.errors.some((e) => /whitespace-only/.test(e))).toBe(true);
   });
 
   it("warns on tag coherence drift", () => {
-    const r = validateData(baseRequired({ tags: ["mold"] }), schema);
+    const r = validateData(patternRequired({ tags: ["mold"] }), schema);
     expect(r.warnings.some((w) => /expected 'pattern'/.test(w))).toBe(true);
   });
 });
@@ -196,7 +201,7 @@ describe("validateDirectory (cross-file)", () => {
 
   it("validates a tiny vault end-to-end", () => {
 
-    writeFm(path.join(dir, "patterns/foo.md"), baseRequired());
+    writeFm(path.join(dir, "patterns/foo.md"), patternRequired());
 
     const r = validateDirectory({
       directory: dir,
@@ -218,7 +223,7 @@ describe("validateDirectory (cross-file)", () => {
       }),
     });
     writeFm(path.join(dir, "patterns/some-pattern.md"), {
-      ...baseRequired({ type: "pattern", tags: ["pattern"], title: "Some Pattern" }),
+      ...patternRequired({ type: "pattern", tags: ["pattern"], title: "Some Pattern" }),
     });
 
     const r = validateDirectory({
@@ -288,7 +293,7 @@ describe("validateDirectory (cross-file)", () => {
       ...baseRequired({ type: "research", tags: ["research/component"], subtype: "component" }),
     });
     writeFm(path.join(dir, "patterns/pattern-x.md"), {
-      ...baseRequired({ type: "pattern", tags: ["pattern"], title: "Pattern X" }),
+      ...patternRequired({ type: "pattern", tags: ["pattern"], title: "Pattern X" }),
     });
     mkdirSync(path.join(dir, "schemas"), { recursive: true });
     writeFileSync(path.join(dir, "schemas/x.schema.json"), "{}");
@@ -314,7 +319,7 @@ describe("validateDirectory (cross-file)", () => {
       }),
     });
     writeFm(path.join(dir, "patterns/not-research.md"), {
-      ...baseRequired({ type: "pattern", tags: ["pattern"], title: "Not Research" }),
+      ...patternRequired({ type: "pattern", tags: ["pattern"], title: "Not Research" }),
     });
 
     const r = validateDirectory({


### PR DESCRIPTION
## Summary
- Add schema-backed pattern maps with `pattern_kind: moc|leaf`.
- Add collection and tabular pattern MOCs and update Galaxy molds to reference them instead of raw surveys.
- Update pattern UI to feature MOCs, topic rollups, and leaf-pattern browsing.
- Fix root site scripts to run the nested site package commands.

## Validation
- `npm run validate`
- `npm run test`
- `npm run site:build`