### PR TITLE
Add Nextflow to Galaxy research notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,8 @@ make fixtures-clean    # remove generated fixture dirs
 
 Before launching or acting as a research subagent that needs corpus evidence, check whether the needed generated dirs exist. If they are missing, use the top-level fixture targets above. If you cannot materialize them, stop and report the missing target instead of inventing evidence.
 
+When launching research subagents, ask for evidence quality explicitly. Reports should separate corpus-observed claims, architectural or design inferences, external-doc claims, and speculative or low-confidence claims. Do not let plausible mappings stand as corpus evidence unless they cite fixtures or existing Foundry notes.
+
 For IWC survey work, prefer `make fixtures-iwc fixtures-skeletons` before mining `$IWC_FORMAT2` or `$IWC_SKELETONS`. For Nextflow example work, prefer `make fixtures-nextflow` before reading `workflow-fixtures/pipelines/`.
 
 ## Package layout

--- a/content/molds/compare-against-iwc-exemplar/index.md
+++ b/content/molds/compare-against-iwc-exemplar/index.md
@@ -8,11 +8,28 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-04-30
-revision: 1
+revised: 2026-05-02
+revision: 2
 ai_generated: true
 summary: "Find nearest IWC exemplar(s) and surface a structural diff against a draft."
 references:
+  - kind: research
+    ref: "[[iwc-nearest-exemplar-selection]]"
+    used_at: runtime
+    load: upfront
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Rank IWC exemplar candidates by domain, collection topology, tool families, DAG motifs, outputs, and tests."
+    trigger: "When selecting nearest IWC workflows for structural comparison against a Galaxy draft."
+  - kind: research
+    ref: "[[galaxy-data-flow-draft-contract]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: hypothesis
+    purpose: "Compare against the draft's abstract intent without turning exemplar comparison into tool resolution."
+    trigger: "When deciding whether to compare abstract data-flow, gxformat2 skeleton structure, or concrete implementation details."
+    verification: "Promote after exemplar comparison flags structural issues without resolving concrete tool metadata."
   - kind: research
     ref: "[[iwc-transformations-survey]]"
     used_at: runtime

--- a/content/molds/debug-galaxy-workflow-output/index.md
+++ b/content/molds/debug-galaxy-workflow-output/index.md
@@ -8,8 +8,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-04-30
-revision: 1
+revised: 2026-05-02
+revision: 2
 ai_generated: true
 summary: "Triage failing Galaxy run outputs; classify failure modes; propose fixes."
 references:
@@ -37,6 +37,14 @@ references:
     evidence: corpus-observed
     purpose: "Diagnose collection shape, mapping, reduction, and element-identifier mismatches in failed Galaxy runs."
     trigger: "When a failing output is a collection, a mapped output, or an unexpectedly nested/flattened structure."
+  - kind: research
+    ref: "[[nextflow-operators-to-galaxy-collection-recipes]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Trace collection output failures back to possibly lossy operator translations."
+    trigger: "When debugging wrong nesting, missing elements, branch merges, bad joins, or gather/reduction mismatches."
 ---
 # debug-galaxy-workflow-output
 

--- a/content/molds/implement-galaxy-tool-step/index.md
+++ b/content/molds/implement-galaxy-tool-step/index.md
@@ -8,8 +8,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-04-30
-revision: 1
+revised: 2026-05-02
+revision: 2
 ai_generated: true
 summary: "Convert an abstract step into a concrete gxformat2 step using a tool summary."
 references:
@@ -21,6 +21,22 @@ references:
     evidence: corpus-observed
     purpose: "Connect concrete Galaxy tool inputs/outputs while preserving collection mapping and reduction semantics."
     trigger: "When implementing a step with data_collection inputs, mapped outputs, reductions, or nested collection wiring."
+  - kind: research
+    ref: "[[nextflow-to-galaxy-channel-shape-mapping]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Check whether a concrete tool input/output can preserve the intended source-derived Galaxy collection shape."
+    trigger: "When implementing concrete steps for source-derived File/list/paired/list:paired/list:list inputs or outputs."
+  - kind: research
+    ref: "[[nextflow-operators-to-galaxy-collection-recipes]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Turn operator-derived abstract transforms into concrete Galaxy wiring, collection operations, or review requests."
+    trigger: "When a concrete step implements behavior traced to map, join, groupTuple, branch, mix, combine, or multiMap."
   - kind: research
     ref: "[[galaxy-collection-tools]]"
     used_at: runtime

--- a/content/molds/summary-to-galaxy-data-flow/index.md
+++ b/content/molds/summary-to-galaxy-data-flow/index.md
@@ -8,8 +8,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-04-30
-revision: 1
+revised: 2026-05-02
+revision: 2
 ai_generated: true
 summary: "Abstract DAG with Galaxy collection / scatter / branching idioms surfaced."
 references:
@@ -28,6 +28,31 @@ references:
     evidence: corpus-observed
     purpose: "Map Nextflow fan-out/fan-in shapes onto Galaxy collection mapping and reduction behavior."
     trigger: "When a channel edge involves collection mapping, reduction, nesting, or paired/list shape changes."
