### PR TITLE
Add Galaxy failure reference guides

### DIFF
--- a/content/molds/debug-galaxy-workflow-output/index.md
+++ b/content/molds/debug-galaxy-workflow-output/index.md
@@ -9,7 +9,7 @@ tags:
 status: draft
 created: 2026-04-30
 revised: 2026-05-02
-revision: 2
+revision: 3
 ai_generated: true
 summary: "Triage failing Galaxy run outputs; classify failure modes; propose fixes."
 references:
@@ -45,6 +45,30 @@ references:
     evidence: corpus-observed
     purpose: "Trace collection output failures back to possibly lossy operator translations."
     trigger: "When debugging wrong nesting, missing elements, branch merges, bad joins, or gather/reduction mismatches."
+  - kind: research
+    ref: "[[galaxy-tool-job-failure-reference]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Interpret Galaxy job-level failure evidence including stdio rules, exit code, job messages, and output dataset state."
+    trigger: "When a failed workflow test includes errored jobs, tool stderr/stdout, non-zero exit codes, or red output datasets."
+  - kind: research
+    ref: "[[galaxy-workflow-invocation-failure-reference]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Interpret Galaxy invocation-level failure evidence including invocation state, structured messages, and step job summaries."
+    trigger: "When a failed workflow test has invocation failure, missing workflow outputs, cancelled/paused steps, subworkflow failures, or collection population errors."
+  - kind: research
+    ref: "[[planemo-workflow-test-architecture]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Locate which Planemo artifact or Galaxy API surface preserves the failure evidence."
+    trigger: "When Planemo output is ambiguous, structured test JSON is available, or rerunning can be avoided by inspecting an existing invocation."
 ---
 # debug-galaxy-workflow-output
 

--- a/content/molds/implement-galaxy-tool-step/index.md
+++ b/content/molds/implement-galaxy-tool-step/index.md
@@ -9,7 +9,7 @@ tags:
 status: draft
 created: 2026-04-30
 revised: 2026-05-02
-revision: 2
+revision: 3
 ai_generated: true
 summary: "Convert an abstract step into a concrete gxformat2 step using a tool summary."
 references:
@@ -69,6 +69,14 @@ references:
     evidence: corpus-observed
     purpose: "Choose corpus-attested tabular recipes when implementing concrete Galaxy steps."
     trigger: "When implementation needs row filtering, column projection, computed columns, joins, grouping, SQL, awk, text-processing wrappers, or tabular-collection bridges."
+  - kind: research
+    ref: "[[galaxy-tool-job-failure-reference]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Preserve concrete tool/job failure evidence while implementing step labels, tool ids, output labels, and collection wiring."
+    trigger: "When a selected wrapper has explicit failure semantics, dynamic outputs, non-default stdio rules, strict-shell behavior, or runtime-only failure risk."
 ---
 # implement-galaxy-tool-step
 

--- a/content/molds/implement-galaxy-workflow-test/index.md
+++ b/content/molds/implement-galaxy-workflow-test/index.md
@@ -8,8 +8,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-04-30
-revision: 1
+revised: 2026-05-02
+revision: 2
 ai_generated: true
 related_notes:
   - "[[iwc-test-data-conventions]]"
@@ -42,6 +42,14 @@ references:
     evidence: corpus-observed
     purpose: "Flag assertion shortcuts that are acceptable in IWC versus shortcuts that should be avoided."
     trigger: "When considering existence-only, size-only, image-only, checksum, output-label, or negative-test patterns."
+  - kind: research
+    ref: "[[planemo-workflow-test-architecture]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Write tests with stable labels and artifacts that Planemo can connect back to Galaxy invocations, jobs, and outputs."
+    trigger: "When adding or revising workflow tests that will be iterated with Planemo or generated from existing invocations."
 ---
 # implement-galaxy-workflow-test
 

--- a/content/molds/run-workflow-test/index.md
+++ b/content/molds/run-workflow-test/index.md
@@ -6,8 +6,8 @@ tags:
   - mold
 status: draft
 created: 2026-04-30
