### PR TITLE
Add Galaxy conditionals patterns

### DIFF
--- a/.claude/commands/iwc-survey.md
+++ b/.claude/commands/iwc-survey.md
@@ -64,7 +64,7 @@ The survey *must* support these moves; section titles and ordering are your call
 ### What the survey does **not** include
 
 - **No `## Decisions` section.** Decisions migrate to `/iwc-survey-act`. The survey ends at open questions.
-- **No speculative pattern proposals.** If the corpus shows zero uptake of a capability, document the gap inline and move on. Do not propose a candidate pattern for it.
+- **No speculative pattern proposals.** If the corpus shows zero uptake of a capability, document the gap inline and move on. Do not propose a candidate pattern for it. Zero uptake is not anti-pattern evidence by itself; call it "catalog capability, no corpus-backed candidate" unless corpus evidence or a user decision gives an explicit don't-endorse reason.
 - **No tool-anchored candidate names.** `tp_grep_tool-page` is wrong; `tabular-filter-by-regex` is right.
 
 ### Style rules

--- a/content/patterns/conditional-gate-on-nonempty-result.md
+++ b/content/patterns/conditional-gate-on-nonempty-result.md
@@ -1,0 +1,148 @@
+---
+type: pattern
+pattern_kind: leaf
+title: "Conditional: gate on non-empty result"
+aliases:
+  - "gate on nonempty result"
+  - "skip reporting on empty output"
+  - "data-derived when gate"
+tags:
+  - pattern
+  - target/galaxy
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+summary: "Derive a boolean from empty or non-empty data, then use when to skip reporting or export steps."
+related_notes:
+  - "[[iwc-conditionals-survey]]"
+related_patterns:
+  - "[[conditional-run-optional-step]]"
+  - "[[conditional-route-between-alternative-outputs]]"
+  - "[[collection-cleanup-after-mapover-failure]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+---
+
+# Conditional: gate on non-empty result
+
+## Tool
+
+Use a Galaxy `when:` gate whose boolean input is computed from upstream data shape or content.
+
+The corpus-backed collection recipe is:
+
+```text
+collection_element_identifiers -> wc_gnu -> column_maker -> param_value_from_file -> when
+```
+
+MGnify proves this shape in IWC, but it is clunky: four shim steps to produce one boolean. Treat it as verified precedent and fallback evidence, not as the final preferred authoring target.
+
+A shorter route might be possible with a Galaxy-native `when` expression or a smaller expression-tool boolean shim, but that needs validation in a small verified-pattern workflow before it becomes the lead recommendation.
+
+## When to reach for it
+
+Use this when downstream reporting, visualization, or export should run only if an upstream dataset or collection has content.
+
+Common shape:
+
+1. Upstream step may produce an empty result.
+2. Workflow computes a boolean from that result.
+3. Boolean is connected as an input named `when`.
+4. Downstream reporting/conversion steps declare `when: $(inputs.when)`.
+
+This is not a generic user toggle. If the user chooses whether to run an optional branch, use [[conditional-run-optional-step]].
+
+This is not map-over cleanup. If the need is to drop empty or failed elements inside a collection before the next collection consumer, use [[collection-cleanup-after-mapover-failure]].
+
+This is not `__FILTER_NULL__`. The conditionals survey found zero `__FILTER_NULL__` usage in `$IWC_FORMAT2`, but zero uptake alone is not an anti-pattern call.
+
+## Operation Boundary
+
+This pattern covers data-derived branch admission:
+
+- input fact: "this result is empty/non-empty";
+- output action: "run or skip downstream steps";
+- gate mechanism: boolean-producing shim connected to Galaxy `when`.
+
+It does not cover routing between mutually exclusive alternatives and merging with `pick_value`, optional transform then pass-through fallback, filtering collection members, or nullable conditional outputs.
+
+## Parameters
+
+Authoring-relevant fields:
+
+- gated step input: `id: when`, with source from the boolean-producing step or subworkflow output;
+- gated step body: `when: $(inputs.when)`;
+- collection boolean shim: count identifiers and convert `count != 0` to boolean;
+- text-like dataset content shim: map empty text to `false` and non-empty text to `true`.
+
+Observed MGnify collection recipe:
+
+```text
+collection_element_identifiers
+  -> wc_gnu
+  -> column_maker with c1 != 0
+  -> param_value_from_file
+  -> gated Krona / BIOM export steps
+```
+
+This is corpus-backed but intentionally not pretty. Prefer it only when no shorter verified recipe is available.
+
+## Idiomatic Shapes
+
+Conceptual gated reporting step:
+
+```yaml
+in:
+  - id: input
+    source: upstream_result
+  - id: when
+    source: nonempty_boolean/output_param_boolean
+when: $(inputs.when)
+```
+
+Conceptual collection-to-boolean shim:
+
+```text
+collection -> collection_element_identifiers -> wc_gnu -> column_maker(c1 != 0) -> param_value_from_file
+```
+
+Conceptual text-like dataset-content shim:
+
+```text
+dataset -> param_value_from_file -> map_param_value(empty string = false, non-empty default = true)
+```
+
+These snippets are summaries of observed IWC shapes. Do not simplify the MGnify chain in a generated workflow until the shorter route validates.
+
+## Pitfalls
+
+- Do not lead with the MGnify four-step shim as "best" just because it is corpus-backed. It proves the operation; it may not be the ideal generated-workflow recipe.
+- Do not invent a shorter `when` expression without validation. Galaxy workflow syntax and tool-form roundtripping need a verified-pattern fixture first.
+- Do not use this when the choice is user-controlled. Direct boolean `when` gates are simpler.
+- Do not replace collection cleanup with a workflow gate. Cleanup changes collection members; this pattern skips whole downstream steps.
+- Do not cite `__FILTER_NULL__` as an IWC-backed conditional pattern. Survey found no corpus uptake.
+
+## Exemplars (IWC)
+
+- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction.gxwf.yml:1358-1483` — embedded subworkflow labeled `Map empty/not empty collection to boolean`; uses `collection_element_identifiers -> wc_gnu -> column_maker -> param_value_from_file`.
+- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction.gxwf.yml:1330-1357` — boolean gates Krona output generation.
+- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction.gxwf.yml:1484-1659` — same boolean gates BIOM conversion/export steps.
+- `$IWC_FORMAT2/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation.gxwf.yml:3057-3218`, `$IWC_FORMAT2/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation.gxwf.yml:3289-3346` — text-like dataset-content variant: telomere BED text is mapped to a boolean before gating Pretext graph steps.
+
+## Verification TODO
+
+Add a small verified-pattern workflow for this operation. Test whether a shorter Galaxy-native `when` expression or expression-tool boolean shim validates and roundtrips cleanly.
+
+If it works, make the shorter verified route the lead recommendation and keep the MGnify recipe as corpus-observed fallback evidence. If it fails, keep the MGnify route as the known-good corpus-backed recipe despite the clunkiness.
+
+Issue: <https://github.com/jmchilton/foundry/issues/84>.
+
+## See Also
+
+- [[iwc-conditionals-survey]] — Candidate C decision record and verification TODO.
+- [[galaxy-conditionals-patterns]] — conditionals MOC.
+- [[conditional-run-optional-step]] — primitive `when:` branch for user booleans.
+- [[conditional-route-between-alternative-outputs]] — route alternatives and merge with `pick_value`.
+- [[collection-cleanup-after-mapover-failure]] — use when empty/failed collection elements should be dropped or replaced, not when whole downstream steps should be skipped.

--- a/content/patterns/conditional-route-between-alternative-outputs.md
+++ b/content/patterns/conditional-route-between-alternative-outputs.md
@@ -1,0 +1,155 @@
+---
+type: pattern
+pattern_kind: leaf
+title: "Conditional: route between alternative outputs"
+aliases:
+  - "when-gated alternatives with pick_value"
+  - "conditional route with pick_value"
+  - "one-of-N Galaxy route"
+tags:
+  - pattern
+  - target/galaxy
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+summary: "Use when-gated alternatives plus pick_value to merge binary or one-of-N routes into one downstream value."
+related_notes:
+  - "[[iwc-conditionals-survey]]"
+related_patterns:
+  - "[[conditional-run-optional-step]]"
+  - "[[conditional-transform-or-pass-through]]"
+  - "[[conditional-gate-on-nonempty-result]]"
+  - "[[collection-cleanup-after-mapover-failure]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+---
+
+# Conditional: route between alternative outputs
+
+## Tool
+
+Use Galaxy `when:` gates on each alternative-producing step, then use `pick_value` to collapse the possible outputs into one downstream value.
+
+This is a graph-visible route pattern: each alternative stays as its own Galaxy step or subworkflow, and `pick_value` is the merge point. It is not a wrapper-internal conditional hidden inside one tool state.
+
+## When to reach for it
+
+Use this when a workflow must run exactly one branch from two or more alternative data-prep or analysis modes, but downstream steps should consume a single logical input.
+
+Good fits include binary input-format routes, one-of-N analysis modes where each mode produces the same kind of downstream artifact, and embedded subworkflow alternatives that rejoin the main workflow.
+
+Do not use this for a simple optional side branch whose outputs are terminal or independent; use [[conditional-run-optional-step]] for that.
+
+Do not use this for cleanup after mapped tools produce empty or failed elements; use [[collection-cleanup-after-mapover-failure]].
+
+Do not use this for "transform if requested, otherwise pass original through" unless the route is truly between peer alternatives. That shape is close, but its operation boundary is fallback-to-original rather than mode routing; use [[conditional-transform-or-pass-through]].
+
+## Operation Boundary
+
+This pattern is:
+
+```text
+route condition(s) -> when-gated alternative steps -> pick_value merge -> one downstream value
+```
+
+The reusable operation is the merge, not just the `when:` field. Every alternative may disappear at runtime, so the downstream step should connect to the `pick_value` output, not directly to any branch output.
+
+For binary routes, one branch often uses the user boolean directly and the other uses a mapped inverse boolean. For one-of-N routes, derive one boolean per mode, gate each mode, then order the candidate outputs in `pick_value`.
+
+## Parameters
+
+On each alternative step:
+
+- connect a boolean input with `id: when`;
+- set `when: $(inputs.when)`;
+- keep each alternative's output type and semantic role compatible with the merge.
+
+On the merge step:
+
+- connect every possible branch output to `pick_value`;
+- order candidates so the intended selected value appears first among present outputs;
+- connect all downstream consumers to the `pick_value` output.
+
+If authoring inverse or mode booleans, use a small mapper step such as `map_param_value` rather than duplicating branch logic inside downstream tools.
+
+## Idiomatic Shapes
+
+Binary route, conceptual shape:
+
+```yaml
+- label: Import legacy 10x matrix
+  tool_id: anndata_import
+  in:
+    - id: when
+      source: use_legacy_10x_boolean
+  when: $(inputs.when)
+
+- label: Import 10x v3 matrix
+  tool_id: anndata_import
+  in:
+    - id: when
+      source: use_v3_10x_boolean
+  when: $(inputs.when)
+
+- label: Pick imported AnnData
+  tool_id: pick_value
+  in:
+    - source: Import legacy 10x matrix/anndata
+    - source: Import 10x v3 matrix/anndata
+```
+
+One-of-N route, conceptual shape:
+
+```yaml
+- label: Run mode A
+  in:
+    - id: when
+      source: mode_a_boolean
+  when: $(inputs.when)
+
+- label: Run mode B
+  in:
+    - id: when
+      source: mode_b_boolean
+  when: $(inputs.when)
+
+- label: Run mode C
+  in:
+    - id: when
+      source: mode_c_boolean
+  when: $(inputs.when)
+
+- label: Pick routed output
+  tool_id: pick_value
+  in:
+    - source: Run mode A/output
+    - source: Run mode B/output
+    - source: Run mode C/output
+```
+
+These snippets are conceptual. Use the cited gxformat2 exemplars for exact serialized shapes.
+
+## Pitfalls
+
+- Forgetting the merge. A gated branch output may be absent. Downstream steps should consume `pick_value`, not one branch directly.
+- Non-exclusive booleans. If two branches can run at once, `pick_value` chooses by input order. That may hide an upstream routing bug.
+- Mismatched output semantics. `pick_value` can merge present values, but it does not make incompatible outputs equivalent. Branches should produce the same logical artifact.
+- Hiding the route in one wrapper. IWC evidence favors graph-visible `when` branches plus merge for these route operations.
+- Confusing route merge with collection cleanup. `__FILTER_EMPTY_DATASETS__` and `__FILTER_FAILED_DATASETS__` clean mapped collection elements; they are not the observed IWC mechanism for one-of-N conditional routing.
+
+## Exemplars (IWC)
+
+- `$IWC_FORMAT2/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy.gxwf.yml:180-211`, `$IWC_FORMAT2/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy.gxwf.yml:337-399` — binary 10x import route: legacy vs v3 `anndata_import`, then `pick_value` selects the present AnnData output.
+- `$IWC_FORMAT2/genome_annotation/functional-annotation/functional-annotation-of-sequences/Functional_annotation_of_sequences.gxwf.yml:244-395`, `$IWC_FORMAT2/genome_annotation/functional-annotation/functional-annotation-of-sequences/Functional_annotation_of_sequences.gxwf.yml:396-429` — one-of-N eggNOG mapper mode fan-out, then `pick_value` collapses the selected annotation output.
+- `$IWC_FORMAT2/microbiome/mags-building/MAGs-generation.gxwf.yml:295-410`, `$IWC_FORMAT2/microbiome/mags-building/MAGs-generation.gxwf.yml:411-439` — alternative assembly route including an embedded subworkflow branch, then `pick_value` chooses among individual, co-assembly, or custom assemblies.
+
+## See Also
+
+- [[iwc-conditionals-survey]] — Candidate B evidence and conditionals boundary decisions.
+- [[galaxy-conditionals-patterns]] — conditionals MOC.
+- [[conditional-run-optional-step]] — direct boolean gate with no required merge.
+- [[conditional-gate-on-nonempty-result]] — derive boolean from empty/non-empty result, then gate reporting/export.
+- [[conditional-transform-or-pass-through]] — optional transform then fallback to original.
+- [[collection-cleanup-after-mapover-failure]] — collection-state cleanup, not route selection.

--- a/content/patterns/conditional-run-optional-step.md
+++ b/content/patterns/conditional-run-optional-step.md
@@ -1,0 +1,128 @@
+---
+type: pattern
+pattern_kind: leaf
+title: "Conditional: run optional step"
+aliases:
+  - "boolean-gated optional step"
+  - "Galaxy when gate"
+  - "optional branch with when"
+tags:
+  - pattern
+  - target/galaxy
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+summary: "Use a workflow boolean connected as inputs.when to skip an optional Galaxy step or branch."
+related_notes:
+  - "[[iwc-conditionals-survey]]"
+related_patterns:
+  - "[[conditional-route-between-alternative-outputs]]"
+  - "[[conditional-gate-on-nonempty-result]]"
+  - "[[conditional-transform-or-pass-through]]"
+  - "[[collection-cleanup-after-mapover-failure]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+---
+
+# Conditional: run optional step
+
+## Tool
+
+Use Galaxy workflow `when:` gating. Expose a boolean workflow input, connect it to each optional step as an input named `when`, and set:
+
+```yaml
+when: $(inputs.when)
+```
+
+This is a workflow-control shape, not a tool-specific recipe. The gated tool can be BUSCO, StringTie, Cufflinks, text-processing, or any other ordinary Galaxy step.
+
+## When to reach for it
+
+Use this when a user-facing boolean decides whether an optional analysis, report, export, or small branch runs.
+
+Use it for optional side branches whose outputs are only meaningful when the branch runs. If downstream always needs one replacement value, add a `pick_value` merge instead; use [[conditional-route-between-alternative-outputs]] or [[conditional-transform-or-pass-through]].
+
+Do not use this for collection cleanup after map-over failures. If the problem is empty or failed collection elements, use [[collection-cleanup-after-mapover-failure]].
+
+Do not use this for data-derived emptiness checks unless you first compute a boolean from the data. That is [[conditional-gate-on-nonempty-result]], not this direct user-boolean gate.
+
+## Parameters
+
+- Workflow input: boolean, named for the user decision, e.g. `Include BUSCO`, `Compute StringTie FPKM`, or `Do you want to add suffixes to the scaffold names?`.
+- Step input: connect that boolean to an input port with `id: when`.
+- Step gate: set `when: $(inputs.when)` on every step that belongs to the optional branch.
+
+For a multi-step optional branch, repeat the same boolean connection and `when:` expression on each gated step. Do not rely on one upstream gated step to implicitly suppress every downstream consumer; make the branch boundary explicit.
+
+## Idiomatic Shapes
+
+Single optional tool step:
+
+```yaml
+- id: Optional report
+  tool_id: toolshed.example/report_tool/report_tool/1.0
+  in:
+    - id: input
+      source: Main analysis/output
+    - id: when
+      source: Run optional report?
+  out:
+    - id: report
+  when: $(inputs.when)
+```
+
+Multi-step optional branch, same user boolean on each optional step:
+
+```yaml
+- id: Compose optional expression
+  tool_id: toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1
+  in:
+    - id: components_1|param_type|component_value
+      source: Optional suffix
+    - id: when
+      source: Add suffixes?
+  out:
+    - id: out1
+  when: $(inputs.when)
+
+- id: Apply optional suffix
+  tool_id: toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.5+galaxy3
+  in:
+    - id: infile
+      source: Input FASTA
+    - id: replacements_0|replace_pattern
+      source: Compose optional expression/out1
+    - id: when
+      source: Add suffixes?
+  out:
+    - id: outfile
+  when: $(inputs.when)
+```
+
+The second shape is conceptual, derived from the VGP Hi-C suffixing branch. The corpus workflow then uses `pick_value` to choose suffixed output or original input, which is outside this page's operation boundary.
+
+## Pitfalls
+
+- Forgetting the `when` input connection. The observed IWC shape connects a boolean into `id: when` and uses `when: $(inputs.when)`.
+- Gating only the first step of a branch. If later optional steps should also disappear, put `when:` on those steps too.
+- Consuming a missing optional output unconditionally. If downstream requires a value regardless of the boolean, add an explicit merge/fallback with `pick_value`.
+- Confusing user choice with data-derived choice. Empty/non-empty result checks need a separate boolean-producing shim before `when:`.
+- Leading with `__FILTER_NULL__` as conditional cleanup. The survey found zero `__FILTER_NULL__` hits in `$IWC_FORMAT2`; keep it as catalog knowledge, not the corpus-backed authoring path.
+
+## Exemplars (IWC)
+
+- `$IWC_FORMAT2/genome_annotation/annotation-braker3/Genome_annotation_with_braker3.gxwf.yml:110-141` — BRAKER3 gates BUSCO on predicted protein sequences with the `Include BUSCO` boolean connected as `when`.
+- `$IWC_FORMAT2/genome_annotation/annotation-braker3/Genome_annotation_with_braker3.gxwf.yml:341-385` — same workflow gates genome BUSCO from the same user-facing boolean, showing repeated optional assessment branches.
+- `$IWC_FORMAT2/transcriptomics/rnaseq-pe/rnaseq-pe.gxwf.yml:1082-1140` — RNA-seq gates the optional StringTie FPKM branch with `Compute StringTie FPKM`.
+- `$IWC_FORMAT2/transcriptomics/rnaseq-pe/rnaseq-pe.gxwf.yml:1141-1214` — RNA-seq gates the optional Cufflinks FPKM branch separately with `Compute Cufflinks FPKM`.
+- `$IWC_FORMAT2/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation.gxwf.yml:338-459` — VGP Hi-C gates a multi-step suffixing branch with a user boolean; downstream fallback uses `pick_value`, marking the boundary with [[conditional-transform-or-pass-through]].
+
+## See Also
+
+- [[iwc-conditionals-survey]] — Candidate A decision and boundaries with route/non-empty candidates.
+- [[galaxy-conditionals-patterns]] — conditionals MOC.
+- [[conditional-route-between-alternative-outputs]] — mutually exclusive branches merged by `pick_value`.
+- [[conditional-gate-on-nonempty-result]] — booleans computed from dataset or collection emptiness.
+- [[collection-cleanup-after-mapover-failure]] — cleanup for empty or failed mapped datasets.

--- a/content/patterns/conditional-transform-or-pass-through.md
+++ b/content/patterns/conditional-transform-or-pass-through.md
@@ -1,0 +1,122 @@
+---
+type: pattern
+pattern_kind: leaf
+title: "Conditional: transform or pass through"
+aliases:
+  - "optional transform with fallback"
+  - "when-gated transform then pick_value"
+  - "transform or keep original"
+tags:
+  - pattern
+  - target/galaxy
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+summary: "Gate an optional transform, then use pick_value to pass transformed data when present or original data otherwise."
+related_notes:
+  - "[[iwc-conditionals-survey]]"
+related_patterns:
+  - "[[conditional-route-between-alternative-outputs]]"
+  - "[[conditional-run-optional-step]]"
+  - "[[conditional-gate-on-nonempty-result]]"
+  - "[[collection-cleanup-after-mapover-failure]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+---
+
+# Conditional: transform or pass through
+
+## Tool
+
+Use a Galaxy `when:` gate on the optional transform branch, then use `pick_value` to collapse the optional transformed output and the original input/output back to one downstream value.
+
+The observed shape is:
+
+1. Derive or expose a boolean.
+2. Connect that boolean as the gated step's `id: when` input.
+3. Set `when: $(inputs.when)` on every step in the optional transform branch.
+4. Feed the transformed output and original value into `pick_value`.
+5. Connect downstream steps only to the selected value.
+
+## When to reach for it
+
+Use this when a workflow should optionally alter a dataset, collection, or report while preserving one stable downstream input slot.
+
+This is not general mode routing. The pass-through side is not a peer algorithm; it is the same data before the optional cleanup, relabel, or rewrite. Reach for this when the user story is "apply the cleanup if requested or needed, otherwise keep the original."
+
+Use [[conditional-route-between-alternative-outputs]] instead when the branches are mutually exclusive peer routes: import mode A vs mode B, annotation mode 1 vs 2 vs 3, co-assembly vs individual assembly. In that route pattern, each branch independently produces a candidate output. Here, one branch is a transform of the other branch's source.
+
+Use [[conditional-run-optional-step]] when the optional branch has side outputs only and no downstream replacement value is needed.
+
+Do not use this as collection failure cleanup. If mapped elements are empty or failed, use [[collection-cleanup-after-mapover-failure]] with `__FILTER_EMPTY_DATASETS__` or `__FILTER_FAILED_DATASETS__`.
+
+## Operation Boundary
+
+`conditional-transform-or-pass-through` is the "same value, optionally modified" pattern.
+
+Keep it separate from route-with-`pick_value` for now because authors need to distinguish:
+
+- Transform/pass-through: original value is valid downstream input; transformed value replaces it only when the branch runs.
+- Route between alternatives: each branch is a different source, mode, or algorithm; there may be no privileged original.
+- Optional side branch: downstream does not need a merged replacement value.
+- Filter null outputs: not corpus-backed in IWC; `__FILTER_NULL__` has zero observed hits in the conditionals survey.
+
+If merged later, this should become a named subsection of [[conditional-route-between-alternative-outputs]], not disappear; the authoring decision is common enough to teach explicitly.
+
+## Parameters
+
+- `when` input on every optional transform step: connected from a workflow boolean, `map_param_value`, or another boolean-producing step.
+- `when: $(inputs.when)` on each gated transform step.
+- `pick_value` input order: put the transformed output before the original fallback so the transformed value wins when present.
+- Original fallback: connect the unmodified value, or an upstream report/output equivalent, into the later `pick_value` candidate slot.
+
+The exact transform tool is operation-specific. IWC examples use text replacement, line replacement, masking, concatenation, and suffixing tools; the pattern is the conditional merge shape, not those tools.
+
+## Idiomatic Shape
+
+Conceptual gxformat2 shape:
+
+```yaml
+- label: Optional transform
+  tool_id: <transform-tool>
+  in:
+    - id: input
+      source: original_input
+    - id: when
+      source: transform_boolean
+  when: $(inputs.when)
+
+- label: Use transformed value if present, otherwise original
+  tool_id: pick_value
+  in:
+    - id: style_cond|pick_from
+      source: Optional transform/output
+    - id: style_cond|pick_from
+      source: original_input
+```
+
+Read this as preserving a downstream contract: later steps consume one value regardless of whether the optional transform ran.
+
+## Pitfalls
+
+- Put the transformed output before the original fallback in `pick_value`; otherwise the original may win even when the transform ran.
+- Gate every step in a multi-step transform branch. A downstream transform step without the same `when` may run with missing inputs.
+- Do not duplicate the whole downstream workflow after the optional transform. Merge once with `pick_value`, then continue with one path.
+- Do not model pass-through as a fake transform step. The unmodified value should be connected directly as the fallback candidate.
+- Do not cite `__FILTER_NULL__` as the IWC idiom for this. The survey found zero `__FILTER_NULL__` hits.
+
+## Exemplars (IWC)
+
+- `$IWC_FORMAT2/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation.gxwf.yml:338-479` — optional haplotype suffixing branch runs only when requested; `pick_value` selects the suffixed haplotype when present or the original haplotype otherwise.
+- `$IWC_FORMAT2/VGP-assembly-v2/Assembly-decontamination-VGP9/Assembly-decontamination-VGP9.gxwf.yml:243-409` — mapped boolean gates adaptor filtering/masking/report-rewrite branch; `pick_value` later falls back to the original `Adaptor Action report` when masking does not run.
+
+## See Also
+
+- [[iwc-conditionals-survey]] — Candidate D and boundary against Candidate B.
+- [[galaxy-conditionals-patterns]] — conditionals MOC.
+- [[conditional-route-between-alternative-outputs]] — sibling route-with-`pick_value` pattern for peer alternatives.
+- [[conditional-run-optional-step]] — primitive `when:` branch without downstream merge.
+- [[conditional-gate-on-nonempty-result]] — data-derived gate for downstream reporting/export.
+- [[collection-cleanup-after-mapover-failure]] — collection-state cleanup, not a `when` + pass-through recipe.

--- a/content/patterns/galaxy-conditionals-patterns.md
+++ b/content/patterns/galaxy-conditionals-patterns.md
@@ -1,0 +1,56 @@
+---
+type: pattern
+pattern_kind: moc
+title: "Galaxy: conditionals patterns"
+aliases:
+  - "Galaxy conditional pattern MOC"
+  - "Galaxy when patterns"
+  - "conditional workflow patterns"
+tags:
+  - pattern
+  - target/galaxy
+  - topic/galaxy-transform
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+summary: "Use this MOC to choose corpus-grounded Galaxy when and pick_value conditional patterns."
+related_notes:
+  - "[[iwc-conditionals-survey]]"
+related_patterns:
+  - "[[conditional-run-optional-step]]"
+  - "[[conditional-route-between-alternative-outputs]]"
+  - "[[conditional-gate-on-nonempty-result]]"
+  - "[[conditional-transform-or-pass-through]]"
+  - "[[collection-cleanup-after-mapover-failure]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+  - "[[summary-to-galaxy-data-flow]]"
+  - "[[summary-to-galaxy-template]]"
+  - "[[compare-against-iwc-exemplar]]"
+---
+
+# Galaxy: conditionals patterns
+
+This is the runtime-facing map for Galaxy conditional workflow choices. Use it before loading raw survey notes. The survey remains evidence backing; the leaf pages are the actionable references.
+
+## Direct Gates
+
+- [[conditional-run-optional-step]] — expose or derive a boolean, connect it as `inputs.when`, and use `when: $(inputs.when)` to skip optional steps.
+- [[conditional-gate-on-nonempty-result]] — compute a boolean from empty/non-empty dataset or collection state before gating downstream reporting/export. The MGnify recipe is corpus-backed but clunky pending verified-pattern workflow work.
+
+## Routes and Fallbacks
+
+- [[conditional-route-between-alternative-outputs]] — run one of several `when`-gated alternatives, then merge possible outputs with `pick_value`.
+- [[conditional-transform-or-pass-through]] — optionally transform a value, then use `pick_value` to choose transformed output or original fallback.
+
+## Not Conditionals
+
+- [[collection-cleanup-after-mapover-failure]] — use collection filters when empty or failed mapped elements should be dropped or replaced. This is collection-state cleanup, not a `when` gate.
+- `__FILTER_NULL__` — catalog capability for null outputs after conditional steps, but no IWC-backed pattern candidate in the conditionals survey. Zero uptake is not itself an anti-pattern call.
+
+## See Also
+
+- [[iwc-conditionals-survey]] — conditionals survey and evidence trail.
+- [[galaxy-collection-patterns]] — companion MOC for collection transforms and cleanup.

--- a/content/research/iwc-conditionals-survey.md
+++ b/content/research/iwc-conditionals-survey.md
@@ -7,11 +7,17 @@ tags:
 status: draft
 created: 2026-05-02
 revised: 2026-05-02
-revision: 1
+revision: 2
 ai_generated: true
 related_notes:
   - "[[iwc-transformations-survey]]"
   - "[[iwc-shortcuts-anti-patterns]]"
+related_patterns:
+  - "[[galaxy-conditionals-patterns]]"
+  - "[[conditional-run-optional-step]]"
+  - "[[conditional-route-between-alternative-outputs]]"
+  - "[[conditional-gate-on-nonempty-result]]"
+  - "[[conditional-transform-or-pass-through]]"
 summary: "Corpus survey of Galaxy conditional step usage in IWC, covering when-gates, boolean shims, and routed output selection."
 ---
 
@@ -149,6 +155,10 @@ Evidence:
 
 Call: **keep**. This is distinct from generic optional branching because the boolean is computed from data shape/content.
 
+User story: a generated Galaxy workflow needs to skip optional reporting/export steps when an upstream dataset or collection is empty. The corpus-backed MGnify recipe proves the shape by turning collection membership into a boolean through `collection_element_identifiers -> wc_gnu -> column_maker -> param_value_from_file`, then using that boolean as `inputs.when`. This is structurally useful but clunky: it is a four-step shim for one boolean, so the pattern page should present it as verified IWC precedent, not necessarily the preferred authoring target.
+
+TODO: revisit this candidate after adding a small verified-pattern workflow that tests the non-empty gate directly. If a shorter Galaxy-native `when` expression or expression-tool boolean shim validates cleanly, lead with the smaller verified pattern and keep the MGnify shape as corpus-observed fallback evidence.
+
 ### Candidate D: `conditional-transform-or-pass-through`
 
 Scope: optionally transform an input, then choose transformed output if present or original input otherwise.
@@ -158,7 +168,7 @@ Evidence:
 - Optional haplotype suffixing then fallback to original haplotypes: `$IWC_FORMAT2/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation.gxwf.yml:338-479`.
 - Optional masking action report then fallback to original report: `$IWC_FORMAT2/VGP-assembly-v2/Assembly-decontamination-VGP9/Assembly-decontamination-VGP9.gxwf.yml:243-409`.
 
-Call: **merge or keep**. Merge into Candidate B if the pattern hierarchy wants one `pick_value` route page; keep separately if pass-through is common enough to warrant a named recipe.
+Call: **keep separately for now**. It shares `pick_value` with Candidate B, but the authoring decision is different: Candidate B routes among peer alternatives, while this recipe preserves one original value unless an optional transform runs. Merge later only if the page proves too thin after use.
 
 ### Candidate E: `conditional-filter-null-outputs`
 
@@ -180,10 +190,10 @@ Call: **merge** into the collection-cleanup pattern family; do not create a cond
 
 1. Should conditionals get a MOC page (`galaxy-conditionals-patterns.md`) now, or wait until at least two leaf pages are authored?
 
-2. Should `conditional-transform-or-pass-through` stay separate from `conditional-route-between-alternative-outputs`, or should both live on one route-with-`pick_value` page?
+2. Answered for now: keep `conditional-transform-or-pass-through` separate from `conditional-route-between-alternative-outputs`. The boundary is "same value optionally modified" vs "peer alternatives routed to one output". Revisit only if the separate page proves too thin.
 
-3. Should `conditional-gate-on-nonempty-result` recommend the MGnify `collection_element_identifiers -> wc_gnu -> column_maker -> param_value_from_file` recipe as-is, or flag it as corpus-backed but clunky and prefer a smaller boolean shim if one exists?
+3. Verification TODO: add a small verified-pattern workflow for `conditional-gate-on-nonempty-result` and use it to decide whether a shorter Galaxy-native `when` expression or expression-tool boolean shim should supersede the MGnify `collection_element_identifiers -> wc_gnu -> column_maker -> param_value_from_file` recipe as the lead recommendation.
 
-4. Should the anti-pattern note add `__FILTER_NULL__` as "catalog capability, no IWC uptake; do not lead with it", or is a survey drop call enough?
+4. No. Do not add `__FILTER_NULL__` to the anti-pattern note from zero uptake alone. Lack of uptake does not make a Galaxy feature an anti-pattern; users can be slow to adopt newer or esoteric features. Keep the survey call as "catalog capability, no IWC-backed pattern candidate" unless separate evidence shows a concrete reason not to endorse it.
 
 5. Does the Foundry need a background reference note for Galaxy `when:` syntax and nullable downstream behavior before leaf pattern pages are useful?


### PR DESCRIPTION
## Summary
- Add a Galaxy conditionals MOC plus four corpus-grounded conditionals leaf patterns.
- Update the IWC conditionals survey with resolved pattern boundaries and the non-empty gate verification TODO.
- Clarify survey guidance that zero corpus uptake is not anti-pattern evidence by itself.

## Testing
- `npm run validate` (passes; existing backlink warnings remain)
- `npm run test`