### PR TITLE
Expand Nextflow summary extraction

### DIFF
--- a/packages/summarize-nextflow/src/resolver.ts
+++ b/packages/summarize-nextflow/src/resolver.ts
@@ -10,11 +10,36 @@ interface Summary {
   profiles: string[];
   tools: Tool[];
   processes: Process[];
-  subworkflows: unknown[];
-  workflow: { name: string; channels: unknown[]; edges: unknown[]; conditionals: unknown[] };
+  subworkflows: Subworkflow[];
+  workflow: { name: string; channels: Channel[]; edges: Edge[]; conditionals: unknown[] };
   test_fixtures: { profile: string; inputs: TestDataRef[]; outputs: unknown[] };
   nf_tests: NfTest[];
   warnings: string[];
+}
+
+interface Subworkflow {
+  name: string;
+  path: string;
+  kind: "pipeline" | "utility";
+  calls: string[];
+  inputs?: ChannelIO[];
+  outputs?: ChannelIO[];
+}
+
+interface ParsedWorkflow extends Subworkflow {
+  body: string;
+}
+
+interface Channel {
+  name: string;
+  source: string;
+  shape: string;
+}
+
+interface Edge {
+  from: string;
+  to: string;
+  via?: string[];
 }
 
 interface Param {
@@ -104,6 +129,8 @@ export async function resolveNextflowSummary(
   );
   const aliases = discoverProcessAliases(pipelineRoot);
   const tools = buildTools(pipelineRoot, processes);
+  const workflows = parseWorkflows(pipelineRoot, processes.map((process) => process.name));
+  const primaryWorkflow = selectPrimaryWorkflow(workflows);
 
   const summary: Summary = {
     source: {
@@ -126,11 +153,13 @@ export async function resolveNextflowSummary(
       tool:
         tools.find((tool) => process.name.toLowerCase().includes(tool.name))?.name ?? process.tool,
     })),
-    subworkflows: [],
+    subworkflows: workflows
+      .filter((workflow) => workflow.name !== primaryWorkflow?.name)
+      .map(stripWorkflowBody),
     workflow: {
-      name: workflowName.split("/").at(-1)?.toUpperCase() ?? "WORKFLOW",
-      channels: [],
-      edges: [],
+      name: primaryWorkflow?.name ?? workflowName.split("/").at(-1)?.toUpperCase() ?? "WORKFLOW",
+      channels: primaryWorkflow ? parseWorkflowChannels(primaryWorkflow.body) : [],
+      edges: primaryWorkflow ? parseWorkflowEdges(primaryWorkflow.body, primaryWorkflow.calls) : [],
       conditionals: [],
     },
     test_fixtures: parseTestFixtures(pipelineRoot, options.profile),
@@ -301,6 +330,151 @@ function discoverProcessAliases(pipelineRoot: string): Map<string, string[]> {
     }
   }
   return new Map([...aliases.entries()].map(([name, values]) => [name, [...values].sort()]));
