### PR TITLE
Harden summarize-nextflow test data resolution

### DIFF
--- a/.changeset/clean-bears-summarize.md
+++ b/.changeset/clean-bears-summarize.md
@@ -1,0 +1,6 @@
+---
+"@galaxy-foundry/summarize-nextflow": patch
+"@galaxy-foundry/summary-nextflow-schema": patch
+---
+
+Resolve nf-core test-data expressions and optionally localize fetched fixtures.

--- a/content/molds/summarize-nextflow/index.md
+++ b/content/molds/summarize-nextflow/index.md
@@ -8,8 +8,8 @@ tags:
   - source/nextflow
 status: draft
 created: 2026-04-30
-revised: 2026-05-01
-revision: 4
+revised: 2026-05-02
+revision: 5
 ai_generated: true
 output_schemas:
   - "content/schemas/summary-nextflow.schema.json"
@@ -68,6 +68,7 @@ The Mold expects:
 - A **path or git URL** to the NF pipeline. Local clone is preferred; a git URL triggers a shallow clone the cast skill manages.
 - Optional **pin**: tag, branch, or commit SHA. Mirrors `SketchSource` semantics from gxy-sketches.
 - Optional **profile hint** (`test`, `test_full`, …) selecting which `conf/<profile>.config` to read for fixtures. Defaults to `test`.
+- Optional **test-data directory**. When provided with fixture fetching, remote samplesheets and referenced files are downloaded under that directory and their local paths are recorded in `test_fixtures.inputs[].path`.
 
 The Mold does **not** accept "summarize this single subworkflow" subset hints; whole-pipeline summary is the unit. Subset summarization is an open question — see Non-goals.
 