-revised: 2026-04-30
-revision: 1
+revised: 2026-05-02
+revision: 2
 ai_generated: true
 summary: "Execute a workflow's tests via Planemo; emit structured pass/fail and outputs."
 references:
@@ -19,6 +19,22 @@ references:
     evidence: corpus-observed
     purpose: "Interpret assertion failures and choose the right fast inner-loop command before full reruns."
     trigger: "When a workflow test file exists and the task is to run, iterate, or classify its test assertions."
+  - kind: research
+    ref: "[[planemo-workflow-test-architecture]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Run workflow tests while preserving Planemo structured artifacts, Galaxy mode, invocation id, history id, and API follow-up context."
+    trigger: "When choosing between managed Galaxy, external Galaxy, full test runs, existing invocation checks, or direct workflow runs."
+  - kind: research
+    ref: "[[galaxy-workflow-invocation-failure-reference]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Preserve invocation identifiers and state summaries needed to inspect workflow-level runtime failures after Planemo returns."
+    trigger: "When Planemo reports a failed, cancelled, missing-output, or ambiguous workflow invocation result."
 ---
 # run-workflow-test
 

--- a/content/molds/validate-galaxy-step/index.md
+++ b/content/molds/validate-galaxy-step/index.md
@@ -9,7 +9,7 @@ tags:
 status: draft
 created: 2026-04-30
 revised: 2026-05-02
-revision: 1
+revision: 2
 ai_generated: true
 summary: "Run gxwf validation on the just-implemented Galaxy step and route failures back to step implementation."
 references:
@@ -22,6 +22,14 @@ references:
     purpose: "Validate a partial gxformat2 workflow while implementing one Galaxy step at a time."
     trigger: "After a Galaxy step is implemented or modified inside the per-step loop."
     verification: "Run the cast skill on an IWC-derived partial workflow and confirm gxwf diagnostics route back to the failing step."
+  - kind: research
+    ref: "[[galaxy-tool-job-failure-reference]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Keep static step validation findings distinct from wrapper-defined runtime failure semantics."
+    trigger: "When a selected tool can validate structurally but may fail at runtime due to stdio rules, exit-code handling, dynamic outputs, or datatype behavior."
 ---
 
 # validate-galaxy-step

--- a/content/molds/validate-galaxy-workflow/index.md
+++ b/content/molds/validate-galaxy-workflow/index.md
@@ -9,7 +9,7 @@ tags:
 status: draft
 created: 2026-05-02
 revised: 2026-05-02
-revision: 1
+revision: 2
 ai_generated: true
 summary: "Run terminal gxwf validation on an assembled Galaxy workflow and classify workflow-level failures."
 references:
@@ -22,6 +22,14 @@ references:
     purpose: "Validate the assembled gxformat2 workflow before runtime testing."
     trigger: "After all Galaxy steps and workflow tests have been assembled."
     verification: "Run the cast skill on a complete IWC-derived workflow and confirm terminal validation findings are separated from runtime test failures."
+  - kind: research
+    ref: "[[galaxy-workflow-invocation-failure-reference]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Keep static workflow validation findings distinct from Galaxy invocation/runtime failure surfaces."
+    trigger: "When a workflow passes gxwf validation but still has likely runtime risks around invocation scheduling, outputs, conditionals, or collection population."
 ---
 
 # validate-galaxy-workflow

--- a/content/research/galaxy-collection-semantics.md
+++ b/content/research/galaxy-collection-semantics.md
@@ -15,6 +15,8 @@ related_notes:
   - "[[galaxy-apply-rules-dsl]]"
   - "[[nextflow-to-galaxy-channel-shape-mapping]]"
   - "[[nextflow-operators-to-galaxy-collection-recipes]]"
+  - "[[galaxy-tool-job-failure-reference]]"
+  - "[[galaxy-workflow-invocation-failure-reference]]"
 sources:
   - "https://github.com/galaxyproject/galaxy/blob/7765fae934fbfdee77e3be5f5b235e43735273ae/lib/galaxy/model/dataset_collections/types/collection_semantics.yml"
 summary: "Vendored formal spec of Galaxy dataset-collection mapping/reduction semantics, with labeled examples and pinned test references."