+  - kind: research
+    ref: "[[nextflow-to-galaxy-channel-shape-mapping]]"
+    used_at: runtime
+    load: upfront
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Translate Nextflow channel, tuple, and path shapes into Galaxy dataset and collection shapes."
+    trigger: "When reading source-summary channel shapes and deciding File/list/paired/list:paired/list:list topology."
+  - kind: research
+    ref: "[[nextflow-operators-to-galaxy-collection-recipes]]"
+    used_at: runtime
+    load: upfront
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Classify Nextflow operators as Galaxy wiring, collection semantics, explicit steps, or review triggers."
+    trigger: "When source-summary edges mention map, join, groupTuple, branch, mix, combine, multiMap, or related channel operators."
+  - kind: research
+    ref: "[[galaxy-data-flow-draft-contract]]"
+    used_at: runtime
+    load: upfront
+    mode: verbatim
+    evidence: hypothesis
+    purpose: "Keep the data-flow draft boundary separate from gxformat2 templating and concrete step implementation."
+    trigger: "When deciding what belongs in the abstract Galaxy data-flow draft versus later Molds."
+    verification: "Promote after two worked Galaxy translations use the boundary without moving fields between Molds."
   - kind: research
     ref: "[[galaxy-collection-tools]]"
     used_at: runtime

--- a/content/molds/summary-to-galaxy-template/index.md
+++ b/content/molds/summary-to-galaxy-template/index.md
@@ -8,8 +8,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-04-30
-revision: 1
+revised: 2026-05-02
+revision: 2
 ai_generated: true
 summary: "gxformat2 skeleton with per-step TODOs from a data-flow summary."
 references:
@@ -28,6 +28,31 @@ references:
     evidence: corpus-observed
     purpose: "Preserve Galaxy collection typing and map-over/reduction semantics in the gxformat2 skeleton."
     trigger: "When creating workflow inputs, outputs, and placeholder connections involving collections."
+  - kind: research
+    ref: "[[nextflow-to-galaxy-channel-shape-mapping]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Choose Galaxy workflow input/output collection shapes from source channel shape evidence."
+    trigger: "When the template needs File/list/paired/list:paired/list:list inputs, outputs, or placeholder connections."
+  - kind: research
+    ref: "[[galaxy-data-flow-draft-contract]]"
+    used_at: runtime
+    load: upfront
+    mode: verbatim
+    evidence: hypothesis
+    purpose: "Respect the handoff from abstract data-flow draft to gxformat2 skeleton."
+    trigger: "When translating abstract nodes, unresolved tool needs, and placeholder transformations into template TODOs."
+    verification: "Promote after two worked Galaxy templates preserve the data-flow/template split without schema changes."
+  - kind: research
+    ref: "[[iwc-nearest-exemplar-selection]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Select likely IWC comparison targets once the skeleton has enough domain, topology, and tool-family signal."
+    trigger: "When preparing a draft skeleton for exemplar comparison or citing representative IWC workflows."
   - kind: research
     ref: "[[iwc-transformations-survey]]"
     used_at: runtime

--- a/content/research/galaxy-apply-rules-dsl.md
+++ b/content/research/galaxy-apply-rules-dsl.md
@@ -7,12 +7,14 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-04-30
-revision: 1
+revised: 2026-05-02
+revision: 2
 ai_generated: true
 related_notes:
   - "[[galaxy-collection-tools]]"
   - "[[galaxy-collection-semantics]]"
+  - "[[nextflow-to-galaxy-channel-shape-mapping]]"
+  - "[[nextflow-operators-to-galaxy-collection-recipes]]"
 sources:
   - "https://github.com/jmchilton/galaxy-agentic-collection-transform (initial research seed)"
   - "https://github.com/galaxyproject/galaxy/blob/main/lib/galaxy/util/rules_dsl.py"

--- a/content/research/galaxy-collection-semantics.md
+++ b/content/research/galaxy-collection-semantics.md
@@ -8,11 +8,13 @@ tags:
 status: draft
 created: 2026-04-30
 revised: 2026-05-02
-revision: 1
+revision: 2
 ai_generated: false
 related_notes:
   - "[[galaxy-collection-tools]]"
   - "[[galaxy-apply-rules-dsl]]"
+  - "[[nextflow-to-galaxy-channel-shape-mapping]]"
+  - "[[nextflow-operators-to-galaxy-collection-recipes]]"
 sources:
   - "https://github.com/galaxyproject/galaxy/blob/7765fae934fbfdee77e3be5f5b235e43735273ae/lib/galaxy/model/dataset_collections/types/collection_semantics.yml"
 summary: "Vendored formal spec of Galaxy dataset-collection mapping/reduction semantics, with labeled examples and pinned test references."

--- a/content/research/galaxy-collection-tools.md
+++ b/content/research/galaxy-collection-tools.md
@@ -7,12 +7,14 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-04-30
-revision: 1
+revised: 2026-05-02
+revision: 2
 ai_generated: true
 related_notes:
   - "[[galaxy-collection-semantics]]"
   - "[[galaxy-apply-rules-dsl]]"