+}
+
+function parseWorkflows(pipelineRoot: string, processNames: string[]): ParsedWorkflow[] {
+  const workflows = new Map<string, ParsedWorkflow>();
+  const knownProcesses = new Set(processNames);
+  for (const path of walk(pipelineRoot).filter((candidate) => candidate.endsWith(".nf"))) {
+    const text = readText(path);
+    const importedNames = new Set(
+      parseIncludeItems(text).map((include) => include.alias ?? include.name),
+    );
+    for (const block of extractWorkflowBlocks(text)) {
+      if (!block.name) continue;
+      const calls = parseWorkflowCalls(block.body, new Set([...knownProcesses, ...importedNames]));
+      workflows.set(block.name, {
+        name: block.name,
+        path: relative(pipelineRoot, path),
+        kind: calls.length > 0 ? "pipeline" : "utility",
+        calls,
+        inputs: parseWorkflowIoBlock(block.body, "take"),
+        outputs: parseWorkflowIoBlock(block.body, "emit"),
+        body: block.body,
+      });
+    }
+  }
+  return [...workflows.values()].sort((left, right) => left.path.localeCompare(right.path));
+}
+
+function selectPrimaryWorkflow(workflows: ParsedWorkflow[]): ParsedWorkflow | null {
+  return [...workflows].sort((left, right) => {
+    const callDiff = right.calls.length - left.calls.length;
+    if (callDiff !== 0) return callDiff;
+    const pathDiff =
+      Number(right.path.startsWith("workflows/")) - Number(left.path.startsWith("workflows/"));
+    if (pathDiff !== 0) return pathDiff;
+    return left.name.localeCompare(right.name);
+  })[0] ?? null;
+}
+
+function stripWorkflowBody(workflow: ParsedWorkflow): Subworkflow {
+  const { body: _body, ...summaryWorkflow } = workflow;
+  return summaryWorkflow;
+}
+
+function extractWorkflowBlocks(text: string): { name: string | null; body: string }[] {
+  const blocks: { name: string | null; body: string }[] = [];
+  const regex = /\bworkflow(?:\s+([A-Za-z0-9_]+))?\s*\{/gu;
+  for (const match of text.matchAll(regex)) {
+    const openIndex = match.index + match[0].lastIndexOf("{");
+    const body = extractBlockAt(text, openIndex);
+    if (body !== null) blocks.push({ name: match[1] ?? null, body });
+  }
+  return blocks;
+}
+
+function parseWorkflowCalls(body: string, knownNames: Set<string>): string[] {
+  const calls = new Set<string>();
+  for (const match of body.matchAll(/^\s*([A-Z][A-Z0-9_]+)\s*\(/gmu)) {
+    const name = match[1]!;
+    if (knownNames.has(name)) calls.add(name);
+  }
+  return [...calls].sort();
+}
+
+function parseWorkflowChannels(body: string): Channel[] {
+  const channels = new Map<string, Channel>();
+  for (const match of body.matchAll(/^\s*(ch_[A-Za-z0-9_]+)\s*=\s*([^\n]+)/gmu)) {
+    channels.set(match[1]!, {
+      name: match[1]!,
+      source: match[2]!.trim(),
+      shape: "channel",
+    });
+  }
+  for (const match of body.matchAll(/([A-Za-z0-9_.()\s]+)\s*\.set\s*\{\s*(ch_[A-Za-z0-9_]+)\s*\}/gu)) {
+    channels.set(match[2]!, {
+      name: match[2]!,
+      source: match[1]!.replace(/\s+/gu, " ").trim(),
+      shape: "channel",
+    });
+  }
+  return [...channels.values()].sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function parseWorkflowEdges(body: string, calls: string[]): Edge[] {
+  const callNames = new Set(calls);
+  const edges: Edge[] = [];
+  for (const invocation of extractCallInvocations(body)) {
+    if (!callNames.has(invocation.name)) continue;
+    for (const argument of invocation.arguments) {
+      edges.push({ from: argument, to: invocation.name, via: [] });
+    }
+  }
+  return edges;
+}
+
+function extractCallInvocations(body: string): { name: string; arguments: string[] }[] {
+  const invocations: { name: string; arguments: string[] }[] = [];
+  const lines = body.split("\n");
+  for (let index = 0; index < lines.length; index += 1) {
+    const singleLine = /^\s*([A-Z][A-Z0-9_]+)\s*\(([^)]*)\)\s*$/u.exec(lines[index]!);
+    if (singleLine) {
+      invocations.push({
+        name: singleLine[1]!,
+        arguments: splitCallArguments(singleLine[2]!),
+      });
+      continue;
+    }
+    const start = /^\s*([A-Z][A-Z0-9_]+)\s*\(\s*$/u.exec(lines[index]!);
+    if (!start) continue;
+    const args: string[] = [];
+    for (index += 1; index < lines.length; index += 1) {
+      const line = lines[index]!.trim();
+      if (line === ")") break;
+      const argument = line.replace(/,$/u, "").trim();
+      if (argument && !argument.startsWith("//")) args.push(argument);
+    }
+    invocations.push({ name: start[1]!, arguments: args });
+  }
+  return invocations;
+}
+
+function splitCallArguments(text: string): string[] {
+  return text
+    .split(",")
+    .map((argument) => argument.trim())
+    .filter(Boolean);
+}
+
+function parseWorkflowIoBlock(text: string, blockName: "take" | "emit"): ChannelIO[] {
+  const block = matchOne(
+    text,
+    new RegExp(`${blockName}:\\s*\\n([\\s\\S]*?)(?:\\n\\s*(?:take|main|emit):|$)`, "u"),
+  );
+  if (!block) return [];
+  return block
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("//"))
+    .map((line) => ({
+      name:
+        matchOne(line, /^([A-Za-z0-9_]+)\s*=/u) ??
+        matchOne(line, /^([A-Za-z0-9_]+)/u) ??
+        `io_${Math.abs(hash(line))}`,
+      shape: line.replace(/\s+/gu, " "),
+      topic: null,
+    }));
 }
 
 function parseIncludeItems(text: string): { name: string; alias: string | null }[] {
@@ -595,34 +769,37 @@ function parseNfTests(pipelineRoot: string): NfTest[] {
   const testsRoot = join(pipelineRoot, "tests");
   return walk(testsRoot)
     .filter((path) => path.endsWith(".nf.test"))
-    .map((path) => {
+    .flatMap((path) => {
       const text = readText(path);
       const relPath = relative(pipelineRoot, path);
-      const name = matchOne(text, /test\("([^"]+)"\)/u) ?? basename(path);
-      return {
-        name,
+      const fileProfiles = parseNfTestFileProfiles(text);
+      const blocks = extractNfTestBlocks(text);
+      return blocks.map((block) => ({
+        name: block.name,
         path: relPath,
-        profiles: parseNfTestProfiles(text, name),
-        params_overrides: parseParamsOverrides(text),
-        assert_workflow_success: text.includes("workflow.success"),
-        snapshot: text.includes("snapshot(")
-          ? {
-              captures: ["versions_yml", "stable_names", "stable_paths"],
-              helpers: [...text.matchAll(/\b([A-Za-z0-9_]+)\(/gu)]
-                .map((match) => match[1]!)
-                .filter((value) => ["getAllFilesFromDir", "removeNextflowVersion"].includes(value)),
-              ignore_files: [...text.matchAll(/ignoreFile:\s*['"]([^'"]+)['"]/gu)].map(
-                (match) => match[1]!,
-              ),
-              ignore_globs: [...text.matchAll(/ignore:\s*\[([^\]]+)\]/gu)].flatMap((match) =>
-                [...match[1]!.matchAll(/['"]([^'"]+)['"]/gu)].map((inner) => inner[1]!),
-              ),
-              snap_path: existsSync(`${path}.snap`) ? `${relPath}.snap` : null,
-            }
-          : null,
-        prose_assertions: [],
-      };
+        profiles: unique([...parseNfTestProfiles(block.body, block.name), ...fileProfiles]),
+        params_overrides: parseParamsOverrides(block.body),
+        assert_workflow_success: block.body.includes("workflow.success"),
+        snapshot: parseSnapshot(path, relPath, block.body),
+        prose_assertions: parseProseAssertions(block.body),
+      }));
     });
+}
+
+function parseNfTestFileProfiles(text: string): string[] {
+  return unique(
+    [...text.matchAll(/^\s*profile\s+["']([^"']+)["']/gmu)].map((match) => match[1]!),
+  );
+}
+
+function extractNfTestBlocks(text: string): { name: string; body: string }[] {
+  const blocks: { name: string; body: string }[] = [];
+  for (const match of text.matchAll(/\btest\("([^"]+)"\)\s*\{/gu)) {
+    const openIndex = match.index + match[0].lastIndexOf("{");
+    const body = extractBlockAt(text, openIndex);
+    if (body !== null) blocks.push({ name: match[1]!, body });
+  }
+  return blocks.length > 0 ? blocks : [{ name: "unnamed", body: text }];
 }
 
 function parseNfTestProfiles(text: string, name: string): string[] {
@@ -647,6 +824,46 @@ function parseParamsOverrides(text: string): Record<string, unknown> {
   return values;
 }
 
+function parseSnapshot(
+  path: string,
+  relPath: string,
+  text: string,
+): NfTest["snapshot"] {
+  if (!text.includes("snapshot(")) return null;
+  return {
+    captures: parseSnapshotCaptures(text),
+    helpers: unique(
+      [...text.matchAll(/\b([A-Za-z0-9_]+)\(/gu)]
+        .map((match) => match[1]!)
+        .filter((value) => ["getAllFilesFromDir", "removeNextflowVersion"].includes(value)),
+    ),
+    ignore_files: [...text.matchAll(/ignoreFile:\s*['"]([^'"]+)['"]/gu)].map((match) => match[1]!),
+    ignore_globs: [...text.matchAll(/ignore:\s*\[([^\]]+)\]/gu)].flatMap((match) =>
+      [...match[1]!.matchAll(/['"]([^'"]+)['"]/gu)].map((inner) => inner[1]!),
+    ),
+    snap_path: existsSync(`${path}.snap`) ? `${relPath}.snap` : null,
+  };
+}
+
+function parseSnapshotCaptures(text: string): string[] {
+  const captures: string[] = [];
+  if (/workflow\.trace\.succeeded\(\)\.size\(\)/u.test(text)) captures.push("succeeded_task_count");
+  if (/removeNextflowVersion\(/u.test(text)) captures.push("versions_yml");
+  for (const match of text.matchAll(/\b(stable_[A-Za-z0-9_]+)\b/gu)) {
+    const capture = match[1]!
+      .replace(/^stable_name$/u, "stable_names")
+      .replace(/^stable_path$/u, "stable_paths");
+    captures.push(capture);
+  }
+  return unique(captures);
+}
+
+function parseProseAssertions(text: string): string[] {
+  return [...text.matchAll(/assert\s+(?!workflow\.success\b)([^}\n]+)/gu)]
+    .map((match) => match[1]!.trim())
+    .filter((assertion) => !assertion.startsWith("snapshot("));
+}
+
 function summarizeScript(name: string): string {
   const tool = name.toLowerCase().replace(/_/gu, " ");
   return `Run ${tool} and emit declared Nextflow outputs.`;
@@ -655,16 +872,26 @@ function summarizeScript(name: string): string {
 function extractNamedBlock(text: string, name: string): string | null {
   const startMatch = new RegExp(`\\b${name}\\s*\\{`, "u").exec(text);
   if (!startMatch) return null;
+  const openIndex = text.indexOf("{", startMatch.index);
+  const block = extractBlockAt(text, openIndex);
+  return block === null ? null : text.slice(startMatch.index, openIndex + block.length + 2);
+}
+
+function extractBlockAt(text: string, openIndex: number): string | null {
   let depth = 0;
-  for (let index = startMatch.index; index < text.length; index += 1) {
+  for (let index = openIndex; index < text.length; index += 1) {
     const char = text[index];
     if (char === "{") depth += 1;
     if (char === "}") {
       depth -= 1;
-      if (depth === 0) return text.slice(startMatch.index, index + 1);
+      if (depth === 0) return text.slice(openIndex + 1, index);
     }
   }
   return null;
+}
+
+function unique<T>(values: T[]): T[] {
+  return [...new Set(values)];
 }
 
 function matchOne(text: string, regex: RegExp): string | null {

--- a/packages/summarize-nextflow/src/resolver.ts
+++ b/packages/summarize-nextflow/src/resolver.ts
@@ -129,7 +129,10 @@ export async function resolveNextflowSummary(
   );
   const aliases = discoverProcessAliases(pipelineRoot);
   const tools = buildTools(pipelineRoot, processes);
-  const workflows = parseWorkflows(pipelineRoot, processes.map((process) => process.name));
+  const workflows = parseWorkflows(
+    pipelineRoot,
+    processes.map((process) => process.name),
+  );
   const primaryWorkflow = selectPrimaryWorkflow(workflows);
 
   const summary: Summary = {
@@ -358,14 +361,16 @@ function parseWorkflows(pipelineRoot: string, processNames: string[]): ParsedWor
 }
 
 function selectPrimaryWorkflow(workflows: ParsedWorkflow[]): ParsedWorkflow | null {
-  return [...workflows].sort((left, right) => {
-    const callDiff = right.calls.length - left.calls.length;
-    if (callDiff !== 0) return callDiff;
-    const pathDiff =
-      Number(right.path.startsWith("workflows/")) - Number(left.path.startsWith("workflows/"));
-    if (pathDiff !== 0) return pathDiff;
-    return left.name.localeCompare(right.name);
-  })[0] ?? null;
+  return (
+    [...workflows].sort((left, right) => {
+      const callDiff = right.calls.length - left.calls.length;
+      if (callDiff !== 0) return callDiff;
+      const pathDiff =
+        Number(right.path.startsWith("workflows/")) - Number(left.path.startsWith("workflows/"));
+      if (pathDiff !== 0) return pathDiff;
+      return left.name.localeCompare(right.name);
+    })[0] ?? null
+  );
 }
 
 function stripWorkflowBody(workflow: ParsedWorkflow): Subworkflow {
@@ -402,7 +407,9 @@ function parseWorkflowChannels(body: string): Channel[] {
       shape: "channel",
     });
   }
-  for (const match of body.matchAll(/([A-Za-z0-9_.()\s]+)\s*\.set\s*\{\s*(ch_[A-Za-z0-9_]+)\s*\}/gu)) {
+  for (const match of body.matchAll(
+    /([A-Za-z0-9_.()\s]+)\s*\.set\s*\{\s*(ch_[A-Za-z0-9_]+)\s*\}/gu,
+  )) {
     channels.set(match[2]!, {
       name: match[2]!,
       source: match[1]!.replace(/\s+/gu, " ").trim(),
@@ -787,9 +794,7 @@ function parseNfTests(pipelineRoot: string): NfTest[] {
 }
 
 function parseNfTestFileProfiles(text: string): string[] {
-  return unique(
-    [...text.matchAll(/^\s*profile\s+["']([^"']+)["']/gmu)].map((match) => match[1]!),
-  );
+  return unique([...text.matchAll(/^\s*profile\s+["']([^"']+)["']/gmu)].map((match) => match[1]!));
 }
 
 function extractNfTestBlocks(text: string): { name: string; body: string }[] {
@@ -824,11 +829,7 @@ function parseParamsOverrides(text: string): Record<string, unknown> {
   return values;
 }
 
-function parseSnapshot(
-  path: string,
-  relPath: string,
-  text: string,
-): NfTest["snapshot"] {
+function parseSnapshot(path: string, relPath: string, text: string): NfTest["snapshot"] {
   if (!text.includes("snapshot(")) return null;
   return {
     captures: parseSnapshotCaptures(text),

--- a/packages/summarize-nextflow/test/integration/cli.test.ts
+++ b/packages/summarize-nextflow/test/integration/cli.test.ts
@@ -549,7 +549,9 @@ describe("summarize-nextflow CLI — real pipeline tree (nf-core/bacass)", () =>
     const data = JSON.parse(r.stdout);
     expect(data.workflow.name).toBe("BACASS");
     expect(data.workflow.edges).toEqual(
-      expect.arrayContaining([{ from: "ch_shortreads_fastqs.multiple", to: "CAT_FASTQ_SHORT", via: [] }]),
+      expect.arrayContaining([
+        { from: "ch_shortreads_fastqs.multiple", to: "CAT_FASTQ_SHORT", via: [] },
+      ]),
     );
     const trim = data.subworkflows.find(
       (workflow: { name: string }) => workflow.name === "FASTQ_TRIM_FASTP_FASTQC",

--- a/packages/summarize-nextflow/test/integration/cli.test.ts
+++ b/packages/summarize-nextflow/test/integration/cli.test.ts
@@ -223,6 +223,164 @@ include { FASTQC } from '../modules/local/fastqc'
     ).processes.find((candidate) => candidate.name === "MINIMAP2_ALIGN");
     expect(process?.aliases).toEqual(["MINIMAP2_CONSENSUS", "MINIMAP2_POLISH"]);
   });
+
+  itIfBuilt("extracts one nf-test entry per test block with snapshot details", async () => {
+    const root = mkdtempSync(join(os.tmpdir(), "foundry-synthetic-nextflow-"));
+    mkdirSync(join(root, "tests"));
+    writeFileSync(
+      join(root, "nextflow.config"),
+      `manifest { name = 'nf-core/synthetic' }
+profiles { test {} test_alt {} }
+`,
+    );
+    writeFileSync(
+      join(root, "tests", "default.nf.test"),
+      `nextflow_pipeline {
+  test("-profile test") {
+    when { params { outdir = "$outputDir" } }
+    then {
+      def stable_name = getAllFilesFromDir(params.outdir, relative: true, ignoreFile: 'tests/.nftignore_files_entirely')
+      def stable_path = getAllFilesFromDir(params.outdir, ignore: ['Prokka/**'])
+      assertAll(
+        { assert workflow.success },
+        { assert snapshot(workflow.trace.succeeded().size(), removeNextflowVersion("$outputDir/versions.yml"), stable_name, stable_path).match() }
+      )
+    }
+  }
+  test("-profile test_alt") {
+    when { params { outdir = "$outputDir" } }
+    then { assert workflow.success }
+  }
+}
+`,
+    );
+
+    const { buildSummary } = (await import("../../dist/index.js")) as {
+      buildSummary: typeof import("../../src/index.js").buildSummary;
+    };
+    const summary = await buildSummary(root, {
+      profile: "test",
+      withNextflow: false,
+      fetchTestData: false,
+      validate: false,
+    });
+    const validation = validateSummary(summary);
+    expect(validation.valid).toBe(true);
+
+    const tests = (
+      summary as {
+        nf_tests: {
+          profiles: string[];
+          snapshot: {
+            captures: string[];
+            helpers: string[];
+            ignore_files: string[];
+            ignore_globs: string[];
+          } | null;
+        }[];
+      }
+    ).nf_tests;
+    expect(tests).toHaveLength(2);
+    expect(tests.map((test) => test.profiles[0])).toEqual(["test", "test_alt"]);
+    expect(tests[0]?.snapshot?.captures).toEqual([
+      "succeeded_task_count",
+      "versions_yml",
+      "stable_names",
+      "stable_paths",
+    ]);
+    expect(tests[0]?.snapshot?.helpers).toEqual(["getAllFilesFromDir", "removeNextflowVersion"]);
+    expect(tests[0]?.snapshot?.ignore_files).toEqual(["tests/.nftignore_files_entirely"]);
+    expect(tests[0]?.snapshot?.ignore_globs).toEqual(["Prokka/**"]);
+  });
+
+  itIfBuilt("extracts named subworkflows and selects the primary workflow", async () => {
+    const root = mkdtempSync(join(os.tmpdir(), "foundry-synthetic-nextflow-"));
+    mkdirSync(join(root, "modules", "local", "align"), { recursive: true });
+    mkdirSync(join(root, "subworkflows", "local", "prep"), { recursive: true });
+    mkdirSync(join(root, "workflows"), { recursive: true });
+    writeFileSync(
+      join(root, "nextflow.config"),
+      `manifest { name = 'nf-core/synthetic' }
+profiles { test {} }
+`,
+    );
+    writeFileSync(
+      join(root, "modules", "local", "align", "main.nf"),
+      `process ALIGN {
+  output:
+  path "*.bam", emit: bam
+  script:
+  """
+  align
+  """
+}
+`,
+    );
+    writeFileSync(
+      join(root, "subworkflows", "local", "prep", "main.nf"),
+      `include { ALIGN } from '../../../modules/local/align'
+workflow PREP_READS {
+  take:
+  ch_reads
+  main:
+  ALIGN(ch_reads)
+  emit:
+  bam = ALIGN.out.bam
+}
+`,
+    );
+    writeFileSync(
+      join(root, "workflows", "synthetic.nf"),
+      `include { PREP_READS } from '../subworkflows/local/prep'
+workflow SYNTHETIC {
+  take:
+  ch_reads
+  main:
+  ch_extra = Channel.empty()
+  PREP_READS(ch_reads)
+  emit:
+  bam = PREP_READS.out.bam
+}
+`,
+    );
+
+    const { buildSummary } = (await import("../../dist/index.js")) as {
+      buildSummary: typeof import("../../src/index.js").buildSummary;
+    };
+    const summary = await buildSummary(root, {
+      profile: "test",
+      withNextflow: false,
+      fetchTestData: false,
+      validate: false,
+    });
+    const validation = validateSummary(summary);
+    expect(validation.valid).toBe(true);
+
+    const data = summary as {
+      workflow: {
+        name: string;
+        channels: { name: string; source: string }[];
+        edges: { from: string; to: string; via: string[] }[];
+      };
+      subworkflows: {
+        name: string;
+        kind: string;
+        calls: string[];
+        inputs: unknown[];
+        outputs: unknown[];
+      }[];
+    };
+    expect(data.workflow.name).toBe("SYNTHETIC");
+    expect(data.workflow.channels).toEqual([
+      { name: "ch_extra", source: "Channel.empty()", shape: "channel" },
+    ]);
+    expect(data.workflow.edges).toEqual([{ from: "ch_reads", to: "PREP_READS", via: [] }]);
+    const prep = data.subworkflows.find((workflow) => workflow.name === "PREP_READS");
+    expect(prep?.kind).toBe("pipeline");
+    expect(prep?.calls).toEqual(["ALIGN"]);
+    expect(prep?.inputs).toHaveLength(1);
+    expect(prep?.outputs).toHaveLength(1);
+  });
 });
 
 describe("summarize-nextflow CLI — real pipeline tree (nf-core/demo)", () => {
@@ -322,6 +480,16 @@ describe("summarize-nextflow CLI — real pipeline tree (nf-core/bacass)", () =>
     expect(validation.valid).toBe(true);
     expect(data.source.workflow).toBe("bacass");
     expect(data.nf_tests.length).toBeGreaterThanOrEqual(9);
+    expect(data.nf_tests[0].snapshot.captures).toEqual([
+      "succeeded_task_count",
+      "versions_yml",
+      "stable_names",
+      "stable_paths",
+    ]);
+    expect(
+      data.nf_tests.find((test: { name: string }) => test.name.includes("test_hybrid_dragonflye"))
+        ?.snapshot.ignore_globs,
+    ).toContain("Prokka/**");
 
     const inputs = data.test_fixtures.inputs as {
       role: string;
@@ -370,6 +538,25 @@ describe("summarize-nextflow CLI — real pipeline tree (nf-core/bacass)", () =>
     const fastqc = data.processes.find((process: { name: string }) => process.name === "FASTQC");
     expect(minimap2.aliases).toEqual(["MINIMAP2_CONSENSUS", "MINIMAP2_POLISH"]);
     expect(fastqc.aliases).toEqual(["FASTQC_RAW", "FASTQC_TRIM"]);
+  });
+
+  itIfBacassFixture("extracts bacass named subworkflows", () => {
+    const r = spawnSync("node", [CLI, BACASS_PIPELINE, "--no-with-nextflow", "--no-validate"], {
+      encoding: "utf8",
+    });
+    expect(r.status).toBe(0);
+
+    const data = JSON.parse(r.stdout);
+    expect(data.workflow.name).toBe("BACASS");
+    expect(data.workflow.edges).toEqual(
+      expect.arrayContaining([{ from: "ch_shortreads_fastqs.multiple", to: "CAT_FASTQ_SHORT", via: [] }]),
+    );
+    const trim = data.subworkflows.find(
+      (workflow: { name: string }) => workflow.name === "FASTQ_TRIM_FASTP_FASTQC",
+    );
+    expect(trim?.path).toBe("subworkflows/nf-core/fastq_trim_fastp_fastqc/main.nf");
+    expect(trim?.kind).toBe("pipeline");
+    expect(trim?.calls).toEqual(["FASTP", "FASTQC_RAW", "FASTQC_TRIM"]);
   });
 });
 


### PR DESCRIPTION
## Summary
- Expand `nf_tests[]` parsing to emit one entry per test block with richer snapshot captures, helpers, ignore files, and ignore globs.
- Extract named Nextflow subworkflows with calls, IO blocks, and primary workflow selection.
- Add a narrow workflow graph v0 for direct channel assignments and direct call edges.

## Tests
- `npm run packages-build`
- `npm run packages-test`
- `npm run validate`

Closes part of #26.