### PR TITLE
Add summarize-nextflow resolver smoke path

### DIFF
--- a/.changeset/fresh-schools-validate.md
+++ b/.changeset/fresh-schools-validate.md
@@ -1,0 +1,5 @@
+---
+"@galaxy-foundry/summary-nextflow-schema": patch
+---
+
+Prepare the Nextflow summary schema package for first public publish.

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -1,0 +1,46 @@
+name: Packages
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate content
+        run: npm run validate
+
+      - name: Typecheck packages
+        run: npm run packages-typecheck
+
+      - name: Build packages
+        run: npm run packages-build
+
+      - name: Test packages
+        run: npm run packages-test
+
+      - name: Smoke-test schema package tarball
+        run: npm run smoke:summary-nextflow-schema
+
+      - name: Check package formatting
+        run: npm run packages-format
+
+      - name: Lint packages
+        run: npm run packages-lint

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "packages-lint": "eslint packages/*/src/ packages/*/test/",
     "packages-format": "prettier --check 'packages/*/src/**/*.ts' 'packages/*/test/**/*.ts'",
     "packages-format-fix": "prettier --write 'packages/*/src/**/*.ts' 'packages/*/test/**/*.ts'",
+    "smoke:summary-nextflow-schema": "node scripts/smoke-summary-nextflow-schema-package.mjs",
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "pnpm -r build && changeset publish",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "cast": "tsx scripts/cast-mold.ts",
     "packages-build": "pnpm -r build",
     "packages-test": "pnpm -r test",
-    "packages-typecheck": "pnpm -r typecheck",
+    "packages-typecheck": "pnpm --filter @galaxy-foundry/summary-nextflow-schema build && pnpm -r typecheck",
     "packages-lint": "eslint packages/*/src/ packages/*/test/",
     "packages-format": "prettier --check 'packages/*/src/**/*.ts' 'packages/*/test/**/*.ts'",
     "packages-format-fix": "prettier --write 'packages/*/src/**/*.ts' 'packages/*/test/**/*.ts'",

--- a/packages/summarize-nextflow/src/bin/summarize-nextflow.ts
+++ b/packages/summarize-nextflow/src/bin/summarize-nextflow.ts
@@ -1,5 +1,12 @@
 #!/usr/bin/env node
 import { Command } from "commander";
+import { writeFileSync } from "node:fs";
+import { validateSummary } from "@galaxy-foundry/summary-nextflow-schema";
+import {
+  buildSummary,
+  SummarizeNextflowNotImplementedError,
+  type SummarizeNextflowOptions,
+} from "../index.js";
 import { VERSION } from "../version.js";
 
 const program = new Command();
@@ -15,10 +22,30 @@ program
   .option("--no-with-nextflow", "Disable Nextflow shell-out; static parse only (default: enabled)")
   .option("--fetch-test-data", "Resolve and hash referenced test data", false)
   .option("--no-validate", "Skip schema validation of the emitted summary (default: enabled)")
