### PR TITLE
Force clean Astro site builds

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build",
+    "build": "astro build --force",
     "preview": "astro preview",
     "astro": "astro"
   },


### PR DESCRIPTION
## Summary
- Run Astro site builds with `--force` so the persistent content data store is cleared before sync.
- Avoid stale duplicate-id warnings after content IDs or loader patterns change.

## Tests
- `npm run site:build`