### PR TITLE
Add Galaxy draft eval plans

### DIFF
--- a/content/molds/summary-to-galaxy-data-flow/eval.md
+++ b/content/molds/summary-to-galaxy-data-flow/eval.md
@@ -1,0 +1,25 @@
+# summary-to-galaxy-data-flow eval
+
+## Case: source-shape to Galaxy topology
+
+- check: llm-judged
+- fixture: Nextflow summary with at least one non-scalar channel shape, such as paired reads, grouped tuples, mixed optional outputs, or nested collections.
+- expectation: produces a Galaxy-facing data-flow draft that records the chosen dataset or collection shape, confidence, and rationale for each non-trivial source shape.
+
+## Case: operator-derived transformation
+
+- check: llm-judged
+- fixture: Nextflow summary with at least one channel operator that changes topology or routing, such as `map`, `join`, `groupTuple`, `branch`, `mix`, `combine`, or `multiMap`.
+- expectation: classifies each operator-derived decision as direct wiring, Galaxy collection semantics, explicit Galaxy step, or user-review item, and cites the research or pattern note used.
+
+## Case: pattern capture from evaluation run
+
+- check: llm-judged
+- fixture: any real translation run that surfaces a repeated or reusable Galaxy data-flow decision.
+- expectation: records whether the decision should become a pattern note, research note, schema change, mold-reference change, or issue; includes evidence needed to research, verify, and document it.
+
+## Case: unresolved translation boundary
+
+- check: llm-judged
+- fixture: data-flow draft with at least one uncertain tool need, placeholder transformation, conditional branch, collection reshape, or tabular bridge.
+- expectation: assigns ownership to data-flow, template, concrete step implementation, or follow-up research; does not hide unresolved semantics in prose-only TODOs.

--- a/content/molds/summary-to-galaxy-template/eval.md
+++ b/content/molds/summary-to-galaxy-template/eval.md
@@ -1,0 +1,25 @@
+# summary-to-galaxy-template eval
+
+## Case: data-flow draft to gxformat2 skeleton
+
+- check: llm-judged
+- fixture: Galaxy data-flow draft with workflow inputs, outputs, abstract nodes, edges, and at least one collection-shaped connection.
+- expectation: emits a gxformat2 skeleton that preserves intended topology, labels unresolved steps clearly, and does not resolve concrete tool metadata prematurely.
+
+## Case: placeholder transformation handoff
+
+- check: llm-judged
+- fixture: data-flow draft with a collection cleanup, identifier synchronization, Apply Rules reshape, tabular bridge, or optional-output route.
+- expectation: renders the transformation as an explicit placeholder or TODO step with enough shape and evidence context for the later implementation mold.
+
+## Case: exemplar comparison preparation
+
+- check: llm-judged
+- fixture: gxformat2 skeleton with enough domain, input topology, tool-family, and output signal to choose IWC exemplars.
+- expectation: records candidate exemplar-selection features and cites the patterns or research notes that should guide compare-against-IWC work.
+
+## Case: pattern capture from evaluation run
+
+- check: llm-judged
+- fixture: any real template-generation run that exposes a reusable skeleton idiom, awkward placeholder, missing pattern, or unclear mold boundary.
+- expectation: records how the observation should be captured: new or revised pattern note, research issue, schema/eval update, mold-reference update, or documentation task; includes concrete evidence required to verify it.


### PR DESCRIPTION
## Summary
- add eval cases for `summary-to-galaxy-data-flow`
- add eval cases for `summary-to-galaxy-template`
- require evaluation runs to capture reusable pattern candidates, research gaps, verification evidence, and documentation follow-ups

## Validation
- npm run validate