--- a/content/research/galaxy-tool-job-failure-reference.md
+++ b/content/research/galaxy-tool-job-failure-reference.md
@@ -1,0 +1,140 @@
+---
+type: research
+subtype: component
+title: "Galaxy tool and job failure reference"
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+related_notes:
+  - "[[galaxy-workflow-invocation-failure-reference]]"
+  - "[[planemo-workflow-test-architecture]]"
+  - "[[galaxy-collection-semantics]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+  - "[[debug-galaxy-workflow-output]]"
+sources:
+  - "~/projects/repositories/galaxy/lib/galaxy/tools/__init__.py"
+  - "~/projects/repositories/galaxy/lib/galaxy/tool_util/parser/xml.py"
+  - "~/projects/repositories/galaxy/lib/galaxy/tool_util/output_checker.py"
+  - "~/projects/repositories/galaxy/lib/galaxy/jobs"
+  - "~/projects/repositories/galaxy/lib/galaxy/webapps/galaxy/api/jobs.py"
+summary: "Reference for Galaxy tool stdio rules, job failure detection, job states, and job API failure surfaces."
+---
+
+# Galaxy Tool And Job Failure Reference
+
+This is reference material, not a debug recipe. Use it to understand what Galaxy can know about a failed tool job and which API surfaces preserve that evidence.
+
+## Model
+
+Galaxy tool failure handling is layered:
+
+- The tool wrapper defines expected failure semantics through `detect_errors`, `<stdio>`, exit-code checks, regex checks, and command strictness.
+- The job runner executes the command and captures exit code plus tool/job stdout and stderr streams.
+- Galaxy evaluates configured failure rules and records structured `job_messages`.
+- The job reaches a terminal state, output datasets may become `error`, and dependent jobs may pause or fail later.
+- Workflow invocation APIs summarize those jobs, but job APIs preserve the most detailed tool-level evidence.
+
+## Tool Wrapper Failure Controls
+
+Important wrapper controls:
+
+| Control | Meaning |
+|---|---|
+| `detect_errors="default"` | For non-legacy XML tools without explicit `<stdio>`, Galaxy defaults to non-zero exit-code failure detection. |
+| `detect_errors="exit_code"` | Adds fatal checks for non-zero exit codes, plus optional OOM exit-code handling. |
+| `detect_errors="aggressive"` | Adds non-zero exit-code checks plus broad stdout/stderr regexes for OOM and generic error text. |
+| `<stdio><exit_code ... /></stdio>` | Adds explicit exit-code ranges or values with levels such as `fatal`, `warning`, or `fatal_oom`. |
+| `<stdio><regex ... /></stdio>` | Adds case-insensitive stdout/stderr regex checks. |
+| `<command strict="...">` | Controls shell strictness; newer tool profiles default to `set -e` behavior. |
+
+Current Galaxy source parses these rules while loading the tool, then stores exit-code and regex rules on the tool object. XML parser behavior lives under `~/projects/repositories/galaxy/lib/galaxy/tool_util/parser/xml.py`; concrete stdio presets live under `~/projects/repositories/galaxy/lib/galaxy/tool_util/parser/stdio.py`.
+
+## Rule Ordering And Levels
+
+Galaxy evaluates explicit and preset rules in a defined order:
+
+- Exit-code rules are evaluated before regex rules.
+- Regexes search stdout and/or stderr case-insensitively.
+- A fatal rule stops later checks.
+- Warnings, log messages, and QC messages can produce `job_messages` without failing the job.
+
+Useful levels:
+
+| Level | Effect |
+|---|---|
+| `log` | Records informational message; does not fail the job. |
+| `qc` | Records QC message; does not fail the job. |
+| `warning` | Records warning; does not fail the job. |
+| `fatal` | Fails the job as a generic tool error. |
+| `fatal_oom` | Fails as out-of-memory; runner behavior can use this for OOM handling/resubmission. |
+
+Low-confidence caveat: OOM resubmission behavior is runner/destination configuration dependent. The wrapper and output checker can classify OOM, but retry policy is not solely a wrapper property.
+
+## Job And Dataset States
+
+Job states relevant to workflow tests include:
+
+- In progress or queued: `new`, `queued`, `running`, `waiting`, `upload`, `resubmitted`.
+- Success: `ok`.
+- Failure or terminal problem: `error`, `failed`, `paused`, `stopped`, `deleted`, `skipped` depending context.
+
+Dataset states relevant to downstream failures include `ok`, `error`, `paused`, `failed_metadata`, `deferred`, and `discarded`.
+
+For workflow debugging, do not collapse job state and dataset state. A job can fail, its outputs can become error datasets, and a downstream workflow step can later fail because it consumes those datasets.
+
+## Stream And Message Fields
+
+Galaxy distinguishes tool streams from job/runner streams:
+
+| Field | Meaning |
+|---|---|
+| `tool_stdout` | stdout from the executed tool command. |
+| `tool_stderr` | stderr from the executed tool command. |
+| `job_stdout` | stdout from job wrapper/runner context. |
+| `job_stderr` | stderr from job wrapper/runner context. |
+| `stdout` | Combined stdout compatibility view. |
+| `stderr` | Combined stderr compatibility view. |
+| `job_messages` | Structured failure/warning messages produced by stdio and output checking. |
+| `exit_code` | Process exit code observed by the runner. |
+
+Prefer `job_messages` plus separate streams for reference-quality failure interpretation. Combined `stdout` and `stderr` are useful for humans but lose provenance.
+
+## API Surfaces
+
+Useful job APIs from Galaxy source under `~/projects/repositories/galaxy/lib/galaxy/webapps/galaxy/api/jobs.py`:
+
+| API | Use |
+|---|---|
+| `GET /api/jobs` | Filter jobs by state, tool id, workflow id, invocation id, history id, etc. |
+| `GET /api/jobs/{job_id}` | Basic job detail. |
+| `GET /api/jobs/{job_id}?full=true` | Full job detail, including streams and `job_messages`. |
+| `GET /api/jobs/{job_id}/stdout` | Combined stdout as plain text. |
+| `GET /api/jobs/{job_id}/stderr` | Combined stderr as plain text. |
+| `GET /api/jobs/{job_id}/console_output` | Live or stored tool stdout/stderr, useful while a job is running. |
+| `GET /api/jobs/{job_id}/inputs` | Input datasets for the job. |
+| `GET /api/jobs/{job_id}/outputs` | Output datasets and output collections. |
+| `GET /api/jobs/{job_id}/metrics` | Job metrics, if available. |
+| `GET /api/jobs/{job_id}/common_problems` | Known simple problems such as empty or duplicate inputs. |
+
+Admin-only or admin-enriched fields can include command line, traceback, destination, runner, handler, external id, and destination parameters. Do not assume a normal workflow-testing API key can retrieve everything.
+
+## Durable Reference Use
+
+This note should inform generated skills when they need to preserve or inspect tool-level failure evidence:
+
+- A concrete workflow step should preserve tool id, version, input labels, output labels, datatype and collection shape so a later job failure can be traced back to the authoring decision.
+- A runtime failure should not be classified from stderr alone if `job_messages`, exit code, and wrapper stdio rules are available.
+- A workflow invocation failure may be caused by an upstream job, but invocation APIs are not a substitute for full job detail.
+
+## Low-Confidence Or Version-Sensitive Points
+
+- Tool profile defaults changed over time. Prefer current Galaxy source and wrapper profile over old generic rules.
+- Some docs describe failure messages as stream text; current code preserves structured `job_messages` separately.
+- OOM handling depends on job runner and destination configuration.
+- Planemo may print or summarize job detail differently from raw Galaxy APIs; see [[planemo-workflow-test-architecture]].

