### PR TITLE
add parameter derivation survey

### DIFF
--- a/content/patterns/compose-runtime-text-parameter.md
+++ b/content/patterns/compose-runtime-text-parameter.md
@@ -1,0 +1,113 @@
+---
+type: pattern
+pattern_kind: leaf
+title: "Parameter: compose runtime text parameter"
+aliases:
+  - "compose_text_param"
+  - "dynamic text parameter"
+  - "connected text expression"
+tags:
+  - pattern
+  - target/galaxy
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+summary: "Use compose_text_param to build connected text expressions from constants plus runtime scalar values."
+related_notes:
+  - "[[iwc-parameter-derivation-survey]]"
+related_patterns:
+  - "[[derive-parameter-from-file]]"
+  - "[[map-workflow-enum-to-tool-parameter]]"
+  - "[[tabular-filter-by-column-value]]"
+  - "[[tabular-cut-and-reorder-columns]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+---
+
+# Parameter: compose runtime text parameter
+
+## Tool
+
+Use `toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1` when a downstream tool parameter must be a runtime-built text string rather than a fixed literal.
+
+The tool concatenates ordered components into `out1`, which then connects into text-like downstream parameters such as `cond`, `columnList`, `regions`, `text_input`, or read-group IDs.
+
+## When to reach for it
+
+Use this when constants and runtime values must become one exact string: `c4 >= <threshold>`, `cN,cM`, genomic ranges, read-group IDs, or config lines.
+
+Use it before tools whose target parameter is text but whose value depends on workflow inputs or upstream scalar parameter steps.
+
+Do not use this for enum-to-flag mapping; use [[map-workflow-enum-to-tool-parameter]].
+
+Do not use this for tabular string computation that should remain a dataset column; use [[tabular-compute-new-column]] or a tabular text-processing pattern.
+
+## Operation Boundary
+
+This pattern covers composing a text parameter at workflow runtime from ordered literal and connected scalar pieces.
+
+It does not cover reading scalar values from files, mapping enum values to dialects, row-wise tabular string computation, or custom wrapper authoring.
+
+## Parameters
+
+- `components`: ordered repeat; order is the output string order.
+- `components[].param_type.select_param_type`: observed values include `text`, `integer`, and `float`.
+- Literal text components carry `component_value` as the exact string to insert.
+- Runtime components carry `component_value: { __class__: ConnectedValue }` and have a matching `in:` connection such as `components_1|param_type|component_value`.
+- Output `out1`: connect to the downstream text parameter.
+
+Preserve spaces, commas, prefixes, and comparison operators exactly in literal chunks. The composer does not understand downstream syntax.
+
+## Idiomatic Shapes
+
+Filter predicate:
+
+```text
+"c4 >= " + integer threshold -> Filter1.cond
+```
+
+Dynamic column list:
+
+```text
+"c" + integer + ",c" + integer -> Cut1.columnList
+```
+
+Config line:
+
+```text
+"pull_coord1_rate = " + float -> add_line_to_file.text_input
+```
+
+Region or read-group string:
+
+```text
+runtime start/end text + literal separators or pool suffix -> downstream text parameter
+```
+
+These snippets are conceptual; use the gxformat2 exemplars for exact serialized shapes.
+
+## Pitfalls
+
+- Component order is semantic. Reordering components without matching connections changes the generated string.
+- Literal whitespace matters. Leading and trailing spaces in config-line chunks are meaningful.
+- There is no downstream syntax validation. `compose_text_param` can build an invalid `Filter1.cond`, invalid `Cut1.columnList`, or invalid genomic range.
+- Connected text is not a dataset. Connect `out1` to a tool parameter, not a dataset input.
+- Do not replace [[map-workflow-enum-to-tool-parameter]]. If the operation is mapping `stranded` to a flag or snippet, map first; compose only when the final task is concatenation.
+- Do not confuse row-wise string construction with runtime parameter composition. If each input row needs a computed string, use tabular tools.
+
+## Exemplars (IWC)
+
+- `$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:102-128`, `$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:318-336` — composes `c4 >= ` plus a workflow integer input, then connects `out1` to `Filter1.cond`.
+- `$IWC_FORMAT2/data-fetching/sra-manifest-to-concatenated-fastqs/sra-manifest-to-concatenated-fastqs.gxwf.yml:61-113` — composes `c<id>,c<id>` and connects it to `Cut1.columnList`.
+- `$IWC_FORMAT2/computational-chemistry/gromacs-dctmd/gromacs-dctmd.gxwf.yml:553-654`, `$IWC_FORMAT2/computational-chemistry/gromacs-dctmd/gromacs-dctmd.gxwf.yml:720-999` — composes GROMACS config lines from float/integer parameters and feeds them into `add_line_to_file.text_input`.
+- `$IWC_FORMAT2/virology/pox-virus-amplicon/pox-virus-half-genome.gxwf.yml:560-669`, `$IWC_FORMAT2/virology/pox-virus-amplicon/pox-virus-half-genome.gxwf.yml:680-819` — composes genomic ranges and pool suffix strings for EMBOSS `regions` and BWA read-group IDs.
+
+## See Also
+
+- [[iwc-parameter-derivation-survey]] — Candidate E decision record.
+- [[derive-parameter-from-file]] — when runtime scalar values start as one-value datasets.
+- [[map-workflow-enum-to-tool-parameter]] — when a workflow-facing enum must become a downstream dialect.
+- [[tabular-filter-by-column-value]] — common downstream consumer via `Filter1.cond`.
+- [[tabular-cut-and-reorder-columns]] — common downstream consumer via `Cut1.columnList`.

--- a/content/patterns/conditional-gate-on-nonempty-result.md
+++ b/content/patterns/conditional-gate-on-nonempty-result.md
@@ -12,11 +12,12 @@ tags:
 status: draft
 created: 2026-05-02
 revised: 2026-05-02
-revision: 1
+revision: 2
 ai_generated: true
 summary: "Derive a boolean from empty or non-empty data, then use when to skip reporting or export steps."
 related_notes:
   - "[[iwc-conditionals-survey]]"
+  - "[[iwc-parameter-derivation-survey]]"
 related_patterns:
   - "[[conditional-run-optional-step]]"
   - "[[conditional-route-between-alternative-outputs]]"
@@ -77,6 +78,14 @@ Authoring-relevant fields:
 - collection boolean shim: count identifiers and convert `count != 0` to boolean;
 - text-like dataset content shim: map empty text to `false` and non-empty text to `true`.
 