@@ -237,7 +238,9 @@ Free-function calls in the workflow body itself (`paramsSummaryMap`, `softwareVe
 
 **`test_fixtures`** — read `conf/<profile>.config` (default `conf/test.config`) for `params.input` (samplesheet URL) and any other URL-shaped params. For nf-core pipelines, follow the samplesheet URL into the `nf-core/test-datasets` repo if a single fetch is enough to enumerate the file paths it references; otherwise emit the samplesheet URL alone as the input. The samplesheet URL may be a runtime concatenation (`params.pipelines_testdata_base_path + 'foo.csv'`); resolve at config-load semantics and record the resolved URL.
 
-Each entry follows `TestDataRef` (inputs) / `ExpectedOutputRef` (outputs) field names verbatim. The `path` vs `url` rules from gxy-sketches' `TestDataRef` carry over; the "must be under `test_data/`" constraint does **not** — see [[GXY_SKETCHES_ALIGNMENT]] §1.
+When fixture fetching is enabled, hash each fetched remote file with SHA-1. When a test-data directory is provided, write the samplesheet and every referenced remote file under that directory using a deterministic URL-derived path and record that local filesystem path in `path` while preserving the original `url`.
+
+Each entry follows `TestDataRef` (inputs) / `ExpectedOutputRef` (outputs) field names verbatim. The `path` vs `url` rules from gxy-sketches' `TestDataRef` carry over, with one extension: `path` may be the local fetched path for a remote URL. The "must be under `test_data/`" constraint does **not** — see [[GXY_SKETCHES_ALIGNMENT]] §1.
 
 **`nf_tests[]`** — enumerate every `tests/*.nf.test` file. Real pipelines have one .nf.test per test profile (bacass has 9). For each:
 
@@ -262,6 +265,7 @@ Validate the assembled object against `schemas/summary-nextflow.schema.json` bef
 
 ## Revision history
 
+- **rev 5 (2026-05-02)** — CLI package hardened against `nf-core/bacass` profile config expressions: resolves `params.pipelines_testdata_base_path + '...'`, fetches samplesheet-referenced remote files, hashes them, and optionally localizes them under `--test-data-dir` while preserving original URLs.
 - **rev 4 (2026-05-01)** — second cast against `nf-core/bacass @ 2.5.0` (33 processes, 9 nf-test files, 11 test profiles) exposed two patterns the first cast couldn't see: process aliasing via `include { X as Y }` (six distinct alias-rename patterns in bacass) and the per-test-file structure of nf-test fixtures. §4 grew the alias-sweep rule; §7 split into `test_fixtures` + `nf_tests[]` with structured snapshot extraction. Schema bumped to rev 3 in lockstep. Cast log: `content/log.md` second 2026-05-01 entry.
 - **rev 3 (2026-05-01)** — first cast against `nf-core/demo @ 1.1.0` exposed the gaps now folded into §1 (multi-workflow selection rule), §4 (verbatim directive capture, channel topics), §5 (ternary container resolver, file-path conda directives, Wave registry), §6 (utility-vs-pipeline subworkflow split, free-function calls). Schema bumped to rev 2 in lockstep — see `[[summary-nextflow]]`'s revision-2 section. Cast log: `content/log.md` 2026-05-01 entry.
 - **rev 2 (2026-04-30)** — substantive body added; output schema declared.
@@ -276,7 +280,7 @@ The procedure assumes — and the cast skill must surface in `warnings[]` when r
 - **Channel shapes are strings, not structured types.** `"tuple(meta, [path,path])"` is enough for downstream Molds to reason about; structured channel typing is a research project. Downstream Molds that need structure must parse the string.
 - **Operator chains are summarized, not executed.** The LLM reconciliation pass is best-effort. Workflows with deeply nested closures (`map { ... }` with substantial Groovy logic) may produce edges flagged with low confidence in `notes`.
 - **`include` aliasing is followed one level.** `include { FASTP as TRIM_PROC } from '...'` resolves to `FASTP` in `processes[].name` and the alias is recorded in the call graph. Multi-level aliasing chains are not chased.
-- **Test-fixture URLs are not fetched for content validation.** The Mold records URL, role, filetype, and (when present) expected SHA-1; it does not download files to verify they exist.
+- **Test-fixture fetching is bounded.** The CLI fetches selected-profile URL params and direct remote URLs discovered in fetched samplesheets. It does not recursively crawl archives or arbitrary generated paths.
 
 ## Non-goals
 

--- a/content/schemas/summary-nextflow.schema.json
+++ b/content/schemas/summary-nextflow.schema.json
@@ -192,7 +192,7 @@
       "required": ["role"],
       "properties": {
         "role":        { "type": "string", "description": "Logical role of the input (e.g. `samplesheet`, `reference_fasta`)." },
-        "path":        { "type": ["string", "null"], "description": "Repo-relative path when the fixture lives in-tree." },
+        "path":        { "type": ["string", "null"], "description": "Repo-relative path when the fixture lives in-tree, or local filesystem path when the CLI fetched the remote fixture into a caller-provided test-data directory." },
         "url":         { "type": ["string", "null"], "format": "uri" },
         "sha1":        { "type": ["string", "null"], "description": "SHA-1 integrity hash when published alongside the fixture." },
         "filetype":    { "type": ["string", "null"], "description": "File format, e.g. `fastq.gz`, `csv`." },

--- a/packages/summarize-nextflow/src/bin/summarize-nextflow.ts
+++ b/packages/summarize-nextflow/src/bin/summarize-nextflow.ts
@@ -21,6 +21,7 @@ program
   .option("--out <path>", "Write JSON to this path instead of stdout")
   .option("--no-with-nextflow", "Disable Nextflow shell-out; static parse only (default: enabled)")
   .option("--fetch-test-data", "Resolve and hash referenced test data", false)
+  .option("--test-data-dir <path>", "Write fetched test data under this directory")
   .option("--no-validate", "Skip schema validation of the emitted summary (default: enabled)")
   .action(async (pathOrUrl: string, options: SummarizeNextflowOptions) => {
     try {

--- a/packages/summarize-nextflow/src/index.ts
+++ b/packages/summarize-nextflow/src/index.ts
@@ -8,6 +8,7 @@ export interface SummarizeNextflowOptions {
   out?: string;
   withNextflow: boolean;
   fetchTestData: boolean;
+  testDataDir?: string;
   validate: boolean;
 }
 
@@ -31,5 +32,6 @@ export async function buildSummary(
     profile: options.profile,
     withNextflow: options.withNextflow,
     fetchTestData: options.fetchTestData,
+    testDataDir: options.testDataDir,
   });
 }

--- a/packages/summarize-nextflow/src/resolver.ts
+++ b/packages/summarize-nextflow/src/resolver.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { basename, dirname, join, relative } from "node:path";
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { basename, dirname, join, relative, resolve } from "node:path";
 
 interface Summary {
   source: Record<string, unknown>;
@@ -85,6 +85,7 @@ export interface ResolveOptions {
   profile: string;
   withNextflow: boolean;
   fetchTestData: boolean;
+  testDataDir?: string;
 }
 
 export async function resolveNextflowSummary(
@@ -135,7 +136,7 @@ export async function resolveNextflowSummary(
   };
 
   if (options.withNextflow) mergeNextflowInspect(summary, pipelineRoot, options.profile);
-  if (options.fetchTestData) await fetchTestData(summary);
+  if (options.fetchTestData) await fetchTestData(summary, options.testDataDir);
   return summary;
 }
 
@@ -145,7 +146,11 @@ function readText(path: string): string {
 
 function gitOutput(cwd: string, args: string[]): string | null {
   try {
-    return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+    return execFileSync("git", args, {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
   } catch {
     return null;
   }
@@ -359,26 +364,81 @@ function isKnownContainer(value: string): boolean {
 function parseTestFixtures(pipelineRoot: string, profile: string): Summary["test_fixtures"] {
   const configPath = join(pipelineRoot, "conf", `${profile}.config`);
   const text = existsSync(configPath) ? readText(configPath) : "";
-  const input = matchOne(text, /input\s*=\s*['"]([^'"]+)['"]/u);
+  const baseParams = parseParamAssignments(
+    readText(join(pipelineRoot, "nextflow.config")),
+    new Map(),
+  );
+  const profileParams = parseParamAssignments(text, baseParams);
+  const remoteInputs = [...profileParams.entries()]
+    .filter(([name]) => isFixtureParam(name))
+    .map(([name, value]) => ({ name, url: normalizeTestDataUrl(value) }))
+    .filter((input): input is { name: string; url: string } => Boolean(input.url));
   return {
     profile,
-    inputs: input
-      ? [
-          {
-            role: "samplesheet",
-            path: input.startsWith("http") ? null : input,
-            url: input.startsWith("http") ? input : null,
-            sha1: null,
-            filetype: input.split(".").at(-1) ?? null,
-            description: `Samplesheet from conf/${profile}.config`,
-          },
-        ]
-      : [],
+    inputs: remoteInputs.map(({ name, url }) => ({
+      role: inferParamRole(name, url),
+      path: null,
+      url,
+      sha1: null,
+      filetype: inferFiletype(url),
+      description: `${name} from conf/${profile}.config`,
+    })),
     outputs: [],
   };
 }
 
-async function fetchTestData(summary: Summary): Promise<void> {
+function parseParamAssignments(
+  text: string,
+  baseParams: Map<string, string>,
+  options: { changedOnly?: boolean } = {},
+): Map<string, string> {
+  const params = new Map(baseParams);
+  const changed = new Map<string, string>();
+  const block = extractNamedBlock(text, "params");
+  if (!block) return options.changedOnly ? changed : params;
+  for (const match of block.matchAll(/^\s*([A-Za-z0-9_]+)\s*=\s*([^\n]+)$/gmu)) {
+    const value = resolveParamExpression(match[2]!.trim(), params);
+    if (value) {
+      params.set(match[1]!, value);
+      changed.set(match[1]!, value);
+    }
+  }
+  return options.changedOnly ? changed : params;
+}
+
+function isFixtureParam(name: string): boolean {
+  return name === "input" || /(^reference_|_fasta$|_gff$|_gtf$|_bed$|_proteins$)/u.test(name);
+}
+
+function resolveParamExpression(expression: string, params: Map<string, string>): string | null {
+  const literal = matchOne(expression, /^['"]([^'"]*)['"]/u);
+  if (literal !== null) return literal;
+  const concat = /^params\.([A-Za-z0-9_]+)\s*\+\s*['"]([^'"]+)['"]/u.exec(expression);
+  if (!concat) return null;
+  const prefix = params.get(concat[1]!);
+  if (!prefix) return null;
+  return joinUrlParts(prefix, concat[2]!);
+}
+
+function joinUrlParts(prefix: string, suffix: string): string {
+  if (!/^https?:\/\//u.test(prefix)) return `${prefix}${suffix}`;
+  const separator = prefix.endsWith("/") || suffix.startsWith("/") ? "" : "/";
+  return `${prefix}${separator}${suffix}`;
+}
+
+function normalizeTestDataUrl(value: string): string | null {
+  if (!/^https?:\/\//u.test(value)) return null;
+  const nfCoreRaw =
+    /^https:\/\/raw\.githubusercontent\.com\/nf-core\/test-datasets\/(?!refs\/heads\/)([^/]+)\/(.+)$/u.exec(
+      value,
+    );
+  if (nfCoreRaw) {
+    return `https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/${nfCoreRaw[1]}/${nfCoreRaw[2]}`;
+  }
+  return value;
+}
+
+async function fetchTestData(summary: Summary, testDataDir?: string): Promise<void> {
   const urls = new Set<string>();
   for (const input of summary.test_fixtures.inputs) {
     if (input.url) urls.add(input.url);
@@ -389,6 +449,7 @@ async function fetchTestData(summary: Summary): Promise<void> {
     try {
       const content = await fetchText(input.url);
       input.sha1 = sha1(content);
+      if (testDataDir) input.path = writeFetchedTestData(testDataDir, input.url, content);
       for (const url of extractRemoteUrls(content)) urls.add(url);
     } catch (err) {
       summary.warnings.push(`failed to fetch test fixture ${input.url}: ${formatError(err)}`);
@@ -408,7 +469,7 @@ async function fetchTestData(summary: Summary): Promise<void> {
       const bytes = await fetchBytes(url);
       summary.test_fixtures.inputs.push({
         role: inferTestDataRole(url),
-        path: null,
+        path: testDataDir ? writeFetchedTestData(testDataDir, url, bytes) : null,
         url,
         sha1: sha1(bytes),
         filetype: inferFiletype(url),
@@ -418,6 +479,19 @@ async function fetchTestData(summary: Summary): Promise<void> {
       summary.warnings.push(`failed to fetch test data ${url}: ${formatError(err)}`);
     }
   }
+}
+
+function writeFetchedTestData(testDataDir: string, url: string, data: string | Uint8Array): string {
+  const path = join(resolve(testDataDir), localTestDataPath(url));
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, data);
+  return path;
+}
+
+function localTestDataPath(url: string): string {
+  const parsed = new URL(url);
+  const parts = parsed.pathname.split("/").filter(Boolean).map(safePathPart);
+  return join(safePathPart(parsed.hostname), ...parts);
 }
 
 async function fetchText(url: string): Promise<string> {
@@ -444,6 +518,15 @@ function inferTestDataRole(url: string): string {
   if (/samplesheet\.(csv|tsv|ya?ml|json)$/u.test(url)) return "samplesheet";
   if (/fastq\.gz$/u.test(url)) return "reads";
   return "test_data";
+}
+
+function inferParamRole(name: string, _url: string): string {
+  if (name === "input") return "samplesheet";
+  return name;
+}
+
+function safePathPart(value: string): string {
+  return value.replace(/[^A-Za-z0-9_.-]/gu, "_");
 }
 
 function inferFiletype(url: string): string | null {

--- a/packages/summarize-nextflow/test/integration/cli.test.ts
+++ b/packages/summarize-nextflow/test/integration/cli.test.ts
@@ -2,9 +2,17 @@
 // Skips gracefully when the workflow-fixtures repo isn't present locally.
 
 import { spawnSync } from "node:child_process";
-import { chmodSync, existsSync, mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
-import { join, resolve } from "node:path";
+import { isAbsolute, join, relative as relativePath, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { validateSummary } from "@galaxy-foundry/summary-nextflow-schema";
 
@@ -13,6 +21,7 @@ const FOUNDRY_ROOT = resolve(PKG_ROOT, "..", "..");
 const CLI = resolve(PKG_ROOT, "dist/bin/summarize-nextflow.js");
 const FIXTURES = resolve(os.homedir(), "projects/repositories/workflow-fixtures/pipelines");
 const DEMO_PIPELINE = resolve(FIXTURES, "nf-core__demo");
+const BACASS_PIPELINE = resolve(FIXTURES, "nf-core__bacass");
 const DEMO_SUMMARY = resolve(
   FOUNDRY_ROOT,
   "casts/claude/summarize-nextflow/runs/nf-core__demo/summary.json",
@@ -22,16 +31,17 @@ function cliBuilt(): boolean {
   return existsSync(CLI);
 }
 
-function fixturesPresent(): boolean {
+function fixturePresent(path: string): boolean {
   try {
-    return statSync(DEMO_PIPELINE).isDirectory();
+    return statSync(path).isDirectory();
   } catch {
     return false;
   }
 }
 
 const itIfBuilt = cliBuilt() ? it : it.skip;
-const itIfFixtures = cliBuilt() && fixturesPresent() ? it : it.skip;
+const itIfDemoFixture = cliBuilt() && fixturePresent(DEMO_PIPELINE) ? it : it.skip;
+const itIfBacassFixture = cliBuilt() && fixturePresent(BACASS_PIPELINE) ? it : it.skip;
 
 describe("summarize-nextflow CLI — built bin", () => {
   itIfBuilt("--version emits a semver", () => {
@@ -46,12 +56,71 @@ describe("summarize-nextflow CLI — built bin", () => {
     expect(r.stdout).toContain("--profile");
     expect(r.stdout).toContain("--no-with-nextflow");
     expect(r.stdout).toContain("--fetch-test-data");
+    expect(r.stdout).toContain("--test-data-dir");
     expect(r.stdout).toContain("--no-validate");
+  });
+
+  itIfBuilt("resolves inherited test-data params and localizes fetched files", async () => {
+    const root = mkdtempSync(join(os.tmpdir(), "foundry-synthetic-nextflow-"));
+    mkdirSync(join(root, "conf"));
+    writeFileSync(
+      join(root, "nextflow.config"),
+      `manifest { name = 'nf-core/synthetic' }
+params {
+  pipelines_testdata_base_path = 'https://example.test/data/'
+  reference_fasta = params.pipelines_testdata_base_path + 'ref.fa'
+}
+profiles { test {} }
+`,
+    );
+    writeFileSync(
+      join(root, "conf", "test.config"),
+      `params {
+  input = params.pipelines_testdata_base_path + 'samplesheet.csv'
+}
+`,
+    );
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const href = String(url);
+      if (href.endsWith("samplesheet.csv")) {
+        return new Response("sample,reads\none,https://example.test/data/reads.fastq.gz\n");
+      }
+      if (href.endsWith("ref.fa")) return new Response(">chr1\nACGT\n");
+      if (href.endsWith("reads.fastq.gz")) return new Response("reads");
+      return new Response("missing", { status: 404, statusText: "Not Found" });
+    }) as typeof fetch;
+
+    try {
+      const { buildSummary } = (await import("../../dist/index.js")) as {
+        buildSummary: typeof import("../../src/index.js").buildSummary;
+      };
+      const summary = await buildSummary(root, {
+        profile: "test",
+        withNextflow: false,
+        fetchTestData: true,
+        testDataDir: relativePath(process.cwd(), join(root, "localized-test-data")),
+        validate: false,
+      });
+      const validation = validateSummary(summary);
+      expect(validation.valid).toBe(true);
+
+      const inputs = (summary as { test_fixtures: { inputs: { role: string; path: string }[] } })
+        .test_fixtures.inputs;
+      expect(inputs.map((input) => input.role)).toEqual(
+        expect.arrayContaining(["samplesheet", "reference_fasta", "reads"]),
+      );
+      expect(inputs.every((input) => isAbsolute(input.path))).toBe(true);
+      expect(inputs.every((input) => existsSync(input.path))).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });
 
 describe("summarize-nextflow CLI — real pipeline tree (nf-core/demo)", () => {
-  itIfFixtures("emits valid JSON summary for the demo fixture", () => {
+  itIfDemoFixture("emits valid JSON summary for the demo fixture", () => {
     const r = spawnSync("node", [CLI, DEMO_PIPELINE, "--no-with-nextflow", "--no-validate"], {
       encoding: "utf8",
     });
@@ -72,7 +141,7 @@ describe("summarize-nextflow CLI — real pipeline tree (nf-core/demo)", () => {
     expect(data.nf_tests[0].profiles).toContain("test");
   });
 
-  itIfFixtures("uses nextflow inspect by default when available", () => {
+  itIfDemoFixture("uses nextflow inspect by default when available", () => {
     const binDir = mkdtempSync(join(os.tmpdir(), "foundry-nextflow-bin-"));
     const fakeNextflow = join(binDir, "nextflow");
     writeFileSync(
@@ -92,7 +161,7 @@ describe("summarize-nextflow CLI — real pipeline tree (nf-core/demo)", () => {
     expect(fastqc.container).toBe("quay.io/example/fastqc:inspect");
   });
 
-  itIfFixtures("fetches samplesheet-referenced test data when requested", () => {
+  itIfDemoFixture("fetches samplesheet-referenced test data when requested", () => {
     const r = spawnSync(
       "node",
       [CLI, DEMO_PIPELINE, "--no-with-nextflow", "--fetch-test-data", "--no-validate"],
@@ -119,6 +188,50 @@ describe("summarize-nextflow CLI — real pipeline tree (nf-core/demo)", () => {
         .filter((input) => input.role === "reads")
         .every((input) => /^[a-f0-9]{40}$/u.test(input.sha1)),
     ).toBe(true);
+  });
+});
+
+describe("summarize-nextflow CLI — real pipeline tree (nf-core/bacass)", () => {
+  itIfBacassFixture("resolves bacass profile test data expressions", () => {
+    const dataDir = mkdtempSync(join(os.tmpdir(), "foundry-bacass-test-data-"));
+    const r = spawnSync(
+      "node",
+      [
+        CLI,
+        BACASS_PIPELINE,
+        "--profile",
+        "test_liftoff",
+        "--no-with-nextflow",
+        "--fetch-test-data",
+        "--test-data-dir",
+        dataDir,
+        "--no-validate",
+      ],
+      { encoding: "utf8", timeout: 120_000 },
+    );
+    expect(r.status).toBe(0);
+
+    const data = JSON.parse(r.stdout);
+    const validation = validateSummary(data);
+    expect(validation.valid).toBe(true);
+    expect(data.source.workflow).toBe("bacass");
+    expect(data.nf_tests.length).toBeGreaterThanOrEqual(9);
+
+    const inputs = data.test_fixtures.inputs as {
+      role: string;
+      path: string;
+      url: string;
+      sha1: string;
+    }[];
+    expect(inputs.map((input) => input.role)).toEqual(
+      expect.arrayContaining(["samplesheet", "reference_fasta", "reference_gff", "reads"]),
+    );
+    expect(inputs.every((input) => input.path.startsWith(dataDir))).toBe(true);
+    expect(inputs.every((input) => existsSync(input.path))).toBe(true);
+    expect(inputs.every((input) => /^[a-f0-9]{40}$/u.test(input.sha1))).toBe(true);
+    expect(inputs.find((input) => input.role === "samplesheet")?.url).toBe(
+      "https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/bacass/bacass_short.tsv",
+    );
   });
 });
 

--- a/packages/summary-nextflow-schema/src/summary-nextflow.schema.generated.ts
+++ b/packages/summary-nextflow-schema/src/summary-nextflow.schema.generated.ts
@@ -513,7 +513,7 @@ export const summaryNextflowSchema = {
             "string",
             "null"
           ],
-          "description": "Repo-relative path when the fixture lives in-tree."
+          "description": "Repo-relative path when the fixture lives in-tree, or local filesystem path when the CLI fetched the remote fixture into a caller-provided test-data directory."
         },
         "url": {
           "type": [

--- a/packages/summary-nextflow-schema/src/summary-nextflow.schema.json
+++ b/packages/summary-nextflow-schema/src/summary-nextflow.schema.json
@@ -192,7 +192,7 @@
       "required": ["role"],
       "properties": {
         "role":        { "type": "string", "description": "Logical role of the input (e.g. `samplesheet`, `reference_fasta`)." },
-        "path":        { "type": ["string", "null"], "description": "Repo-relative path when the fixture lives in-tree." },
+        "path":        { "type": ["string", "null"], "description": "Repo-relative path when the fixture lives in-tree, or local filesystem path when the CLI fetched the remote fixture into a caller-provided test-data directory." },
         "url":         { "type": ["string", "null"], "format": "uri" },
         "sha1":        { "type": ["string", "null"], "description": "SHA-1 integrity hash when published alongside the fixture." },
         "filetype":    { "type": ["string", "null"], "description": "File format, e.g. `fastq.gz`, `csv`." },


### PR DESCRIPTION
## Summary
- Resolve nf-core profile test-data expressions like `params.pipelines_testdata_base_path + '...'`.
- Add `--test-data-dir` to localize fetched samplesheets and referenced remote files while preserving source URLs and SHA-1 hashes.
- Cover bacass-style fixture resolution with real and synthetic tests, and update the schema/Mold docs.

## Tests
- `npm run packages-build`
- `npm run packages-test`
- `npm run packages-typecheck`
- `npm run packages-format`
- `npm run packages-lint`
- `npm run smoke:summary-nextflow-schema`
- `npm run validate` (passes with existing backlink warnings)