+  - "[[nextflow-to-galaxy-channel-shape-mapping]]"
+  - "[[nextflow-operators-to-galaxy-collection-recipes]]"
 sources:
   - "https://github.com/jmchilton/galaxy-agentic-collection-transform (initial research seed)"
   - "https://github.com/galaxyproject/galaxy/tree/main/lib/galaxy/tools (XML wrappers; source of truth)"

--- a/content/research/galaxy-data-flow-draft-contract.md
+++ b/content/research/galaxy-data-flow-draft-contract.md
@@ -1,0 +1,127 @@
+---
+type: research
+subtype: design-spec
+title: "Galaxy data-flow draft contract"
+tags:
+  - research/design-spec
+  - target/galaxy
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+related_notes:
+  - "[[nextflow-to-galaxy-channel-shape-mapping]]"
+  - "[[nextflow-operators-to-galaxy-collection-recipes]]"
+  - "[[iwc-nearest-exemplar-selection]]"
+related_molds:
+  - "[[summary-to-galaxy-data-flow]]"
+  - "[[summary-to-galaxy-template]]"
+  - "[[compare-against-iwc-exemplar]]"
+sources:
+  - "https://github.com/jmchilton/foundry/issues/54"
+summary: "Defines the proposed boundary between Galaxy data-flow drafts, gxformat2 templates, and concrete step implementation."
+---
+
+# Galaxy Data-Flow Draft Contract
+
+This is an architectural contract, not a schema. Evidence is strongest for Mold and Pipeline boundaries. Proposed fields are speculative until exercised by two or three worked translations.
+
+## Boundary
+
+The data-flow draft owns a target-shaped abstract DAG for Galaxy. It should not be valid `gxformat2` and should not resolve exact Tool Shed tools.
+
+Data-flow draft owns:
+
+- Galaxy-facing workflow inputs and outputs.
+- Abstract nodes, edges, branches, collection mapping, collection reduction, and placeholder transformations.
+- Input/output shape decisions such as `File`, `list`, `paired`, `list:paired`, or `list:list`.
+- Conceptual Galaxy idioms: map-over, reduction, Apply Rules, collection cleanup, identifier synchronization, tabular bridge.
+- Abstract unresolved tool needs with input and output shapes.
+- Confidence and rationale on inferred nodes, edges, transforms, and tool needs.
+
+The Galaxy template owns:
+
+- A `gxformat2` skeleton.
+- Ordered placeholder steps, labels, TODO slots, workflow inputs, workflow outputs, and rough connections.
+- Placeholder collection-operation or Apply Rules steps only when the data-flow draft says they are necessary.
+- Handoff units for the per-step implementation loop.
+
+Concrete step implementation owns:
+
+- Exact `tool_id`, version, owner/repository metadata, changeset, parameters, and `input_connections`.
+- Concrete built-in collection-operation steps and parameters.
+- Validation with `gxwf` and repair after schema/lint failures.
+
+## Proposed Body-Level Contract
+
+Do not add these as frontmatter fields yet.
+
+| Concept | Status | Notes |
+|---|---|---|
+| `source_summary_ref` | Speculative | Reference to the source summary consumed by the Mold. |
+| `workflow_inputs` | Speculative | Abstract Galaxy-facing inputs and collection types. |
+| `workflow_outputs` | Speculative | Intended outputs and source-summary provenance. |
+| `nodes` | Speculative | Abstract operations, not concrete Galaxy tools. |
+| `edges` | Speculative | Data dependencies, shape before/after, and source evidence. |
+| `galaxy_idioms` | Speculative | Map-over, reduction, Apply Rules, collection filter, tabular bridge, etc. |
+| `unresolved_tool_needs` | Speculative | Per abstract step needs for `discover-shed-tool` or `author-galaxy-tool-wrapper`. |
+| `placeholder_transformations` | Speculative | Shape/text/table transforms needed for Galaxy semantics but not concretely implemented. |
+| `confidence` | Speculative | Prefer `high`, `medium`, `low` plus rationale. |
+| `handoff_notes` | Speculative | Instructions to template, exemplar comparison, and per-step Molds. |
+| `open_questions` | Speculative | Semantic/tooling issues carried forward. |
+
+## Handoff Examples
+
+Unresolved tool need:
+
+- [[summary-to-galaxy-data-flow]] emits an abstract node such as `trim FASTQ reads`, input `list:paired fastq`, output `list:paired fastq`, tool need `read trimming`, confidence `medium`.
+- [[summary-to-galaxy-template]] creates a placeholder step with TODOs and collection-shaped connections.
+- The harness routes through tool discovery or wrapper authoring.
+- [[implement-galaxy-tool-step]] fills exact Galaxy tool metadata, parameters, and connections.
+
+Collection cleanup after fan-out:
+
+- Data-flow records a conceptual cleanup transform after a mapped step.
+- Template materializes a placeholder collection-operation step.
+- Implementation chooses exact built-in tool and parameters.
+
+Identifier-derived reshaping:
+
+- Data-flow records desired input shape, output shape, and identifier transformation.
+- Template emits an Apply Rules placeholder only if needed.
+- Implementation fills concrete rule JSON after exemplar comparison confirms the shape.
+
+IWC exemplar comparison:
+
+- Data-flow and template should hand [[compare-against-iwc-exemplar]] the abstract topology, placeholder transformations, unresolved tool needs, and confidence notes.
+- Exemplar comparison should flag structural divergence, not resolve tools.
+
+## Confidence Guidance
+
+- Attach confidence to the smallest useful unit: node, edge, transformation, or tool need.
+- Use qualitative `high`, `medium`, `low` until examples justify a richer schema.
+- Require rationale for low confidence.
+- Do not reuse source-summary `warnings[]` as data-flow confidence.
+- Keep evidence quality distinct from translation confidence. A claim can be corpus-observed but still low-confidence for a specific workflow.
+
+## Risks
+
+If the data-flow draft is too broad, it duplicates the template Mold, makes premature tool decisions, and leaks harness routing into Mold output.
+
+If it is too narrow, the template Mold receives source-summary details without Galaxy-shaped semantics, exemplar comparison has only a surface skeleton to diff, and tool discovery loses input/output shape context.
+
+## Evidence
+
+- [[nextflow-to-galaxy-channel-shape-mapping]] and [[nextflow-operators-to-galaxy-collection-recipes]] show why a Galaxy-shaped abstraction is needed between source summary and `gxformat2` template.
+- [[iwc-nearest-exemplar-selection]] shows exemplar comparison needs abstract topology and intended shapes, not just a rendered skeleton.
+- `content/pipelines/nextflow-to-galaxy.md` places data-flow before template, exemplar comparison, and per-step implementation.
+- `content/molds/summarize-nextflow/index.md` says source summarization should not produce Galaxy data flow.
+- `content/molds/implement-galaxy-tool-step/index.md` owns concrete step implementation.
+
+## TODOs
+
+- Decide whether to author `galaxy-data-flow-draft.schema.json` now or wait for worked examples.
+- Decide whether confidence should be a single enum or per-axis vector.
+- Decide how much ordering guidance belongs in data-flow versus template.
+- Decide whether built-in collection operations should be abstract placeholders or concrete template steps.