+## Boolean Derivation Mechanics
+
+For collections, the observed IWC recipe is explicit: extract collection element identifiers, count those identifier lines, compute `c1 != 0`, then read that one-cell result as a boolean parameter.
+
+In MGnify, the embedded subworkflow labeled `Map empty/not empty collection to boolean` uses `collection_element_identifiers`, `wc_gnu` with `options: [lines]`, `column_maker` with `ops.header_lines_select: no` and `cond: c1 != 0`, then `param_value_from_file` with `param_type: boolean` and `remove_newlines: true`.
+
+For text-like datasets, the VGP Hi-C workflow reads the dataset with `param_value_from_file` as `text`, then maps `"" -> false` with `map_param_value`; unmapped non-empty text defaults to `true`.
+
 Observed MGnify collection recipe:
 
 ```text
@@ -129,7 +138,7 @@ These snippets are summaries of observed IWC shapes. Do not simplify the MGnify 
 - `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction.gxwf.yml:1358-1483` — embedded subworkflow labeled `Map empty/not empty collection to boolean`; uses `collection_element_identifiers -> wc_gnu -> column_maker -> param_value_from_file`.
 - `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction.gxwf.yml:1330-1357` — boolean gates Krona output generation.
 - `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction.gxwf.yml:1484-1659` — same boolean gates BIOM conversion/export steps.
-- `$IWC_FORMAT2/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation.gxwf.yml:3057-3218`, `$IWC_FORMAT2/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation.gxwf.yml:3289-3346` — text-like dataset-content variant: telomere BED text is mapped to a boolean before gating Pretext graph steps.
+- `$IWC_FORMAT2/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation.gxwf.yml:3057-3218`, `$IWC_FORMAT2/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation.gxwf.yml:3289-3346`, `$IWC_FORMAT2/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation.gxwf.yml:3458-3510` — text-like dataset-content variant: telomere BED text is mapped to a boolean before gating Pretext graph steps.
 
 ## Verification TODO
 
@@ -142,6 +151,7 @@ Issue: <https://github.com/jmchilton/foundry/issues/84>.
 ## See Also
 
 - [[iwc-conditionals-survey]] — Candidate C decision record and verification TODO.
+- [[iwc-parameter-derivation-survey]] — parameter-derivation survey that merges non-empty boolean mechanics into this page.
 - [[galaxy-conditionals-patterns]] — conditionals MOC.
 - [[conditional-run-optional-step]] — primitive `when:` branch for user booleans.
 - [[conditional-route-between-alternative-outputs]] — route alternatives and merge with `pick_value`.

--- a/content/patterns/conditional-route-between-alternative-outputs.md
+++ b/content/patterns/conditional-route-between-alternative-outputs.md
@@ -12,11 +12,12 @@ tags:
 status: draft
 created: 2026-05-02
 revised: 2026-05-02
-revision: 1
+revision: 2
 ai_generated: true
 summary: "Use when-gated alternatives plus pick_value to merge binary or one-of-N routes into one downstream value."
 related_notes:
   - "[[iwc-conditionals-survey]]"
+  - "[[iwc-parameter-derivation-survey]]"
 related_patterns:
   - "[[conditional-run-optional-step]]"
   - "[[conditional-transform-or-pass-through]]"
@@ -73,6 +74,12 @@ On the merge step:
 - connect all downstream consumers to the `pick_value` output.
 
 If authoring inverse or mode booleans, use a small mapper step such as `map_param_value` rather than duplicating branch logic inside downstream tools.
+
+For mapped route booleans, use `map_param_value` as a graph-visible normalization step before the gated alternatives.
+
+Binary inverse route: map the direct user boolean to its opposite for the second branch, then gate one branch from the original boolean and the other from `map_param_value/output_param_boolean`.
+
+One-of-N route: create one `map_param_value` step per mode. Each mapper turns one selected enum/text value into `true` and uses `unmapped.default_value: false`; each branch consumes its own boolean as `inputs.when`.
 
 ## Idiomatic Shapes
 
@@ -137,6 +144,7 @@ These snippets are conceptual. Use the cited gxformat2 exemplars for exact seria
 - Non-exclusive booleans. If two branches can run at once, `pick_value` chooses by input order. That may hide an upstream routing bug.
 - Mismatched output semantics. `pick_value` can merge present values, but it does not make incompatible outputs equivalent. Branches should produce the same logical artifact.
 - Hiding the route in one wrapper. IWC evidence favors graph-visible `when` branches plus merge for these route operations.
+- Duplicating enum comparisons inside every downstream tool. Normalize once with `map_param_value`, then connect the resulting boolean to `id: when`.
 - Confusing route merge with collection cleanup. `__FILTER_EMPTY_DATASETS__` and `__FILTER_FAILED_DATASETS__` clean mapped collection elements; they are not the observed IWC mechanism for one-of-N conditional routing.
 
 ## Exemplars (IWC)
@@ -144,10 +152,13 @@ These snippets are conceptual. Use the cited gxformat2 exemplars for exact seria
 - `$IWC_FORMAT2/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy.gxwf.yml:180-211`, `$IWC_FORMAT2/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy.gxwf.yml:337-399` — binary 10x import route: legacy vs v3 `anndata_import`, then `pick_value` selects the present AnnData output.
 - `$IWC_FORMAT2/genome_annotation/functional-annotation/functional-annotation-of-sequences/Functional_annotation_of_sequences.gxwf.yml:244-395`, `$IWC_FORMAT2/genome_annotation/functional-annotation/functional-annotation-of-sequences/Functional_annotation_of_sequences.gxwf.yml:396-429` — one-of-N eggNOG mapper mode fan-out, then `pick_value` collapses the selected annotation output.
 - `$IWC_FORMAT2/microbiome/mags-building/MAGs-generation.gxwf.yml:295-410`, `$IWC_FORMAT2/microbiome/mags-building/MAGs-generation.gxwf.yml:411-439` — alternative assembly route including an embedded subworkflow branch, then `pick_value` chooses among individual, co-assembly, or custom assemblies.
+- `$IWC_FORMAT2/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy.gxwf.yml:173-241` — binary route uses direct boolean for one branch and `map_param_value` inversion for the other.
+- `$IWC_FORMAT2/genome_annotation/functional-annotation/functional-annotation-of-sequences/Functional_annotation_of_sequences.gxwf.yml:55-195` — one enum input maps into one boolean per eggNOG mode before the gated branches.
 
 ## See Also
 
 - [[iwc-conditionals-survey]] — Candidate B evidence and conditionals boundary decisions.
+- [[iwc-parameter-derivation-survey]] — boundary between conditional boolean mapping and tool-parameter mapping.
 - [[galaxy-conditionals-patterns]] — conditionals MOC.
 - [[conditional-run-optional-step]] — direct boolean gate with no required merge.
 - [[conditional-gate-on-nonempty-result]] — derive boolean from empty/non-empty result, then gate reporting/export.

--- a/content/patterns/conditional-run-optional-step.md
+++ b/content/patterns/conditional-run-optional-step.md
@@ -12,11 +12,12 @@ tags:
 status: draft
 created: 2026-05-02
 revised: 2026-05-02
-revision: 1
+revision: 2
 ai_generated: true
 summary: "Use a workflow boolean connected as inputs.when to skip an optional Galaxy step or branch."
 related_notes:
   - "[[iwc-conditionals-survey]]"
+  - "[[iwc-parameter-derivation-survey]]"
 related_patterns:
   - "[[conditional-route-between-alternative-outputs]]"
   - "[[conditional-gate-on-nonempty-result]]"
@@ -55,6 +56,10 @@ Do not use this for data-derived emptiness checks unless you first compute a boo
 - Step gate: set `when: $(inputs.when)` on every step that belongs to the optional branch.
 
 For a multi-step optional branch, repeat the same boolean connection and `when:` expression on each gated step. Do not rely on one upstream gated step to implicitly suppress every downstream consumer; make the branch boundary explicit.
+
+The `when` source does not have to be a raw workflow boolean. If the workflow-facing input is an enum, integer, text value, or inverted boolean, normalize it first with `map_param_value` and connect `output_param_boolean` as `id: when`.
+
+If multiple mapped booleans select among peer alternatives and downstream needs one merged output, use [[conditional-route-between-alternative-outputs]] instead.
 
 ## Idiomatic Shapes
 
@@ -109,6 +114,7 @@ The second shape is conceptual, derived from the VGP Hi-C suffixing branch. The 
 - Gating only the first step of a branch. If later optional steps should also disappear, put `when:` on those steps too.
 - Consuming a missing optional output unconditionally. If downstream requires a value regardless of the boolean, add an explicit merge/fallback with `pick_value`.
 - Confusing user choice with data-derived choice. Empty/non-empty result checks need a separate boolean-producing shim before `when:`.
+- Duplicating normalization logic inside optional tools. If the gate depends on a derived boolean, compute it once and connect that boolean as `id: when`.
 - Leading with `__FILTER_NULL__` as conditional cleanup. The survey found zero `__FILTER_NULL__` hits in `$IWC_FORMAT2`; keep it as catalog knowledge, not the corpus-backed authoring path.
 
 ## Exemplars (IWC)
@@ -118,10 +124,12 @@ The second shape is conceptual, derived from the VGP Hi-C suffixing branch. The 
 - `$IWC_FORMAT2/transcriptomics/rnaseq-pe/rnaseq-pe.gxwf.yml:1082-1140` — RNA-seq gates the optional StringTie FPKM branch with `Compute StringTie FPKM`.
 - `$IWC_FORMAT2/transcriptomics/rnaseq-pe/rnaseq-pe.gxwf.yml:1141-1214` — RNA-seq gates the optional Cufflinks FPKM branch separately with `Compute Cufflinks FPKM`.
 - `$IWC_FORMAT2/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation.gxwf.yml:338-459` — VGP Hi-C gates a multi-step suffixing branch with a user boolean; downstream fallback uses `pick_value`, marking the boundary with [[conditional-transform-or-pass-through]].
+- `$IWC_FORMAT2/VGP-assembly-v2/Assembly-decontamination-VGP9/Assembly-decontamination-VGP9.gxwf.yml:205-305` — integer-derived value is normalized with `map_param_value`, then the boolean gates optional filtering steps.
 
 ## See Also
 
 - [[iwc-conditionals-survey]] — Candidate A decision and boundaries with route/non-empty candidates.
+- [[iwc-parameter-derivation-survey]] — parameter survey boundary for mapped booleans.
 - [[galaxy-conditionals-patterns]] — conditionals MOC.
 - [[conditional-route-between-alternative-outputs]] — mutually exclusive branches merged by `pick_value`.
 - [[conditional-gate-on-nonempty-result]] — booleans computed from dataset or collection emptiness.

--- a/content/patterns/derive-parameter-from-file.md
+++ b/content/patterns/derive-parameter-from-file.md
@@ -1,0 +1,151 @@
+---
+type: pattern
+pattern_kind: leaf
+title: "Parameter: derive from file"
+aliases:
+  - "file-to-parameter bridge"
+  - "read scalar parameter from file"
+  - "count-to-parameter"
+  - "derive-count-parameter-from-file-or-collection"
+tags:
+  - pattern
+  - target/galaxy
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+summary: "Read a one-value dataset with param_value_from_file, including count recipes that feed typed parameters."
+related_notes:
+  - "[[iwc-parameter-derivation-survey]]"
+related_patterns:
+  - "[[conditional-gate-on-nonempty-result]]"
+  - "[[tabular-compute-new-column]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+---
+
+# Parameter: derive from file
+
+## Tool
+
+Use `param_value_from_file` when an upstream dataset contains exactly one scalar value that must become a connected Galaxy runtime parameter.
+
+The corpus-backed shape is:
+
+```text
+dataset -> param_value_from_file -> downstream tool parameter
+```
+
+`param_type` selects the typed output port: `integer_param`, `float_param`, `text_param`, or `boolean_param`. In the observed scalar-read examples, `remove_newlines: true` is the normal setting.
+
+## When to reach for it
+
+Use this when a workflow computes or receives a small file containing one value, and a downstream tool needs that value as a typed parameter rather than as a dataset input.
+
+Good fits include computed genome sizes, coverage estimates, minimum counts, repeat counts, line counts, file-derived text, and boolean shims.
+
+Do not use this for ordinary tabular transformations whose output remains a dataset; use tabular patterns such as [[tabular-compute-new-column]].
+
+Do not use this for dynamic expression strings built directly from parameters; use [[compose-runtime-text-parameter]].
+
+Do not center non-empty gating here. If the user story is "skip downstream work when empty," use [[conditional-gate-on-nonempty-result]].
+
+## Operation Boundary
+
+This pattern covers file-to-parameter bridging:
+
+- input fact: a dataset contains one scalar value, or an upstream count recipe produces one scalar value;
+- output action: expose that scalar as a Galaxy typed runtime parameter port;
+- bridge mechanism: `param_value_from_file`.
+
+It covers file-to-integer, file-to-float, file-to-text, file-to-boolean, count-to-integer, and collection-size-to-boolean when explaining the bridge.
+
+It does not cover enum mapping, runtime text composition, branch topology after a boolean exists, general column computation, or collection cleanup.
+
+## Parameters
+
+- `input1`: connected scalar dataset.
+- `param_type`: set to `integer`, `float`, `text`, or `boolean`; downstream steps must connect the matching typed output port.
+- `remove_newlines`: set `true` for one-value files unless the downstream text parameter explicitly needs line breaks.
+
+Changing `param_type` changes which output port is meaningful. A generated workflow must connect `integer_param` to integer inputs, `float_param` to float inputs, and so on.
+
+## Count, Then Parameterize
+
+Use `wc_gnu` with `options: [lines]` when a line count must drive a downstream integer parameter. For collections, first expose element identifiers with `collection_element_identifiers`, then count those identifier rows.
+
+The reusable operation is still "produce a scalar file, then parameterize it":
+
+```text
+dataset -> wc_gnu(options: [lines]) -> param_value_from_file(param_type: integer)
+```
+
+For collection non-empty booleans, the corpus adds a tabular boolean step:
+
+```text
+collection -> collection_element_identifiers -> wc_gnu -> column_maker(c1 != 0) -> param_value_from_file(param_type: boolean)
+```
+
+That final shape belongs operationally to [[conditional-gate-on-nonempty-result]] when it feeds `when`.
+
+## Tabular Scalar Round Trip
+
+Some workflows compute one value in tabular-land, then escape back to parameter-land. Consensus peaks uses `table_compute` to get a minimum value, then reads that value back with `param_value_from_file`. MGnify uses `column_maker` only to turn a count into `c1 != 0` before reading the result as a boolean.
+
+Keep the tabular mechanics on the tabular page. This page owns the escape hatch from one-value dataset to typed parameter.
+
+## Idiomatic Shapes
+
+Conceptual scalar read:
+
+```yaml
+tool_id: param_value_from_file
+in:
+  - id: input1
+    source: upstream_scalar_file
+out:
+  - id: integer_param
+tool_state:
+  input1:
+    __class__: ConnectedValue
+  param_type: integer
+  remove_newlines: true
+```
+
+Conceptual count-to-integer:
+
+```text
+dataset -> wc_gnu(options: [lines]) -> param_value_from_file(param_type: integer)
+```
+
+Conceptual collection non-empty boolean:
+
+```text
+collection -> collection_element_identifiers -> wc_gnu -> column_maker(c1 != 0) -> param_value_from_file(param_type: boolean)
+```
+
+## Pitfalls
+
+- Do not connect the dataset output when the downstream tool expects a typed parameter port.
+- Do not connect the wrong typed output port after changing `param_type`.
+- Do not leave newlines in one-value scalar files unless downstream text syntax requires them.
+- Do not treat `wc_gnu` output as numeric until `param_value_from_file` converts it.
+- Do not bury the operation under `wc_gnu`; counts are just one upstream scalar-producing recipe.
+- Do not duplicate [[conditional-gate-on-nonempty-result]]. If the user story is "skip when empty," the conditional page owns the recommendation.
+- Do not present MGnify's four-step boolean shim as best. It is corpus-backed but clunky and pending verified-pattern issue #84.
+
+## Exemplars (IWC)
+
+- `$IWC_FORMAT2/VGP-assembly-v2/kmer-profiling-hifi-VGP1/kmer-profiling-hifi-VGP1.gxwf.yml:1022-1038` — reads homozygous read coverage as `float_param`.
+- `$IWC_FORMAT2/VGP-assembly-v2/kmer-profiling-hifi-VGP1/kmer-profiling-hifi-VGP1.gxwf.yml:1042-1088` — reads estimated genome size as `integer_param` and connects it to `rdeval.expected_gsize`.
+- `$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:263-318`, `$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:372-423`, `$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:467-499` — table minimum and replicate count are converted through text/integer parameter ports before downstream subsampling.
+- `$IWC_FORMAT2/virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping.gxwf.yml:198-287`, `$IWC_FORMAT2/virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping.gxwf.yml:287-346` — line counts become integer parameters used as collection duplication counts.
+- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction.gxwf.yml:1358-1463` — collection identifiers are counted, converted with `column_maker(c1 != 0)`, then read as `boolean_param`.
+
+## See Also
+
+- [[iwc-parameter-derivation-survey]] — Candidate A/B decision record.
+- [[conditional-gate-on-nonempty-result]] — when a derived boolean feeds `when`.
+- [[tabular-compute-new-column]] — when the main operation is tabular computation, not file-to-parameter bridging.
+- [[compose-runtime-text-parameter]] — when the goal is to build a text parameter from runtime pieces.