--- a/content/research/galaxy-workflow-invocation-failure-reference.md
+++ b/content/research/galaxy-workflow-invocation-failure-reference.md
@@ -1,0 +1,141 @@
+---
+type: research
+subtype: component
+title: "Galaxy workflow invocation failure reference"
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+related_notes:
+  - "[[galaxy-tool-job-failure-reference]]"
+  - "[[planemo-workflow-test-architecture]]"
+  - "[[galaxy-collection-semantics]]"
+related_molds:
+  - "[[run-workflow-test]]"
+  - "[[debug-galaxy-workflow-output]]"
+  - "[[validate-galaxy-workflow]]"
+sources:
+  - "~/projects/repositories/galaxy/lib/galaxy/schema/invocation.py"
+  - "~/projects/repositories/galaxy/lib/galaxy/workflow/run.py"
+  - "~/projects/repositories/galaxy/lib/galaxy/workflow/modules.py"
+  - "~/projects/repositories/galaxy/lib/galaxy/webapps/galaxy/api/workflows.py"
+summary: "Reference for Galaxy workflow invocation states, messages, failure reasons, and invocation API surfaces."
+---
+
+# Galaxy Workflow Invocation Failure Reference
+
+This note describes workflow-level failure surfaces in Galaxy. It is separate from [[galaxy-tool-job-failure-reference]] because invocation state answers whether Galaxy could schedule and drive the workflow, while job state answers whether individual tool jobs succeeded.
+
+## Invocation Versus Job Failure
+
+Important distinction:
+
+- Invocation state says whether Galaxy scheduled, cancelled, failed, or completed the workflow invocation.
+- Job state says whether jobs produced by invocation steps succeeded or failed.
+- Invocation messages explain scheduler/evaluation/cancellation problems.
+- Step states usually describe scheduling progress, not actual job success, unless a legacy serialization mode substitutes job state.
+
+A robust workflow test reference should inspect both invocation APIs and job APIs.
+
+## Invocation States
+
+Galaxy invocation states are defined in `~/projects/repositories/galaxy/lib/galaxy/schema/invocation.py` and related model code.
+
+| State | Meaning |
+|---|---|
+| `new` | Newly created invocation. |
+| `requires_materialization` | Deferred or undeferred inputs must materialize before scheduling can continue. |
+| `ready` | Ready for another scheduler iteration. |
+| `scheduled` | Workflow has been scheduled. Older clients may treat this as successful terminal state. |
+| `cancelling` | Scheduler will cancel jobs and subworkflow invocations. |
+| `cancelled` | Cancellation terminal state. |
+| `failed` | Scheduler/evaluation/materialization failure terminal state. |
+| `completed` | Newer completion state after all jobs reach terminal states. |
+
+Version caveat: `completed` may not be uniformly available across all Galaxy/Planemo combinations. Planemo accounts for both `scheduled` and `completed` as success-like invocation states.
+
+## Invocation Message Reasons
+
+Structured invocation messages are the main durable surface for workflow-level failures.
+
+| Reason | Typical meaning |
+|---|---|
+| `dataset_failed` | Dataset input or upstream dataset was failed/unusable. |
+| `collection_failed` | Collection was failed, incompletely populated, or unusable. |
+| `job_failed` | Upstream dependent job failed. |
+| `output_not_found` | Expected step/subworkflow output could not be resolved. |
+| `expression_evaluation_failed` | Workflow expression or condition evaluation failed. |
+| `when_not_boolean` | Conditional `when` expression did not return a boolean. |
+| `unexpected_failure` | Scheduler or evaluation failure without a more specific safe reason. |
+| `workflow_parameter_invalid` | Workflow parameter validation failed. |
+| `step_input_deleted` | Step input dataset/collection was deleted. |
+| `history_deleted` | Invocation history was deleted, causing cancellation. |
+| `user_request` | User/API cancellation. |
+| `cancelled_on_review` | Pause/review step rejected continuation. |
+| `workflow_output_not_found` | Warning: declared workflow output was not found. |
+
+Message records can include affected workflow step id, dependent step id, job id, HDA/HDCA ids, output name, and nested workflow step index path. These fields matter more than free-text messages for reference-quality diagnosis.
+
+## Common Workflow-Level Failure Surfaces
+
+| Surface | Reference signal |
+|---|---|
+| Request-time validation | API returns an error before useful invocation state exists. |
+| Input materialization | Invocation enters `requires_materialization`, then may fail with `dataset_failed`. |
+| Conditional evaluation | Invocation messages include `expression_evaluation_failed` or `when_not_boolean`. |
+| Missing output graph edge | Invocation messages include `output_not_found`. |
+| Deleted/purged inputs | Invocation messages include `step_input_deleted` or `dataset_failed`. |
+| Upstream job failure | Invocation messages or summaries point to `job_failed`; job API has details. |
+| Collection population failure | Invocation messages include `collection_failed`; inspect HDCA and mapped jobs. |
+| Pause/review rejection | Cancellation reason `cancelled_on_review`. |
+| User/history cancellation | Cancellation messages `user_request` or `history_deleted`. |
+| Warning-only missing output | `workflow_output_not_found` warning; may later become Planemo assertion failure. |
+
+## API Surfaces
+
+Useful invocation APIs from `~/projects/repositories/galaxy/lib/galaxy/webapps/galaxy/api/workflows.py`:
+
+| API | Use |
+|---|---|
+| `GET /api/invocations/{invocation_id}` | Invocation state, messages, inputs, outputs, and steps. |
+| `GET /api/invocations/{invocation_id}?step_details=true` | Richer step detail, jobs, outputs, and output collections. |
+| `GET /api/invocations/steps/{step_id}` | Detail for one invocation step. |
+| `GET /api/invocations/{invocation_id}/steps/{step_id}` | Step detail scoped to invocation. |
+| `GET /api/invocations/{invocation_id}/jobs_summary` | Job state summary across the invocation. |
+| `GET /api/invocations/{invocation_id}/step_jobs_summary` | Job state summary per workflow invocation step. |
+| `GET /api/invocations/{invocation_id}/completion` | Completion record, if available. |
+| `DELETE /api/invocations/{invocation_id}` | Cancel invocation. |
+| `PUT /api/invocations/{invocation_id}/steps/{step_id}` | Continue or cancel pause/review step. |
+| `GET /api/invocations/{invocation_id}/report` | Invocation report surface. |
+
+Workflow aliases under `/api/workflows/{workflow_id}/invocations/...` also exist.
+
+## Planemo Caveats
+
+Planemo polls invocation and job state, but its user-facing output may not expose all structured invocation messages. Treat Planemo terminal output as a summary; use raw invocation and job APIs when the failure class matters.
+
+Likely noisy boundaries:
+
+- Planemo may show failed job details but omit structured invocation messages.
+- `step_jobs_summary` is useful in Galaxy but not necessarily surfaced directly by Planemo output.
+- Subworkflow paths can be represented in Galaxy message fields but may not be displayed by Planemo.
+- A workflow can be `completed` or `scheduled` while one or more jobs failed; job summaries must still be inspected.
+
+## Durable Reference Use
+
+Use this note when a workflow run fails before or around job scheduling, when outputs are missing without an obvious tool stderr cause, or when Planemo only reports a generic invocation failure.
+
+The goal is not to prescribe a single repair loop. The goal is to preserve which Galaxy API surface proves the failure mode so later Molds can decide whether the defect belongs to data-flow, template, concrete step implementation, workflow test assertions, or runtime environment.
+
+## Verification Gaps
+
+Actual runs should verify:
+
+- Whether Planemo surfaces invocation `messages` for each reason.
+- Whether `completed` and `/completion` are populated in the target Galaxy used by tests.
+- How mapped collections and subworkflow failures appear in `step_jobs_summary`.
+- How warning-only `workflow_output_not_found` interacts with Planemo assertions.