--- a/content/research/iwc-nearest-exemplar-selection.md
+++ b/content/research/iwc-nearest-exemplar-selection.md
@@ -1,0 +1,88 @@
+---
+type: research
+subtype: component
+title: "IWC nearest exemplar selection"
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+related_notes:
+  - "[[galaxy-data-flow-draft-contract]]"
+  - "[[iwc-transformations-survey]]"
+  - "[[iwc-tabular-operations-survey]]"
+  - "[[iwc-test-data-conventions]]"
+related_molds:
+  - "[[compare-against-iwc-exemplar]]"
+  - "[[summary-to-galaxy-template]]"
+sources:
+  - "https://github.com/jmchilton/foundry/issues/55"
+summary: "Defines a feature hierarchy for selecting useful IWC exemplar workflows for structural comparison."
+---
+
+# IWC Nearest Exemplar Selection
+
+Use a feature hierarchy, not one global similarity score. “Nearest” means “best comparison target for the current authoring decision,” usually after a Galaxy template exists and before concrete per-step implementation.
+
+## Feature Hierarchy
+
+1. Domain or analysis intent.
+2. Input collection topology.
+3. Primary tool families.
+4. DAG motifs and structural recipes.
+5. Output types and report shape.
+6. Test style and fixture topology.
+
+Domain comes first so a structurally similar workflow in the wrong science area does not become a misleading exemplar. Topology comes second because collection shape is one of the most important Galaxy-specific design decisions. Test style is useful after a workflow match, but should not drive initial retrieval.
+
+## Example Exemplar Anchors
+
+| Scenario | Candidate exemplar | Why useful |
+|---|---|---|
+| Read QC and trimming | `$IWC_SKELETONS/read-preprocessing/short-read-qc-trimming/short-read-quality-control-and-trimming.gxwf.yml` | Minimal `list:paired` FASTQ, `fastp`, `MultiQC`, and simple QC topology. |
+| Paired-end RNA-seq | `$IWC_SKELETONS/transcriptomics/rnaseq-pe/rnaseq-pe.gxwf.yml` | `list:paired` reads, align/count/report tool families, coverage/report branches, MultiQC aggregation. |
+| SARS-CoV-2 VCF reporting | `$IWC_SKELETONS/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml` | VCF collection handling, SnpSift filtering/extracting, tabular transforms, joins, plots, report outputs. |
+| Metagenome-assembled genomes | `$IWC_SKELETONS/microbiome/mags-building/MAGs-generation.gxwf.yml` | Metagenomic `list:paired`, assembler/binning/refinement choices, collection building/flattening, report aggregation. |
+| LC-MS metabolomics | `$IWC_SKELETONS/metabolomics/lcms-preprocessing/Mass_spectrometry__LC-MS_preprocessing_with_XCMS.gxwf.yml` | List of mzML-like inputs, XCMS/CAMERA preprocessing, sample metadata, matrix/report outputs. |
+
+Use `$IWC_FORMAT2/...` for parameter-level evidence and exact `tool_state`. Use `$IWC_SKELETONS/...` for topology, labels, tool-family order, workflow inputs/outputs, and collection shapes.
+
+## Citation Guidance
+
+- Pair generated fixture citations with pinned upstream source URLs when the note makes a durable claim.
+- Prefer `$IWC_SKELETONS` for structural comparison and `$IWC_FORMAT2` for exact parameter evidence.
+- Cite upstream IWC source URLs pinned to fixture commit `deafc4876f2c778aaf075e48bd8e95f3604ccc92` when possible.
+- Use tests only after selecting a likely workflow exemplar; tests are often conventions rather than workflow semantics.
+
+## Confidence Levels
+
+| Level | Meaning |
+|---|---|
+| High | Same domain/subdomain, same input topology, same primary tool families, same major DAG motifs, and matching test fixture shape. |
+| Medium | Same domain and topology, but partial tool-family or output match. Useful exemplar, not canonical. |
+| Low | Cross-domain structural match only. Useful for a pattern comparison, not a nearest domain exemplar. |
+| No nearest exemplar | Candidate lacks domain or topology alignment, or only shares generic tools such as `MultiQC`. |
+
+## Failure Modes
+
+- Do not claim nearest from tool overlap alone. `MultiQC`, `fastp`, `Cut1`, `awk`, and `datamash` are too common.
+- Do not rank cross-domain structural recipes above same-domain workflows unless explicitly comparing a pattern.
+- Do not overfit exact tool versions.
+- Do not use tests as the primary match driver.
+- Avoid nearest-exemplar claims for off-corpus features such as composite data, unusual deep collections, negative tests, or tools absent from IWC.
+- If multiple weak candidates tie, report no high-confidence nearest and compare against pattern exemplars instead.
+
+## Mold Use
+
+- [[compare-against-iwc-exemplar]] should use this as the selection procedure for finding and ranking exemplar candidates.
+- [[summary-to-galaxy-template]] should use this on demand when a skeleton is mature enough to pick comparison targets.
+
+## TODOs
+
+- Decide whether exemplar comparison should emit one nearest workflow or two to three ranked exemplars.
+- Decide whether confidence should be a single label or a per-axis vector.
+- Decide whether output schema should require source URL plus local fixture citation pairs.
+- Decide whether runtime retrieval uses local fixtures, live IWC listings, `gxwf`, or a user-supplied corpus path.