--- a/content/patterns/map-workflow-enum-to-tool-parameter.md
+++ b/content/patterns/map-workflow-enum-to-tool-parameter.md
@@ -1,0 +1,129 @@
+---
+type: pattern
+pattern_kind: leaf
+title: "Parameter: map workflow enum to tool parameter"
+aliases:
+  - "map_param_value"
+  - "enum-to-tool-dialect mapping"
+  - "workflow enum normalization"
+tags:
+  - pattern
+  - target/galaxy
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+summary: "Use map_param_value to translate workflow enum values into downstream tool codes, flags, or snippets."
+related_notes:
+  - "[[iwc-parameter-derivation-survey]]"
+related_patterns:
+  - "[[conditional-route-between-alternative-outputs]]"
+  - "[[conditional-run-optional-step]]"
+  - "[[compose-runtime-text-parameter]]"
+  - "[[tabular-compute-new-column]]"
+  - "[[tabular-split-taxonomy-string]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+---
+
+# Parameter: map workflow enum to tool parameter
+
+## Tool
+
+Use `toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0` when a workflow input uses a human-facing enum or label, but downstream tools require exact codes, flags, snippets, or naming fragments.
+
+The corpus-backed shape is:
+
+```text
+workflow enum/string -> map_param_value -> downstream tool parameter
+```
+
+## When to reach for it
+
+Use this when one logical workflow option must feed multiple downstream tools with different parameter vocabularies.
+
+Good fits include strandedness codes, tool flags, suffix abbreviations, and snippets selected from an enum.
+
+Do not use this page for `when` gate booleans. If the mapped output controls branch topology, use [[conditional-route-between-alternative-outputs]] or [[conditional-run-optional-step]].
+
+Do not use this for arithmetic or row-wise computation; use tabular patterns such as [[tabular-compute-new-column]].
+
+If the mapped value becomes one component inside a larger expression string, this page covers the enum-to-fragment step; [[compose-runtime-text-parameter]] covers the concatenation.
+
+## Operation Boundary
+
+This pattern covers parameter dialect normalization:
+
+- input fact: a workflow-facing value is readable to users;
+- output action: a downstream tool receives the exact dialect it expects;
+- mapping mechanism: `map_param_value`.
+
+It does not cover enum-to-boolean route selection, direct optional gates, tabular row computation, or runtime string assembly from multiple pieces.
+
+## Parameters
+
+- `input_param_type.type`: usually `text` for enum/string values.
+- `input_param_type.input_param`: connected upstream workflow value.
+- `input_param_type.mappings`: list of `{from, to}` pairs.
+- `output_param_type`: usually `text` for tool dialects and snippets.
+- `unmapped.on_unmapped`: prefer `fail` for closed enums and exact downstream dialects.
+
+`on_unmapped: input` can intentionally pass through labels, but it can also leak a human-facing label into a strict tool parameter. Use it only when passthrough is deliberate.
+
+## Idiomatic Shapes
+
+RNA-seq strandedness mapped to `featureCounts` codes:
+
+```yaml
+tool_id: toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0
+in:
+  - id: input_param_type|input_param
+    source: Strandedness
+out:
+  - id: output_param_text
+    hide: true
+tool_state:
+  input_param_type:
+    type: text
+    input_param:
+      __class__: ConnectedValue
+    mappings:
+      - from: stranded - forward
+        to: "1"
+      - from: stranded - reverse
+        to: "2"
+      - from: unstranded
+        to: "0"
+  output_param_type: text
+  unmapped:
+    on_unmapped: fail
+```
+
+The same workflow enum maps through sibling `map_param_value` steps into Cufflinks library types and StringTie flags. Keep those as separate mapper steps because the downstream dialects are incompatible.
+
+## Pitfalls
+
+- Do not duplicate enum comparisons inside every downstream tool. Normalize once with `map_param_value`, then connect the resulting typed parameter.
+- Do not use this page as the main reference for booleans that feed `when`; that is conditional routing.
+- Do not drop empty string mappings as missing. StringTie maps `unstranded` to `""`, which is meaningful.
+- Do not silently change quoted numeric codes into numeric output types unless the downstream parameter expects a numeric type.
+- Do not use one mapper output for incompatible tool dialects. One workflow value may need several mapper steps.
+- Treat long generated snippets as brittle. The taxonomy awk examples prove the mechanism, but a clearer wrapper or smaller expression is easier to maintain when available.
+
+## Exemplars (IWC)
+
+- `$IWC_FORMAT2/transcriptomics/rnaseq-pe/rnaseq-pe.gxwf.yml:270-299` — `Strandedness` to `featureCounts` codes `1`, `2`, `0` with `unmapped.on_unmapped: fail`.
+- `$IWC_FORMAT2/transcriptomics/rnaseq-pe/rnaseq-pe.gxwf.yml:303-332` — same workflow enum mapped to Cufflinks library types `fr-secondstrand`, `fr-firststrand`, `fr-unstranded`.
+- `$IWC_FORMAT2/transcriptomics/rnaseq-pe/rnaseq-pe.gxwf.yml:336-365` — same workflow enum mapped to StringTie flags `--fr`, `--rf`, and empty string.
+- `$IWC_FORMAT2/transcriptomics/rnaseq-pe/rnaseq-pe.gxwf.yml:1017-1081`, `$IWC_FORMAT2/transcriptomics/rnaseq-pe/rnaseq-pe.gxwf.yml:1082-1140`, `$IWC_FORMAT2/transcriptomics/rnaseq-pe/rnaseq-pe.gxwf.yml:1141-1152` — mapped outputs connected into `featureCounts`, StringTie, and Cufflinks parameters.
+- `$IWC_FORMAT2/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8.gxwf.yml:276-313`, `$IWC_FORMAT2/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8.gxwf.yml:1497-1522` — haplotype labels mapped to suffix abbreviations, then consumed by `compose_text_param`.
+- `$IWC_FORMAT2/amplicon/amplicon-mgnify/taxonomic-rank-abundance-summary-table/taxonomic-rank-abundance-summary-table.gxwf.yml:35-72`, `$IWC_FORMAT2/amplicon/amplicon-mgnify/taxonomic-rank-abundance-summary-table/taxonomic-rank-abundance-summary-table.gxwf.yml:118-139` — taxonomic rank mapped to awk program text and connected as `tp_awk_tool.code`.
+
+## See Also
+
+- [[iwc-parameter-derivation-survey]] — Candidate D decision record.
+- [[conditional-route-between-alternative-outputs]] — boundary for enum/boolean mapping used to select graph branches.
+- [[conditional-run-optional-step]] — boundary for simple `when` gating.
+- [[compose-runtime-text-parameter]] — when mapped fragments must be assembled into a larger string.
+- [[tabular-compute-new-column]] — row-wise computation in dataset-land.

