### PR TITLE
Track Galaxy failure modalities in evals

### DIFF
--- a/content/molds/debug-galaxy-workflow-output/eval.md
+++ b/content/molds/debug-galaxy-workflow-output/eval.md
@@ -1,0 +1,25 @@
+# debug-galaxy-workflow-output eval
+
+## Case: distinguish failure surfaces
+
+- check: llm-judged
+- fixture: failed Planemo workflow test with structured output, invocation id, at least one failed or missing output, and access to Galaxy API details.
+- expectation: classifies the first failure surface as tool/job failure, workflow invocation failure, collection output mismatch, missing workflow output, or assertion mismatch before proposing repairs.
+
+## Case: job failure reference capture
+
+- check: llm-judged
+- fixture: failed workflow test where a Galaxy job has state `error`, `failed`, `stopped`, or equivalent terminal failure.
+- expectation: records job id, tool id, exit code, job messages, stdout/stderr distinction, output dataset state, and whether the wrapper failure semantics explain the failure.
+
+## Case: invocation failure reference capture
+
+- check: llm-judged
+- fixture: failed workflow test where the invocation state or invocation messages indicate scheduling, materialization, cancellation, conditional, or output-resolution failure.
+- expectation: records invocation state, structured message reason, affected step, subworkflow path if present, jobs summary, and whether Planemo surfaced or hid the relevant Galaxy API detail.
+
+## Case: reference gap discovery
+
+- check: llm-judged
+- fixture: any debug run where the failure cannot be classified confidently from existing references.
+- expectation: creates or recommends a focused follow-up for reference documentation, pattern capture, API verification, or eval coverage rather than converting uncertainty into a repair recipe.

--- a/content/molds/implement-galaxy-tool-step/eval.md
+++ b/content/molds/implement-galaxy-tool-step/eval.md
@@ -1,0 +1,13 @@
+# implement-galaxy-tool-step eval
+
+## Case: concrete step preserves failure evidence
+
+- check: llm-judged
+- fixture: abstract step plus Galaxy tool summary where the wrapper defines exit-code, stdio regex, strict-shell, or dynamic output behavior.
+- expectation: implements the step without erasing failure evidence needed later, including tool id, input labels, output labels, collection shape, and any wrapper failure semantics relevant to runtime debugging.
+
+## Case: runtime failure ownership hint
+
+- check: llm-judged
+- fixture: concrete step implementation with a plausible mismatch between expected source behavior and Galaxy wrapper inputs, outputs, datatype, or collection support.
+- expectation: records whether a later failure should be investigated as tool/job failure, data-flow mistake, template wiring mistake, wrapper mismatch, or test/assertion issue.

--- a/content/molds/run-workflow-test/eval.md
+++ b/content/molds/run-workflow-test/eval.md
@@ -1,0 +1,19 @@
+# run-workflow-test eval
+
+## Case: structured Planemo artifact capture
+
+- check: deterministic
+- fixture: workflow test run with Planemo configured to emit structured test output.
+- expectation: preserves the invocation id, history id, workflow id, Planemo structured result, and any test output artifact paths needed by debug molds.
+
+## Case: existing versus managed Galaxy mode
+
+- check: llm-judged
+- fixture: workflow test configuration that can run against either an existing Galaxy or a Planemo-managed Galaxy.
+- expectation: records which Galaxy mode was used, how tools/workflows/test data were staged, and which API credentials or URLs are needed for follow-up failure inspection.
+
+## Case: failure modality handoff
+
+- check: llm-judged
+- fixture: workflow test run that exits non-zero or reports failed assertions, failed jobs, failed invocation, missing outputs, or upload/staging problems.
+- expectation: hands off a structured summary that identifies the observed failure modality and the next reference surface to inspect: Planemo result, Galaxy job API, Galaxy invocation API, history contents, or test assertion report.

--- a/content/molds/summary-to-galaxy-data-flow/eval.md
+++ b/content/molds/summary-to-galaxy-data-flow/eval.md
@@ -23,3 +23,9 @@
 - check: llm-judged
 - fixture: data-flow draft with at least one uncertain tool need, placeholder transformation, conditional branch, collection reshape, or tabular bridge.
 - expectation: assigns ownership to data-flow, template, concrete step implementation, or follow-up research; does not hide unresolved semantics in prose-only TODOs.
+
+## Case: failure modality forecast
+
+- check: llm-judged
+- fixture: data-flow draft that includes a tool need, workflow-level route, collection mapping, and expected workflow outputs.
+- expectation: records which later failures would be tool/job failures, workflow invocation failures, Planemo assertion failures, or missing-reference gaps; links each forecast to the artifact or API surface that should verify it during a run.

--- a/content/molds/summary-to-galaxy-template/eval.md
+++ b/content/molds/summary-to-galaxy-template/eval.md
@@ -23,3 +23,9 @@
 - check: llm-judged
 - fixture: any real template-generation run that exposes a reusable skeleton idiom, awkward placeholder, missing pattern, or unclear mold boundary.
 - expectation: records how the observation should be captured: new or revised pattern note, research issue, schema/eval update, mold-reference update, or documentation task; includes concrete evidence required to verify it.
+
+## Case: failure surface preservation
+
+- check: llm-judged
+- fixture: gxformat2 skeleton with unresolved tool placeholders, workflow outputs, collection outputs, and at least one conditional or optional path.
+- expectation: preserves labels, outputs, and TODO context needed to trace later Planemo failures back to tool/job state, workflow invocation state, or assertion/output mismatch without relying only on terminal logs.

--- a/content/molds/validate-galaxy-step/eval.md
+++ b/content/molds/validate-galaxy-step/eval.md
@@ -11,3 +11,9 @@
 - check: llm-judged
 - fixture: partial workflow where a selected Tool Shed wrapper lacks an expected parameter.
 - expectation: distinguishes fix-in-step from re-summarize/re-author wrapper work and explains the recommended loop target.
+
+## Case: tool failure semantics visibility
+
+- check: llm-judged
+- fixture: partial workflow step whose selected wrapper has non-default failure detection, such as explicit stdio regexes, exit-code ranges, or strict-shell behavior.
+- expectation: records whether static step validation can see the relevant tool failure semantics and what job API fields must be inspected if the step later fails at runtime.

--- a/content/molds/validate-galaxy-workflow/eval.md
+++ b/content/molds/validate-galaxy-workflow/eval.md
@@ -11,3 +11,9 @@
 - check: llm-judged
 - fixture: complete gxformat2 workflow with a workflow-level connection or output problem.
 - expectation: classifies the failure as terminal workflow validation, identifies the likely responsible phase, and does not treat it as a Planemo runtime failure.
+
+## Case: validation versus runtime boundary
+
+- check: llm-judged
+- fixture: gxformat2 workflow that passes static validation but still has a plausible runtime failure risk, such as missing tool runtime behavior, optional output assumptions, or collection element mismatch.
+- expectation: records why static validation is insufficient and names the runtime artifact that should prove or disprove the risk, such as invocation messages, job details, output collections, or Planemo structured test output.


### PR DESCRIPTION
## Summary
- add eval coverage for run/debug/implement Galaxy workflow failure surfaces
- extend Galaxy data-flow/template/validation evals to preserve failure-modality evidence
- require eval runs to distinguish tool/job failures, invocation failures, Planemo assertion mismatches, and reference gaps

## Validation
- npm run validate