--- a/content/research/iwc-tabular-operations-survey.md
+++ b/content/research/iwc-tabular-operations-survey.md
@@ -6,13 +6,15 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-04-30
-revision: 1
+revised: 2026-05-02
+revision: 2
 ai_generated: true
 related_notes:
   - "[[iwc-test-data-conventions]]"
   - "[[iwc-shortcuts-anti-patterns]]"
   - "[[planemo-asserts-idioms]]"
+  - "[[nextflow-operators-to-galaxy-collection-recipes]]"
+  - "[[iwc-nearest-exemplar-selection]]"
 summary: "Corpus survey of tabular tools and operations across IWC workflows; map for the leaf pattern hierarchy on row/column data manipulation."
 ---
 

--- a/content/research/iwc-test-data-conventions.md
+++ b/content/research/iwc-test-data-conventions.md
@@ -6,14 +6,15 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-04-30
-revision: 1
+revised: 2026-05-02
+revision: 2
 ai_generated: true
 related_notes:
   - "[[iwc-shortcuts-anti-patterns]]"
   - "[[planemo-asserts-idioms]]"
   - "[[implement-galaxy-workflow-test]]"
   - "[[tests-format]]"
+  - "[[iwc-nearest-exemplar-selection]]"
 summary: "How IWC workflows organize and reference test data — Zenodo-first, SHA-1 integrity, collection shapes, CVMFS gotchas."
 ---
 

--- a/content/research/iwc-transformations-survey.md
+++ b/content/research/iwc-transformations-survey.md
@@ -6,8 +6,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-05-01
-revised: 2026-05-01
-revision: 1
+revised: 2026-05-02
+revision: 2
 ai_generated: true
 related_notes:
   - "[[galaxy-collection-tools]]"
@@ -15,6 +15,9 @@ related_notes:
   - "[[galaxy-apply-rules-dsl]]"
   - "[[iwc-tabular-operations-survey]]"
   - "[[iwc-shortcuts-anti-patterns]]"
+  - "[[nextflow-to-galaxy-channel-shape-mapping]]"
+  - "[[nextflow-operators-to-galaxy-collection-recipes]]"
+  - "[[iwc-nearest-exemplar-selection]]"
 summary: "Corpus survey of collection-shape transformations across IWC: built-in collection ops, toolshed transformers, and the multi-step recipes that bracket map-over."
 ---
 