--- a/content/patterns/tabular-compute-new-column.md
+++ b/content/patterns/tabular-compute-new-column.md
@@ -7,15 +7,17 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-04-30
-revision: 1
+revised: 2026-05-02
+revision: 2
 ai_generated: true
 summary: "Use column_maker (Add_a_column1) with strict error_handling to insert/replace a computed column. Per-expression-kind auto_col_types rule."
 related_notes:
   - "[[iwc-tabular-operations-survey]]"
+  - "[[iwc-parameter-derivation-survey]]"
 related_patterns:
   - "[[tabular-cut-and-reorder-columns]]"
   - "[[tabular-sql-query]]"
+  - "[[derive-parameter-from-file]]"
 related_molds:
   - "[[implement-galaxy-tool-step]]"
 ---
@@ -31,6 +33,8 @@ related_molds:
 Insert, replace, or append a column whose value is a Python expression over the existing `cN` columns. Multiple expressions can be sequenced inside a single tool step (each one operates on the running output of the previous). Use this for arithmetic, simple type coercion, and string concatenation.
 
 If the row decision needs a multi-line conditional or `split`/`gsub`, prefer awk (see the awk recipe sub-pages cross-referenced from [[iwc-tabular-operations-survey]]). If columns and a row predicate are computed together, prefer [[tabular-sql-query]].
