### PR TITLE
Expand summarize-nextflow resolver extraction

### DIFF
--- a/.changeset/clean-bears-summarize.md
+++ b/.changeset/clean-bears-summarize.md
@@ -3,4 +3,4 @@
 "@galaxy-foundry/summary-nextflow-schema": patch
 ---
 
-Resolve nf-core test-data expressions and optionally localize fetched fixtures.
+Resolve nf-core test-data expressions, optionally localize fetched fixtures, extract every Bioconda dependency from module environments, and capture repeated module aliases.

--- a/content/molds/summarize-nextflow/index.md
+++ b/content/molds/summarize-nextflow/index.md
@@ -9,7 +9,7 @@ tags:
 status: draft
 created: 2026-04-30
 revised: 2026-05-02
-revision: 5
+revision: 7
 ai_generated: true
 output_schemas:
   - "content/schemas/summary-nextflow.schema.json"
@@ -216,7 +216,7 @@ Walk per-process `container` and `conda` directives. **Container directives are 
   - `community.wave.seqera.io/library/<name>:<version>--<digest>` or `https://community-cr-prod.seqera.io/.../sha256/<digest>/data` → `tools[].wave`.
   - Anything else → `tools[].docker`.
 
-**Conda directives are usually file references** to `${moduleDir}/environment.yml`; read the file and extract its `dependencies:` list. When the list contains a single `bioconda::<name>=<version>` entry, that string becomes `tools[].bioconda`. Legacy literal-string directives (`conda "bioconda::<name>=<version>"`) feed the same field.
+**Conda directives are usually file references** to `${moduleDir}/environment.yml`; read the file and extract its `dependencies:` list. Each `bioconda::<name>=<version>` entry becomes a `tools[]` entry with `tools[].bioconda` set to the original dependency string. Multi-tool environments are common (`minimap2` + `samtools` + `htslib`, `racon` + `multiqc`); keep every Bioconda dependency rather than selecting the first. Legacy literal-string directives (`conda "bioconda::<name>=<version>"`) feed the same field.
 
 Tool name and version are typically derivable from any of the resolved fields. Deduplicate by `(name, version)` across processes; one entry per tool. `processes[].tool` is a foreign key into `tools[].name`. This block is the bridge to `[[author-galaxy-tool-wrapper]]` — it consumes container/conda info to translate into Galaxy `<requirements>`.
 
@@ -265,6 +265,8 @@ Validate the assembled object against `schemas/summary-nextflow.schema.json` bef
 
 ## Revision history
 
+- **rev 7 (2026-05-02)** — CLI package now sweeps `include { X as Y } from ...` statements across workflow and subworkflow files to populate `processes[].aliases`, tested against bacass repeated imports (`MINIMAP2_ALIGN`, `FASTQC`).
+- **rev 6 (2026-05-02)** — CLI package now parses multi-dependency module `environment.yml` files into separate Bioconda-backed `tools[]` entries, tested against bacass modules such as `minimap2/align` and `samtools/sort`.
 - **rev 5 (2026-05-02)** — CLI package hardened against `nf-core/bacass` profile config expressions: resolves `params.pipelines_testdata_base_path + '...'`, fetches samplesheet-referenced remote files, hashes them, and optionally localizes them under `--test-data-dir` while preserving original URLs.
 - **rev 4 (2026-05-01)** — second cast against `nf-core/bacass @ 2.5.0` (33 processes, 9 nf-test files, 11 test profiles) exposed two patterns the first cast couldn't see: process aliasing via `include { X as Y }` (six distinct alias-rename patterns in bacass) and the per-test-file structure of nf-test fixtures. §4 grew the alias-sweep rule; §7 split into `test_fixtures` + `nf_tests[]` with structured snapshot extraction. Schema bumped to rev 3 in lockstep. Cast log: `content/log.md` second 2026-05-01 entry.
 - **rev 3 (2026-05-01)** — first cast against `nf-core/demo @ 1.1.0` exposed the gaps now folded into §1 (multi-workflow selection rule), §4 (verbatim directive capture, channel topics), §5 (ternary container resolver, file-path conda directives, Wave registry), §6 (utility-vs-pipeline subworkflow split, free-function calls). Schema bumped to rev 2 in lockstep — see `[[summary-nextflow]]`'s revision-2 section. Cast log: `content/log.md` 2026-05-01 entry.

