### PR TITLE
Move Mold meta-content out of index.md body

### DIFF
--- a/content/molds/discover-shed-tool/index.md
+++ b/content/molds/discover-shed-tool/index.md
@@ -161,8 +161,3 @@ The procedure assumes — and the cast skill must surface in its rationale when 
 - **Caching.** This Mold emits a pin recommendation. The caller (or the next phase) runs `galaxy-tool-cache add toolshed.g2.bx.psu.edu/repos/<owner>/<repo>/<tool_id> --version <v>` to populate the cache.
 - **Galaxy-instance discovery.** Hitting a running Galaxy server's installed-tool index (EDAM-aware, panel-aware) is a different mechanism — the future `discover-tool-via-galaxy-api` Mold. The contrast is sketched in `[[component-tool-shed-search]]` §4.
 - **Test-data resolution.** Out of scope; handled by the `test-data-resolution` branch elsewhere in the pipeline.
-
-## Reference dispatch (for casting)
-
-- `cli_commands` ([[tool-search]], [[tool-versions]], [[tool-revisions]]) — cast as JSON sidecars per the per-action manpage dispatch (see `COMPILATION_PIPELINE.md`). The cast skill calls these as subprocess commands at runtime.
-- `[[component-tool-shed-search]]` — research note. **Not** packaged into the cast skill. It is the Foundry-internal grounding for the gotchas listed above; casting selects only the operationally relevant slices when condensing the procedural body.

--- a/content/molds/summarize-nextflow/changes.md
+++ b/content/molds/summarize-nextflow/changes.md
@@ -1,0 +1,11 @@
+# summarize-nextflow — changes
+
+Revision history for the `summarize-nextflow` Mold. Maintained alongside `index.md` but never packaged into casts.
+
+- **rev 7 (2026-05-02)** — CLI package now sweeps `include { X as Y } from ...` statements across workflow and subworkflow files to populate `processes[].aliases`, tested against bacass repeated imports (`MINIMAP2_ALIGN`, `FASTQC`).
+- **rev 6 (2026-05-02)** — CLI package now parses multi-dependency module `environment.yml` files into separate Bioconda-backed `tools[]` entries, tested against bacass modules such as `minimap2/align` and `samtools/sort`.
+- **rev 5 (2026-05-02)** — CLI package hardened against `nf-core/bacass` profile config expressions: resolves `params.pipelines_testdata_base_path + '...'`, fetches samplesheet-referenced remote files, hashes them, and optionally localizes them under `--test-data-dir` while preserving original URLs.
+- **rev 4 (2026-05-01)** — second cast against `nf-core/bacass @ 2.5.0` (33 processes, 9 nf-test files, 11 test profiles) exposed two patterns the first cast couldn't see: process aliasing via `include { X as Y }` (six distinct alias-rename patterns in bacass) and the per-test-file structure of nf-test fixtures. §4 grew the alias-sweep rule; §7 split into `test_fixtures` + `nf_tests[]` with structured snapshot extraction. Schema bumped to rev 3 in lockstep. Cast log: `content/log.md` second 2026-05-01 entry.
+- **rev 3 (2026-05-01)** — first cast against `nf-core/demo @ 1.1.0` exposed the gaps now folded into §1 (multi-workflow selection rule), §4 (verbatim directive capture, channel topics), §5 (ternary container resolver, file-path conda directives, Wave registry), §6 (utility-vs-pipeline subworkflow split, free-function calls). Schema bumped to rev 2 in lockstep — see `[[summary-nextflow]]`'s revision-2 section. Cast log: `content/log.md` 2026-05-01 entry.
+- **rev 2 (2026-04-30)** — substantive body added; output schema declared.
+- **rev 1 (2026-04-30)** — stub.

--- a/content/molds/summarize-nextflow/index.md
+++ b/content/molds/summarize-nextflow/index.md
@@ -263,16 +263,6 @@ Each entry follows `TestDataRef` (inputs) / `ExpectedOutputRef` (outputs) field 
 
 Validate the assembled object against `schemas/summary-nextflow.schema.json` before emitting. On schema failure, the cast skill should fail loud — the downstream Molds bind to the schema and will produce worse errors later. `additionalProperties: false` at every level catches drift early.
 
-## Revision history
-
-- **rev 7 (2026-05-02)** — CLI package now sweeps `include { X as Y } from ...` statements across workflow and subworkflow files to populate `processes[].aliases`, tested against bacass repeated imports (`MINIMAP2_ALIGN`, `FASTQC`).
-- **rev 6 (2026-05-02)** — CLI package now parses multi-dependency module `environment.yml` files into separate Bioconda-backed `tools[]` entries, tested against bacass modules such as `minimap2/align` and `samtools/sort`.
-- **rev 5 (2026-05-02)** — CLI package hardened against `nf-core/bacass` profile config expressions: resolves `params.pipelines_testdata_base_path + '...'`, fetches samplesheet-referenced remote files, hashes them, and optionally localizes them under `--test-data-dir` while preserving original URLs.
-- **rev 4 (2026-05-01)** — second cast against `nf-core/bacass @ 2.5.0` (33 processes, 9 nf-test files, 11 test profiles) exposed two patterns the first cast couldn't see: process aliasing via `include { X as Y }` (six distinct alias-rename patterns in bacass) and the per-test-file structure of nf-test fixtures. §4 grew the alias-sweep rule; §7 split into `test_fixtures` + `nf_tests[]` with structured snapshot extraction. Schema bumped to rev 3 in lockstep. Cast log: `content/log.md` second 2026-05-01 entry.
-- **rev 3 (2026-05-01)** — first cast against `nf-core/demo @ 1.1.0` exposed the gaps now folded into §1 (multi-workflow selection rule), §4 (verbatim directive capture, channel topics), §5 (ternary container resolver, file-path conda directives, Wave registry), §6 (utility-vs-pipeline subworkflow split, free-function calls). Schema bumped to rev 2 in lockstep — see `[[summary-nextflow]]`'s revision-2 section. Cast log: `content/log.md` 2026-05-01 entry.
-- **rev 2 (2026-04-30)** — substantive body added; output schema declared.
-- **rev 1 (2026-04-30)** — stub.
-
 ## Caveats baked into the procedure
 
 The procedure assumes — and the cast skill must surface in `warnings[]` when relevant — the following NF realities:

--- a/docs/COMPILATION_PIPELINE.md
+++ b/docs/COMPILATION_PIPELINE.md
@@ -99,7 +99,7 @@ Drift surfaces today via `cast-mold.ts <mold> --check` (per-Mold) and `cast-skil
 
 To cast a Mold, the casting process consumes:
 
-- **The Mold directory** — `index.md` (frontmatter manifest + procedural body) plus, if the schema permits, casting hints. **Not** `eval.md` — evals stay in the Foundry.
+- **The Mold directory** — `index.md` (frontmatter manifest + procedural body) plus, if the schema permits, casting hints. The cast consumes only the procedural body of `index.md`; sibling files (`eval.md`, `changes.md`, `cast-skill-verification.md`) are Foundry-only and never packaged. Author-facing meta-content (changelog entries, casting open-questions) belongs in those sibling files, not in the body of `index.md` — anything in the body is a candidate for the cast.
 - **All typed references declared in the manifest**, resolved by kind:
   - `references` — object-shaped typed references with `kind`, `ref`, `used_at`, `load`, and `mode`; this is the preferred manifest for new operational references.
   - `patterns` — legacy wiki links into `content/patterns/`.

--- a/docs/MOLD_SPEC.md
+++ b/docs/MOLD_SPEC.md
@@ -18,9 +18,18 @@ Optional files:
 
 - `casting.md` — Mold-owned guidance read by casting itself (skill assembly notes, condensation prompts). Not packaged into the generated skill runtime unless explicitly incorporated by the cast.
 - `cast-skill-verification.md` — Mold-owned dynamic-review checklist for a generated skill. Used after casting by reviewers or verification agents; not packaged into runtime artifacts.
+- `changes.md` — Mold-owned revision history / changelog. Use this for content that documents how the Mold has evolved across casts. Never packaged into cast artifacts.
 - `examples/` — local examples or small fixtures referenced by `index.md` or `eval.md`.
 
 Non-`index.md` Markdown files inside a Mold directory must not contain frontmatter. If a supporting note needs frontmatter, move it to the appropriate content collection and reference it from the Mold.
+
+### `index.md` body discipline
+
+The body of `index.md` is procedural content the cast skill consumes. **Do not put author-facing meta-content in the body** — it leaks into casts. In particular:
+
+- Revision history / changelog → `changes.md`.
+- "Reference dispatch (for casting)" or similar redundant restatements of the `references:` manifest → delete; the metadata is the contract.
+- Open authoring questions about scope or future references → `casting.md` (cast-time) or the Mold's eval/notes, not the body.
 
 ### File roles at a glance
 
@@ -30,6 +39,7 @@ Non-`index.md` Markdown files inside a Mold directory must not contain frontmatt
 | `eval.md`                     | Foundry maintainers               | Never                          |
 | `casting.md`                  | Cast skill / casting LLM          | Read at cast time              |
 | `cast-skill-verification.md`  | Post-cast reviewer / agent        | Never                          |
+| `changes.md`                  | Mold authors / reviewers          | Never                          |
 | `examples/`                   | `index.md`, `eval.md`             | Only if referenced explicitly  |
 
 ## Index Contract


### PR DESCRIPTION
## Summary

The body of \`content/molds/<slug>/index.md\` is procedural content casting consumes and propagates into generated skills. Author-facing meta-content there leaks. This PR:

- Establishes \`<mold>/changes.md\` as the convention for Mold revision history / changelog. Never packaged.
- Removes redundant \"Reference dispatch (for casting)\" sections that just restate the \`references:\` manifest — the metadata is the contract.

## Changes

- \`content/molds/summarize-nextflow/changes.md\` — new file with the revision history previously in the body of \`index.md\`.
- \`content/molds/summarize-nextflow/index.md\` — \`## Revision history\` section removed.
- \`content/molds/discover-shed-tool/index.md\` — redundant \`## Reference dispatch (for casting)\` section removed (every entry was already encoded in the \`references:\` metadata).
- \`docs/MOLD_SPEC.md\` — declares \`changes.md\` as optional Mold-source file (never packaged) and adds an \"index.md body discipline\" note.
- \`docs/COMPILATION_PIPELINE.md\` — input-contract bullet now lists \`changes.md\` and \`cast-skill-verification.md\` alongside \`eval.md\` as Foundry-only siblings.

## Test plan

- [x] \`npm run validate\` clean (warnings only)
- [x] \`npm run test\` (47/47)

## Out of scope (flagged)

- \`summarize-nextflow/index.md\` still has its own \`## Reference dispatch (for casting)\` section. Unlike \`discover-shed-tool\`'s, it mixes redundant restatements with authoring open-questions (\"examples — pending\", bundling-vs-URL discussion) — left alone in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)