+
+If the computed table value is only an intermediate scalar or boolean that will be read back with `param_value_from_file`, keep the `column_maker` mechanics here but follow [[derive-parameter-from-file]] or [[conditional-gate-on-nonempty-result]] downstream. MGnify uses this shape for `c1 != 0` before reading the result as a boolean.
 
 ## Parameters
 
@@ -147,6 +151,7 @@ Cited at `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting
 - `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:307-329` — raw-`cN` arithmetic, `auto_col_types: true`, insert + replace pair.
 - `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:438-475` — string concat, `auto_col_types: false`, append (`mode: ""`).
 - `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation.gxwf.yml:343-378` — explicit-cast arithmetic (`int(c2) - …`), `auto_col_types: false`, `--skip-non-computable`. Counter-example to "arithmetic always implies `auto_col_types: true`."
+- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction.gxwf.yml:1396-1463` — computes `c1 != 0`, then reads the result as a boolean parameter for a non-empty gate.
 
 ## Legacy alternative
 
@@ -155,5 +160,7 @@ Cited at `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting
 ## See also
 
 - [[iwc-tabular-operations-survey]] — corpus survey, §7 decision record for the `auto_col_types` rule.
+- [[iwc-parameter-derivation-survey]] — compute-then-parameterize seam.
 - [[tabular-cut-and-reorder-columns]] — pure column projection without computation.
 - [[tabular-sql-query]] — when project + compute + filter need to fuse.
+- [[derive-parameter-from-file]] — when a one-value dataset must become a typed runtime parameter.

--- a/content/research/iwc-parameter-derivation-survey.md
+++ b/content/research/iwc-parameter-derivation-survey.md
@@ -1,0 +1,255 @@
+---
+type: research
+subtype: component
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+related_notes:
+  - "[[iwc-conditionals-survey]]"
+  - "[[iwc-tabular-operations-survey]]"
+  - "[[iwc-transformations-survey]]"
+related_patterns:
+  - "[[conditional-gate-on-nonempty-result]]"
+  - "[[conditional-route-between-alternative-outputs]]"
+  - "[[tabular-filter-by-column-value]]"
+  - "[[tabular-compute-new-column]]"
+  - "[[tabular-cut-and-reorder-columns]]"
+  - "[[tabular-split-taxonomy-string]]"
+sources:
+  - "https://github.com/jmchilton/foundry/issues/89"
+summary: "Corpus survey of Galaxy workflow recipes that turn upstream data, metadata, or small files into runtime parameters."
+---
+
+# IWC parameter derivation survey
+
+Source corpus: 120 cleaned `gxformat2` workflows under `$IWC_FORMAT2/`, materialized in `workflow-fixtures/iwc-format2/` from pinned IWC commit `deafc4876f2c778aaf075e48bd8e95f3604ccc92`. Counts below are parsed step counts over top-level and embedded subworkflow `steps`, excluding trailing `unique_tools` summaries. Citations use `$IWC_FORMAT2/path:line`.
+
+Scope: workflow steps that derive a Galaxy runtime parameter from upstream data, metadata, or a small intermediate file. This is the shim layer between ordinary data transforms and tools whose inputs are typed as `integer_param`, `float_param`, `text_param`, `boolean_param`, or connected expression strings.
+
+Out of scope:
+
+- Pure row/column transformations whose output remains a dataset; covered by [[iwc-tabular-operations-survey]].
+- Pure collection structure work; covered by [[iwc-transformations-survey]].
+- Conditional graph topology after a boolean already exists; covered by [[iwc-conditionals-survey]].
+
+## 1. Tool inventory
+
+| Tool / family | Parsed steps | Workflow files | Main role |
+|---|---:|---:|---|
+| `compose_text_param` | 63 | 30 | Build connected text expressions, filters, labels, command fragments, and region strings |
+| `param_value_from_file` | 50 | 26 | Read a scalar from a dataset into a typed runtime parameter |
+| `map_param_value` | 26 | 14 | Map booleans/enums/text/integer values into booleans, tool flags, enum codes, or generated snippets |
+| `pick_value` | 49 | 16 | Choose first present value or provide defaults; adjacent but usually conditional/defaulting rather than derivation |
+| `column_maker` / `Add_a_column1` | 20 | 13 | Compute values in tabular-land; only a parameter-derivation shim when immediately followed by `param_value_from_file` |
+| `collection_element_identifiers` | 18 | 12 | Expose collection metadata as lines; feeds counts, relabels, filters, or other collection recipes |
+| `wc_gnu` | 8 | 5 | Count lines or characters when its output is later consumed as a parameter |
+
+The grep surface is larger because `unique_tools` repeats tool IDs and some surveys count those summaries. The parsed count above is better for authored step shapes.
+
+## 2. Observed derivation classes
+
+### 2a. Dataset scalar to typed parameter
+
+`param_value_from_file` is the central bridge from file-land to parameter-land. The pattern is: some upstream step writes one scalar into a tiny dataset, then `param_value_from_file` reads it as `integer`, `float`, `text`, or `boolean` with `remove_newlines: true`.
+
+Examples:
+
+- VGP assembly workflows read computed genome-size and coverage files into integer/float parameters for downstream assembly tools. Examples include estimated genome size and read coverage in `$IWC_FORMAT2/VGP-assembly-v2/kmer-profiling-hifi-VGP1/kmer-profiling-hifi-VGP1.gxwf.yml` and related VGP workflows, with repeated `param_value_from_file` steps concentrated in the VGP family.
+- Consensus peak workflows compute a minimum read count table, convert it to text, replicate it into a small collection, split it, and read each scalar back as an integer parameter for `samtools_view` subsampling (`$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:372-410`, `$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:410-499`). The same recipe appears in `consensus-peaks-chip-pe` and `consensus-peaks-chip-sr`.
+- Influenza counts forward and reverse collection elements with `wc_gnu`, then converts those counts to integer parameters before duplicating files into collections (`$IWC_FORMAT2/virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping.gxwf.yml:198-287`).
+- VGP Hi-C reads telomere BED contents as text, then maps empty text to `false` and non-empty text to `true` for gating Pretext tracks (`$IWC_FORMAT2/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation.gxwf.yml:3057-3218`).
+
+This bridge is generic. The upstream calculation is domain-specific, but the final scalar-read step is reusable and easy to get wrong because downstream tools need the typed output port, not the dataset.
+
+### 2b. Count file or collection shape, then parameterize
+
+The tightest recurring numeric recipe is `wc_gnu -> param_value_from_file`. The count may be a line count, a character count, or an element-count proxy after `collection_element_identifiers`.
+
+Examples:
+
+- Consensus peaks count the number of replicate rows with `wc_gnu`, read the count as an integer parameter, and use it as the repeat count for generating a per-replicate scalar dataset (`$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:299-318`, `$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:392-423`).
+- Influenza counts lines in two upstream files and reads both counts as integer parameters (`$IWC_FORMAT2/virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping.gxwf.yml:198-287`).
+- HyPhy counts characters in a cleaned regular expression with `wc_gnu` (`options: [characters]`) before downstream checks (`$IWC_FORMAT2/comparative_genomics/hyphy/capheine-core-and-compare.gxwf.yml:754-769`). This is a thinner signal than line-count-to-integer, but it shows the same "measure a file, then branch or parameterize" posture.
+
+For collections, the count step often starts from `collection_element_identifiers`. The MGnify embedded subworkflow extracts element identifiers, counts lines, computes `c1 != 0` with `column_maker`, and reads the result as a boolean parameter (`$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction.gxwf.yml:1358-1483`). That recipe is already the strongest evidence for [[conditional-gate-on-nonempty-result]].
+
+### 2c. Map enum or boolean inputs to tool-specific parameter values
+
+`map_param_value` appears in two broad forms.
+
+The first is graph-control or boolean normalization: invert a boolean, map one enum member to `true`, or turn empty/non-empty text into a boolean. This mostly belongs to the conditional pattern family.
+
+Examples:
+
+- Scanpy inverts a user boolean so legacy 10x and 10x v3 import branches can be mutually exclusive, then `pick_value` selects the available AnnData output (`$IWC_FORMAT2/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy.gxwf.yml:173-241`, `$IWC_FORMAT2/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy.gxwf.yml:337-404`).
+- Functional annotation maps `Selected sequence type` to one boolean per eggNOG mode, gates four mutually exclusive branches, then selects the available outputs (`$IWC_FORMAT2/genome_annotation/functional-annotation/functional-annotation-of-sequences/Functional_annotation_of_sequences.gxwf.yml:90-239`, `$IWC_FORMAT2/genome_annotation/functional-annotation/functional-annotation-of-sequences/Functional_annotation_of_sequences.gxwf.yml:240-429`).
+- VGP Hi-C maps empty text from telomere BED files to `false` and unmapped non-empty text to `true` (`$IWC_FORMAT2/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation.gxwf.yml:3057-3218`).
+
+The second form is tool-parameter normalization: map one workflow-facing enum into the exact flag/code/snippet needed by a downstream tool.
+
+Examples:
+
+- RNA-seq maps `Strandedness` into separate parameter dialects for `featureCounts`, Cufflinks, StringTie, replacement regexes, and STAR-count awk (`$IWC_FORMAT2/transcriptomics/rnaseq-pe/rnaseq-pe.gxwf.yml:270-369`; more mappings continue later in the same workflow and are mirrored in `rnaseq-sr`).
+- VGP Hi-C maps haplotype labels like `Haplotype 1`, `Haplotype 2`, `Primary`, and `Alternate` into short suffixes (`H1`, `H2`, `pri`, `alt`) before composing replacement expressions (`$IWC_FORMAT2/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8.gxwf.yml:276-340`).
+- The taxonomic-rank summary workflow maps `Taxonomic rank` into large awk programs, then connects those generated snippets as the `code` parameter of `tp_awk_tool` (`$IWC_FORMAT2/amplicon/amplicon-mgnify/taxonomic-rank-abundance-summary-table/taxonomic-rank-abundance-summary-table.gxwf.yml:40-140`). This is powerful but brittle; the reusable pattern is enum-to-snippet mapping, not the biological taxonomy code itself.
+
+The boundary is important: boolean mapping for branch topology should merge into conditionals, while enum-to-tool-dialect mapping deserves a parameter-derivation page.
+
+### 2d. Compose connected text expressions from typed parameters
+
+`compose_text_param` is the dominant connected-text builder. It constructs expression strings for filters, awk snippets, tool config lines, labels, and genomic regions from user parameters or upstream scalar parameters.
+
+Examples:
+
+- Consensus peaks builds a `Filter1` condition `c4 >= <minimum overlap>` from a workflow integer input, then connects it as the `cond` parameter (`$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:102-128`, `$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:318-337`).
+- SRA manifest processing maps zero-based user input to a one-based column number, composes `c<id>,c<id>` text, and connects it to `Cut1.columnList` (`$IWC_FORMAT2/data-fetching/sra-manifest-to-concatenated-fastqs/sra-manifest-to-concatenated-fastqs.gxwf.yml:32-113`).
+- GROMACS dcTMD composes config lines such as `pull_coord1_rate = <rate>`, `dt = <step length>`, and `nsteps = <number>` (`$IWC_FORMAT2/computational-chemistry/gromacs-dctmd/gromacs-dctmd.gxwf.yml:553-654`).
+- Pox virus amplicon processing composes genomic ranges and pool suffixes from upstream text parameters (`$IWC_FORMAT2/virology/pox-virus-amplicon/pox-virus-half-genome.gxwf.yml:560-669`).
+- SARS-CoV-2 and generic variant-reporting workflows compose complex filter expressions from AF/DP thresholds; those are domain-specific but show the same connected-expression mechanism.
+
+This is a strong generic shim pattern because it is the only corpus-backed way to turn typed workflow parameters into dynamic expression strings for tools that accept text parameters but need exact syntax.
+
+### 2e. Compute a table value, then escape back to parameter-land
+
+`column_maker` usually belongs to the tabular hierarchy, but there is one parameter-derivation subcase: compute a single value in a table, then read it back with `param_value_from_file`.
+
+Examples:
+
+- MGnify non-empty collection gate computes `c1 != 0` over a one-line count file, then reads the boolean with `param_value_from_file` (`$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction.gxwf.yml:1396-1463`).
+- VGP workflows compute formulas like `c3/<integer>` after converting coverage or genome-size estimates to parameters; these are mostly domain-specific assembly calculations rather than standalone parameter patterns.
+
+The reusable bit is not `column_maker` by itself. It is the round trip: file scalar -> tabular expression -> typed parameter. Keep this as a subsection inside scalar/boolean derivation pages rather than a standalone page.
+
+## 3. Generic shims vs tool-tied derivations
+
+Generic shims:
+
+- `param_value_from_file` as the file-to-typed-parameter bridge.
+- `wc_gnu -> param_value_from_file` for count-to-integer.
+- `collection_element_identifiers -> wc_gnu -> column_maker -> param_value_from_file` for collection non-empty boolean.
+- `map_param_value` for enum-to-boolean and enum-to-tool-dialect mapping.
+- `compose_text_param` for dynamic text/expression construction.
+
+Tool-tied derivations:
+
+- RNA-seq strandedness maps are reusable across RNA-seq workflows but still tied to downstream tool dialects (`featureCounts`, Cufflinks, StringTie, STAR-count awk).
+- Taxonomic-rank-to-awk snippets are specific to the MGnify summary workflow shape.
+- GROMACS config-line composition is specific to GROMACS tools, even though the `compose_text_param` mechanism is generic.
+- VGP haplotype suffix abbreviation is a domain convention, not a Galaxy-wide parameter derivation rule.
+
+The pattern pages should lead with the generic shim, then include tool-tied examples as evidence and caveats. Do not make a page for every downstream dialect.
+
+## 4. Candidate pattern boundaries
+
+### Candidate A: `derive-parameter-from-file`
+
+Scope: read a scalar dataset into a typed Galaxy runtime parameter with `param_value_from_file`, including `integer`, `float`, `text`, and `boolean` outputs.
+
+Evidence:
+
+- Consensus peak minimum-read and replicate-count scalar reads: `$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:372-410`, `$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:467-499`.
+- Influenza line counts converted to integer parameters: `$IWC_FORMAT2/virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping.gxwf.yml:198-287`.
+- VGP telomere text read for later boolean mapping: `$IWC_FORMAT2/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation.gxwf.yml:3057-3092`.
+
+Call: **keep**. This is the central data-to-parameter bridge, repeated across domains.
+
+### Candidate B: `derive-count-parameter-from-file-or-collection`
+
+Scope: count lines/elements/characters with `wc_gnu` or `collection_element_identifiers`, then use the count as a runtime parameter.
+
+Evidence:
+
+- Replicate count in consensus peaks: `$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:299-318`, `$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:392-423`.
+- Influenza count-to-collection-size parameters: `$IWC_FORMAT2/virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping.gxwf.yml:198-287`.
+- MGnify collection identifier count: `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction.gxwf.yml:1376-1414`.
+
+Call: **keep, likely as a subsection of Candidate A unless the page gets too large**. The recipe is smaller than the scalar bridge but common enough to name.
+
+### Candidate C: `derive-nonempty-boolean-parameter`
+
+Scope: derive `true`/`false` from whether a dataset or collection has content, then use it as a `when` input or other boolean parameter.
+
+Evidence:
+
+- MGnify collection non-empty subworkflow: `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction.gxwf.yml:1358-1483`.
+- VGP telomere text empty/non-empty mapping: `$IWC_FORMAT2/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation.gxwf.yml:3057-3218`.
+- Gated downstream Pretext/Krona/BIOM outputs are already covered in [[iwc-conditionals-survey]].
+
+Call: **merge into [[conditional-gate-on-nonempty-result]]**. The boolean-derivation mechanics should be a major section of that pattern, not a separate sibling page. Verified-pattern workflow issue #84 should test this directly before recommending a shorter alternative over the MGnify four-step recipe: https://github.com/jmchilton/foundry/issues/84.
+
+### Candidate D: `map-workflow-enum-to-tool-parameter`
+
+Scope: map a workflow-facing enum or string value to one or more downstream tool dialects: numeric codes, flags, replacement snippets, or command fragments.
+
+Evidence:
+
+- RNA-seq `Strandedness` mapped into `featureCounts`, Cufflinks, StringTie, replacement regexes, and STAR-count awk snippets: `$IWC_FORMAT2/transcriptomics/rnaseq-pe/rnaseq-pe.gxwf.yml:270-369` and later mappings in the same file; mirrored in `rnaseq-sr`.
+- VGP haplotype labels mapped to suffix abbreviations: `$IWC_FORMAT2/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8.gxwf.yml:276-340`.
+- Taxonomic rank mapped to generated awk programs: `$IWC_FORMAT2/amplicon/amplicon-mgnify/taxonomic-rank-abundance-summary-table/taxonomic-rank-abundance-summary-table.gxwf.yml:40-140`.
+
+Call: **keep**. This is distinct from conditionals when the output is a tool parameter, not a branch-control boolean.
+
+### Candidate E: `compose-runtime-text-parameter`
+
+Scope: build connected text/expression parameters with `compose_text_param` from constants plus workflow or upstream scalar values.
+
+Evidence:
+
+- `Filter1.cond` expression in consensus peaks: `$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:102-128`, `$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:318-337`.
+- Dynamic `Cut1.columnList` in SRA manifest processing: `$IWC_FORMAT2/data-fetching/sra-manifest-to-concatenated-fastqs/sra-manifest-to-concatenated-fastqs.gxwf.yml:32-113`.
+- GROMACS config-line construction: `$IWC_FORMAT2/computational-chemistry/gromacs-dctmd/gromacs-dctmd.gxwf.yml:553-654`.
+- Pox virus range and suffix construction: `$IWC_FORMAT2/virology/pox-virus-amplicon/pox-virus-half-genome.gxwf.yml:560-669`.
+
+Call: **keep**. This is the highest-value standalone page from this survey after `param_value_from_file` because it explains how to build dynamic expressions without writing a custom wrapper.
+
+### Candidate F: `map-parameter-for-conditional-routing`
+
+Scope: invert booleans or map enum values to booleans for `when` gates.
+
+Evidence:
+
+- Scanpy 10x import branch inversion: `$IWC_FORMAT2/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy.gxwf.yml:173-241`, `$IWC_FORMAT2/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy.gxwf.yml:337-404`.
+- Functional annotation one-of-N eggNOG gates: `$IWC_FORMAT2/genome_annotation/functional-annotation/functional-annotation-of-sequences/Functional_annotation_of_sequences.gxwf.yml:90-239`, `$IWC_FORMAT2/genome_annotation/functional-annotation/functional-annotation-of-sequences/Functional_annotation_of_sequences.gxwf.yml:240-429`.
+
+Call: **merge into [[conditional-route-between-alternative-outputs]] and [[conditional-run-optional-step]]**. Do not create a parameter-derivation page just for boolean gate plumbing.
+
+### Candidate G: `compute-tabular-value-then-parameterize`
+
+Scope: use `column_maker`, `table_compute`, or a tabular tool to compute one scalar, then read it as a parameter.
+
+Evidence:
+
+- MGnify `c1 != 0` boolean in the non-empty collection gate: `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction.gxwf.yml:1396-1463`.
+- Consensus peaks `table_compute` minimum value used to drive subsampling: `$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:263-299`, `$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:372-499`.
+
+Call: **merge**. Cover the tabular computation in [[tabular-compute-new-column]] or a relevant tabular page, and cover the escape back to parameter-land in Candidate A. A standalone page would duplicate both.
+
+### Candidate H: `pick-default-or-first-available-parameter`
+
+Scope: use `pick_value` for defaults or to collapse nullable branch outputs.
+
+Evidence:
+
+- Scanpy defaults several optional numeric parameters with `pick_value`, then also uses it to select the available AnnData output (`$IWC_FORMAT2/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy.gxwf.yml:241-404`).
+- Conditional surveys already cover `pick_value` as the branch-output merge after gated alternatives.
+
+Call: **drop from this survey's hierarchy**. It is parameter defaulting or conditional output selection, not derivation from upstream data. Keep it inside conditionals and optional-input/default-value guidance if that page lands later.
+
+## 5. Cross-links to conditionals and verified patterns
+
+The parameter-derivation and conditional surveys overlap at exactly one high-value seam: **derive a boolean from data, then use it as `when`**. The pattern page should be [[conditional-gate-on-nonempty-result]], not a separate parameter page, because the user story is "skip downstream work when upstream data is empty" rather than "read a boolean from a file".
+
+The MGnify recipe is corpus-backed but clunky: `collection_element_identifiers -> wc_gnu -> column_maker(c1 != 0) -> param_value_from_file`. Issue #84 should verify whether a smaller Galaxy-native workflow can replace it as the recommended authoring target while preserving the MGnify shape as IWC evidence: https://github.com/jmchilton/foundry/issues/84.
+
+## 6. Open questions
+
+- **Q1.** Candidate A and B: one page with count recipes as a section, or two pages? Lean: one page first.
+- **Q2.** Candidate D: one enum-mapping page, or one page per common dialect family such as strandedness? Lean: one generic page plus domain examples.
+- **Q3.** Candidate E: should `compose_text_param` page be operation-named (`compose-runtime-text-parameter`) or tool-named? Lean: operation-named, per prior tabular decisions.
+- **Q4.** Should `pick_value` get a separate defaulting page later, outside this derivation hierarchy? Lean: defer until optional-input/defaulting becomes a known Mold need.
+- **Q5.** Verified-pattern issue #84: can a shorter non-empty gate replace the MGnify four-step recipe as recommendation, or must the corpus recipe remain primary?


### PR DESCRIPTION
## Summary
- Add IWC corpus survey for Galaxy parameter derivation patterns.
- Classify reusable shims around `param_value_from_file`, `map_param_value`, `compose_text_param`, `wc_gnu`, and related tabular/conditional bridges.
- Capture keep/drop/merge calls for candidate pattern boundaries and link verified-pattern follow-up in #84.

## Tests
- `npm run validate` (passes; existing backlink warnings)
- `npm run test`

Closes #89