--- a/content/research/nextflow-operators-to-galaxy-collection-recipes.md
+++ b/content/research/nextflow-operators-to-galaxy-collection-recipes.md
@@ -1,0 +1,99 @@
+---
+type: research
+subtype: component
+title: "Nextflow operators to Galaxy collection recipes"
+tags:
+  - research/component
+  - source/nextflow
+  - target/galaxy
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+related_notes:
+  - "[[nextflow-to-galaxy-channel-shape-mapping]]"
+  - "[[galaxy-collection-semantics]]"
+  - "[[galaxy-collection-tools]]"
+  - "[[galaxy-apply-rules-dsl]]"
+  - "[[iwc-transformations-survey]]"
+  - "[[iwc-tabular-operations-survey]]"
+  - "[[galaxy-data-flow-draft-contract]]"
+related_molds:
+  - "[[summary-to-galaxy-data-flow]]"
+  - "[[implement-galaxy-tool-step]]"
+  - "[[debug-galaxy-workflow-output]]"
+sources:
+  - "https://github.com/jmchilton/foundry/issues/53"
+summary: "Classifies common Nextflow operators as Galaxy wiring, collection semantics, explicit steps, or review triggers."
+---
+
+# Nextflow Operators To Galaxy Collection Recipes
+
+Most Nextflow operators are not Galaxy tools. Translate them first as source-side data-flow intent, then decide whether the Galaxy representation is simple wiring, collection semantics, an explicit Galaxy step, or a user-review checkpoint.
+
+## Decision Vocabulary
+
+| Label | Meaning |
+|---|---|
+| `channel-only rewiring` | The operator disappears into Galaxy connections, labels, branch wiring, or output selection. |
+| `Galaxy collection semantics` | Translation relies on collection identifiers, collection type, map-over, reduction, or nesting behavior. |
+| `explicit Galaxy step` | Add a collection-operation, tabular, text-processing, or domain tool step. |
+| `user review` | Translation is likely lossy or semantically ambiguous. |
+
+## Operator Recipes
+
+| Nextflow operator | Galaxy recipe | Class | Confidence |
+|---|---|---|---|
+| `map` | Treat metadata-only projection as wiring. Use Apply Rules only when materialized identifiers or collection shape must change. Use an explicit tool if file contents or table rows change. | Usually channel-only; sometimes collection semantics or explicit step | High for metadata-only, medium for identifier parsing |
+| `join` | If two Galaxy collections have matching identifiers and structure, use normal multi-input map-over. Otherwise add synchronization by extracting, sorting, filtering, or relabeling identifiers. Use tabular joins for row-key joins. | Collection semantics or explicit step | High for file/index pairing, medium for loose joins |
+| `groupTuple` | If grouping represents nested collection structure, model collection nesting or Apply Rules. If grouping is scatter/gather for a domain operation, implement the downstream merge/reduce tool. | Collection semantics plus explicit reduction | High for interval gather, medium for arbitrary grouping |
+| `branch` | Use branch wiring only for static workflow-level classes. Per-element conditional routing usually needs explicit filters/classifiers or user review. | Channel-only, explicit step, or review | Medium |
+| `mix` | Keep report/version aggregation as wiring. Use `__MERGE_COLLECTION__` or `__BUILD_LIST__` only when a materialized collection is required. | Usually channel-only; explicit collection assembly when materialized | High for report/version aggregation |
+| `combine` | With `by:`, treat like keyed pairing. Without `by`, treat as Cartesian expansion and require review unless a specific Galaxy cross-product recipe is intended. | Collection semantics or review | Medium-low for unkeyed combine |
+| `multiMap` | Usually split one tuple into separate synchronized Galaxy inputs. Preserve enough edge notes to rejoin later if needed. | Usually channel-only | Medium |
+
+## User-Review Triggers
+
+- `branch` has non-trivial predicates, an `unknown`/default branch, or discarded branch data.
+- `join` uses optional/remainder behavior, duplicate keys, non-metadata keys, or mismatch-tolerant settings.
+- `combine` lacks `by:` and may imply all-vs-all expansion.
+- `groupTuple` uses explicit size, sort, or `groupKey` behavior.
+- `map` mutates metadata, parses identifiers with regex, returns variable arity, or hides content-level computation.
+- `mix` combines branches with overlapping identifiers or unclear ordering.
+- Any Groovy closure transforms file bytes or table rows.
+
+## Evidence
+
+Pinned Nextflow fixtures provide direct examples of all covered operators except some edge cases of `combine` and arbitrary `map` closures:
+
+- `workflow-fixtures/pipelines/nf-core__taxprofiler/main.nf` for `map`, `branch`, `mix`, and collection split/merge behavior.
+- `workflow-fixtures/pipelines/nf-core__taxprofiler/subworkflows/local/visualization_krona/main.nf` for keyed `combine` plus `multiMap`.
+- `workflow-fixtures/pipelines/nf-core__sarek/subworkflows/local/*/main.nf` for `join`, interval `groupTuple`, and scatter/gather patterns.
+- `workflow-fixtures/pipelines/nf-core__fetchngs/workflows/sra/main.nf` for accession/data-fetching branches and reductions.
+
+Galaxy-side evidence:
+
+- [[galaxy-collection-semantics]] for map-over and reduction behavior.
+- [[iwc-transformations-survey]] for cleanup-after-fanout, identifier synchronization, collection flattening, and corpus-observed collection recipes.
+- [[galaxy-collection-tools]] for built-in collection operations.
+- [[galaxy-apply-rules-dsl]] for identifier-derived collection reshaping.
+- [[iwc-tabular-operations-survey]] for cases where operator translation leaves collection-land and becomes tabular/text transformation.
+
+## Low-Confidence Areas
+
+- Unkeyed `combine` can be represented by Galaxy cross-product collection tools, but the IWC survey found little or no corpus uptake. Prefer review.
+- `branch` cleanup via null filtering is possible but weakly attested; avoid claiming it as the default pattern.
+- Arbitrary `map` closures cannot be safely translated from syntax alone. Summarization should classify closure intent when possible.
+
+## Mold Use
+
+- [[summary-to-galaxy-data-flow]] should use this as the primary operator-translation reference.
+- [[implement-galaxy-tool-step]] should use this when operator decisions become concrete Galaxy collection or tabular steps.
+- [[debug-galaxy-workflow-output]] should use this when wrong nesting, missing elements, branch merges, or gather outputs indicate a bad operator translation.
+
+## TODOs
+
+- Decide whether `summary-nextflow.schema.json` should record operator parameters such as `by`, `remainder`, `failOnMismatch`, `size`, and `sort`.
+- Consider a dedicated pattern for Nextflow per-element `branch` to Galaxy conditionals/filtering.
+- Decide whether unkeyed `combine` always requires review.