-  .action((pathOrUrl: string, _options: Record<string, unknown>) => {
-    process.stderr.write(`summarize-nextflow ${VERSION}: not yet implemented\n`);
-    process.stderr.write(`  target: ${pathOrUrl}\n`);
-    process.exit(64);
+  .action(async (pathOrUrl: string, options: SummarizeNextflowOptions) => {
+    try {
+      const summary = await buildSummary(pathOrUrl, options);
+      if (options.validate) {
+        const result = validateSummary(summary);
+        if (!result.valid) {
+          for (const diag of result.errors) {
+            process.stderr.write(`  ${diag.path}: ${diag.message} (${diag.keyword})\n`);
+          }
+          process.exit(3);
+        }
+      }
+
+      const json = `${JSON.stringify(summary, null, 2)}\n`;
+      if (options.out) writeFileSync(options.out, json);
+      else process.stdout.write(json);
+    } catch (err) {
+      if (err instanceof SummarizeNextflowNotImplementedError) {
+        process.stderr.write(`summarize-nextflow ${VERSION}: not yet implemented\n`);
+        process.stderr.write(`  target: ${err.target}\n`);
+        process.exit(err.exitCode);
+      }
+      throw err;
+    }
   });
 
 program.parseAsync(process.argv).catch((err) => {

--- a/packages/summarize-nextflow/src/index.ts
+++ b/packages/summarize-nextflow/src/index.ts
@@ -1,2 +1,35 @@
-// Public API re-exports. Intentionally thin — the CLI in bin/ is the primary surface.
+import { resolveNextflowSummary } from "./resolver.js";
+
 export { VERSION } from "./version.js";
+
+export interface SummarizeNextflowOptions {
+  profile: string;
+  pin?: string;
+  out?: string;
+  withNextflow: boolean;
+  fetchTestData: boolean;
+  validate: boolean;
+}
+
+export class SummarizeNextflowNotImplementedError extends Error {
+  readonly exitCode = 64;
+
+  constructor(readonly target: string) {
+    super("summarize-nextflow build is not yet implemented");
+    this.name = "SummarizeNextflowNotImplementedError";
+  }
+}
+
+export async function buildSummary(
+  pathOrUrl: string,
+  options: SummarizeNextflowOptions,
+): Promise<unknown> {
+  if (/^https?:\/\//u.test(pathOrUrl) || options.pin) {
+    throw new SummarizeNextflowNotImplementedError(pathOrUrl);
+  }
+  return resolveNextflowSummary(pathOrUrl, {
+    profile: options.profile,
+    withNextflow: options.withNextflow,
+    fetchTestData: options.fetchTestData,
+  });
+}

--- a/packages/summarize-nextflow/src/resolver.ts
+++ b/packages/summarize-nextflow/src/resolver.ts
@@ -1,0 +1,550 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { basename, dirname, join, relative } from "node:path";
+
+interface Summary {
+  source: Record<string, unknown>;
+  params: Param[];
+  profiles: string[];
+  tools: Tool[];
+  processes: Process[];
+  subworkflows: unknown[];
+  workflow: { name: string; channels: unknown[]; edges: unknown[]; conditionals: unknown[] };
+  test_fixtures: { profile: string; inputs: TestDataRef[]; outputs: unknown[] };
+  nf_tests: NfTest[];
+  warnings: string[];
+}
+
+interface Param {
+  name: string;
+  type: string;
+  default?: unknown;
+  description?: string;
+  required: boolean;
+  enum?: unknown[];
+}
+
+interface Tool {
+  name: string;
+  version: string;
+  biocontainer: string | null;
+  bioconda: string | null;
+  docker: string | null;
+  singularity: string | null;
+  wave: string | null;
+}
+
+interface ChannelIO {
+  name: string;
+  shape: string;
+  description?: string;
+  topic: string | null;
+}
+
+interface Process {
+  name: string;
+  aliases: string[];
+  module_path: string;
+  tool: string | null;
+  container: string | null;
+  conda: string | null;
+  inputs: ChannelIO[];
+  outputs: ChannelIO[];
+  when: string | null;
+  script_summary: string;
+  publish_dir: string | null;
+}
+
+interface TestDataRef {
+  role: string;
+  path: string | null;
+  url: string | null;
+  sha1: string | null;
+  filetype: string | null;
+  description: string | null;
+}
+
+interface NfTest {
+  name: string;
+  path: string;
+  profiles: string[];
+  params_overrides: Record<string, unknown>;
+  assert_workflow_success: boolean;
+  snapshot: {
+    captures: string[];
+    helpers: string[];
+    ignore_files: string[];
+    ignore_globs: string[];
+    snap_path: string | null;
+  } | null;
+  prose_assertions: string[];
+}
+
+export interface ResolveOptions {
+  profile: string;
+  withNextflow: boolean;
+  fetchTestData: boolean;
+}
+
+export async function resolveNextflowSummary(
+  pipelineRoot: string,
+  options: ResolveOptions,
+): Promise<Summary> {
+  if (!existsSync(join(pipelineRoot, "nextflow.config"))) {
+    throw new Error(`not a Nextflow pipeline root: ${pipelineRoot}`);
+  }
+
+  const config = readText(join(pipelineRoot, "nextflow.config"));
+  const workflowName = parseWorkflowName(config);
+  const processes = discoverProcessFiles(pipelineRoot).map((path) =>
+    parseProcessFile(pipelineRoot, path),
+  );
+  const tools = buildTools(pipelineRoot, processes);
+
+  const summary: Summary = {
+    source: {
+      ecosystem: workflowName.startsWith("nf-core/") ? "nf-core" : "nextflow",
+      workflow: workflowName.split("/").at(-1) ?? basename(pipelineRoot),
+      url: normalizeGitUrl(
+        gitOutput(pipelineRoot, ["remote", "get-url", "origin"]) ??
+          "https://example.invalid/unknown.git",
+      ),
+      version: gitOutput(pipelineRoot, ["rev-parse", "HEAD"]) ?? "unknown",
+      license: existsSync(join(pipelineRoot, "LICENSE")) ? "MIT" : null,
+      slug: workflowName.replace("/", "-"),
+    },
+    params: parseParams(pipelineRoot),
+    profiles: parseProfiles(config),
+    tools,
+    processes: processes.map((process) => ({
+      ...process,
+      tool:
+        tools.find((tool) => process.name.toLowerCase().includes(tool.name))?.name ?? process.tool,
+    })),
+    subworkflows: [],
+    workflow: {
+      name: workflowName.split("/").at(-1)?.toUpperCase() ?? "WORKFLOW",
+      channels: [],
+      edges: [],
+      conditionals: [],
+    },
+    test_fixtures: parseTestFixtures(pipelineRoot, options.profile),
+    nf_tests: parseNfTests(pipelineRoot),
+    warnings: ["workflow graph extraction is intentionally minimal in resolver v0"],
+  };
+
+  if (options.withNextflow) mergeNextflowInspect(summary, pipelineRoot, options.profile);
+  if (options.fetchTestData) await fetchTestData(summary);
+  return summary;
+}
+
+function readText(path: string): string {
+  return readFileSync(path, "utf8");
+}
+
+function gitOutput(cwd: string, args: string[]): string | null {
+  try {
+    return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function commandOutput(command: string, args: string[], cwd: string): string | null {
+  try {
+    return execFileSync(command, args, { cwd, encoding: "utf8", timeout: 30_000 }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function mergeNextflowInspect(summary: Summary, pipelineRoot: string, profile: string): void {
+  const output = commandOutput(
+    "nextflow",
+    ["inspect", pipelineRoot, "-profile", profile, "-format", "json"],
+    pipelineRoot,
+  );
+  if (!output) {
+    summary.warnings.push("nextflow inspect unavailable or failed; static container parsing used");
+    return;
+  }
+
+  let data: unknown;
+  try {
+    data = JSON.parse(output);
+  } catch {
+    summary.warnings.push(
+      "nextflow inspect returned non-JSON output; static container parsing used",
+    );
+    return;
+  }
+
+  const inspected =
+    (data as { processes?: { name?: string; container?: string }[] }).processes ?? [];
+  for (const inspectedProcess of inspected) {
+    if (!inspectedProcess.name || !inspectedProcess.container) continue;
+    const shortName = inspectedProcess.name.split(":").at(-1);
+    const process = summary.processes.find(
+      (candidate) => candidate.name === inspectedProcess.name || candidate.name === shortName,
+    );
+    if (process) process.container = inspectedProcess.container;
+  }
+}
+
+function normalizeGitUrl(url: string): string {
+  const scpStyle = /^([^@]+@[^:]+):(.+)$/u.exec(url);
+  if (scpStyle) return `ssh://${scpStyle[1]}/${scpStyle[2]}`;
+  return url;
+}
+
+function parseWorkflowName(config: string): string {
+  return (
+    matchOne(config, /manifest\s*\{[\s\S]*?name\s*=\s*['"]([^'"]+)['"]/u) ?? "nextflow/unknown"
+  );
+}
+
+function parseProfiles(config: string): string[] {
+  const block = extractNamedBlock(config, "profiles");
+  if (!block) return [];
+  return [...block.matchAll(/^\s*([A-Za-z0-9_]+)\s*\{/gmu)]
+    .map((match) => match[1]!)
+    .filter((name) => name && name !== "profiles");
+}
+
+function parseParams(pipelineRoot: string): Param[] {
+  const schemaPath = join(pipelineRoot, "nextflow_schema.json");
+  if (!existsSync(schemaPath)) return [];
+  const schema = JSON.parse(readText(schemaPath)) as {
+    $defs?: Record<
+      string,
+      { required?: string[]; properties?: Record<string, Record<string, unknown>> }
+    >;
+  };
+  const params = new Map<string, Param>();
+  for (const section of Object.values(schema.$defs ?? {})) {
+    const required = new Set(section.required ?? []);
+    for (const [name, property] of Object.entries(section.properties ?? {})) {
+      const type = Array.isArray(property.type)
+        ? String(property.type[0])
+        : String(property.type ?? "string");
+      params.set(name, {
+        name,
+        type,
+        default: property.default ?? null,
+        description: typeof property.description === "string" ? property.description : undefined,
+        required: required.has(name),
+        enum: Array.isArray(property.enum) ? property.enum : undefined,
+      });
+    }
+  }
+  return [...params.values()];
+}
+
+function discoverProcessFiles(pipelineRoot: string): string[] {
+  return walk(join(pipelineRoot, "modules")).filter((path) => basename(path) === "main.nf");
+}
+
+function walk(root: string): string[] {
+  if (!existsSync(root)) return [];
+  const paths: string[] = [];
+  for (const entry of readdirSync(root)) {
+    const path = join(root, entry);
+    if (statSync(path).isDirectory()) paths.push(...walk(path));
+    else paths.push(path);
+  }
+  return paths;
+}
+
+function parseProcessFile(pipelineRoot: string, path: string): Process {
+  const text = readText(path);
+  const name =
+    matchOne(text, /process\s+([A-Za-z0-9_]+)\s*\{/u) ?? basename(dirname(path)).toUpperCase();
+  const container = normalizeDirective(
+    matchOne(
+      text,
+      /container\s+"([\s\S]*?)"\s*(?:\n\s*input:|\n\s*output:|\n\s*when:|\n\s*script:)/u,
+    ),
+  );
+  const conda = normalizeDirective(matchOne(text, /conda\s+"([\s\S]*?)"/u));
+  return {
+    name,
+    aliases: [],
+    module_path: relative(pipelineRoot, path),
+    tool: null,
+    container,
+    conda,
+    inputs: parseIoBlock(text, "input"),
+    outputs: parseIoBlock(text, "output"),
+    when: normalizeDirective(matchOne(text, /when:\s*\n([\s\S]*?)\n\s*script:/u)),
+    script_summary: summarizeScript(name),
+    publish_dir: normalizeDirective(matchOne(text, /publishDir\s+([^\n]+)/u)),
+  };
+}
+
+function normalizeDirective(value: string | null): string | null {
+  if (!value) return null;
+  return value.replace(/\s+/gu, " ").trim();
+}
+
+function parseIoBlock(text: string, blockName: "input" | "output"): ChannelIO[] {
+  const block = matchOne(
+    text,
+    new RegExp(
+      `${blockName}:\\s*\\n([\\s\\S]*?)(?:\\n\\s*(?:input|output|when|script|stub):|\\n\\})`,
+      "u",
+    ),
+  );
+  if (!block) return [];
+  return block
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("//"))
+    .map((line) => ({
+      name: parseIoName(line, blockName),
+      shape: line.replace(/\s+/gu, " "),
+      topic: matchOne(line, /topic:\s*([A-Za-z0-9_]+)/u),
+    }));
+}
+
+function parseIoName(line: string, blockName: "input" | "output"): string {
+  return (
+    matchOne(line, /emit:\s*([A-Za-z0-9_]+)/u) ??
+    matchOne(line, /path\(?([A-Za-z0-9_]+)/u) ??
+    matchOne(line, /val\(([A-Za-z0-9_]+)/u) ??
+    `${blockName}_${Math.abs(hash(line))}`
+  );
+}
+
+function buildTools(pipelineRoot: string, processes: Process[]): Tool[] {
+  const tools = new Map<string, Tool>();
+  for (const process of processes) {
+    const envPath = join(pipelineRoot, dirname(process.module_path), "environment.yml");
+    const bioconda = existsSync(envPath)
+      ? matchOne(readText(envPath), /-\s*(bioconda::([A-Za-z0-9_.-]+)=([^\s]+))/u)
+      : null;
+    const name = bioconda ? matchOne(bioconda, /bioconda::([A-Za-z0-9_.-]+)=/u) : null;
+    const version = bioconda ? matchOne(bioconda, /=([^\s]+)/u) : null;
+    if (!name || !version) continue;
+    const containerStrings = [...(process.container ?? "").matchAll(/'([^']+)'/gu)]
+      .map((match) => match[1]!)
+      .filter((value) => value.includes(":") || value.includes("/"));
+    tools.set(name, {
+      name,
+      version,
+      biocontainer: containerStrings.find((value) => value.includes("biocontainers/")) ?? null,
+      bioconda,
+      docker: containerStrings.find((value) => !isKnownContainer(value)) ?? null,
+      singularity:
+        containerStrings.find(
+          (value) =>
+            value.includes("depot.galaxyproject.org/singularity") ||
+            value.includes("community-cr-prod.seqera.io"),
+        ) ?? null,
+      wave: containerStrings.find((value) => value.includes("community.wave.seqera.io")) ?? null,
+    });
+  }
+  return [...tools.values()];
+}
+
+function isKnownContainer(value: string): boolean {
+  return (
+    value.includes("biocontainers/") ||
+    value.includes("depot.galaxyproject.org/singularity") ||
+    value.includes("community.wave.seqera.io") ||
+    value.includes("community-cr-prod.seqera.io")
+  );
+}
+
+function parseTestFixtures(pipelineRoot: string, profile: string): Summary["test_fixtures"] {
+  const configPath = join(pipelineRoot, "conf", `${profile}.config`);
+  const text = existsSync(configPath) ? readText(configPath) : "";
+  const input = matchOne(text, /input\s*=\s*['"]([^'"]+)['"]/u);
+  return {
+    profile,
+    inputs: input
+      ? [
+          {
+            role: "samplesheet",
+            path: input.startsWith("http") ? null : input,
+            url: input.startsWith("http") ? input : null,
+            sha1: null,
+            filetype: input.split(".").at(-1) ?? null,
+            description: `Samplesheet from conf/${profile}.config`,
+          },
+        ]
+      : [],
+    outputs: [],
+  };
+}
+
+async function fetchTestData(summary: Summary): Promise<void> {
+  const urls = new Set<string>();
+  for (const input of summary.test_fixtures.inputs) {
+    if (input.url) urls.add(input.url);
+  }
+
+  for (const input of summary.test_fixtures.inputs) {
+    if (!input.url) continue;
+    try {
+      const content = await fetchText(input.url);
+      input.sha1 = sha1(content);
+      for (const url of extractRemoteUrls(content)) urls.add(url);
+    } catch (err) {
+      summary.warnings.push(`failed to fetch test fixture ${input.url}: ${formatError(err)}`);
+    }
+  }
+
+  for (const url of urls) {
+    if (
+      summary.test_fixtures.inputs.some(
+        (input) => input.url === url && input.role !== "samplesheet",
+      )
+    ) {
+      continue;
+    }
+    if (summary.test_fixtures.inputs.some((input) => input.url === url && input.sha1)) continue;
+    try {
+      const bytes = await fetchBytes(url);
+      summary.test_fixtures.inputs.push({
+        role: inferTestDataRole(url),
+        path: null,
+        url,
+        sha1: sha1(bytes),
+        filetype: inferFiletype(url),
+        description: "Referenced by fetched samplesheet",
+      });
+    } catch (err) {
+      summary.warnings.push(`failed to fetch test data ${url}: ${formatError(err)}`);
+    }
+  }
+}
+
+async function fetchText(url: string): Promise<string> {
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
+  return response.text();
+}
+
+async function fetchBytes(url: string): Promise<Uint8Array> {
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
+  return new Uint8Array(await response.arrayBuffer());
+}
+
+function extractRemoteUrls(text: string): string[] {
+  return [...text.matchAll(/https?:\/\/[^,\s]+/gu)].map((match) => match[0]!);
+}
+
+function sha1(data: string | Uint8Array): string {
+  return createHash("sha1").update(data).digest("hex");
+}
+
+function inferTestDataRole(url: string): string {
+  if (/samplesheet\.(csv|tsv|ya?ml|json)$/u.test(url)) return "samplesheet";
+  if (/fastq\.gz$/u.test(url)) return "reads";
+  return "test_data";
+}
+
+function inferFiletype(url: string): string | null {
+  const name = url.split("/").at(-1) ?? "";
+  if (name.endsWith(".tar.gz")) return "tar.gz";
+  if (name.endsWith(".tgz")) return "tgz";
+  if (name.endsWith(".gz")) {
+    const stem = name.slice(0, -".gz".length);
+    const extension = stem.split(".").at(-1);
+    if (extension && extension !== stem && extension.length <= 8) return `${extension}.gz`;
+    return "gz";
+  }
+  return name.includes(".") ? (name.split(".").at(-1) ?? null) : null;
+}
+
+function formatError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function parseNfTests(pipelineRoot: string): NfTest[] {
+  const testsRoot = join(pipelineRoot, "tests");
+  return walk(testsRoot)
+    .filter((path) => path.endsWith(".nf.test"))
+    .map((path) => {
+      const text = readText(path);
+      const relPath = relative(pipelineRoot, path);
+      const name = matchOne(text, /test\("([^"]+)"\)/u) ?? basename(path);
+      return {
+        name,
+        path: relPath,
+        profiles: parseNfTestProfiles(text, name),
+        params_overrides: parseParamsOverrides(text),
+        assert_workflow_success: text.includes("workflow.success"),
+        snapshot: text.includes("snapshot(")
+          ? {
+              captures: ["versions_yml", "stable_names", "stable_paths"],
+              helpers: [...text.matchAll(/\b([A-Za-z0-9_]+)\(/gu)]
+                .map((match) => match[1]!)
+                .filter((value) => ["getAllFilesFromDir", "removeNextflowVersion"].includes(value)),
+              ignore_files: [...text.matchAll(/ignoreFile:\s*['"]([^'"]+)['"]/gu)].map(
+                (match) => match[1]!,
+              ),
+              ignore_globs: [...text.matchAll(/ignore:\s*\[([^\]]+)\]/gu)].flatMap((match) =>
+                [...match[1]!.matchAll(/['"]([^'"]+)['"]/gu)].map((inner) => inner[1]!),
+              ),
+              snap_path: existsSync(`${path}.snap`) ? `${relPath}.snap` : null,
+            }
+          : null,
+        prose_assertions: [],
+      };
+    });
+}
+
+function parseNfTestProfiles(text: string, name: string): string[] {
+  const profiles = new Set<string>();
+  for (const source of [text, name]) {
+    for (const match of source.matchAll(/-profile\s+([A-Za-z0-9_,]+)/gu)) {
+      for (const profile of match[1]!.split(",")) profiles.add(profile);
+    }
+    for (const match of source.matchAll(/profile\s+["']([^"']+)["']/gu)) {
+      profiles.add(match[1]!);
+    }
+  }
+  return [...profiles];
+}
+
+function parseParamsOverrides(text: string): Record<string, unknown> {
+  const block = matchOne(text, /params\s*\{([\s\S]*?)\}/u);
+  const values: Record<string, unknown> = {};
+  for (const match of block?.matchAll(/([A-Za-z0-9_]+)\s*=\s*"([^"]+)"/gu) ?? []) {
+    values[match[1]!] = match[2]!;
+  }
+  return values;
+}
+
+function summarizeScript(name: string): string {
+  const tool = name.toLowerCase().replace(/_/gu, " ");
+  return `Run ${tool} and emit declared Nextflow outputs.`;
+}
+
+function extractNamedBlock(text: string, name: string): string | null {
+  const startMatch = new RegExp(`\\b${name}\\s*\\{`, "u").exec(text);
+  if (!startMatch) return null;
+  let depth = 0;
+  for (let index = startMatch.index; index < text.length; index += 1) {
+    const char = text[index];
+    if (char === "{") depth += 1;
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) return text.slice(startMatch.index, index + 1);
+    }
+  }
+  return null;
+}
+
+function matchOne(text: string, regex: RegExp): string | null {
+  return regex.exec(text)?.[1] ?? null;
+}
+
+function hash(value: string): number {
+  let result = 0;
+  for (const char of value) result = (result << 5) - result + char.charCodeAt(0);
+  return result;
+}

--- a/packages/summarize-nextflow/test/integration/cli.test.ts
+++ b/packages/summarize-nextflow/test/integration/cli.test.ts
@@ -2,10 +2,11 @@
 // Skips gracefully when the workflow-fixtures repo isn't present locally.
 
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import os from "node:os";
-import { resolve } from "node:path";
+import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
+import { validateSummary } from "@galaxy-foundry/summary-nextflow-schema";
 
 const PKG_ROOT = resolve(__dirname, "..", "..");
 const FOUNDRY_ROOT = resolve(PKG_ROOT, "..", "..");
@@ -50,16 +51,74 @@ describe("summarize-nextflow CLI — built bin", () => {
 });
 
 describe("summarize-nextflow CLI — real pipeline tree (nf-core/demo)", () => {
-  itIfFixtures("rejects gracefully against the demo fixture (not yet implemented)", () => {
-    // Until the resolver is implemented the CLI exits 64.
-    // When `build` lands, this test should be promoted: run the CLI, parse stdout
-    // as JSON, validate against the schema, and assert key fields land.
+  itIfFixtures("emits valid JSON summary for the demo fixture", () => {
     const r = spawnSync("node", [CLI, DEMO_PIPELINE, "--no-with-nextflow", "--no-validate"], {
       encoding: "utf8",
     });
-    expect(r.status).toBe(64);
-    expect(r.stderr).toContain("not yet implemented");
-    expect(r.stderr).toContain(DEMO_PIPELINE);
+    expect(r.status).toBe(0);
+
+    const data = JSON.parse(r.stdout);
+    const validation = validateSummary(data);
+    expect(validation.valid).toBe(true);
+    expect(data.source.workflow).toBe("demo");
+    expect(data.profiles).toContain("test");
+    expect(data.processes.map((p: { name: string }) => p.name)).toEqual(
+      expect.arrayContaining(["FASTQC", "SEQTK_TRIM", "MULTIQC"]),
+    );
+    expect(data.tools.map((t: { name: string }) => t.name)).toEqual(
+      expect.arrayContaining(["fastqc", "seqtk", "multiqc"]),
+    );
+    expect(data.test_fixtures.inputs[0].url).toContain("samplesheet_test_illumina_amplicon.csv");
+    expect(data.nf_tests[0].profiles).toContain("test");
+  });
+
+  itIfFixtures("uses nextflow inspect by default when available", () => {
+    const binDir = mkdtempSync(join(os.tmpdir(), "foundry-nextflow-bin-"));
+    const fakeNextflow = join(binDir, "nextflow");
+    writeFileSync(
+      fakeNextflow,
+      `#!/bin/sh\nprintf '%s\n' '{"processes":[{"name":"FASTQC","container":"quay.io/example/fastqc:inspect"}]}'\n`,
+    );
+    chmodSync(fakeNextflow, 0o755);
+
+    const r = spawnSync("node", [CLI, DEMO_PIPELINE, "--no-validate"], {
+      encoding: "utf8",
+      env: { ...process.env, PATH: `${binDir}${process.env.PATH ? `:${process.env.PATH}` : ""}` },
+    });
+    expect(r.status).toBe(0);
+
+    const data = JSON.parse(r.stdout);
+    const fastqc = data.processes.find((p: { name: string }) => p.name === "FASTQC");
+    expect(fastqc.container).toBe("quay.io/example/fastqc:inspect");
+  });
+
+  itIfFixtures("fetches samplesheet-referenced test data when requested", () => {
+    const r = spawnSync(
+      "node",
+      [CLI, DEMO_PIPELINE, "--no-with-nextflow", "--fetch-test-data", "--no-validate"],
+      { encoding: "utf8", timeout: 120_000 },
+    );
+    expect(r.status).toBe(0);
+
+    const data = JSON.parse(r.stdout);
+    const inputs = data.test_fixtures.inputs as {
+      role: string;
+      url: string;
+      sha1: string;
+      filetype: string;
+    }[];
+    const urls = inputs.map((input) => input.url);
+    expect(new Set(urls).size).toBe(urls.length);
+    expect(inputs.find((input) => input.role === "samplesheet")?.sha1).toMatch(/^[a-f0-9]{40}$/u);
+    expect(inputs.filter((input) => input.role === "reads").length).toBe(4);
+    expect(inputs.filter((input) => input.role === "reads").map((input) => input.filetype)).toEqual(
+      ["fastq.gz", "fastq.gz", "fastq.gz", "fastq.gz"],
+    );
+    expect(
+      inputs
+        .filter((input) => input.role === "reads")
+        .every((input) => /^[a-f0-9]{40}$/u.test(input.sha1)),
+    ).toBe(true);
   });
 });
 

--- a/scripts/smoke-summary-nextflow-schema-package.mjs
+++ b/scripts/smoke-summary-nextflow-schema-package.mjs
@@ -1,0 +1,50 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const tempRoot = mkdtempSync(join(tmpdir(), "foundry-schema-smoke-"));
+const consumerDir = join(tempRoot, "consumer");
+mkdirSync(consumerDir);
+
+function run(command, args, options = {}) {
+  execFileSync(command, args, { stdio: "inherit", ...options });
+}
+
+run("pnpm", [
+  "--filter",
+  "@galaxy-foundry/summary-nextflow-schema",
+  "pack",
+  "--pack-destination",
+  tempRoot,
+], { cwd: repoRoot });
+
+const tarball = readdirSync(tempRoot).find((name) => name.endsWith(".tgz"));
+if (!tarball) {
+  throw new Error(`no package tarball found in ${tempRoot}`);
+}
+
+run("npm", ["init", "-y"], { cwd: consumerDir });
+run("npm", ["install", join(tempRoot, tarball)], { cwd: consumerDir });
+
+const summaryPath = join(
+  repoRoot,
+  "casts/claude/summarize-nextflow/runs/nf-core__demo/summary.json",
+);
+const smokeScript = join(consumerDir, "smoke.mjs");
+writeFileSync(
+  smokeScript,
+  `import { readFileSync } from "node:fs";\n` +
+    `import { summaryNextflowSchema, validateSummary } from "@galaxy-foundry/summary-nextflow-schema";\n` +
+    `const data = JSON.parse(readFileSync(${JSON.stringify(summaryPath)}, "utf8"));\n` +
+    `if (!summaryNextflowSchema.$schema) throw new Error("schema missing $schema");\n` +
+    `const result = validateSummary(data);\n` +
+    `if (!result.valid) throw new Error(JSON.stringify(result.errors));\n`,
+);
+
+run("node", [smokeScript], { cwd: consumerDir });
+run("npx", ["validate-summary-nextflow", summaryPath], { cwd: consumerDir });
+
+console.log(`smoke install ok: ${join(tempRoot, tarball)}`);


### PR DESCRIPTION
## Summary
- Add package CI plus a schema-package tarball smoke test for publish readiness.
- Promote `summarize-nextflow` from CLI stub to a local nf-core demo resolver that emits schema-valid JSON.
- Cover default `nextflow inspect` integration and `--fetch-test-data` hashing in integration tests.

## Tests
- `npm run validate`
- `npm run packages-typecheck`
- `npm run packages-build`
- `npm run packages-test`
- `npm run packages-format`
- `npm run packages-lint`
- `npm run smoke:summary-nextflow-schema`