--- a/packages/summarize-nextflow/src/resolver.ts
+++ b/packages/summarize-nextflow/src/resolver.ts
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, relative, resolve } from "node:path";
+import YAML from "yaml";
 
 interface Summary {
   source: Record<string, unknown>;
@@ -101,6 +102,7 @@ export async function resolveNextflowSummary(
   const processes = discoverProcessFiles(pipelineRoot).map((path) =>
     parseProcessFile(pipelineRoot, path),
   );
+  const aliases = discoverProcessAliases(pipelineRoot);
   const tools = buildTools(pipelineRoot, processes);
 
   const summary: Summary = {
@@ -120,6 +122,7 @@ export async function resolveNextflowSummary(
     tools,
     processes: processes.map((process) => ({
       ...process,
+      aliases: aliases.get(process.name) ?? [],
       tool:
         tools.find((tool) => process.name.toLowerCase().includes(tool.name))?.name ?? process.tool,
     })),
@@ -287,6 +290,30 @@ function parseProcessFile(pipelineRoot: string, path: string): Process {
   };
 }
 
+function discoverProcessAliases(pipelineRoot: string): Map<string, string[]> {
+  const aliases = new Map<string, Set<string>>();
+  for (const path of walk(pipelineRoot).filter((candidate) => candidate.endsWith(".nf"))) {
+    for (const include of parseIncludeItems(readText(path))) {
+      if (!include.alias || include.alias === include.name) continue;
+      const existing = aliases.get(include.name) ?? new Set<string>();
+      existing.add(include.alias);
+      aliases.set(include.name, existing);
+    }
+  }
+  return new Map([...aliases.entries()].map(([name, values]) => [name, [...values].sort()]));
+}
+
+function parseIncludeItems(text: string): { name: string; alias: string | null }[] {
+  const items: { name: string; alias: string | null }[] = [];
+  for (const match of text.matchAll(/include\s*\{([^}]+)\}\s*from\s*['"][^'"]+['"]/gu)) {
+    for (const item of match[1]!.split(";")) {
+      const include = /^\s*([A-Za-z0-9_]+)(?:\s+as\s+([A-Za-z0-9_]+))?\s*$/u.exec(item);
+      if (include) items.push({ name: include[1]!, alias: include[2] ?? null });
+    }
+  }
+  return items;
+}
+
 function normalizeDirective(value: string | null): string | null {
   if (!value) return null;
   return value.replace(/\s+/gu, " ").trim();
@@ -325,31 +352,49 @@ function buildTools(pipelineRoot: string, processes: Process[]): Tool[] {
   const tools = new Map<string, Tool>();
   for (const process of processes) {
     const envPath = join(pipelineRoot, dirname(process.module_path), "environment.yml");
-    const bioconda = existsSync(envPath)
-      ? matchOne(readText(envPath), /-\s*(bioconda::([A-Za-z0-9_.-]+)=([^\s]+))/u)
-      : null;
-    const name = bioconda ? matchOne(bioconda, /bioconda::([A-Za-z0-9_.-]+)=/u) : null;
-    const version = bioconda ? matchOne(bioconda, /=([^\s]+)/u) : null;
-    if (!name || !version) continue;
     const containerStrings = [...(process.container ?? "").matchAll(/'([^']+)'/gu)]
       .map((match) => match[1]!)
       .filter((value) => value.includes(":") || value.includes("/"));
-    tools.set(name, {
-      name,
-      version,
-      biocontainer: containerStrings.find((value) => value.includes("biocontainers/")) ?? null,
-      bioconda,
-      docker: containerStrings.find((value) => !isKnownContainer(value)) ?? null,
-      singularity:
-        containerStrings.find(
-          (value) =>
-            value.includes("depot.galaxyproject.org/singularity") ||
-            value.includes("community-cr-prod.seqera.io"),
-        ) ?? null,
-      wave: containerStrings.find((value) => value.includes("community.wave.seqera.io")) ?? null,
-    });
+    for (const dependency of existsSync(envPath)
+      ? parseBiocondaDependencies(readText(envPath))
+      : []) {
+      tools.set(dependency.name, {
+        name: dependency.name,
+        version: dependency.version,
+        biocontainer: containerStrings.find((value) => value.includes("biocontainers/")) ?? null,
+        bioconda: dependency.spec,
+        docker: containerStrings.find((value) => !isKnownContainer(value)) ?? null,
+        singularity:
+          containerStrings.find(
+            (value) =>
+              value.includes("depot.galaxyproject.org/singularity") ||
+              value.includes("community-cr-prod.seqera.io"),
+          ) ?? null,
+        wave: containerStrings.find((value) => value.includes("community.wave.seqera.io")) ?? null,
+      });
+    }
   }
   return [...tools.values()];
+}
+
+function parseBiocondaDependencies(
+  text: string,
+): { name: string; version: string; spec: string }[] {
+  const data = YAML.parse(text) as { dependencies?: unknown[] } | null;
+  return (data?.dependencies ?? [])
+    .filter((dependency): dependency is string => typeof dependency === "string")
+    .map(parseBiocondaDependency)
+    .filter((dependency): dependency is { name: string; version: string; spec: string } =>
+      Boolean(dependency),
+    );
+}
+
+function parseBiocondaDependency(
+  spec: string,
+): { name: string; version: string; spec: string } | null {
+  const match = /^bioconda::([A-Za-z0-9_.-]+)(?:=([^=\s]+))?/u.exec(spec);
+  if (!match) return null;
+  return { name: match[1]!, version: match[2] ?? "unknown", spec };
 }
 
 function isKnownContainer(value: string): boolean {

--- a/packages/summarize-nextflow/test/integration/cli.test.ts
+++ b/packages/summarize-nextflow/test/integration/cli.test.ts
@@ -117,6 +117,112 @@ profiles { test {} }
       globalThis.fetch = originalFetch;
     }
   });
+
+  itIfBuilt("extracts all bioconda dependencies from module environments", async () => {
+    const root = mkdtempSync(join(os.tmpdir(), "foundry-synthetic-nextflow-"));
+    const moduleDir = join(root, "modules", "local", "align");
+    mkdirSync(moduleDir, { recursive: true });
+    writeFileSync(
+      join(root, "nextflow.config"),
+      `manifest { name = 'nf-core/synthetic' }
+profiles { test {} }
+`,
+    );
+    writeFileSync(
+      join(moduleDir, "main.nf"),
+      `process MINIMAP2_ALIGN {
+  conda "\${moduleDir}/environment.yml"
+  input:
+  path reads
+  output:
+  path "*.bam", emit: bam
+  script:
+  """
+  minimap2 | samtools sort
+  """
+}
+`,
+    );
+    writeFileSync(
+      join(moduleDir, "environment.yml"),
+      `name: synthetic
+dependencies:
+  - bioconda::minimap2=2.24
+  - bioconda::samtools=1.18
+  - bioconda::htslib=1.18
+  - conda-forge::pigz=2.6
+`,
+    );
+
+    const { buildSummary } = (await import("../../dist/index.js")) as {
+      buildSummary: typeof import("../../src/index.js").buildSummary;
+    };
+    const summary = await buildSummary(root, {
+      profile: "test",
+      withNextflow: false,
+      fetchTestData: false,
+      validate: false,
+    });
+    const validation = validateSummary(summary);
+    expect(validation.valid).toBe(true);
+
+    const tools = (summary as { tools: { name: string; version: string; bioconda: string }[] })
+      .tools;
+    expect(tools.map((tool) => tool.name)).toEqual(
+      expect.arrayContaining(["minimap2", "samtools", "htslib"]),
+    );
+    expect(tools.find((tool) => tool.name === "htslib")?.bioconda).toBe("bioconda::htslib=1.18");
+    expect(tools.some((tool) => tool.name === "pigz")).toBe(false);
+  });
+
+  itIfBuilt("extracts process aliases from include statements", async () => {
+    const root = mkdtempSync(join(os.tmpdir(), "foundry-synthetic-nextflow-"));
+    const moduleDir = join(root, "modules", "local", "align");
+    mkdirSync(join(root, "workflows"), { recursive: true });
+    mkdirSync(moduleDir, { recursive: true });
+    writeFileSync(
+      join(root, "nextflow.config"),
+      `manifest { name = 'nf-core/synthetic' }
+profiles { test {} }
+`,
+    );
+    writeFileSync(
+      join(root, "workflows", "synthetic.nf"),
+      `include { MINIMAP2_ALIGN as MINIMAP2_CONSENSUS } from '../modules/local/align'
+include { MINIMAP2_ALIGN as MINIMAP2_POLISH } from '../modules/local/align'
+include { FASTQC } from '../modules/local/fastqc'
+`,
+    );
+    writeFileSync(
+      join(moduleDir, "main.nf"),
+      `process MINIMAP2_ALIGN {
+  output:
+  path "*.paf", emit: paf
+  script:
+  """
+  minimap2
+  """
+}
+`,
+    );
+
+    const { buildSummary } = (await import("../../dist/index.js")) as {
+      buildSummary: typeof import("../../src/index.js").buildSummary;
+    };
+    const summary = await buildSummary(root, {
+      profile: "test",
+      withNextflow: false,
+      fetchTestData: false,
+      validate: false,
+    });
+    const validation = validateSummary(summary);
+    expect(validation.valid).toBe(true);
+
+    const process = (
+      summary as { processes: { name: string; aliases: string[] }[] }
+    ).processes.find((candidate) => candidate.name === "MINIMAP2_ALIGN");
+    expect(process?.aliases).toEqual(["MINIMAP2_CONSENSUS", "MINIMAP2_POLISH"]);
+  });
 });
 
 describe("summarize-nextflow CLI — real pipeline tree (nf-core/demo)", () => {
@@ -232,6 +338,38 @@ describe("summarize-nextflow CLI — real pipeline tree (nf-core/bacass)", () =>
     expect(inputs.find((input) => input.role === "samplesheet")?.url).toBe(
       "https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/bacass/bacass_short.tsv",
     );
+  });
+
+  itIfBacassFixture("extracts multi-dependency bioconda tools from bacass modules", () => {
+    const r = spawnSync("node", [CLI, BACASS_PIPELINE, "--no-with-nextflow", "--no-validate"], {
+      encoding: "utf8",
+    });
+    expect(r.status).toBe(0);
+
+    const data = JSON.parse(r.stdout);
+    const validation = validateSummary(data);
+    expect(validation.valid).toBe(true);
+    expect(data.tools.map((tool: { name: string }) => tool.name)).toEqual(
+      expect.arrayContaining(["samtools", "htslib", "minimap2", "multiqc", "racon"]),
+    );
+    expect(data.tools.find((tool: { name: string }) => tool.name === "htslib")?.bioconda).toMatch(
+      /^bioconda::htslib=/u,
+    );
+  });
+
+  itIfBacassFixture("extracts repeated module aliases from bacass includes", () => {
+    const r = spawnSync("node", [CLI, BACASS_PIPELINE, "--no-with-nextflow", "--no-validate"], {
+      encoding: "utf8",
+    });
+    expect(r.status).toBe(0);
+
+    const data = JSON.parse(r.stdout);
+    const minimap2 = data.processes.find(
+      (process: { name: string }) => process.name === "MINIMAP2_ALIGN",
+    );
+    const fastqc = data.processes.find((process: { name: string }) => process.name === "FASTQC");
+    expect(minimap2.aliases).toEqual(["MINIMAP2_CONSENSUS", "MINIMAP2_POLISH"]);
+    expect(fastqc.aliases).toEqual(["FASTQC_RAW", "FASTQC_TRIM"]);
   });
 });
 


### PR DESCRIPTION
## Summary
- Parse every Bioconda dependency from module `environment.yml` files instead of selecting only the first match.
- Populate `processes[].aliases` from repeated `include { X as Y } from ...` imports across workflow/subworkflow files.
- Add synthetic and real `nf-core/bacass` integration coverage for multi-dependency envs and repeated module aliases.

## Tests
- `npm run packages-build`
- `npm run packages-test`
- `npm run packages-typecheck`
- `npm run packages-format`
- `npm run packages-lint`
- `npm run smoke:summary-nextflow-schema`
- `npm run validate` (passes with existing backlink warnings)