--- a/content/research/nextflow-to-galaxy-channel-shape-mapping.md
+++ b/content/research/nextflow-to-galaxy-channel-shape-mapping.md
@@ -1,0 +1,103 @@
+---
+type: research
+subtype: component
+title: "Nextflow-to-Galaxy channel shape mapping"
+tags:
+  - research/component
+  - source/nextflow
+  - target/galaxy
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+related_notes:
+  - "[[galaxy-collection-semantics]]"
+  - "[[galaxy-collection-tools]]"
+  - "[[galaxy-apply-rules-dsl]]"
+  - "[[iwc-transformations-survey]]"
+  - "[[nextflow-operators-to-galaxy-collection-recipes]]"
+  - "[[galaxy-data-flow-draft-contract]]"
+related_molds:
+  - "[[summary-to-galaxy-data-flow]]"
+  - "[[summary-to-galaxy-template]]"
+  - "[[implement-galaxy-tool-step]]"
+sources:
+  - "https://github.com/jmchilton/foundry/issues/52"
+summary: "Maps common Nextflow channel, tuple, and path shapes to Galaxy dataset and collection shapes."
+---
+
+# Nextflow-to-Galaxy Channel Shape Mapping
+
+This note maps source-level Nextflow channel shapes onto Galaxy data and dataset-collection shapes. Evidence quality is uneven: Galaxy collection semantics and IWC collection operations are well grounded; several Nextflow shapes are observed in the pinned fixtures; `fromFilePairs` and arbitrary deep tuple mapping remain low-confidence without direct fixture evidence.
+
+## Shape Mapping
+
+| Nextflow shape | Galaxy shape | Confidence | Notes |
+|---|---|---|---|
+| `path(x)` or a single `Channel.fromPath(...).first()` | `File` | High | One dataset input or output. |
+| `val(meta)` alone | No dataset shape | High | Treat as identifiers, labels, tags, sample-sheet metadata, or parameters. It is not a Galaxy dataset by itself. |
+| Repeated `tuple val(meta), path(file)` | `list` | High | One dataset per sample/key. Galaxy maps tools over list collections. |
+| One `tuple(meta, [R1, R2])` | `paired` | High | Use only when the workflow input is one paired sample or one tool consumes one pair. |
+| Repeated `tuple(meta, [R1, R2])` | `list:paired` | High | Common paired-end workflow input shape. |
+| Repeated `tuple(meta, [single])` | `list` | High | nf-core often normalizes single-end reads to one-element lists, but Galaxy should not model this as `paired`. |
+| Mixed single-end and paired-end reads | `paired_or_unpaired` or split `list` plus `list:paired` | Medium | Galaxy supports mixed collections, but branch-splitting may be clearer when tools diverge. |
+| `tuple(meta, path(a), path(b))` | Parallel lists or per-step `File` inputs | Medium | Not automatically a `paired` collection. It is usually a keyed record of multiple tool inputs. |
+| Global file plus per-sample files | Broadcast `File` plus mapped `list` | Medium | If one input is global, connect it once and map the collection input. |
+| `collect()` or `toList()` | Collection reduction | High | Usually one downstream invocation over a collection or multiple-input value. |
+| `collectFile(...)` | `File` | High | Nextflow creates one new file; Galaxy should model a tool output, not a collection operation. |
+| `groupTuple()` by key | `list`, `list:paired`, or `list:list` | Medium | Depends on grouped payload and whether the grouping axis matters downstream. |
+| `transpose()` after grouping | Explicit reshape or subcollection mapping | Medium | May need flattening, Apply Rules, or identifier-preserving reshaping. |
+| `combine(..., by: key)` or `join(...)` | Multi-input collection map if identifiers match | Medium | Otherwise use explicit synchronization by identifiers/order. |
+| `branch { ... }` | Branch wiring or explicit filters | Medium | Shape is whatever each branch returns; per-element routing needs review. |
+| `mix(...)` | Merge compatible streams/collections | Medium | Use direct wiring for reports/versions; use `__MERGE_COLLECTION__` or `__BUILD_LIST__` when materialized. |
+| `multiMap { ... }` | Synchronized split into Galaxy inputs | Medium | Usually channel-only fan-out, but downstream rejoin depends on identifier discipline. |
+| `fromFilePairs` | `paired` or `list:paired` | Low | Conceptually clean, but not directly observed in the pinned fixtures. |
+| Arbitrary deep tuples | Parallel lists, `list:list`, or manual modeling | Low | Galaxy collection types are not arbitrary tuple records. Require per-tool review. |
+
+## Explicit Galaxy Operations
+
+Use explicit Galaxy collection-operation or tabular steps when the translation changes materialized collection shape rather than only wiring an existing collection into a mapped step.
+
+| Need | Candidate Galaxy recipe |
+|---|---|
+| Build a collection from separate datasets | `__BUILD_LIST__` |
+| Pair forward/reverse files | `__ZIP_COLLECTION__` or Apply Rules paired mapping |
+| Split paired reads into forward/reverse collections | `__UNZIP_COLLECTION__` |
+| Flatten nested collections | `__FLATTEN__` |
+| Regroup, swap nesting, split identifiers, or build pairs from metadata | `__APPLY_RULES__` |
+| Harmonize sibling collections by identifiers/order | identifier extraction, filtering, sorting, or relabeling |
+| Remove empty, failed, or null elements after fan-out | filter empty/failed/null collection tools |
+| Unbox a singleton collection | `__EXTRACT_DATASET__` |
+| Convert a collection of tabular outputs to one table | `collapse_dataset` or `collection_column_join` |
+
+## Evidence
+
+Corpus-observed Galaxy semantics:
+
+- [[galaxy-collection-semantics]] defines map-over, reduction, paired collections, nested collections, and `sample_sheet` behavior.
+- [[galaxy-collection-tools]] catalogs built-in collection operation tools.
+- [[galaxy-apply-rules-dsl]] explains identifier-derived collection reshaping.
+- [[iwc-transformations-survey]] records which collection transformations appear in IWC workflows.
+
+Pinned fixture examples used by the research pass:
+
+- `workflow-fixtures/pipelines/nf-core__demo/subworkflows/local/utils_nfcore_demo_pipeline/main.nf` for `tuple(meta, reads)` paired-read handling.
+- `workflow-fixtures/pipelines/nf-core__rnaseq/main.nf` for single-end versus paired-end branching and reads normalization.
+- `workflow-fixtures/pipelines/nf-core__taxprofiler/main.nf` and `workflow-fixtures/pipelines/nf-core__taxprofiler/subworkflows/local/*/main.nf` for `groupTuple`, `transpose`, `mix`, `combine`, and `multiMap` patterns.
+- `workflow-fixtures/pipelines/nf-core__fetchngs/workflows/sra/main.nf` for `collectFile` and accession-driven data fetching.
+- `$IWC_FORMAT2/virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping.gxwf.yml` as a Galaxy `list:paired` exemplar.
+
+## Low-Confidence TODOs
+
+- Confirm `fromFilePairs` with a direct fixture or external Nextflow documentation before treating it as corpus-observed.
+- Define a small shape grammar for `summary-nextflow` outputs, or explicitly require downstream Molds to preserve shape strings plus rationale.
+- Decide whether mixed single/paired reads should prefer Galaxy `paired_or_unpaired` or split branches.
+- Add a decision rule for grouped runs: preserve as `list:list` when the run axis matters; reduce to `list` only when downstream semantics ignore that axis.
+- Avoid using `list:list` just because a Nextflow tuple is nested.
+
+## Mold Use
+
+- [[summary-to-galaxy-data-flow]] should consult this note while translating source channel shapes into Galaxy-facing abstract data-flow.
+- [[summary-to-galaxy-template]] should consult this note while choosing workflow input/output collection shapes.
+- [[implement-galaxy-tool-step]] should consult this note when deciding whether a concrete tool connection can be direct mapped wiring or needs an explicit collection operation.


### PR DESCRIPTION
## Summary
- add research notes for Nextflow channel shapes, operator recipes, Galaxy data-flow draft boundaries, and IWC exemplar selection
- link the new notes into relevant Galaxy-targeting molds with typed research references
- document evidence-quality expectations for research subagents in AGENTS.md

## Validation
- npm run validate
- npm run test