--- a/content/research/planemo-asserts-idioms.md
+++ b/content/research/planemo-asserts-idioms.md
@@ -6,14 +6,15 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-04-30
-revision: 1
+revised: 2026-05-02
+revision: 2
 ai_generated: true
 related_notes:
   - "[[iwc-test-data-conventions]]"
   - "[[iwc-shortcuts-anti-patterns]]"
   - "[[implement-galaxy-workflow-test]]"
   - "[[tests-format]]"
+  - "[[planemo-workflow-test-architecture]]"
 summary: "Decision and idiom guide for picking planemo workflow-test assertions: which family per output type, how to size tolerances, when to validate."
 ---
 

--- a/content/research/planemo-workflow-test-architecture.md
+++ b/content/research/planemo-workflow-test-architecture.md
@@ -1,0 +1,149 @@
+---
+type: research
+subtype: component
+title: "Planemo workflow-test architecture"
+tags:
+  - research/component
+  - tool/planemo
+  - target/galaxy
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+related_notes:
+  - "[[galaxy-tool-job-failure-reference]]"
+  - "[[galaxy-workflow-invocation-failure-reference]]"
+  - "[[planemo-asserts-idioms]]"
+related_molds:
+  - "[[run-workflow-test]]"
+  - "[[debug-galaxy-workflow-output]]"
+  - "[[implement-galaxy-workflow-test]]"
+sources:
+  - "~/projects/repositories/planemo/planemo/commands/cmd_test.py"
+  - "~/projects/repositories/planemo/planemo/commands/cmd_run.py"
+  - "~/projects/repositories/planemo/planemo/galaxy/activity.py"
+  - "~/projects/repositories/planemo/planemo/galaxy/invocations"
+  - "~/projects/repositories/planemo/planemo/galaxy/config.py"
+summary: "Reference for Planemo workflow test/run architecture, Galaxy modes, API polling, and noisy failure boundaries."
+---
+
+# Planemo Workflow-Test Architecture
+
+This note describes Planemo architecture relevant to workflow tests and workflow runs. It is reference material for Molds that need to run tests or interpret Planemo artifacts, not a command-selection recipe.
+
+## Main Commands
+
+| User action | Command | Core behavior |
+|---|---|---|
+| Full workflow test | `planemo test <workflow>` | Finds test definitions, starts or targets Galaxy, stages inputs, invokes workflow, checks assertions, writes reports. |
+| Direct run | `planemo run <workflow> <job.yml>` | Runs one workflow/job pair and can download outputs without assertion checks. |
+| Recheck assertions | `planemo workflow_test_on_invocation <tests.yml> <invocation_id>` | Runs test assertions against an existing invocation without rerunning the workflow. |
+| Track invocation | `planemo workflow_track <invocation_id>` | Polls an existing invocation and displays progress. |
+| Generate test from invocation | `planemo workflow_test_init --from_invocation <id>` | Builds a test template from a completed invocation and its outputs. |
+| Generate job template | `planemo workflow_job_init <workflow>` | Creates a job-input template for a workflow. |
+
+Observed code paths live under `~/projects/repositories/planemo/planemo/commands/`, `planemo/engine/`, and `planemo/galaxy/`.
+
+## Engine Selection
+
+Planemo chooses between engines early:
+
+- CWL runnables can use CWL-specific engines.
+- Supplying `--galaxy_url` implies an external running Galaxy unless an engine is explicitly selected.
+- Default Galaxy workflow testing uses a managed local Galaxy engine.
+- `--engine docker_galaxy` uses a managed Dockerized Galaxy.
+- `--engine external_galaxy` uses an existing running Galaxy.
+
+“Existing Galaxy” can mean two different things:
+
+- Existing local Galaxy source tree, still managed by Planemo for this run.
+- Existing running Galaxy server, addressed through URL and API keys.
+
+Mold output and eval logs should record which meaning applies.
+
+## Managed Galaxy Configuration
+
+For managed Galaxy, Planemo builds a temporary configuration directory and generated Galaxy config. It can configure tool config, shed tool config, job config, file sources, object store paths, dependency config, SQLite database by default, admin users, API keys, and environment overrides.
+
+Important managed-mode behavior:
+
+- Planemo may find a local Galaxy root or install/use a cached Galaxy source tree.
+- Managed Galaxy defaults are convenient but may not match production Galaxy behavior.
+- Planemo can install workflow tool dependencies through Tool Shed metadata when configured.
+- Test histories are created automatically unless a history id is supplied.
+
+## External Galaxy Configuration
+
+For external Galaxy, Planemo uses supplied Galaxy URL and API keys. A user key runs workflows; an admin key may be needed for installing missing repositories or creating a user key.
+
+External Galaxy mode is useful when the target environment matters, but failure surfaces can include server configuration, installed tools, permissions, and existing history state. Eval logs should preserve URL/key mode without storing secrets.
+
+## API Interaction
+
+Planemo primarily talks to Galaxy through BioBlend-backed clients.
+
+Important operations:
+
+- Import workflows into Galaxy.
+- Stage datasets and collections into histories.
+- Invoke workflows by input names.
+- Poll invocations and jobs.
+- Fetch job details with full detail when needed.
+- Download outputs and output collections.
+- Run assertion checks and write structured reports.
+
+For workflows, Planemo invokes Galaxy using input labels/names. Stable generated labels are therefore important for both test execution and debugging.
+
+## Structured Artifacts
+
+Useful Planemo artifacts and fields:
+
+| Artifact or field | Use |
+|---|---|
+| `tool_test_output.json` | Primary structured result artifact for tests. |
+| invocation id | Key for Galaxy invocation API follow-up. |
+| history id | Key for history contents and output inspection. |
+| workflow id | Key for workflow invocation aliases and reruns. |
+| output problems | Assertion and missing-output failures. |
+| execution problem | Staging, invocation, API, or other execution-level failure. |
+| invocation details | Step/job/output details Planemo collected from Galaxy. |
+| job details | Tool id, state, exit code, command, stdout/stderr when collected. |
+
+Terminal output is not enough for durable failure analysis. Preserve structured output whenever possible.
+
+## Noisy Boundaries
+
+Planemo transforms and summarizes Galaxy failure information. These are likely information-loss boundaries:
+
+- Exceptions during execution can become stringified `ErrorRunResponse` values.
+- Polling may summarize “at least one job is in error” while detailed job evidence is printed elsewhere or stored separately.
+- Missing outputs become assertion/output problems, which can conflate label mismatch, workflow output omission, optional output absence, failed invocation, or output download issue.
+- Output download failures may be logged but not always propagated as the most specific failure.
+- External Galaxy without an admin key may defer missing-tool problems until runtime.
+- `allow_tool_state_corrections=True` can let Galaxy adjust tool state during invocation, which is useful but can mask definition drift.
+- `--no_wait` is not suitable for debug conclusions because invocation creation can succeed before jobs fail.
+
+## Reference Use For Molds
+
+For [[run-workflow-test]]:
+
+- Preserve structured Planemo result output, invocation id, history id, workflow id, and Galaxy mode.
+- Record whether the run used managed local Galaxy, Docker Galaxy, or external Galaxy.
+- Do not treat terminal output as the primary failure artifact.
+
+For [[debug-galaxy-workflow-output]]:
+
+- Start from structured Planemo output.
+- If the failure is job-level, inspect Galaxy job APIs described in [[galaxy-tool-job-failure-reference]].
+- If the failure is invocation-level, inspect Galaxy invocation APIs described in [[galaxy-workflow-invocation-failure-reference]].
+- If only assertions failed, use [[planemo-asserts-idioms]] before deciding to rerun.
+
+## Verification Gaps
+
+Actual runs should verify:
+
+- Which invocation messages Planemo exposes directly.
+- Whether target Planemo/Galaxy versions populate `completed`, `/completion`, and step job summaries.
+- How `workflow_test_on_invocation` behaves for failed, warning-only, mapped collection, and subworkflow invocations.
+- Whether generated test cases from invocation preserve nested output collection structure correctly.


### PR DESCRIPTION
## Summary
- add reference notes for Galaxy tool/job failure handling, workflow invocation failures, and Planemo workflow-test architecture
- link the notes from run/debug/validation/implementation molds where runtime failure evidence matters
- distinguish durable reference surfaces from actionable debug recipes

## Validation
- npm run validate
- npm run test