### PR TITLE
Support package-vendored schemas in cast-mold

### DIFF
--- a/casts/claude/implement-galaxy-workflow-test/_provenance.json
+++ b/casts/claude/implement-galaxy-workflow-test/_provenance.json
@@ -1,0 +1,88 @@
+{
+  "provenance_schema_version": 2,
+  "cast_target": "claude",
+  "mold": {
+    "name": "implement-galaxy-workflow-test",
+    "path": "content/molds/implement-galaxy-workflow-test/index.md",
+    "revision": 2,
+    "content_hash": "70aed95c448839bbba15eccda9d277b164265bf29eaf0a6c5fc67ccb4d978c8c",
+    "commit": "4be9b4fbb5bc46ffbef6e3b3484f9482c6f8df73"
+  },
+  "cast_at": "2026-05-03T11:29:35.676Z",
+  "refs": [
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[iwc-shortcuts-anti-patterns]]",
+      "src": "content/research/iwc-shortcuts-anti-patterns.md",
+      "dst": "references/notes/iwc-shortcuts-anti-patterns.md",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Flag assertion shortcuts that are acceptable in IWC versus shortcuts that should be avoided.",
+      "trigger": "When considering existence-only, size-only, image-only, checksum, output-label, or negative-test patterns.",
+      "src_hash": "7dc5b5451df779bd32505ae9967027bd005d1a3c79797e4dd0307f7a2952ffa3",
+      "dst_hash": "7dc5b5451df779bd32505ae9967027bd005d1a3c79797e4dd0307f7a2952ffa3",
+      "source": "deterministic"
+    },
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[iwc-test-data-conventions]]",
+      "src": "content/research/iwc-test-data-conventions.md",
+      "dst": "references/notes/iwc-test-data-conventions.md",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Assemble job input fixtures, remote URLs, hashes, collection shapes, and test-data layout in IWC style.",
+      "trigger": "When writing or revising the job/input side of a Galaxy workflow test file.",
+      "src_hash": "6bda84ade1f43a4ca9736f4e68fb23f166785a796e24497181b8788cfbb465d1",
+      "dst_hash": "6bda84ade1f43a4ca9736f4e68fb23f166785a796e24497181b8788cfbb465d1",
+      "source": "deterministic"
+    },
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[planemo-asserts-idioms]]",
+      "src": "content/research/planemo-asserts-idioms.md",
+      "dst": "references/notes/planemo-asserts-idioms.md",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Choose assertion families, tolerance magnitudes, and the static/Planemo validation loop.",
+      "trigger": "When writing or revising output assertions for a Galaxy workflow test file.",
+      "src_hash": "d0db9df7ecde0eba8aff23bece34079cb0496fb17510a57bc1dc1158cfdb15d1",
+      "dst_hash": "d0db9df7ecde0eba8aff23bece34079cb0496fb17510a57bc1dc1158cfdb15d1",
+      "source": "deterministic"
+    },
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[planemo-workflow-test-architecture]]",
+      "src": "content/research/planemo-workflow-test-architecture.md",
+      "dst": "references/notes/planemo-workflow-test-architecture.md",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Write tests with stable labels and artifacts that Planemo can connect back to Galaxy invocations, jobs, and outputs.",
+      "trigger": "When adding or revising workflow tests that will be iterated with Planemo or generated from existing invocations.",
+      "src_hash": "02b9723f6db1c846959dab01aa4b68776b24b722fa0aa3f979e205dfda2ca7f8",
+      "dst_hash": "02b9723f6db1c846959dab01aa4b68776b24b722fa0aa3f979e205dfda2ca7f8",
+      "source": "deterministic"
+    },
+    {
+      "kind": "schema",
+      "mode": "verbatim",
+      "ref": "[[tests-format]]",
+      "src": "package://@galaxy-tool-util/schema#testsSchema",
+      "dst": "references/schemas/tests-format.schema.json",
+      "used_at": "runtime",
+      "load": "upfront",
+      "evidence": "corpus-observed",
+      "purpose": "JSON Schema contract for the Galaxy workflow test format. Output of this Mold must validate against it.",
+      "src_hash": "5b640f383f848e3a7b2cacac2fbd7f96ef1a04cca1283b237b772edc142bf066",
+      "dst_hash": "5b640f383f848e3a7b2cacac2fbd7f96ef1a04cca1283b237b772edc142bf066",
+      "source": "deterministic"
+    }
+  ]
+}

--- a/casts/claude/implement-galaxy-workflow-test/references/notes/iwc-shortcuts-anti-patterns.md
+++ b/casts/claude/implement-galaxy-workflow-test/references/notes/iwc-shortcuts-anti-patterns.md
@@ -1,0 +1,348 @@
+---
+type: research
+subtype: component
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-04-30
+revised: 2026-04-30
+revision: 1
+ai_generated: true
+related_notes:
+  - "[[iwc-test-data-conventions]]"
+  - "[[planemo-asserts-idioms]]"
+  - "[[implement-galaxy-workflow-test]]"
+  - "[[tests-format]]"
+summary: "What IWC test suites cut corners on (accepted) vs what's a code smell — existence-only probes, sim_size deltas, image dim checks, label coupling."
+---
+
+# IWC test-suite shortcuts and anti-patterns
+
+## Purpose
+
+When an agent translates or authors a Galaxy workflow for IWC submission, the test suite it writes will be reviewed against IWC's *de facto* style — not against an idealized assertion ladder. That style routinely tolerates assertions that look weak in isolation. This note distinguishes the corner-cutting that is **normal and accepted** in the corpus from the patterns that an agent should treat as **smells** worth flagging.
+
+Grounding: 115 `*-tests.yml` files under `workflow-fixtures/iwc-src/workflows/` (mirror of `galaxyproject/iwc`), prior synthesis in `galaxy-brain/vault/projects/workflow_state/skills/COMPONENT_GALAXY_WORKFLOW_TESTING.md`. Path citations below are relative to `iwc-src/workflows/` unless absolute.
+
+## TL;DR rules of thumb
+
+1. **Default to tolerant assertions.** `compare: sim_size` + `delta:`, `has_image_*` + `delta:`, `has_text` substring, `has_h5_keys`, `has_n_lines` + `delta:` are *the IWC vocabulary*. Strict `compare: diff` or exact-`file:` is the exception, used only when the upstream tool is fully deterministic on fixed inputs.
+2. **No negative tests.** `expect_failure:` does not appear in the corpus. Don't author one.
+3. **No checksums.** `md5:` / `checksum:` do not appear on outputs in the corpus. SHA-1 hashes are used on **inputs** (integrity of remote fetch), never on output assertions.
+4. **Preserve labels.** Inputs and outputs are referenced by label. Renaming silently breaks tests; treat label changes as breaking changes that require a sibling `-tests.yml` update.
+5. **Big data goes to Zenodo.** In-repo `test-data/` is for toy fixtures and expected outputs only.
+
+---
+
+## 1. Existence-only content probes
+
+### Accepted
+
+The HyPhy test files reduce JSON output validation to "starts with `{`":
+
+- `comparative_genomics/hyphy/hyphy-core-tests.yml:32-71` — four output collections (`meme_output`, `prime_output`, `busted_output`, `fel_output`), each gene element asserts `has_text: text: "{"` and nothing else.
+- `comparative_genomics/hyphy/hyphy-compare-tests.yml`, `capheine-core-and-compare-tests.yml` — same pattern across the rest of the family.
+
+This is **accepted** because:
+- HyPhy's MEME/PRIME/BUSTED/FEL/CFEL/RELAX statistical outputs embed run-dependent floats throughout (likelihoods, AIC, posterior probabilities). Substring assertions on numeric fields would fail intermittently.
+- Selecting any specific gene name or category in the JSON would couple the test to internal HyPhy keying that the wrapper has changed across versions.
+- The assertion does verify "the tool ran, produced JSON, did not crash, and the collection structure matches expected element identifiers" — which is genuinely useful given HyPhy's history of opaque failures.
+
+A quick scan finds **298 lines** matching the existence-style `has_text:` pattern across the corpus (`grep "has_text:\s*$\|text: \"{\"$"` yields 298 hits across many files). It is widespread, not a HyPhy quirk.
+
+Other variants in the same accepted-shortcut family:
+
+- **First-line-of-header probes**: `amplicon/amplicon-mgnify/.../mgnify-amplicon-pipeline-v5-rrna-prediction-tests.yml:46-49` asserts `has_text: "# mapseq v1.2.6 (Jan 20 2023)"` — version banner only.
+- **`has_n_columns` schema probes**: same file lines 50-52, 67-69 — "the table has 15 columns" / "4 columns" with no row-content check.
+- **`has_h5_keys` structure probes**: `scRNAseq/scanpy-clustering/.../Preprocessing-...-Scanpy-tests.yml:27-32, 159-166` — confirms AnnData has `obs/louvain`, `var/highly_variable`, `uns/rank_genes_groups`, etc., but says nothing about cluster labels or values. Also `imaging/tissue-microarray-analysis/multiplex-tissue-microarray-analysis/multiplex-tma-tests.yml` for Merged anndata.
+
+### Smell
+
+Existence probes on **deterministic** outputs. If the underlying tool is deterministic on fixed inputs (alignment, simple QC stats, well-defined transformations), reducing to `has_text: "{"` is laziness — agent should at least pull a known stable substring from the expected JSON.
+
+Heuristic for an agent: **if the source workflow's tool is on the "stochastic / floating-point heavy / version-fragile" list (HyPhy, RepeatModeler, scanpy plots, MCMC samplers, ML inference), existence probes are accepted. Otherwise, prefer `has_text` against a stable token from a real output.**
+
+---
+
+## 2. Size-only comparisons (`compare: sim_size` + `delta:`)
+
+### Accepted
+
+Canonical example: `repeatmasking/RepeatMasking-Workflow-tests.yml:11-46` — every output is `compare: sim_size` with `delta: 30000` (30 KB) on small outputs and `delta: 90000000` (90 MB!) on the Stockholm seed-alignment file. RepeatModeler's discovered repeat families differ run-to-run; only output magnitude is reproducible.
+
+`grep "compare: sim_size"` returns 9 files using this pattern:
+- `repeatmasking/RepeatMasking-Workflow-tests.yml`, `repeatmasking/Repeat-masking-with-RepeatModeler-and-RepeatMasker-tests.yml` (RepeatModeler — large delta band)
+- `epigenetics/hic-hicup-cooler/chic-fastq-to-cool-hicup-cooler-tests.yml`, `epigenetics/hic-hicup-cooler/hic-fastq-to-cool-hicup-cooler-tests.yml` (HiC matrices)
+- `genome_annotation/functional-annotation/functional-annotation-of-sequences/Functional_annotation_of_sequences-tests.yml`
+- `VGP-assembly-v2/kmer-profiling-hifi-trio-VGP2/kmer-profiling-hifi-trio-VGP2-tests.yml`
+- `genome-assembly/polish-with-long-reads/Assembly-polishing-with-long-reads-tests.yml`
+- `scRNAseq/baredsc/baredSC-1d-logNorm-tests.yml`, `scRNAseq/baredsc/baredSC-2d-logNorm-tests.yml` (Bayesian sampling — uses `delta_frac:` here)
+
+### Delta-magnitude survey
+
+From `grep "delta: [0-9]+"` distribution across the corpus:
+
+| Delta band | Count | Typical use |
+|---|---|---|
+| 4–100 (tiny) | ~20 | image pixel dimensions, line counts |
+| 1K–10K | ~40 | small text/tabular outputs, plot PNGs |
+| 25K–100K | ~25 | mid-size reports, multi-page plots |
+| 200K–1M | ~10 | report HTML, BAM stats |
+| 1M–10M | ~10 | medium BAM/BCF/cool files |
+| 10M+ (up to 90M) | ~7 | RepeatModeler libraries, large alignments |
+
+The 90 MB delta on `RepeatMasking-Workflow-tests.yml:20` is at the extreme. It says "this output is somewhere between zero bytes and 180 MB" — effectively only catches the empty-output failure mode. Accepted because RepeatModeler's seed alignments are known to vary by tens of MB across runs.
+
+### `delta_frac:`
+
+Used in 3 files (`scRNAseq/baredsc/*`, `genome-assembly/polish-with-long-reads/*`). Preferred over absolute `delta:` when the expected output size scales with input. An agent translating a workflow whose output size depends on input volume should consider `delta_frac:` over `delta:`.
+
+### Smell
+
+`compare: sim_size` on outputs from a **deterministic** tool. If the tool is bwa/bowtie2/samtools-sort with fixed seeds and pinned versions, there's no excuse for size-only — `compare: diff` (with modest `lines_diff:`) or content assertions are appropriate.
+
+Also a smell: stacking size + `has_image_*` checks on a PNG without any content assertion when the workflow's claim is *about the data shown* (e.g., a clustering plot). The corpus does this routinely (Scanpy file below) — accepted, but a translated workflow that has a more deterministic plotter should do better.
+
+---
+
+## 3. Image plot assertions
+
+### Accepted
+
+`scRNAseq/scanpy-clustering/.../Preprocessing-...-Scanpy-tests.yml:33-205` is the dense example. ~15 PNG outputs each get the same triple:
+
+```yaml
+UMAP of louvain:
+  has_size:
+    size: 68416
+    delta: 6000
+  has_image_width:
+    width: 601
+    delta: 30
+  has_image_height:
+    height: 429
+    delta: 25
+```
+
+What this catches:
+- Plot was rendered (non-zero size).
+- Render dimensions are stable (matplotlib defaults didn't drift, theme didn't change).
+- Approximate file size hasn't shifted by an order of magnitude (no catastrophic content change like all-white or all-noise).
+
+What this **misses**: cluster assignments wrong, axes mislabeled, points in wrong positions, colors swapped, the wrong subset plotted, NaN handling regression. Two visually different UMAPs can have identical width/height/size-within-10%.
+
+Other observed image-assertion users (`grep "has_image"`):
+- `imaging/tissue-microarray-analysis/tissue-microarray-analysis/tissue-micro-array-analysis-tests.yml`
+- `imaging/tissue-microarray-analysis/multiplex-tissue-microarray-analysis/multiplex-tma-tests.yml`
+
+The TMA tests use a friendlier shorthand: `has_size: size: 181K, delta: 50K` (human-readable units).
+
+### Smell
+
+Asserting `has_image_width`/`has_image_height` with **zero delta** on a tool that re-encodes (PNG round-trips through matplotlib) is brittle. The corpus uses 5–10% deltas; an agent emitting `delta: 0` should be flagged unless the renderer is byte-stable.
+
+Note `has_image_channels`, `has_image_center_of_mass` are documented (galaxy XSD) but **not observed** in the sampled corpus. An agent with a deterministic mask/segmentation output could use `has_image_center_of_mass` to actually verify spatial correctness — this would be an *upgrade* over the current corpus norm, not a smell.
+
+---
+
+## 4. Happy-path-only culture (`expect_failure:`)
+
+`grep -r "expect_failure"` over all 115 tests files returns **zero hits**. The IWC corpus has no negative tests. Period.
+
+This is a structural property of IWC: the workflows are published artifacts intended to *succeed* on canonical inputs. Adversarial / error-path testing happens in tool wrappers, not in workflow tests.
+
+**Implication for an agent:** Do not author `expect_failure:` cases when translating a workflow. If the source pipeline (e.g., nf-core) had a "fail on bad reference" test, drop it — it doesn't belong in IWC. If the validation logic is important, it should be in a wrapper-level tool test, not a workflow test.
+
+---
+
+## 5. `md5:` / `checksum:` rarity
+
+`grep -r "md5:\|checksum:"` over `*-tests.yml`: **zero hits**.
+
+SHA-1 `hashes:` blocks are pervasive — but exclusively on **inputs** (`hash_function: SHA-1` paired with a remote `location:`), to guard against silent corruption of the fetched fixture. Output assertions never use them.
+
+Accepted. The reason is empirical: outputs of real bioinformatics tools (BAM with PG headers and timestamps, VCFs with command-line provenance, JSON with run dates) are almost never byte-stable across runs. A `checksum:` would fail intermittently.
+
+**Smell:** an agent emitting `checksum:` or `md5:` on a workflow output. Even for "fully deterministic" tools, embedded provenance breaks checksums. Use `compare: diff` + `lines_diff:` instead, or content assertions.
+
+---
+
+## 6. Output label coupling
+
+Test files key outputs by **workflow label**, with spaces, capitals, punctuation preserved verbatim. Examples:
+
+- `scanpy-clustering/.../Preprocessing-...-Scanpy-tests.yml:27` — `Anndata with Celltype Annotation:` (spaces, mixed case)
+- `scanpy-clustering/.../Preprocessing-...-Scanpy-tests.yml:33` — `UMAP of louvain and top ranked genes:`
+- `imaging/tissue-microarray-analysis/multiplex-tissue-microarray-analysis/multiplex-tma-tests.yml` — `Merged anndata:`, `Spatial Scatterplot Montage:`
+- `consensus-from-variation-tests.yml:30` — `multisample_consensus_fasta:` (snake-case style)
+
+**Both styles coexist.** Snake-case (older / SARS-CoV-2 family) and natural-language-with-spaces (newer / scanpy / TMA) are equally valid. Reviewers do not enforce a single convention.
+
+### Coupling consequences
+
+Renaming an output label in the `.ga` without updating the sibling `-tests.yml` is a silent breakage:
+- Test references the old label → key not present in invocation outputs → assertion mismatch surfaces as an opaque "output not found" error in planemo.
+- `planemo workflow_lint --iwc` enforces that workflow outputs are *labeled*, not that test labels match.
+
+**Discipline observed:** every output a test asserts on is a labeled workflow output. The corpus does not assert on positional / unlabeled outputs.
+
+**Smell:** a translated workflow with unlabeled outputs that later need test coverage. Agent should label every output it intends to assert on, before writing assertions.
+
+---
+
+## 7. Intermediate-step output gap
+
+`-tests.yml` can only assert on workflow-level **outputs** (entries in the `.ga`'s top-level outputs). Intermediate step results are inaccessible to assertions.
+
+Observed workaround across the corpus: **promote the intermediate to a workflow output**. This is visible indirectly — many workflows expose what would naturally be intermediates as labeled outputs solely for testability:
+
+- `scanpy-clustering` exposes `Initial Anndata General Info`, `Anndata with raw attribute`, `Plot highly variable`, `Elbow plot of PCs and variance` — these are mid-pipeline checkpoints surfaced specifically to be assertable. Compare counts: 22 outputs asserted vs the 7-or-so "user-meaningful" final artifacts.
+- `MAGs-generation-tests.yml` exposes a `Full MultiQC Report` even though MultiQC is logically intermediate to MAG annotation.
+
+**Cost:** "test-only" outputs clutter the workflow's user-facing output list. Reviewers tolerate this in exchange for testability.
+
+**Accepted shortcut:** promoting an intermediate to a workflow output for test purposes. Not a smell.
+
+**Smell:** asserting on a step output via some side-channel (e.g., relying on Galaxy collection ordering, indexing into `tool_state`). The corpus does not do this and an agent should not invent it.
+
+---
+
+## 8. Remote-data fragility
+
+### Pattern
+
+Overwhelming preference for **Zenodo** as the input store. Every remote `location:` is paired with a SHA-1 `hashes:` block. Examples already cited in nearly every snippet above.
+
+Non-Zenodo remote sources observed (from `grep "ftp.sra.ebi\|ftp://\|figshare\|github.com"`):
+- `virology/pox-virus-amplicon/pox-virus-half-genome-tests.yml:27,34,48,55` — `ftp://ftp.sra.ebi.ac.uk/...` SRA fastqs
+- `amplicon/amplicon-mgnify/.../mgnify-amplicon-pipeline-v5-rrna-prediction-tests.yml:21` — `ftp://ftp.ebi.ac.uk/...` reference DB
+- `data-fetching/parallel-accession-download/parallel-accession-download-tests.yml`, `VGP-assembly-v2/Plot-Nx-Size/...` — accession-driven
+- `variant-calling/generic-variant-calling-wgs-pe/Generic-variation-analysis-on-WGS-PE-data-tests.yml` — github raw URLs
+
+### The fragility
+
+- **Zenodo is a single point of failure across CI.** A Zenodo outage breaks every IWC PR concurrently. SHA-1 hashes guard against silent corruption but provide no mitigation for outages or HTTP 503s.
+- **EBI/SRA FTP is even less reliable** — observed flake-prone in the broader Galaxy CI history.
+- No retry / backoff configured at the test-format level; planemo-ci-action's defaults handle transient failures only via re-running the chunk job manually.
+
+### Accepted
+
+This is just life in the IWC. Don't try to "fix" it in a translated workflow by inlining large data — reviewers will push back (see §10).
+
+### Smell
+
+Inputs hosted on a contributor's personal endpoint, S3 bucket, or Dropbox. Reviewers ask for migration to Zenodo before merge.
+
+---
+
+## 9. `compare: diff` on timestamped outputs
+
+`compare: diff` usage from `grep`:
+
+- `sars-cov-2-variant-calling/sars-cov-2-ont-artic-variant-calling/ont-artic-variation-tests.yml:32` — `compare: diff, lines_diff: 6` on annotated VCF
+- `sars-cov-2-variant-calling/sars-cov-2-pe-illumina-wgs-variant-calling/pe-wgs-variation-tests.yml:35` — same
+- `imaging/fluorescence-nuclei-segmentation-and-counting/segmentation-and-counting-tests.yml:16` — `lines_diff: 0`
+- `variant-calling/variation-reporting/Generic-variation-analysis-reporting-tests.yml:21,25,29,33` — `lines_diff: 6`
+- `variant-calling/generic-variant-calling-wgs-pe/Generic-variation-analysis-on-WGS-PE-data-tests.yml:39,45,55` — `lines_diff: 6`
+
+The `lines_diff: 6` constant is suspicious — 6 lines is the typical VCF header preamble that embeds `##fileDate=...` and `##source=...`. The use is **defensible**: tolerance window matches the known mutable header lines, content lines are diffed strictly.
+
+### Smell
+
+- `compare: diff` with `lines_diff: 0` on a file that contains *any* timestamp, command-line capture, version banner, or random tie-break (hash-ordered dictionaries in Python output, etc.). The single observed `lines_diff: 0` case (`segmentation-and-counting-tests.yml:16`) appears to be on a numeric tabular output where it's defensible — verify content type before flagging.
+- `compare: diff` on a BAM. BAM headers include `@PG` lines with full command lines and Galaxy job IDs. Use `has_size` + content extracts via `has_archive_member` or `samtools view`-piped XML asserts — not byte-level diff.
+
+**Recommended replacement** when timestamps appear:
+- For VCF: `compare: diff, lines_diff: <header-line-count>` (corpus convention is 6).
+- For tabular reports: `has_text` against stable column headers + `has_n_columns`.
+- For HTML reports (MultiQC etc.): `has_text` substring on stable section names — example `short-read-qc-trimming/short-read-quality-control-and-trimming-tests.yml:25-28` asserts `"Filtered Reads"` substring on the MultiQC HTML report rather than diffing.
+
+---
+
+## 10. Reviewer-feedback recurring asks
+
+Synthesized from the COMPONENT_GALAXY_WORKFLOW_TESTING.md analysis (sections 9 and the "Common PR-review feedback" subsection) plus structural observation of what every accepted workflow has and rejected drafts apparently lack:
+
+| Reviewer ask | Where it bites | Source |
+|---|---|---|
+| **Creator `identifier:` must be a full ORCID URI** (`https://orcid.org/...`), not bare ID. | `.ga` frontmatter `creator:` block. Most common lint failure. | planemo PR #1458; `consensus-from-variation.ga:4-10` shows the conformant shape. |
+| **Move large inputs to Zenodo.** Inline `path: test-data/big.bam` for >1 MB inputs gets pushback. | `-tests.yml` job inputs. | `iwc/workflows/README.md` (per prior analysis). |
+| **Bump `release` + add CHANGELOG.md entry in the same PR.** | `.ga` `release:` and sibling `CHANGELOG.md`. Enforced by `bump_version.py`. | `iwc/workflows/README.md:217-247`. |
+| **Generate tests via `planemo workflow_test_init --from_invocation <id>`**, not by hand. Reviewers push back on hand-authored job blocks. | Any new test contribution. | help.galaxyproject.org thread 13903. |
+| **Don't use `compare: diff` on outputs that embed timestamps.** Switch to `has_text`/`has_n_lines` with `delta:`. | See §9. | Recurring review comment. |
+| **Add labeled outputs for any output you assert on.** Unlabeled outputs caught by `planemo workflow_lint --iwc`. | `.ga` outputs. | §6 above. |
+| **Hashes on every remote `location:`.** SHA-1 block paired with the URL. Reviewers spot-check. | `-tests.yml` job inputs. | Universal in the corpus; missing hashes get flagged. |
+
+### Smell to flag for an agent submission
+
+- Bare ORCID ID (`0000-0002-...`) in `creator:` instead of full URL.
+- Test job referencing >1 MB local fixture instead of a Zenodo URL.
+- PR that bumps a workflow without CHANGELOG / `release:` bump.
+- Hand-authored `-tests.yml` that reads "too clean" — reviewers know `--from_invocation` output has a recognizable fingerprint.
+
+---
+
+## Summary cheatsheet for the implement-galaxy-workflow-test mold
+
+**Use these freely (accepted shortcuts):**
+- `has_text: text: "{"` for stochastic JSON outputs.
+- `compare: sim_size, delta:` for non-deterministic file outputs; pick delta from §2 distribution by tool family.
+- `has_image_width/height/has_size` triple with 5–10% delta for matplotlib plots.
+- `has_h5_keys` for AnnData/HDF5 — assert structure not values.
+- Promoting intermediates to workflow outputs to make them assertable.
+- Labels with spaces, mixed case, punctuation as the output key.
+- SHA-1 hashes on every input `location:`.
+
+**Avoid (smells reviewers or future-you will catch):**
+- `expect_failure:` — not an IWC pattern.
+- `md5:` / `checksum:` on outputs.
+- `compare: diff, lines_diff: 0` on anything containing timestamps, BAM `@PG` lines, or Python dict ordering.
+- `has_image_*` with zero delta.
+- Existence-only `has_text: "{"` on outputs from a deterministic tool.
+- Asserting on positional/unlabeled outputs.
+- Inlining >1 MB binary fixtures in `test-data/`.
+- Bare ORCID identifier in `.ga` frontmatter.
+
+**Review-time checklist before submission:**
+1. Every output asserted on has a label in the `.ga`.
+2. Every remote `location:` has a `hashes: SHA-1` block.
+3. Inputs >1 MB live on Zenodo, not in `test-data/`.
+4. `release:` bumped and `CHANGELOG.md` updated if `.ga` changed.
+5. `creator.identifier:` is a full `https://orcid.org/...` URL.
+6. Test was generated by `planemo workflow_test_init --from_invocation`, not hand-written.
+
+---
+
+## Sources
+
+- Prior synthesis: `/Users/jxc755/projects/repositories/galaxy-brain/vault/projects/workflow_state/skills/COMPONENT_GALAXY_WORKFLOW_TESTING.md` (sections 2c, 2d, 2e, 9).
+- Corpus root: `/Users/jxc755/projects/repositories/workflow-fixtures/iwc-src/workflows/` (115 `*-tests.yml` files across 22 categories).
+- Specific files cited:
+  - `comparative_genomics/hyphy/hyphy-core-tests.yml`, `hyphy-compare-tests.yml`, `capheine-core-and-compare-tests.yml`
+  - `repeatmasking/RepeatMasking-Workflow-tests.yml`, `Repeat-masking-with-RepeatModeler-and-RepeatMasker-tests.yml`
+  - `scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml`
+  - `read-preprocessing/short-read-qc-trimming/short-read-quality-control-and-trimming-tests.yml`
+  - `virology/pox-virus-amplicon/pox-virus-half-genome-tests.yml`
+  - `metabolomics/lcms-preprocessing/Mass_spectrometry__LC-MS_preprocessing_with_XCMS-tests.yml`
+  - `sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation-tests.yml`
+  - `sars-cov-2-variant-calling/sars-cov-2-pe-illumina-wgs-variant-calling/pe-wgs-variation-tests.yml`
+  - `sars-cov-2-variant-calling/sars-cov-2-ont-artic-variant-calling/ont-artic-variation-tests.yml`
+  - `variant-calling/variation-reporting/Generic-variation-analysis-reporting-tests.yml`
+  - `variant-calling/generic-variant-calling-wgs-pe/Generic-variation-analysis-on-WGS-PE-data-tests.yml`
+  - `imaging/fluorescence-nuclei-segmentation-and-counting/segmentation-and-counting-tests.yml`
+  - `imaging/tissue-microarray-analysis/multiplex-tissue-microarray-analysis/multiplex-tma-tests.yml`
+  - `amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction-tests.yml`
+  - `epigenetics/atacseq/atacseq-tests.yml`
+  - `epigenetics/hic-hicup-cooler/chic-fastq-to-cool-hicup-cooler-tests.yml`, `hic-fastq-to-cool-hicup-cooler-tests.yml`
+  - `microbiome/mags-building/MAGs-generation-tests.yml`
+  - `genome-assembly/polish-with-long-reads/Assembly-polishing-with-long-reads-tests.yml`
+  - `scRNAseq/baredsc/baredSC-1d-logNorm-tests.yml`, `baredSC-2d-logNorm-tests.yml`
+- Corpus-wide grep tallies:
+  - `expect_failure`: 0 hits.
+  - `md5:|checksum:` on outputs: 0 hits.
+  - `compare: sim_size`: 9 files.
+  - `compare: diff`: 5 files (variant-calling and imaging).
+  - `has_image_*`: 3 files.
+  - Existence-style `has_text:` patterns: ~298 line matches.
+  - `delta_frac:`: 3 files.

--- a/casts/claude/implement-galaxy-workflow-test/references/notes/iwc-test-data-conventions.md
+++ b/casts/claude/implement-galaxy-workflow-test/references/notes/iwc-test-data-conventions.md
@@ -1,0 +1,297 @@
+---
+type: research
+subtype: component
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-04-30
+revised: 2026-05-02
+revision: 2
+ai_generated: true
+related_notes:
+  - "[[iwc-shortcuts-anti-patterns]]"
+  - "[[planemo-asserts-idioms]]"
+  - "[[implement-galaxy-workflow-test]]"
+  - "[[tests-format]]"
+  - "[[iwc-nearest-exemplar-selection]]"
+summary: "How IWC workflows organize and reference test data — Zenodo-first, SHA-1 integrity, collection shapes, CVMFS gotchas."
+---
+
+# IWC test data conventions
+
+Reference for an agent implementing or editing a `<workflow>-tests.yml` in IWC style. All evidence cited from `/Users/jxc755/projects/repositories/workflow-fixtures/iwc-src/workflows/` (raw IWC clone) and `workflows/README.md`. Authoritative spec: [planemo.readthedocs.io/en/latest/test_format.html](https://planemo.readthedocs.io/en/latest/test_format.html). The companion analysis at `/Users/jxc755/projects/repositories/galaxy-brain/vault/projects/workflow_state/skills/COMPONENT_GALAXY_WORKFLOW_TESTING.md` is the synthesized source for several normative claims here.
+
+## 1. Where does test data live? Remote vs in-repo
+
+Two storage patterns. They mix freely inside one job.
+
+**Remote `location:` (default for any non-trivial input).** Strongly preferred for anything bigger than a toy fixture. Order of preference, observed in the corpus:
+
+- **Zenodo** — overwhelming default, persistent DOI-backed URL.
+  - `read-preprocessing/short-read-qc-trimming/short-read-quality-control-and-trimming-tests.yml:13,17` — `https://zenodo.org/records/11484215/files/paired_r1.fastq.gz` (note the modern `/records/` plural form; older entries use `/record/`).
+  - `metabolomics/lcms-preprocessing/Mass_spectrometry__LC-MS_preprocessing_with_XCMS-tests.yml:6,17,24,...` — 11+ mzML files all hosted at `zenodo.org/record/10130758/files/...`.
+  - `sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation-tests.yml:5` — `https://zenodo.org/record/4555735/files/NC_045512.2_reference.fasta?download=1`.
+  - `repeatmasking/RepeatMasking-Workflow-tests.yml:5` — `https://zenodo.org/record/8364146/files/eco.fasta?download=1`. The `?download=1` query suffix is acceptable but optional; both forms appear.
+- **EBI/ENA REST** — for canonical reference sequences.
+  - `virology/pox-virus-amplicon/pox-virus-half-genome-tests.yml:5` — `https://www.ebi.ac.uk/ena/browser/api/fasta/AF325528.1?download=true`.
+- **SRA / ENA FTP** — for raw read accessions where re-uploading to Zenodo is wasteful.
+  - `pox-virus-half-genome-tests.yml:27,34,49,56` — `ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR151/076/SRR15145276/SRR15145276_1.fastq.gz`.
+
+**In-repo `path: test-data/...` (toy fixtures + small expected outputs only).** Used when:
+
+- File is small enough to commit (rule of thumb from corpus: low single-digit MB or smaller).
+- File is a hand-crafted toy or trimmed reference (e.g. a 5-element FASTA for HyPhy).
+- File is the *expected output* baseline for a `file:` exact-comparison assertion: `consensus-from-variation-tests.yml:31` — `file: test-data/masked_consensus.fa`.
+
+`workflows/README.md:67` makes the contract explicit: "try to generate a toy dataset … and then publish it to zenodo to have a permanent URL." `workflows/README.md:98`: "if some outputs are large, it is better to use assertions than storing the whole output file to the iwc repository."
+
+Subdirectory layout inside `test-data/` is free-form and used to organize related fixtures, e.g. `comparative_genomics/hyphy/test-data/unaligned_seqs/`, `test-data/codon_alignments/`, `test-data/iqtree_trees/` (referenced from `hyphy-core-tests.yml:13,17,21,...`).
+
+**Decision rule for an agent:**
+
+1. Expected-output baseline that's small — commit to `test-data/`.
+2. Toy/trimmed input < ~5 MB — commit to `test-data/`.
+3. Anything else — Zenodo (or EBI/SRA for canonical accessions). Add `hashes:` SHA-1.
+4. If the input is a reference index resolvable from CVMFS (`hg38`, `dm6`, `mm10`, …), use the plain string form. See section 5.
+
+## 2. The `class: File` block — exact YAML shapes
+
+All snippets verbatim from the IWC corpus.
+
+### 2a. Single remote file (with integrity hash)
+
+`virology/pox-virus-amplicon/pox-virus-half-genome-tests.yml:3-9`:
+
+```yaml
+Reference FASTA:
+  class: File
+  location: "https://www.ebi.ac.uk/ena/browser/api/fasta/AF325528.1?download=true"
+  filetype: fasta
+  hashes:
+  - hash_function: SHA-1
+    hash_value: 927d0d00b7db6ad60524bb9e50d3ab41c4ac5ecf
+```
+
+Field order is conventional but not enforced. `filetype:` is the Galaxy datatype name (`fasta`, `fastqsanger.gz`, `mzml`, `bed`, `tabular`, `csv`, `gtf`, `vcf`, …). `location:` URLs may be quoted or bare; both forms occur.
+
+### 2b. Single local file
+
+`comparative_genomics/hyphy/hyphy-core-tests.yml:3-6`:
+
+```yaml
+reference cds:
+  class: File
+  path: test-data/denv1_ref_cds.fasta
+  filetype: fasta
+```
+
+`path:` is relative to the workflow directory (the directory containing the `-tests.yml`). Hashes are usually omitted on local files — the file is in-tree, so integrity is implicit. They are nonetheless added in some workflows: `consensus-from-variation-tests.yml:15-18` shows `path: test-data/aligned_reads_for_coverage.bam` paired with a SHA-1 hash. The pattern appears to be: hashes added when the `-tests.yml` was generated by `planemo workflow_test_init --from_invocation`, which mints them automatically.
+
+A dataset attribute can be set on a single file to force a `dbkey`, e.g. `epigenetics/consensus-peaks/consensus-peaks-chip-pe-tests.yml:7-10`:
+
+```yaml
+- class: File
+  identifier: rep1
+  path: test-data/rep1.bam
+  dbkey: mm10
+```
+
+`dbkey:` and `decompress: true` (`scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:30`) are documented per-file attributes that ride alongside `class: File`.
+
+### 2c. List collection
+
+`hyphy-core-tests.yml:7-30`:
+
+```yaml
+unaligned sequences:
+  class: Collection
+  collection_type: list
+  elements:
+  - identifier: AB178040.1|2002
+    class: File
+    path: test-data/unaligned_seqs/AB178040.1|2002.fasta
+    filetype: fasta
+  - identifier: AB195673.1|2003
+    class: File
+    path: test-data/unaligned_seqs/AB195673.1|2003.fasta
+    filetype: fasta
+  ...
+```
+
+Each element is a single-file dict with an `identifier:`. A larger remote-only example with hashes per element: `metabolomics/lcms-preprocessing/Mass_spectrometry__LC-MS_preprocessing_with_XCMS-tests.yml:11-22`:
+
+```yaml
+Mass-spectrometry Dataset Collection:
+  class: Collection
+  collection_type: list
+  elements:
+  - class: File
+    identifier: Blanc05.mzML
+    location: https://zenodo.org/record/10130758/files/Blanc05.mzML
+    filetype: mzml
+    hashes:
+    - hash_function: SHA-1
+      hash_value: e98d5a4cd8849a145a032bdc31c348ad97cb59c3
+```
+
+### 2d. Paired collection (single pair)
+
+A `paired` collection is a Collection whose two elements have identifiers `forward` and `reverse`. In IWC it is rarely used at top level — it is almost always wrapped as a single-element `list:paired` (see 2e). When it appears bare, the shape is the inner block of 2e without the outer `list:paired` wrapper.
+
+### 2e. `list:paired` collection
+
+`read-preprocessing/short-read-qc-trimming/short-read-quality-control-and-trimming-tests.yml:3-18`:
+
+```yaml
+Raw reads:
+  class: Collection
+  collection_type: list:paired
+  elements:
+  - class: Collection
+    type: paired
+    identifier: pair
+    elements:
+    - class: File
+      identifier: forward
+      location: https://zenodo.org/records/11484215/files/paired_r1.fastq.gz
+      filetype: fastqsanger.gz
+    - class: File
+      identifier: reverse
+      location: https://zenodo.org/records/11484215/files/paired_r2.fastq.gz
+      filetype: fastqsanger.gz
+```
+
+Note: outer `collection_type: list:paired`, inner `type: paired` (not `collection_type:`). Inner element identifiers are the literal strings `forward` and `reverse` — these are reserved.
+
+A multi-pair list:paired with full hashes: `virology/pox-virus-amplicon/pox-virus-half-genome-tests.yml:17-38` or `scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:3-24`.
+
+### 2f. `list:list:paired` and deeper
+
+Not directly observed in sampled IWC inputs. The shape is recursive — wrap a `list:paired` element list inside another `class: Collection, collection_type: list:list:paired`, where each outer element is `class: Collection, type: list:paired` (analogous to the `list:paired` → `paired` nesting in 2e). For deeply-nested collections planemo's [`_writing_collections.rst`](https://github.com/galaxyproject/planemo/blob/master/docs/_writing_collections.rst) is the de-facto reference.
+
+Output side: nested-collection assertions DO exist in the corpus. `scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:82-98`:
+
+```yaml
+Seurat input for gene expression (filtered):
+  attributes: {collection_type: list:list}
+  element_tests:
+    subsample:
+      elements:
+        matrix:
+          asserts:
+            has_line:
+              line: "23932 3 1171"
+        barcodes:
+          asserts:
+            has_line:
+              line: "CACATGATCATAAGGA"
+```
+
+Pattern: outer `element_tests:` keyed by outer identifier; inner `elements:` (note plural, not `element_tests:` here) keyed by inner identifier. Optional `attributes: {collection_type: ...}` asserts the shape of the produced collection.
+
+### 2g. `composite_data:`
+
+**Not observed** in the sampled IWC corpus (`grep -rln "composite\|imzml\|primary_file\|extra_files" workflows/ --include="*-tests.yml"` returns nothing). Per the planemo spec the shape is a `composite_data:` mapping listing each component file path, but an agent emitting one in IWC style has no in-corpus reference and should treat it as unproven territory — fall back to the planemo docs and verify against `galaxy.tool_util.parser.yaml`.
+
+### 2h. CWL-style shorthand (list of File dicts without identifiers)
+
+Documented in planemo; not observed in sampled IWC. IWC always supplies explicit identifiers.
+
+### 2i. `tags:` on elements (Galaxy 20.09+)
+
+Documented in planemo; not surfaced in sampled IWC `-tests.yml` files (`grep "  tags:" --include="*-tests.yml"` empty across the sampled set). Practical absence — IWC tests rely on identifier matching, not tags.
+
+## 3. SHA-1 integrity hashes — when, when not, why
+
+**Format.** Always a list under `hashes:`, even for one entry. Each entry is `{hash_function: SHA-1, hash_value: <40-hex>}`. Verbatim from `pox-virus-half-genome-tests.yml:7-9`:
+
+```yaml
+hashes:
+- hash_function: SHA-1
+  hash_value: 927d0d00b7db6ad60524bb9e50d3ab41c4ac5ecf
+```
+
+Only `SHA-1` observed in the IWC corpus. The planemo spec also accepts `MD5`, `SHA-256`, `SHA-512` as `hash_function:` values; IWC does not exercise these.
+
+**When present:**
+
+- Every remote `location:`-fetched input in the sampled corpus carries a SHA-1 (Zenodo, EBI REST, SRA FTP). The hash guards against silent upstream corruption — Zenodo records are immutable but bit-rot and CDN-edge errors do happen; ENA FASTA endpoints can quietly change line-wrap.
+- Many local `path:`-loaded inputs also carry a SHA-1. This is `--from_invocation` autogeneration leaking through (planemo emits hashes for every input it captured).
+- `consensus-from-variation-tests.yml:6-8,17-18,27-28` — every input in the test, local and remote, has a hash.
+
+**When omitted:**
+
+- Hand-written local-file fixtures often skip hashes — `hyphy-core-tests.yml:3-30` has zero `hashes:` blocks across six local-file inputs.
+- Output assertions: `file:`-comparison outputs and `location:`-comparison outputs (`RepeatMasking-Workflow-tests.yml:13`) **do not** carry `hashes:`. The integrity story for outputs is handled by `compare:` / `asserts:` instead.
+
+**Why bother on local files.** Catches accidental corruption when collaborators hand-edit `test-data/` fixtures.
+
+## 4. Element identifier conventions
+
+Identifiers are arbitrary strings, used both as the YAML key (`element_tests:`) and as the produced Galaxy collection element name. Conventions surfaced from the corpus:
+
+- **Pipes are legal** and survive YAML round-trip without quoting on the input side: `hyphy-core-tests.yml:11` — `identifier: AB178040.1|2002`. On the *output* side they're quoted because they appear as YAML mapping keys: `hyphy-core-tests.yml:34` — `"NC_001477.1|capsid_protein_C|95-394_DENV1":`. Quote when the identifier contains characters that would otherwise start a YAML flow node (`{`, `[`, `&`, `*`, `!`, `|`, `>`, `'`, `"`, `%`, `@`, `` ` ``) or look like a number/bool.
+- **Dots, hyphens, underscores** — common, no quoting needed: `Blanc05.mzML`, `HU_neg_048.mzML`, `SRR11578257`, `Rep1`, `subsample`, `pair`.
+- **Reserved inside `paired` collections:** `forward` and `reverse` (lowercase). Never use these names for outer identifiers in `list:paired`.
+- **Inline comments after identifier** are legal and used for provenance: `pox-virus-half-genome-tests.yml:23` — `identifier: 20L70   # SRR15145276`.
+- **Whitespace and special chars in workflow input *labels*** survive too — they are job-mapping keys, not collection identifiers, but the same YAML quoting rules apply. Example from the analysis doc: `Manually annotate celltypes?: true` as a job key in `Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml:23`.
+
+## 5. CVMFS / `.loc` / built-in-index references
+
+When a workflow input is a Galaxy data-table-backed reference (built-in genome index, dbsnp file, kraken DB, …), the input takes a **plain string** matching the `value` column of a `.loc` file. No `class: File`, no `location:`. Examples:
+
+- `scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:25` — `reference genome: dm6 # To test on usegalaxy.eu dm6full`
+- `epigenetics/cutandrun/cutandrun-tests.yml:27` — `reference_genome: 'hg38canon'`
+- `epigenetics/atacseq/atacseq-tests.yml:25` — `reference_genome: hg19`
+- `microbiome/host-contamination-removal/host-contamination-removal-short-reads/host-or-contamination-removal-on-short-reads-tests.yml:19` — `Host/Contaminant Reference Genome: hg38`
+- `microbiome/pathogen-identification/nanopore-pre-processing/Nanopore-Pre-Processing-tests.yml:22` — `host_reference_genome: apiMel3`
+- `transcriptomics/goseq/goseq-go-kegg-enrichment-analsis-tests.yml:24` — `Select genome to use: mm10`
+
+The string is the first column of the `.loc` entry. `workflows/README.md:169-182` shows the lookup procedure: browse `http://datacache.galaxyproject.org/indexes/location/<table>.loc`, find the `.loc` row, take the value column (which column varies by tool — check the matching `tool_data_table_conf.xml.sample`).
+
+**Portability implication:** these tests **only** run on a Galaxy with CVMFS mounted at `/cvmfs/data.galaxyproject.org`. IWC CI mounts CVMFS in-runner (`setup-cvmfs: true` in `.github/workflows/test_workflows.yml`). On a plain developer laptop running `planemo test`, CVMFS-string inputs fail unresolved. An agent generating tests should either:
+
+1. Stay URL-driven: replace the CVMFS string with a `class: File` + `location:` to a Zenodo-hosted reference (portable, slower CI, larger inputs).
+2. Use the CVMFS string and document "CI-only" — the user cannot reproduce locally without a CVMFS mount.
+
+There is no `.loc`-resolution shorthand in the YAML — it is just a bare string parameter. Agents must not invent `class: DataTable` or similar.
+
+## 6. Reviewer-feedback patterns (PR-review)
+
+Recurring asks from IWC reviewers, distilled from the contribution README and community help threads:
+
+- **Move large data to Zenodo before merge.** Anything bigger than a toy fixture committed in `test-data/` will be flagged. `workflows/README.md:67`.
+- **Use assertions, not exact-file comparison, for large outputs.** `workflows/README.md:98` — "if some outputs are large, it is better to use assertions than storing the whole output file."
+- **Generate tests with `planemo workflow_test_init --from_invocation`, don't hand-write.** `workflows/README.md:88-94`. The autogenerated test will mint correct hashes, correct labels, and a working `test-data/` snapshot.
+- **Set creator `identifier:` to a full ORCID URL** (e.g. `https://orcid.org/0000-0002-1825-0097`) — `workflows/README.md:53`. The most common lint failure; enforced in [planemo#1458](https://github.com/galaxyproject/planemo/pull/1458).
+- **Don't use `compare: diff` on outputs that embed timestamps or non-deterministic ordering.** Switch to `has_text` / `has_n_lines` (with `delta:`) or `compare: sim_size`+`delta:`.
+- **Bump `release:` in the `.ga` and add a `CHANGELOG.md` entry** in the same PR — enforced by the IWC PR template; reviewers verify via `bump_version.py`.
+- **Lower-case + `-` only** in directory names — `workflows/README.md:11,72`.
+- **Element identifiers must round-trip** — quote in YAML when they contain pipes/colons/whitespace.
+
+## 7. What is *not* covered by current convention
+
+Gaps an agent should be aware of:
+
+- **`composite_data:` is unrepresented in the IWC corpus.** No working examples to imitate for imzml+ibd or other multi-file datatypes. Treat as off-trail; cite planemo docs and verify by parser.
+- **`tags:` on elements unused.** Galaxy 20.09+ supports them; IWC does not exercise them.
+- **CWL-style shorthand File lists unused.** IWC always names elements.
+- **No negative tests.** Zero `expect_failure:` across the sampled corpus. There is no IWC convention for asserting a workflow *should* fail on bad input.
+- **No checksum-based output assertion in the wild.** `checksum: "sha1$..."` is documented and used at the input side as `hashes:`, but output-side `checksum:` was not surfaced in sampled tests. The corpus prefers `file:` (exact), `compare: sim_size`+`delta:` (size only), or `asserts:` (content probes).
+- **No data-cache layer beyond pip/planemo.** Every test re-pulls remote inputs from Zenodo / EBI / SRA on every CI run. A Zenodo outage breaks many PRs simultaneously. There is no IWC-side mirror or cache.
+- **No per-test timeout / retry convention.** A hung tool blocks the whole chunk until the GitHub Actions 6-hour limit.
+- **No portable story for CVMFS-only tests.** The same `-tests.yml` either works locally (URL-driven) or works in CI (CVMFS-string-driven), not both. There is no documented switch.
+- **Hash function is de-facto SHA-1.** The spec accepts SHA-256/SHA-512/MD5; IWC does not use them. Agents that emit a stronger hash will pass planemo but break corpus convention.
+- **Local-file `hashes:` are inconsistently present.** `--from_invocation`-generated tests have them, hand-written tests usually don't. Either is accepted; don't expect uniformity.
+- **`decompress: true` and `dbkey:` are file-level attributes** but undocumented at the planemo test_format page in the same place as `class:`/`location:`/`hashes:`. Cross-reference against the `gxformat2` Schema-Salad bindings if unsure.
+- **`?download=1` query string on Zenodo URLs** is optional. Both forms appear (`/record/4555735/files/X?download=1` vs `/records/11484215/files/Y`). The newer `/records/` plural is the modern Zenodo URL form; both work.
+
+## Cross-references
+
+- `/Users/jxc755/projects/repositories/galaxy-brain/vault/projects/workflow_state/skills/COMPONENT_GALAXY_WORKFLOW_TESTING.md` — full synthesis with assertion-vocabulary table, CI internals, and tooling rundown. Sections 2b, 3, 4, 5, 9 are the direct upstream of this note.
+- planemo test format spec: [planemo.readthedocs.io/en/latest/test_format.html](https://planemo.readthedocs.io/en/latest/test_format.html).
+- planemo best practices: [planemo.readthedocs.io/en/latest/best_practices_workflows.html](https://planemo.readthedocs.io/en/latest/best_practices_workflows.html).
+- planemo collections reference: [github.com/galaxyproject/planemo/blob/master/docs/_writing_collections.rst](https://github.com/galaxyproject/planemo/blob/master/docs/_writing_collections.rst).
+- IWC contribution contract: `workflows/README.md` in [github.com/galaxyproject/iwc](https://github.com/galaxyproject/iwc).
+- Galaxy datacache (CVMFS `.loc` browsing): [datacache.galaxyproject.org/indexes/location/](http://datacache.galaxyproject.org/indexes/location/).

--- a/casts/claude/implement-galaxy-workflow-test/references/notes/planemo-asserts-idioms.md
+++ b/casts/claude/implement-galaxy-workflow-test/references/notes/planemo-asserts-idioms.md
@@ -1,0 +1,235 @@
+---
+type: research
+subtype: component
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-04-30
+revised: 2026-05-02
+revision: 2
+ai_generated: true
+related_notes:
+  - "[[iwc-test-data-conventions]]"
+  - "[[iwc-shortcuts-anti-patterns]]"
+  - "[[implement-galaxy-workflow-test]]"
+  - "[[tests-format]]"
+  - "[[planemo-workflow-test-architecture]]"
+summary: "Decision and idiom guide for picking planemo workflow-test assertions: which family per output type, how to size tolerances, when to validate."
+---
+
+# Planemo asserts: idiom and decision guide
+
+Companion to [[iwc-test-data-conventions]] (input shapes) and [[iwc-shortcuts-anti-patterns]] (what's accepted vs smell). This note is forward-looking: when authoring a new `<workflow>-tests.yml`, which assertion family fits which output, and what the recommended tolerances and operators are.
+
+The **vocabulary itself is not restated here** — every assertion's parameter list, types, defaults, required fields, and Python docstring is rendered from the test-format JSON Schema at [[tests-format]]. Assertion names below deep-link into that page (e.g. `[[tests-format#has_text_model|has_text]]` jumps straight to that `$def`).
+
+## 1. Choose by output type
+
+The single most useful decision table. Pick the row that matches the file format the workflow emits; default to the recommended assertion family.
+
+| Output type | Default assertion family | Why | Fallback |
+|---|---|---|---|
+| **Plain text reports / logs** (FastQC summary, MultiQC text section) | [[tests-format#has_text_model|has_text]] (substring on a known stable token) + [[tests-format#has_n_lines_model|has_n_lines]] with `delta:` | Substring is robust across versions; line count catches truncation | [[tests-format#has_text_matching_model|has_text_matching]] (regex) when token text changes per run |
+| **HTML reports** (MultiQC HTML, custom dashboards) | [[tests-format#has_text_model|has_text]] against stable section names | HTML embeds timestamps and asset hashes; byte-diff is hopeless | [[tests-format#has_size_model|has_size]] + large `delta` as last resort |
+| **Tabular** (TSV, CSV, BED-like) | [[tests-format#has_n_columns_model|has_n_columns]] + [[tests-format#has_text_model|has_text]] for headers + [[tests-format#has_n_lines_model|has_n_lines]] with `delta:` | Schema-shape + content probes; tolerant to row reordering | [[tests-format#has_line_matching_model|has_line_matching]] for a known canonical row |
+| **VCF** | `compare: diff` with `lines_diff: 6` | The `lines_diff: 6` constant matches the typical VCF header preamble that embeds `##fileDate=` and `##source=` | [[tests-format#has_text_matching_model|has_text_matching]] for known variants |
+| **BAM** | [[tests-format#has_size_model|has_size]] + [[tests-format#has_archive_member_model|has_archive_member]] (BAM is a gzipped block format) | Headers contain `@PG` lines with command lines and Galaxy job IDs; never byte-diff | Convert to SAM in a downstream step and assert on text |
+| **FASTA** (deterministic — assemblies, consensus) | `file:` exact comparison or [[tests-format#has_text_model|has_text]] for known sequence | Output is byte-stable when the upstream tool is deterministic | [[tests-format#has_n_lines_model|has_n_lines]] if line wrapping varies |
+| **FASTA** (non-deterministic — RepeatModeler libraries) | `compare: sim_size` with large `delta:` | Family content varies run-to-run | [[tests-format#has_n_lines_model|has_n_lines]] with `delta:` |
+| **FASTQ** (rare as workflow output) | [[tests-format#has_n_lines_model|has_n_lines]] (must be multiple of 4) | Quality scores are read-id-dependent | `compare: sim_size` |
+| **JSON** (deterministic — config dumps, params) | [[tests-format#has_json_property_with_value_model|has_json_property_with_value]] / [[tests-format#has_json_property_with_text_model|has_json_property_with_text]] | Surgical: assert on the property you care about, ignore the rest | `compare: diff` if the JSON is fully canonical |
+| **JSON** (stochastic — HyPhy stats, MCMC results) | `has_text: text: "{"` (existence-only) | Embedded floats break any structural assertion; see [[iwc-shortcuts-anti-patterns]] §1 | [[tests-format#has_h5_keys_model|has_h5_keys]]-equivalent for top-level structural keys |
+| **HDF5 / AnnData** | [[tests-format#has_h5_keys_model|has_h5_keys]] + [[tests-format#has_h5_attribute_model|has_h5_attribute]] for known structure | Asserts shape, not values — values are float-noisy | [[tests-format#has_size_model|has_size]] with `delta:` |
+| **XML** | [[tests-format#is_valid_xml_model|is_valid_xml]] + [[tests-format#has_element_with_path_model|has_element_with_path]] + `element_text_is`/`element_text_matches` | Surgical structural probes; byte-diff fails on whitespace/attribute-order | [[tests-format#has_n_elements_with_path_model|has_n_elements_with_path]] for cardinality |
+| **PNG / image plots** | [[tests-format#has_image_width_model|has_image_width]] + [[tests-format#has_image_height_model|has_image_height]] + [[tests-format#has_size_model|has_size]] with `delta:` (5–10%) | Catches "rendered something with the right dimensions"; corpus norm | [[tests-format#has_image_center_of_mass_model|has_image_center_of_mass]] if mask/segmentation outputs are deterministic |
+| **TIFF / multipage images** | [[tests-format#has_image_frames_model|has_image_frames]] + [[tests-format#has_image_channels_model|has_image_channels]] + [[tests-format#has_size_model|has_size]] with `delta:` | Same logic, channel/frame structure matters | — |
+| **Archives** (zip, tar.gz) | `has_archive_member: path: "regex"` with nested `asserts:` | Asserts on a specific member; archive timestamps never byte-stable | [[tests-format#has_size_model|has_size]] with `delta:` |
+| **GFF / GTF** | [[tests-format#has_n_lines_model|has_n_lines]] with `delta:` + [[tests-format#has_text_model|has_text]] for known feature | Tools reorder freely; hard to byte-diff | `has_n_columns: 9` (GFF spec) |
+| **Cool / HiC matrices** | `compare: sim_size` with multi-MB `delta:` | Binary, run-to-run variance | [[tests-format#has_archive_member_model|has_archive_member]] for HDF5 component |
+
+When in doubt: start with [[tests-format#has_size_model|has_size]] + `delta_frac: 0.1`. It catches the catastrophic failure mode (empty / 10x bigger output). Then add a content probe.
+
+## 2. The `compare:` operators
+
+Top-level on a `file:` output assertion. Vocabulary, in decreasing strictness:
+
+- **`diff`** (default). Byte-for-byte equality with optional `lines_diff:` tolerance for a fixed number of header lines. Use only when the upstream tool is deterministic on fixed inputs *and* the output has no embedded timestamps, command lines, version banners, or hash-ordered Python-dict-style keys.
+- **`re_match` / `re_match_multiline`**. Each line of the expected fixture is a regex that must match the corresponding output line. Useful when a few fields per row are timestamped but the rest is canonical. Rare in the corpus.
+- **`contains`**. The expected fixture is a substring of the output. Cheap; weak. Prefer `asserts: has_text` for new code unless you genuinely have a multi-line block to assert as a whole.
+- **`sim_size`**. Output file size matches the fixture's size within `delta:` (bytes) or `delta_frac:` (fraction). Use when the output is necessarily non-deterministic but its rough size is reproducible (RepeatModeler libraries, HiC matrices, Bayesian sampler outputs).
+
+Picking `lines_diff:`: count the mutable header lines in the output format. VCF: ~6 (`##fileformat`, `##fileDate`, `##source`, `##reference`, contig/info lines vary). SAM/text headers: count `@HD`/`@PG`/`@CO` lines. Set `lines_diff:` to the count exactly — looser values mask real diffs.
+
+## 3. Tolerance picking
+
+**`delta:`** is bytes (for [[tests-format#has_size_model|has_size]] and `compare: sim_size`) or absolute count (for [[tests-format#has_n_lines_model|has_n_lines]], [[tests-format#has_n_columns_model|has_n_columns]], [[tests-format#has_image_width_model|has_image_width]], etc.). Suffix multipliers documented in the schema — `1K`, `1M`, `1G` work.
+
+**`delta_frac:`** is a fraction (0.1 = 10%). Use when expected size scales with input volume. Three IWC tests use it (`scRNAseq/baredsc/*`, `genome-assembly/polish-with-long-reads/*`); the rest use absolute `delta:`.
+
+**Picking magnitudes** (from corpus survey in [[iwc-shortcuts-anti-patterns]] §2):
+
+- Image dimensions: `delta: 25–30` pixels (5% of typical matplotlib defaults).
+- Image file size: `delta: 5K–60K` (5–10% of file size).
+- Small text reports: `delta: 1K–10K`.
+- HTML reports: `delta: 25K–100K`.
+- BAM files: `delta: 1M–10M`.
+- RepeatModeler / Bayesian sampler outputs: `delta: 30K–90M` (extreme, but justified by the underlying nondeterminism).
+
+**Heuristic for new outputs:** `delta_frac: 0.1` is a defensible default. Tighten if the output proves more deterministic than expected.
+
+## 4. Text family — [[tests-format#has_text_model|has_text]] vs [[tests-format#has_text_matching_model|has_text_matching]] vs [[tests-format#has_line_model|has_line]] vs [[tests-format#has_line_matching_model|has_line_matching]] vs [[tests-format#has_n_lines_model|has_n_lines]]
+
+All five are common; choose by what you're verifying.
+
+- **[[tests-format#has_text_model|has_text]]** — output contains the substring `text:`. Anywhere in the output, any number of times. Add `n:` / `min:` / `max:` to constrain occurrence count. Add `delta:` to allow slack on the count.
+- **[[tests-format#has_text_matching_model|has_text_matching]]** — output matches the regex `expression:`. Use sparingly; prefer literal [[tests-format#has_text_model|has_text]] when you can.
+- **[[tests-format#has_line_model|has_line]]** — output has at least one *line* matching `line:` exactly. Use when line boundaries matter (e.g. asserting on a specific row in a table).
+- **[[tests-format#has_line_matching_model|has_line_matching]]** — same but with regex.
+- **[[tests-format#has_n_lines_model|has_n_lines]]** — assert the line count is `n:` ± `delta:`.
+
+A common combination in IWC: `has_n_lines: n: 100, delta: 5` + `has_text: text: "expected_token"` — line-count sanity-check plus a content marker. This catches both truncation and content drift in one assertion pair.
+
+`negate: true` is supported on every assertion. Used for the "this output should NOT contain X" case.
+
+## 5. Collection output assertions (`element_tests:`)
+
+For Galaxy collection outputs, the test format keys element assertions by element identifier:
+
+```yaml
+my_collection_output:
+  element_tests:
+    sample_1:
+      asserts:
+        has_text:
+          text: "expected"
+    sample_2:
+      file: test-data/expected_sample_2.txt
+```
+
+Optional `attributes:` at the collection level can assert on the produced collection shape:
+
+```yaml
+my_collection_output:
+  attributes: {collection_type: list:list}
+  element_tests:
+    ...
+```
+
+Nested collections: outer `element_tests:` keyed by outer identifier; inner uses `elements:` (note plural, no `_tests` suffix on the inner). See [[iwc-test-data-conventions]] §2f for the live example.
+
+For a list-of-files where every element should pass the same minimal check, the existence-probe pattern (`has_text: "{"` for JSON; `has_size: min: 100` for any non-empty binary) is widely used and accepted in IWC.
+
+## 6. The validate-against-workflow inner loop
+
+A `-tests.yml` file can be **structurally invalid** in two distinct ways:
+
+1. **Schema-invalid** — wrong field names, wrong nesting, wrong types. Caught by the test-format JSON Schema.
+2. **Workflow-incoherent** — schema-valid YAML, but the input/output labels don't match the actual workflow. Renaming an output in the `.ga` and forgetting to update its sibling `-tests.yml` produces this case. Planemo will surface it as an "output not found" error at test-runtime, but only after a full workflow run.
+
+The `@galaxy-tool-util/schema` npm package ships **two** validators that catch both cases statically — no Galaxy or Planemo invocation needed:
+
+- **`validateTestsFile(yaml)`** — runs the file against `tests.schema.json` (AJV). Reports schema violations with paths.
+- **`checkTestsAgainstWorkflow(workflow, tests)`** — cross-checks a `.ga` / format2 workflow against a tests file: missing input labels, missing output labels, type incompatibilities (e.g. test supplies a `File` for a parameter typed `int`).
+
+Both are pure-JS, take milliseconds, and have no Galaxy dependency. Wire them into the inner authoring loop:
+
+```
+edit -tests.yml
+  → validateTestsFile()                    # schema gate
+  → checkTestsAgainstWorkflow(.ga, tests)  # coherence gate
+  → planemo workflow_test_on_invocation    # assertion gate (no full re-run)
+  → planemo test                           # full integration (slow)
+```
+
+The first two gates short-circuit cheap mistakes before a slow planemo run. They are the static-validation equivalent of `gxwf` for tests, and the `implement-galaxy-workflow-test` mold should reference them as its primary inner-loop tooling. Source: galaxy-tool-util-ts package, `src/test-format/index.ts` exports.
+
+## 7. Authoring loop — generation, then refinement
+
+Reviewer convention is to **generate** the initial `-tests.yml` rather than hand-write it. Two planemo subcommands cover this:
+
+- **`planemo workflow_test_init --from_invocation <invocation_id>`** — given a successful Galaxy invocation ID, emit a `-tests.yml` with a `job:` block that captures all inputs (with SHA-1 hashes) and an `outputs:` block with `file:` references to the actual outputs (downloaded into `test-data/`). Hand-tighten the assertions afterward.
+- **`planemo workflow_test_on_invocation <tests.yml> <invocation_id>`** — re-evaluate an edited `-tests.yml` against a saved invocation without re-running the workflow. The fast inner loop for assertion iteration; complements the static gates in §6.
+
+Together these cut the assertion-iteration cost dramatically. An agent should:
+
+1. Run the workflow once on usegalaxy.* (or local) to get a known-good invocation.
+2. `--from_invocation` to bootstrap the test file.
+3. Replace the autogenerated `file:` exact-comparison assertions with assertion-family-appropriate alternatives per §1.
+4. `workflow_test_on_invocation` after each edit; full `planemo test` at the end.
+
+## 8. What the schema gives you for free
+
+When the test-format schema lands as a Foundry-rendered note, the agent can consult any assertion's `$def` directly for: parameter types, defaults, required fields, the `that` discriminator constant, and the original Python docstring (carried through as `description`). This note does **not** restate that vocabulary — it complements it with the corpus-grounded *which-and-when*.
+
+What's still missing from the schema and worth keeping in research notes:
+
+- This decision table (§1) — output-type → assertion family.
+- Tolerance magnitudes (§3) — corpus-derived defaults.
+- The `validateTestsFile` / `checkTestsAgainstWorkflow` integration story (§6).
+- Anti-pattern flags — see [[iwc-shortcuts-anti-patterns]].
+
+## 9. Common combinations (recipes)
+
+Six recipes worth memorizing.
+
+**Stable text report (FastQC summary, simple stats).**
+```yaml
+my_report:
+  asserts:
+    has_n_lines: { n: 12, delta: 2 }
+    has_text: { text: "Total Sequences" }
+```
+
+**MultiQC HTML report.**
+```yaml
+multiqc_report:
+  asserts:
+    has_text: { text: "Filtered Reads" }
+    has_text: { text: "FastQC" }
+```
+
+**VCF (pinned tool, fixed reference).**
+```yaml
+called_variants:
+  file: test-data/expected.vcf
+  compare: diff
+  lines_diff: 6
+```
+
+**Stochastic JSON (HyPhy-style).**
+```yaml
+hyphy_meme:
+  element_tests:
+    geneA: { asserts: { has_text: { text: "{" } } }
+    geneB: { asserts: { has_text: { text: "{" } } }
+```
+
+**Matplotlib plot.**
+```yaml
+umap_plot:
+  asserts:
+    has_size: { size: 68416, delta: 6000 }
+    has_image_width: { width: 601, delta: 30 }
+    has_image_height: { height: 429, delta: 25 }
+```
+
+**AnnData (HDF5).**
+```yaml
+clustered_anndata:
+  asserts:
+    has_h5_keys: { keys: "obs/louvain" }
+    has_h5_keys: { keys: "var/highly_variable" }
+    has_h5_keys: { keys: "uns/rank_genes_groups" }
+    has_size: { size: 12000000, delta: 1500000 }
+```
+
+## 10. Cross-references
+
+- [[iwc-test-data-conventions]] — input-side conventions (job inputs, collection shapes, `hashes:`, CVMFS).
+- [[iwc-shortcuts-anti-patterns]] — accepted-vs-smell catalog and corpus prevalence; this note's mirror image.
+- Test-format schema (`@galaxy-tool-util/schema` npm package) — authoritative vocabulary; will be vendored into a Foundry-rendered schema note. See `docs/COMPILATION_PIPELINE.md` for the casting story.
+- Planemo test-format spec: [planemo.readthedocs.io/en/latest/test_format.html](https://planemo.readthedocs.io/en/latest/test_format.html).
+- Galaxy XSD (assertion source of truth): [galaxy/lib/galaxy/tool_util/xsd/galaxy.xsd](https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/tool_util/xsd/galaxy.xsd).
+- Tightening of the schema and Pydantic source: [galaxyproject/galaxy#22566](https://github.com/galaxyproject/galaxy/pull/22566).
+- TS schema sync into npm: [jmchilton/galaxy-tool-util-ts#75](https://github.com/jmchilton/galaxy-tool-util-ts/pull/75).

--- a/casts/claude/implement-galaxy-workflow-test/references/notes/planemo-workflow-test-architecture.md
+++ b/casts/claude/implement-galaxy-workflow-test/references/notes/planemo-workflow-test-architecture.md
@@ -1,0 +1,149 @@
+---
+type: research
+subtype: component
+title: "Planemo workflow-test architecture"
+tags:
+  - research/component
+  - tool/planemo
+  - target/galaxy
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+related_notes:
+  - "[[galaxy-tool-job-failure-reference]]"
+  - "[[galaxy-workflow-invocation-failure-reference]]"
+  - "[[planemo-asserts-idioms]]"
+related_molds:
+  - "[[run-workflow-test]]"
+  - "[[debug-galaxy-workflow-output]]"
+  - "[[implement-galaxy-workflow-test]]"
+sources:
+  - "~/projects/repositories/planemo/planemo/commands/cmd_test.py"
+  - "~/projects/repositories/planemo/planemo/commands/cmd_run.py"
+  - "~/projects/repositories/planemo/planemo/galaxy/activity.py"
+  - "~/projects/repositories/planemo/planemo/galaxy/invocations"
+  - "~/projects/repositories/planemo/planemo/galaxy/config.py"
+summary: "Reference for Planemo workflow test/run architecture, Galaxy modes, API polling, and noisy failure boundaries."
+---
+
+# Planemo Workflow-Test Architecture
+
+This note describes Planemo architecture relevant to workflow tests and workflow runs. It is reference material for Molds that need to run tests or interpret Planemo artifacts, not a command-selection recipe.
+
+## Main Commands
+
+| User action | Command | Core behavior |
+|---|---|---|
+| Full workflow test | `planemo test <workflow>` | Finds test definitions, starts or targets Galaxy, stages inputs, invokes workflow, checks assertions, writes reports. |
+| Direct run | `planemo run <workflow> <job.yml>` | Runs one workflow/job pair and can download outputs without assertion checks. |
+| Recheck assertions | `planemo workflow_test_on_invocation <tests.yml> <invocation_id>` | Runs test assertions against an existing invocation without rerunning the workflow. |
+| Track invocation | `planemo workflow_track <invocation_id>` | Polls an existing invocation and displays progress. |
+| Generate test from invocation | `planemo workflow_test_init --from_invocation <id>` | Builds a test template from a completed invocation and its outputs. |
+| Generate job template | `planemo workflow_job_init <workflow>` | Creates a job-input template for a workflow. |
+
+Observed code paths live under `~/projects/repositories/planemo/planemo/commands/`, `planemo/engine/`, and `planemo/galaxy/`.
+
+## Engine Selection
+
+Planemo chooses between engines early:
+
+- CWL runnables can use CWL-specific engines.
+- Supplying `--galaxy_url` implies an external running Galaxy unless an engine is explicitly selected.
+- Default Galaxy workflow testing uses a managed local Galaxy engine.
+- `--engine docker_galaxy` uses a managed Dockerized Galaxy.
+- `--engine external_galaxy` uses an existing running Galaxy.
+
+“Existing Galaxy” can mean two different things:
+
+- Existing local Galaxy source tree, still managed by Planemo for this run.
+- Existing running Galaxy server, addressed through URL and API keys.
+
+Mold output and eval logs should record which meaning applies.
+
+## Managed Galaxy Configuration
+
+For managed Galaxy, Planemo builds a temporary configuration directory and generated Galaxy config. It can configure tool config, shed tool config, job config, file sources, object store paths, dependency config, SQLite database by default, admin users, API keys, and environment overrides.
+
+Important managed-mode behavior:
+
+- Planemo may find a local Galaxy root or install/use a cached Galaxy source tree.
+- Managed Galaxy defaults are convenient but may not match production Galaxy behavior.
+- Planemo can install workflow tool dependencies through Tool Shed metadata when configured.
+- Test histories are created automatically unless a history id is supplied.
+
+## External Galaxy Configuration
+
+For external Galaxy, Planemo uses supplied Galaxy URL and API keys. A user key runs workflows; an admin key may be needed for installing missing repositories or creating a user key.
+
+External Galaxy mode is useful when the target environment matters, but failure surfaces can include server configuration, installed tools, permissions, and existing history state. Eval logs should preserve URL/key mode without storing secrets.
+
+## API Interaction
+
+Planemo primarily talks to Galaxy through BioBlend-backed clients.
+
+Important operations:
+
+- Import workflows into Galaxy.
+- Stage datasets and collections into histories.
+- Invoke workflows by input names.
+- Poll invocations and jobs.
+- Fetch job details with full detail when needed.
+- Download outputs and output collections.
+- Run assertion checks and write structured reports.
+
+For workflows, Planemo invokes Galaxy using input labels/names. Stable generated labels are therefore important for both test execution and debugging.
+
+## Structured Artifacts
+
+Useful Planemo artifacts and fields:
+
+| Artifact or field | Use |
+|---|---|
+| `tool_test_output.json` | Primary structured result artifact for tests. |
+| invocation id | Key for Galaxy invocation API follow-up. |
+| history id | Key for history contents and output inspection. |
+| workflow id | Key for workflow invocation aliases and reruns. |
+| output problems | Assertion and missing-output failures. |
+| execution problem | Staging, invocation, API, or other execution-level failure. |
+| invocation details | Step/job/output details Planemo collected from Galaxy. |
+| job details | Tool id, state, exit code, command, stdout/stderr when collected. |
+
+Terminal output is not enough for durable failure analysis. Preserve structured output whenever possible.
+
+## Noisy Boundaries
+
+Planemo transforms and summarizes Galaxy failure information. These are likely information-loss boundaries:
+
+- Exceptions during execution can become stringified `ErrorRunResponse` values.
+- Polling may summarize “at least one job is in error” while detailed job evidence is printed elsewhere or stored separately.
+- Missing outputs become assertion/output problems, which can conflate label mismatch, workflow output omission, optional output absence, failed invocation, or output download issue.
+- Output download failures may be logged but not always propagated as the most specific failure.
+- External Galaxy without an admin key may defer missing-tool problems until runtime.
+- `allow_tool_state_corrections=True` can let Galaxy adjust tool state during invocation, which is useful but can mask definition drift.
+- `--no_wait` is not suitable for debug conclusions because invocation creation can succeed before jobs fail.
+
+## Reference Use For Molds
+
+For [[run-workflow-test]]:
+
+- Preserve structured Planemo result output, invocation id, history id, workflow id, and Galaxy mode.
+- Record whether the run used managed local Galaxy, Docker Galaxy, or external Galaxy.
+- Do not treat terminal output as the primary failure artifact.
+
+For [[debug-galaxy-workflow-output]]:
+
+- Start from structured Planemo output.
+- If the failure is job-level, inspect Galaxy job APIs described in [[galaxy-tool-job-failure-reference]].
+- If the failure is invocation-level, inspect Galaxy invocation APIs described in [[galaxy-workflow-invocation-failure-reference]].
+- If only assertions failed, use [[planemo-asserts-idioms]] before deciding to rerun.
+
+## Verification Gaps
+
+Actual runs should verify:
+
+- Which invocation messages Planemo exposes directly.
+- Whether target Planemo/Galaxy versions populate `completed`, `/completion`, and step job summaries.
+- How `workflow_test_on_invocation` behaves for failed, warning-only, mapped collection, and subworkflow invocations.
+- Whether generated test cases from invocation preserve nested output collection structure correctly.

--- a/casts/claude/implement-galaxy-workflow-test/references/schemas/tests-format.schema.json
+++ b/casts/claude/implement-galaxy-workflow-test/references/schemas/tests-format.schema.json
@@ -1,0 +1,7278 @@
+{
+  "$defs": {
+    "Collection": {
+      "additionalProperties": false,
+      "properties": {
+        "class": {
+          "const": "Collection",
+          "title": "Class",
+          "type": "string"
+        },
+        "collection_type": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Collection Type"
+        },
+        "elements": {
+          "anyOf": [
+            {
+              "items": {
+                "oneOf": [
+                  {
+                    "oneOf": [
+                      {
+                        "$ref": "#/$defs/LocationFile"
+                      },
+                      {
+                        "$ref": "#/$defs/PathFile"
+                      },
+                      {
+                        "$ref": "#/$defs/ContentsFile"
+                      },
+                      {
+                        "$ref": "#/$defs/CompositeDataFile"
+                      }
+                    ]
+                  },
+                  {
+                    "$ref": "#/$defs/Collection"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Elements"
+        },
+        "identifier": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Identifier"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Name"
+        },
+        "rows": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "items": {},
+                "type": "array"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rows"
+        }
+      },
+      "required": [
+        "class"
+      ],
+      "title": "Collection",
+      "type": "object"
+    },
+    "CollectionAttributes": {
+      "additionalProperties": false,
+      "properties": {
+        "collection_type": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Collection Type"
+        }
+      },
+      "title": "CollectionAttributes",
+      "type": "object"
+    },
+    "CompositeDataFile": {
+      "additionalProperties": false,
+      "properties": {
+        "class": {
+          "const": "File",
+          "title": "Class",
+          "type": "string"
+        },
+        "composite_data": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Composite Data",
+          "type": "array"
+        },
+        "contents": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Contents"
+        },
+        "dbkey": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Dbkey"
+        },
+        "decompress": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Decompress"
+        },
+        "deferred": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Deferred"
+        },
+        "filetype": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "File Type"
+        },
+        "hashes": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/HashEntry"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Hashes"
+        },
+        "identifier": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Identifier"
+        },
+        "info": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Info"
+        },
+        "location": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Location"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Name"
+        },
+        "path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Path"
+        },
+        "space_to_tab": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Space To Tab"
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tags"
+        },
+        "to_posix_lines": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "To POSIX Lines"
+        }
+      },
+      "required": [
+        "class",
+        "composite_data"
+      ],
+      "title": "CompositeDataFile",
+      "type": "object"
+    },
+    "ContentsFile": {
+      "additionalProperties": false,
+      "description": "CWL File literal — content inlined as a string.",
+      "properties": {
+        "class": {
+          "const": "File",
+          "title": "Class",
+          "type": "string"
+        },
+        "composite_data": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Composite Data"
+        },
+        "contents": {
+          "title": "Contents",
+          "type": "string"
+        },
+        "dbkey": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Dbkey"
+        },
+        "decompress": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Decompress"
+        },
+        "deferred": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Deferred"
+        },
+        "filetype": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "File Type"
+        },
+        "hashes": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/HashEntry"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Hashes"
+        },
+        "identifier": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Identifier"
+        },
+        "info": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Info"
+        },
+        "location": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Location"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Name"
+        },
+        "path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Path"
+        },
+        "space_to_tab": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Space To Tab"
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tags"
+        },
+        "to_posix_lines": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "To POSIX Lines"
+        }
+      },
+      "required": [
+        "class",
+        "contents"
+      ],
+      "title": "ContentsFile",
+      "type": "object"
+    },
+    "Directory": {
+      "additionalProperties": false,
+      "description": "CWL-style directory input. Supported by stage_inputs for directory-typed\ndatasets (e.g. bwa_mem2_index test fixtures). Rare in workflow tests; IWC\ndoes not use it.",
+      "properties": {
+        "class": {
+          "const": "Directory",
+          "title": "Class",
+          "type": "string"
+        },
+        "filetype": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "File Type"
+        },
+        "location": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Location"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Name"
+        },
+        "path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Path"
+        }
+      },
+      "required": [
+        "class"
+      ],
+      "title": "Directory",
+      "type": "object"
+    },
+    "HashEntry": {
+      "additionalProperties": false,
+      "properties": {
+        "hash_function": {
+          "enum": [
+            "MD5",
+            "SHA-1",
+            "SHA-256",
+            "SHA-512"
+          ],
+          "title": "Hash Function",
+          "type": "string"
+        },
+        "hash_value": {
+          "title": "Hash Value",
+          "type": "string"
+        }
+      },
+      "required": [
+        "hash_function",
+        "hash_value"
+      ],
+      "title": "HashEntry",
+      "type": "object"
+    },
+    "Job": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "oneOf": [
+              {
+                "$ref": "#/$defs/LocationFile"
+              },
+              {
+                "$ref": "#/$defs/PathFile"
+              },
+              {
+                "$ref": "#/$defs/ContentsFile"
+              },
+              {
+                "$ref": "#/$defs/CompositeDataFile"
+              }
+            ]
+          },
+          {
+            "$ref": "#/$defs/Collection"
+          },
+          {
+            "$ref": "#/$defs/Directory"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "integer"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "boolean"
+          },
+          {
+            "items": {
+              "anyOf": [
+                {
+                  "oneOf": [
+                    {
+                      "$ref": "#/$defs/LocationFile"
+                    },
+                    {
+                      "$ref": "#/$defs/PathFile"
+                    },
+                    {
+                      "$ref": "#/$defs/ContentsFile"
+                    },
+                    {
+                      "$ref": "#/$defs/CompositeDataFile"
+                    }
+                  ]
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "title": "Job",
+      "type": "object"
+    },
+    "LocationFile": {
+      "additionalProperties": false,
+      "properties": {
+        "class": {
+          "const": "File",
+          "title": "Class",
+          "type": "string"
+        },
+        "composite_data": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Composite Data"
+        },
+        "contents": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Contents"
+        },
+        "dbkey": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Dbkey"
+        },
+        "decompress": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Decompress"
+        },
+        "deferred": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Deferred"
+        },
+        "filetype": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "File Type"
+        },
+        "hashes": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/HashEntry"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Hashes"
+        },
+        "identifier": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Identifier"
+        },
+        "info": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Info"
+        },
+        "location": {
+          "title": "Location",
+          "type": "string"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Name"
+        },
+        "path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Path"
+        },
+        "space_to_tab": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Space To Tab"
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tags"
+        },
+        "to_posix_lines": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "To POSIX Lines"
+        }
+      },
+      "required": [
+        "class",
+        "location"
+      ],
+      "title": "LocationFile",
+      "type": "object"
+    },
+    "OutputCompareType": {
+      "enum": [
+        "diff",
+        "re_match",
+        "sim_size",
+        "re_match_multiline",
+        "contains",
+        "image_diff"
+      ],
+      "title": "OutputCompareType",
+      "type": "string"
+    },
+    "PathFile": {
+      "additionalProperties": false,
+      "properties": {
+        "class": {
+          "const": "File",
+          "title": "Class",
+          "type": "string"
+        },
+        "composite_data": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Composite Data"
+        },
+        "contents": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Contents"
+        },
+        "dbkey": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Dbkey"
+        },
+        "decompress": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Decompress"
+        },
+        "deferred": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Deferred"
+        },
+        "filetype": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "File Type"
+        },
+        "hashes": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/HashEntry"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Hashes"
+        },
+        "identifier": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Identifier"
+        },
+        "info": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Info"
+        },
+        "location": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Location"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Name"
+        },
+        "path": {
+          "title": "Path",
+          "type": "string"
+        },
+        "space_to_tab": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Space To Tab"
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tags"
+        },
+        "to_posix_lines": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "To POSIX Lines"
+        }
+      },
+      "required": [
+        "class",
+        "path"
+      ],
+      "title": "PathFile",
+      "type": "object"
+    },
+    "TestCollectionCollectionElementAssertions": {
+      "additionalProperties": false,
+      "properties": {
+        "class": {
+          "anyOf": [
+            {
+              "const": "Collection",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "Collection",
+          "title": "Class"
+        },
+        "element_tests": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "oneOf": [
+                  {
+                    "$ref": "#/$defs/TestCollectionDatasetElementAssertions"
+                  },
+                  {
+                    "$ref": "#/$defs/TestCollectionCollectionElementAssertions"
+                  }
+                ]
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Element Tests"
+        },
+        "elements": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "oneOf": [
+                  {
+                    "$ref": "#/$defs/TestCollectionDatasetElementAssertions"
+                  },
+                  {
+                    "$ref": "#/$defs/TestCollectionCollectionElementAssertions"
+                  }
+                ]
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Elements"
+        }
+      },
+      "title": "TestCollectionCollectionElementAssertions",
+      "type": "object"
+    },
+    "TestCollectionDatasetElementAssertions": {
+      "additionalProperties": false,
+      "properties": {
+        "asserts": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "$ref": "#/$defs/assertion_dict"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Assertions about the content of the output.",
+          "title": "Asserts"
+        },
+        "checksum": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The target output's checksum should match the value specified here, in the form `hash_type$hash_value` (e.g. `sha1$8156d7ca0f46ed7abac98f82e36cfaddb2aca041`). Useful for large static files where uploading the whole file is inconvenient.",
+          "title": "Checksum"
+        },
+        "class": {
+          "anyOf": [
+            {
+              "const": "File",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "File",
+          "title": "Class"
+        },
+        "compare": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OutputCompareType"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Comparison mode used when matching the output against the reference file.",
+          "title": "Compare"
+        },
+        "decompress": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "If true, decompress files before comparison. Applies to assertions expressed with `assert_contents` or `compare` set to anything but `sim_size`. Useful for testing compressed outputs that are non-deterministic despite having deterministic decompressed contents. By default, only files compressed with bz2, gzip and zip are automatically decompressed.",
+          "title": "Decompress"
+        },
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "If `compare` is set to `sim_size`, the maximum allowed absolute size difference (in bytes) between the generated data set and the reference file in `test-data/`. Default is 10000 bytes. Can be combined with `delta_frac`.",
+          "title": "Delta"
+        },
+        "delta_frac": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "If `compare` is set to `sim_size`, the maximum allowed relative size difference between the generated data set and the reference file in `test-data/`. 0.1 means the generated file can differ by at most 10%. Default is not to check for relative size difference. Can be combined with `delta`.",
+          "title": "Delta Frac"
+        },
+        "file": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Name of the output file stored in the target `test-data` directory that will be used to compare against the results of executing the tool via the functional test framework.",
+          "title": "File"
+        },
+        "ftype": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "If specified, this value is checked against the corresponding output's data type. If these do not match, the test will fail.",
+          "title": "File Type"
+        },
+        "lines_diff": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Applies when `compare` is set to `diff`, `re_match`, or `contains`. For `diff`, the number of lines of difference to allow (a modified line counts as two: one added, one removed).",
+          "title": "Lines Diff"
+        },
+        "location": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "URL that points to a remote output file that will be downloaded and used for output comparison. Use only when the file cannot be included in the `test-data` folder. May be combined with `file` (downloads when missing on disk) or used alone (filename inferred from the URL). A `checksum` is also used to verify the download when provided.",
+          "title": "Location"
+        },
+        "metadata": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Mapping of metadata keys to expected values for this output.",
+          "title": "Metadata"
+        },
+        "path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Filesystem path to a local output file used for comparison.",
+          "title": "Path"
+        },
+        "sort": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Applies only if `compare` is `diff`, `re_match` or `re_match_multiline`. Sorts the lines of the history data set before comparison; for `diff` and `re_match` the local file is also sorted. Useful for non-deterministic output.",
+          "title": "Sort"
+        }
+      },
+      "title": "TestCollectionDatasetElementAssertions",
+      "type": "object"
+    },
+    "TestCollectionOutputAssertions": {
+      "additionalProperties": false,
+      "properties": {
+        "attributes": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CollectionAttributes"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Attributes"
+        },
+        "class": {
+          "anyOf": [
+            {
+              "const": "Collection",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "Collection",
+          "title": "Class"
+        },
+        "collection_type": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Collection Type"
+        },
+        "element_count": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Element Count"
+        },
+        "element_tests": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "oneOf": [
+                  {
+                    "$ref": "#/$defs/TestCollectionDatasetElementAssertions"
+                  },
+                  {
+                    "$ref": "#/$defs/TestCollectionCollectionElementAssertions"
+                  }
+                ]
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Element Tests"
+        },
+        "elements": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "oneOf": [
+                  {
+                    "$ref": "#/$defs/TestCollectionDatasetElementAssertions"
+                  },
+                  {
+                    "$ref": "#/$defs/TestCollectionCollectionElementAssertions"
+                  }
+                ]
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Elements"
+        }
+      },
+      "title": "TestCollectionOutputAssertions",
+      "type": "object"
+    },
+    "TestDataOutputAssertions": {
+      "additionalProperties": false,
+      "properties": {
+        "asserts": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "$ref": "#/$defs/assertion_dict"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Assertions about the content of the output.",
+          "title": "Asserts"
+        },
+        "checksum": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The target output's checksum should match the value specified here, in the form `hash_type$hash_value` (e.g. `sha1$8156d7ca0f46ed7abac98f82e36cfaddb2aca041`). Useful for large static files where uploading the whole file is inconvenient.",
+          "title": "Checksum"
+        },
+        "class": {
+          "anyOf": [
+            {
+              "const": "File",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "File",
+          "title": "Class"
+        },
+        "compare": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OutputCompareType"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Comparison mode used when matching the output against the reference file.",
+          "title": "Compare"
+        },
+        "decompress": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "If true, decompress files before comparison. Applies to assertions expressed with `assert_contents` or `compare` set to anything but `sim_size`. Useful for testing compressed outputs that are non-deterministic despite having deterministic decompressed contents. By default, only files compressed with bz2, gzip and zip are automatically decompressed.",
+          "title": "Decompress"
+        },
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "If `compare` is set to `sim_size`, the maximum allowed absolute size difference (in bytes) between the generated data set and the reference file in `test-data/`. Default is 10000 bytes. Can be combined with `delta_frac`.",
+          "title": "Delta"
+        },
+        "delta_frac": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "If `compare` is set to `sim_size`, the maximum allowed relative size difference between the generated data set and the reference file in `test-data/`. 0.1 means the generated file can differ by at most 10%. Default is not to check for relative size difference. Can be combined with `delta`.",
+          "title": "Delta Frac"
+        },
+        "file": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Name of the output file stored in the target `test-data` directory that will be used to compare against the results of executing the tool via the functional test framework.",
+          "title": "File"
+        },
+        "ftype": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "If specified, this value is checked against the corresponding output's data type. If these do not match, the test will fail.",
+          "title": "File Type"
+        },
+        "lines_diff": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Applies when `compare` is set to `diff`, `re_match`, or `contains`. For `diff`, the number of lines of difference to allow (a modified line counts as two: one added, one removed).",
+          "title": "Lines Diff"
+        },
+        "location": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "URL that points to a remote output file that will be downloaded and used for output comparison. Use only when the file cannot be included in the `test-data` folder. May be combined with `file` (downloads when missing on disk) or used alone (filename inferred from the URL). A `checksum` is also used to verify the download when provided.",
+          "title": "Location"
+        },
+        "metadata": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Mapping of metadata keys to expected values for this output.",
+          "title": "Metadata"
+        },
+        "path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Filesystem path to a local output file used for comparison.",
+          "title": "Path"
+        },
+        "sort": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Applies only if `compare` is `diff`, `re_match` or `re_match_multiline`. Sorts the lines of the history data set before comparison; for `diff` and `re_match` the local file is also sorted. Useful for non-deterministic output.",
+          "title": "Sort"
+        }
+      },
+      "title": "TestDataOutputAssertions",
+      "type": "object"
+    },
+    "TestJob": {
+      "additionalProperties": false,
+      "properties": {
+        "doc": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Describes the purpose of the test.",
+          "title": "Doc"
+        },
+        "expect_failure": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": false,
+          "description": "If true, the workflow is expected to produce an error.",
+          "title": "Expect Failure"
+        },
+        "job": {
+          "$ref": "#/$defs/Job",
+          "description": "Defines the job to execute. Can be a path to a file or an inline dictionary describing the job inputs."
+        },
+        "outputs": {
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/$defs/TestCollectionOutputAssertions"
+              },
+              {
+                "$ref": "#/$defs/TestDataOutputAssertions"
+              },
+              {
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          },
+          "description": "Defines assertions about outputs (datasets, collections or parameters). Each key corresponds to a labeled output; values are dictionaries describing the expected output.",
+          "title": "Outputs",
+          "type": "object"
+        }
+      },
+      "required": [
+        "job",
+        "outputs"
+      ],
+      "title": "TestJob",
+      "type": "object"
+    },
+    "assertion_dict": {
+      "additionalProperties": false,
+      "properties": {
+        "attribute_is": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_attribute_is_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Attribute Is"
+        },
+        "attribute_matches": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_attribute_matches_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Attribute Matches"
+        },
+        "element_text": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_element_text_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Element Text"
+        },
+        "element_text_is": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_element_text_is_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Element Text Is"
+        },
+        "element_text_matches": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_element_text_matches_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Element Text Matches"
+        },
+        "has_archive_member": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_archive_member_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Archive Member"
+        },
+        "has_element_with_path": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_element_with_path_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Element With Path"
+        },
+        "has_h5_attribute": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_h5_attribute_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has H5 Attribute"
+        },
+        "has_h5_keys": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_h5_keys_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has H5 Keys"
+        },
+        "has_image_center_of_mass": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_image_center_of_mass_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Image Center Of Mass"
+        },
+        "has_image_channels": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_image_channels_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Image Channels"
+        },
+        "has_image_depth": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_image_depth_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Image Depth"
+        },
+        "has_image_frames": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_image_frames_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Image Frames"
+        },
+        "has_image_height": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_image_height_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Image Height"
+        },
+        "has_image_mean_intensity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_image_mean_intensity_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Image Mean Intensity"
+        },
+        "has_image_mean_object_size": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_image_mean_object_size_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Image Mean Object Size"
+        },
+        "has_image_n_labels": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_image_n_labels_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Image N Labels"
+        },
+        "has_image_width": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_image_width_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Image Width"
+        },
+        "has_json_property_with_text": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_json_property_with_text_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Json Property With Text"
+        },
+        "has_json_property_with_value": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_json_property_with_value_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Json Property With Value"
+        },
+        "has_line": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_line_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Line"
+        },
+        "has_line_matching": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_line_matching_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Line Matching"
+        },
+        "has_n_columns": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_n_columns_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has N Columns"
+        },
+        "has_n_elements_with_path": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_n_elements_with_path_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has N Elements With Path"
+        },
+        "has_n_lines": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_n_lines_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has N Lines"
+        },
+        "has_size": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_size_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Size"
+        },
+        "has_text": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_text_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Text"
+        },
+        "has_text_matching": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_text_matching_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Text Matching"
+        },
+        "is_valid_xml": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_is_valid_xml_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Is Valid Xml"
+        },
+        "not_has_text": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_not_has_text_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Not Has Text"
+        },
+        "xml_element": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_xml_element_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Xml Element"
+        }
+      },
+      "title": "assertion_dict",
+      "type": "object"
+    },
+    "assertion_list": {
+      "items": {
+        "anyOf": [
+          {
+            "discriminator": {
+              "mapping": {
+                "attribute_is": "#/$defs/attribute_is_model",
+                "attribute_matches": "#/$defs/attribute_matches_model",
+                "element_text": "#/$defs/element_text_model",
+                "element_text_is": "#/$defs/element_text_is_model",
+                "element_text_matches": "#/$defs/element_text_matches_model",
+                "has_archive_member": "#/$defs/has_archive_member_model",
+                "has_element_with_path": "#/$defs/has_element_with_path_model",
+                "has_h5_attribute": "#/$defs/has_h5_attribute_model",
+                "has_h5_keys": "#/$defs/has_h5_keys_model",
+                "has_image_center_of_mass": "#/$defs/has_image_center_of_mass_model",
+                "has_image_channels": "#/$defs/has_image_channels_model",
+                "has_image_depth": "#/$defs/has_image_depth_model",
+                "has_image_frames": "#/$defs/has_image_frames_model",
+                "has_image_height": "#/$defs/has_image_height_model",
+                "has_image_mean_intensity": "#/$defs/has_image_mean_intensity_model",
+                "has_image_mean_object_size": "#/$defs/has_image_mean_object_size_model",
+                "has_image_n_labels": "#/$defs/has_image_n_labels_model",
+                "has_image_width": "#/$defs/has_image_width_model",
+                "has_json_property_with_text": "#/$defs/has_json_property_with_text_model",
+                "has_json_property_with_value": "#/$defs/has_json_property_with_value_model",
+                "has_line": "#/$defs/has_line_model",
+                "has_line_matching": "#/$defs/has_line_matching_model",
+                "has_n_columns": "#/$defs/has_n_columns_model",
+                "has_n_elements_with_path": "#/$defs/has_n_elements_with_path_model",
+                "has_n_lines": "#/$defs/has_n_lines_model",
+                "has_size": "#/$defs/has_size_model",
+                "has_text": "#/$defs/has_text_model",
+                "has_text_matching": "#/$defs/has_text_matching_model",
+                "is_valid_xml": "#/$defs/is_valid_xml_model",
+                "not_has_text": "#/$defs/not_has_text_model",
+                "xml_element": "#/$defs/xml_element_model"
+              },
+              "propertyName": "that"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/has_line_model"
+              },
+              {
+                "$ref": "#/$defs/has_line_matching_model"
+              },
+              {
+                "$ref": "#/$defs/has_n_lines_model"
+              },
+              {
+                "$ref": "#/$defs/has_text_model"
+              },
+              {
+                "$ref": "#/$defs/has_text_matching_model"
+              },
+              {
+                "$ref": "#/$defs/not_has_text_model"
+              },
+              {
+                "$ref": "#/$defs/has_n_columns_model"
+              },
+              {
+                "$ref": "#/$defs/attribute_is_model"
+              },
+              {
+                "$ref": "#/$defs/attribute_matches_model"
+              },
+              {
+                "$ref": "#/$defs/element_text_model"
+              },
+              {
+                "$ref": "#/$defs/element_text_is_model"
+              },
+              {
+                "$ref": "#/$defs/element_text_matches_model"
+              },
+              {
+                "$ref": "#/$defs/has_element_with_path_model"
+              },
+              {
+                "$ref": "#/$defs/has_n_elements_with_path_model"
+              },
+              {
+                "$ref": "#/$defs/is_valid_xml_model"
+              },
+              {
+                "$ref": "#/$defs/xml_element_model"
+              },
+              {
+                "$ref": "#/$defs/has_json_property_with_text_model"
+              },
+              {
+                "$ref": "#/$defs/has_json_property_with_value_model"
+              },
+              {
+                "$ref": "#/$defs/has_h5_attribute_model"
+              },
+              {
+                "$ref": "#/$defs/has_h5_keys_model"
+              },
+              {
+                "$ref": "#/$defs/has_archive_member_model"
+              },
+              {
+                "$ref": "#/$defs/has_size_model"
+              },
+              {
+                "$ref": "#/$defs/has_image_center_of_mass_model"
+              },
+              {
+                "$ref": "#/$defs/has_image_channels_model"
+              },
+              {
+                "$ref": "#/$defs/has_image_depth_model"
+              },
+              {
+                "$ref": "#/$defs/has_image_frames_model"
+              },
+              {
+                "$ref": "#/$defs/has_image_height_model"
+              },
+              {
+                "$ref": "#/$defs/has_image_mean_intensity_model"
+              },
+              {
+                "$ref": "#/$defs/has_image_mean_object_size_model"
+              },
+              {
+                "$ref": "#/$defs/has_image_n_labels_model"
+              },
+              {
+                "$ref": "#/$defs/has_image_width_model"
+              }
+            ]
+          },
+          {
+            "$ref": "#/$defs/has_line_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_line_matching_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_n_lines_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_text_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_text_matching_model_nested"
+          },
+          {
+            "$ref": "#/$defs/not_has_text_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_n_columns_model_nested"
+          },
+          {
+            "$ref": "#/$defs/attribute_is_model_nested"
+          },
+          {
+            "$ref": "#/$defs/attribute_matches_model_nested"
+          },
+          {
+            "$ref": "#/$defs/element_text_model_nested"
+          },
+          {
+            "$ref": "#/$defs/element_text_is_model_nested"
+          },
+          {
+            "$ref": "#/$defs/element_text_matches_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_element_with_path_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_n_elements_with_path_model_nested"
+          },
+          {
+            "$ref": "#/$defs/is_valid_xml_model_nested"
+          },
+          {
+            "$ref": "#/$defs/xml_element_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_json_property_with_text_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_json_property_with_value_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_h5_attribute_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_h5_keys_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_archive_member_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_size_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_image_center_of_mass_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_image_channels_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_image_depth_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_image_frames_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_image_height_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_image_mean_intensity_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_image_mean_object_size_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_image_n_labels_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_image_width_model_nested"
+          }
+        ]
+      },
+      "title": "assertion_list",
+      "type": "array"
+    },
+    "attribute_is_model": {
+      "additionalProperties": false,
+      "description": "Asserts the XML ``attribute`` for the element (or tag) with the specified\nXPath-like ``path`` is the specified ``text``.\n\nFor example:\n\n```xml\n<attribute_is path=\"outerElement/innerElement1\" attribute=\"foo\" text=\"bar\" />\n```\n\nThe assertion implicitly also asserts that an element matching ``path`` exists.\nWith ``negate`` the result of the assertion (on the equality) can be inverted (the\nimplicit assertion on the existence of the path is not affected).",
+      "properties": {
+        "attribute": {
+          "description": "The XML attribute name to test against from the target XML element.",
+          "title": "Attribute",
+          "type": "string"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        },
+        "text": {
+          "description": "The expected attribute value to test against on the target XML element",
+          "title": "Text",
+          "type": "string"
+        },
+        "that": {
+          "const": "attribute_is",
+          "default": "attribute_is",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "attribute",
+        "text"
+      ],
+      "title": "Assert Attribute Is",
+      "type": "object"
+    },
+    "attribute_is_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "attribute_is": {
+          "$ref": "#/$defs/base_attribute_is_model",
+          "title": "Assert Attribute Is"
+        }
+      },
+      "required": [
+        "attribute_is"
+      ],
+      "title": "Assert Attribute Is (Nested)",
+      "type": "object"
+    },
+    "attribute_matches_model": {
+      "additionalProperties": false,
+      "description": "Asserts the XML ``attribute`` for the element (or tag) with the specified\nXPath-like ``path`` matches the regular expression specified by ``expression``.\n\nFor example:\n\n```xml\n<attribute_matches path=\"outerElement/innerElement2\" attribute=\"foo2\" expression=\"bar\\d+\" />\n```\n\nThe assertion implicitly also asserts that an element matching ``path`` exists.\nWith ``negate`` the result of the assertion (on the matching) can be inverted (the\nimplicit assertion on the existence of the path is not affected).",
+      "properties": {
+        "attribute": {
+          "description": "The XML attribute name to test against from the target XML element.",
+          "title": "Attribute",
+          "type": "string"
+        },
+        "expression": {
+          "description": "The regular expressions to apply against the named attribute on the target XML element.",
+          "title": "Expression",
+          "type": "string"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        },
+        "that": {
+          "const": "attribute_matches",
+          "default": "attribute_matches",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "attribute",
+        "expression"
+      ],
+      "title": "Assert Attribute Matches",
+      "type": "object"
+    },
+    "attribute_matches_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "attribute_matches": {
+          "$ref": "#/$defs/base_attribute_matches_model",
+          "title": "Assert Attribute Matches"
+        }
+      },
+      "required": [
+        "attribute_matches"
+      ],
+      "title": "Assert Attribute Matches (Nested)",
+      "type": "object"
+    },
+    "base_attribute_is_model": {
+      "additionalProperties": false,
+      "description": "base model for attribute_is describing attributes.",
+      "properties": {
+        "attribute": {
+          "description": "The XML attribute name to test against from the target XML element.",
+          "title": "Attribute",
+          "type": "string"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        },
+        "text": {
+          "description": "The expected attribute value to test against on the target XML element",
+          "title": "Text",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "attribute",
+        "text"
+      ],
+      "title": "base_attribute_is_model",
+      "type": "object"
+    },
+    "base_attribute_matches_model": {
+      "additionalProperties": false,
+      "description": "base model for attribute_matches describing attributes.",
+      "properties": {
+        "attribute": {
+          "description": "The XML attribute name to test against from the target XML element.",
+          "title": "Attribute",
+          "type": "string"
+        },
+        "expression": {
+          "description": "The regular expressions to apply against the named attribute on the target XML element.",
+          "title": "Expression",
+          "type": "string"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "attribute",
+        "expression"
+      ],
+      "title": "base_attribute_matches_model",
+      "type": "object"
+    },
+    "base_element_text_is_model": {
+      "additionalProperties": false,
+      "description": "base model for element_text_is describing attributes.",
+      "properties": {
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        },
+        "text": {
+          "description": "The expected element text (body of the XML tag) to test against on the target XML element",
+          "title": "Text",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "text"
+      ],
+      "title": "base_element_text_is_model",
+      "type": "object"
+    },
+    "base_element_text_matches_model": {
+      "additionalProperties": false,
+      "description": "base model for element_text_matches describing attributes.",
+      "properties": {
+        "expression": {
+          "description": "The regular expressions to apply against the target element.",
+          "title": "Expression",
+          "type": "string"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "expression"
+      ],
+      "title": "base_element_text_matches_model",
+      "type": "object"
+    },
+    "base_element_text_model": {
+      "additionalProperties": false,
+      "description": "base model for element_text describing attributes.",
+      "properties": {
+        "asserts": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Asserts"
+        },
+        "children": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Children"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "base_element_text_model",
+      "type": "object"
+    },
+    "base_has_archive_member_model": {
+      "additionalProperties": false,
+      "description": "base model for has_archive_member describing attributes.",
+      "properties": {
+        "all": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "Check the sub-assertions for all paths matching the path. Default: false, i.e. only the first",
+          "title": "All"
+        },
+        "asserts": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Asserts"
+        },
+        "children": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Children"
+        },
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The regular expression specifying the archive member.",
+          "title": "Path",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "base_has_archive_member_model",
+      "type": "object"
+    },
+    "base_has_element_with_path_model": {
+      "additionalProperties": false,
+      "description": "base model for has_element_with_path describing attributes.",
+      "properties": {
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "base_has_element_with_path_model",
+      "type": "object"
+    },
+    "base_has_h5_attribute_model": {
+      "additionalProperties": false,
+      "description": "base model for has_h5_attribute describing attributes.",
+      "properties": {
+        "key": {
+          "description": "HDF5 attribute to check value of.",
+          "title": "Key",
+          "type": "string"
+        },
+        "value": {
+          "description": "Expected value of HDF5 attribute to check.",
+          "title": "Value",
+          "type": "string"
+        }
+      },
+      "required": [
+        "key",
+        "value"
+      ],
+      "title": "base_has_h5_attribute_model",
+      "type": "object"
+    },
+    "base_has_h5_keys_model": {
+      "additionalProperties": false,
+      "description": "base model for has_h5_keys describing attributes.",
+      "properties": {
+        "keys": {
+          "description": "HDF5 attributes to check value of as a comma-separated string.",
+          "title": "Keys",
+          "type": "string"
+        }
+      },
+      "required": [
+        "keys"
+      ],
+      "title": "base_has_h5_keys_model",
+      "type": "object"
+    },
+    "base_has_image_center_of_mass_model": {
+      "additionalProperties": false,
+      "description": "base model for has_image_center_of_mass describing attributes.",
+      "properties": {
+        "center_of_mass": {
+          "description": "The required center of mass of the image intensities (horizontal and vertical coordinate, separated by a comma).",
+          "title": "Center Of Mass",
+          "type": "string"
+        },
+        "channel": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific channel of the image (where ``0`` corresponds to the first image channel).",
+          "title": "Channel"
+        },
+        "eps": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.01,
+          "description": "The maximum allowed Euclidean distance to the required center of mass (defaults to ``0.01``).",
+          "title": "Eps"
+        },
+        "frame": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific frame of the image sequence (where ``0`` corresponds to the first image frame).",
+          "title": "Frame"
+        },
+        "slice": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific slice of the image (where ``0`` corresponds to the first image slice).",
+          "title": "Slice"
+        }
+      },
+      "required": [
+        "center_of_mass"
+      ],
+      "title": "base_has_image_center_of_mass_model",
+      "type": "object"
+    },
+    "base_has_image_channels_model": {
+      "additionalProperties": false,
+      "description": "base model for has_image_channels describing attributes.",
+      "properties": {
+        "channels": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected number of channels of the image.",
+          "title": "Channels"
+        },
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the number of channels (default is 0). The observed number of channels has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed number of channels.",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed number of channels.",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        }
+      },
+      "title": "base_has_image_channels_model",
+      "type": "object"
+    },
+    "base_has_image_depth_model": {
+      "additionalProperties": false,
+      "description": "base model for has_image_depth describing attributes.",
+      "properties": {
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the image depth (number of slices, default is 0). The observed depth has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "depth": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected depth of the image (number of slices).",
+          "title": "Depth"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed depth of the image (number of slices).",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed depth of the image (number of slices).",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        }
+      },
+      "title": "base_has_image_depth_model",
+      "type": "object"
+    },
+    "base_has_image_frames_model": {
+      "additionalProperties": false,
+      "description": "base model for has_image_frames describing attributes.",
+      "properties": {
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the number of frames in the image sequence (number of time steps, default is 0). The observed number of frames has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "frames": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected number of frames in the image sequence (number of time steps).",
+          "title": "Frames"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed number of frames in the image sequence (number of time steps).",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed number of frames in the image sequence (number of time steps).",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        }
+      },
+      "title": "base_has_image_frames_model",
+      "type": "object"
+    },
+    "base_has_image_height_model": {
+      "additionalProperties": false,
+      "description": "base model for has_image_height describing attributes.",
+      "properties": {
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the image height (in pixels, default is 0). The observed height has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "height": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected height of the image (in pixels).",
+          "title": "Height"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed height of the image (in pixels).",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed height of the image (in pixels).",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        }
+      },
+      "title": "base_has_image_height_model",
+      "type": "object"
+    },
+    "base_has_image_mean_intensity_model": {
+      "additionalProperties": false,
+      "description": "base model for has_image_mean_intensity describing attributes.",
+      "properties": {
+        "channel": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific channel of the image (where ``0`` corresponds to the first image channel).",
+          "title": "Channel"
+        },
+        "eps": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.01,
+          "description": "The absolute tolerance to be used for ``value`` (defaults to ``0.01``). The observed mean value of the image intensities has to be in the range ``value +- eps``.",
+          "title": "Eps"
+        },
+        "frame": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific frame of the image sequence (where ``0`` corresponds to the first image frame).",
+          "title": "Frame"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "An upper bound of the required mean value of the image intensities.",
+          "title": "Max"
+        },
+        "mean_intensity": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The required mean value of the image intensities.",
+          "title": "Mean Intensity"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A lower bound of the required mean value of the image intensities.",
+          "title": "Min"
+        },
+        "slice": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific slice of the image (where ``0`` corresponds to the first image slice).",
+          "title": "Slice"
+        }
+      },
+      "title": "base_has_image_mean_intensity_model",
+      "type": "object"
+    },
+    "base_has_image_mean_object_size_model": {
+      "additionalProperties": false,
+      "description": "base model for has_image_mean_object_size describing attributes.",
+      "properties": {
+        "channel": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific channel of the image (where ``0`` corresponds to the first image channel).",
+          "title": "Channel"
+        },
+        "eps": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.01,
+          "description": "The absolute tolerance to be used for ``value`` (defaults to ``0.01``). The observed mean size of the uniquely labeled objects has to be in the range ``value +- eps``.",
+          "title": "Eps"
+        },
+        "exclude_labels": {
+          "anyOf": [
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "List of labels to be excluded from consideration, separated by a comma. The primary usage of this attribute is to exclude the background of a label image. Cannot be used in combination with ``labels``.",
+          "title": "Exclude Labels"
+        },
+        "frame": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific frame of the image sequence (where ``0`` corresponds to the first image frame).",
+          "title": "Frame"
+        },
+        "labels": {
+          "anyOf": [
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "List of labels, separated by a comma. Labels *not* on this list will be excluded from consideration. Cannot be used in combination with ``exclude_labels``.",
+          "title": "Labels"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "An upper bound of the required mean size of the uniquely labeled objects.",
+          "title": "Max"
+        },
+        "mean_object_size": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The required mean size of the uniquely labeled objects.",
+          "title": "Mean Object Size"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A lower bound of the required mean size of the uniquely labeled objects.",
+          "title": "Min"
+        },
+        "slice": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific slice of the image (where ``0`` corresponds to the first image slice).",
+          "title": "Slice"
+        }
+      },
+      "title": "base_has_image_mean_object_size_model",
+      "type": "object"
+    },
+    "base_has_image_n_labels_model": {
+      "additionalProperties": false,
+      "description": "base model for has_image_n_labels describing attributes.",
+      "properties": {
+        "channel": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific channel of the image (where ``0`` corresponds to the first image channel).",
+          "title": "Channel"
+        },
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the number of labels (default is 0). The observed number of labels has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "exclude_labels": {
+          "anyOf": [
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "List of labels to be excluded from consideration, separated by a comma. The primary usage of this attribute is to exclude the background of a label image. Cannot be used in combination with ``labels``.",
+          "title": "Exclude Labels"
+        },
+        "frame": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific frame of the image sequence (where ``0`` corresponds to the first image frame).",
+          "title": "Frame"
+        },
+        "labels": {
+          "anyOf": [
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "List of labels, separated by a comma. Labels *not* on this list will be excluded from consideration. Cannot be used in combination with ``exclude_labels``.",
+          "title": "Labels"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed number of labels.",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed number of labels.",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected number of labels.",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "slice": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific slice of the image (where ``0`` corresponds to the first image slice).",
+          "title": "Slice"
+        }
+      },
+      "title": "base_has_image_n_labels_model",
+      "type": "object"
+    },
+    "base_has_image_width_model": {
+      "additionalProperties": false,
+      "description": "base model for has_image_width describing attributes.",
+      "properties": {
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the image width (in pixels, default is 0). The observed width has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed width of the image (in pixels).",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed width of the image (in pixels).",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "width": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected width of the image (in pixels).",
+          "title": "Width"
+        }
+      },
+      "title": "base_has_image_width_model",
+      "type": "object"
+    },
+    "base_has_json_property_with_text_model": {
+      "additionalProperties": false,
+      "description": "base model for has_json_property_with_text describing attributes.",
+      "properties": {
+        "property": {
+          "description": "The property name to search the JSON document for.",
+          "title": "Property",
+          "type": "string"
+        },
+        "text": {
+          "description": "The expected text value of the target JSON attribute.",
+          "title": "Text",
+          "type": "string"
+        }
+      },
+      "required": [
+        "property",
+        "text"
+      ],
+      "title": "base_has_json_property_with_text_model",
+      "type": "object"
+    },
+    "base_has_json_property_with_value_model": {
+      "additionalProperties": false,
+      "description": "base model for has_json_property_with_value describing attributes.",
+      "properties": {
+        "property": {
+          "description": "The property name to search the JSON document for.",
+          "title": "Property",
+          "type": "string"
+        },
+        "value": {
+          "description": "The expected JSON value of the target JSON attribute (as a JSON encoded string).",
+          "title": "Value",
+          "type": "string"
+        }
+      },
+      "required": [
+        "property",
+        "value"
+      ],
+      "title": "base_has_json_property_with_value_model",
+      "type": "object"
+    },
+    "base_has_line_matching_model": {
+      "additionalProperties": false,
+      "description": "base model for has_line_matching describing attributes.",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "expression": {
+          "description": "The regular expressions to attempt match in the output.",
+          "title": "Expression",
+          "type": "string"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        }
+      },
+      "required": [
+        "expression"
+      ],
+      "title": "base_has_line_matching_model",
+      "type": "object"
+    },
+    "base_has_line_model": {
+      "additionalProperties": false,
+      "description": "base model for has_line describing attributes.",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "line": {
+          "description": "The full line of text to search for in the output.",
+          "title": "Line",
+          "type": "string"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        }
+      },
+      "required": [
+        "line"
+      ],
+      "title": "base_has_line_model",
+      "type": "object"
+    },
+    "base_has_n_columns_model": {
+      "additionalProperties": false,
+      "description": "base model for has_n_columns describing attributes.",
+      "properties": {
+        "comment": {
+          "default": "",
+          "description": "Comment character(s) used to skip comment lines (which should not be used for counting columns)",
+          "title": "Comment",
+          "type": "string"
+        },
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "sep": {
+          "default": "\t",
+          "description": "Separator defining columns, default: tab",
+          "title": "Sep",
+          "type": "string"
+        }
+      },
+      "title": "base_has_n_columns_model",
+      "type": "object"
+    },
+    "base_has_n_elements_with_path_model": {
+      "additionalProperties": false,
+      "description": "base model for has_n_elements_with_path describing attributes.",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "base_has_n_elements_with_path_model",
+      "type": "object"
+    },
+    "base_has_n_lines_model": {
+      "additionalProperties": false,
+      "description": "base model for has_n_lines describing attributes.",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        }
+      },
+      "title": "base_has_n_lines_model",
+      "type": "object"
+    },
+    "base_has_size_model": {
+      "additionalProperties": false,
+      "description": "base model for has_size describing attributes.",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "size": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired size of the output (in bytes), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Size"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Deprecated alias for `size`",
+          "title": "Value"
+        }
+      },
+      "title": "base_has_size_model",
+      "type": "object"
+    },
+    "base_has_text_matching_model": {
+      "additionalProperties": false,
+      "description": "base model for has_text_matching describing attributes.",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "expression": {
+          "description": "The regular expressions to attempt match in the output.",
+          "title": "Expression",
+          "type": "string"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        }
+      },
+      "required": [
+        "expression"
+      ],
+      "title": "base_has_text_matching_model",
+      "type": "object"
+    },
+    "base_has_text_model": {
+      "additionalProperties": false,
+      "description": "base model for has_text describing attributes.",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "text": {
+          "description": "The text to search for in the output.",
+          "title": "Text",
+          "type": "string"
+        }
+      },
+      "required": [
+        "text"
+      ],
+      "title": "base_has_text_model",
+      "type": "object"
+    },
+    "base_is_valid_xml_model": {
+      "additionalProperties": false,
+      "description": "base model for is_valid_xml describing attributes.",
+      "properties": {},
+      "title": "base_is_valid_xml_model",
+      "type": "object"
+    },
+    "base_not_has_text_model": {
+      "additionalProperties": false,
+      "description": "base model for not_has_text describing attributes.",
+      "properties": {
+        "text": {
+          "description": "The text to search for in the output.",
+          "title": "Text",
+          "type": "string"
+        }
+      },
+      "required": [
+        "text"
+      ],
+      "title": "base_not_has_text_model",
+      "type": "object"
+    },
+    "base_xml_element_model": {
+      "additionalProperties": false,
+      "description": "base model for xml_element describing attributes.",
+      "properties": {
+        "all": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "Check the sub-assertions for all paths matching the path. Default: false, i.e. only the first ",
+          "title": "All"
+        },
+        "asserts": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Asserts"
+        },
+        "attribute": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The XML attribute name to test against from the target XML element.",
+          "title": "Attribute"
+        },
+        "children": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Children"
+        },
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "base_xml_element_model",
+      "type": "object"
+    },
+    "element_text_is_model": {
+      "additionalProperties": false,
+      "description": "Asserts the text of the XML element with the specified XPath-like ``path`` is\nthe specified ``text``.\n\nFor example:\n\n```xml\n<element_text_is path=\"BlastOutput_program\" text=\"blastp\" />\n```\n\nThe assertion implicitly also asserts that an element matching ``path`` exists.\nWith ``negate`` the result of the assertion (on the equality) can be inverted (the\nimplicit assertion on the existence of the path is not affected).",
+      "properties": {
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        },
+        "text": {
+          "description": "The expected element text (body of the XML tag) to test against on the target XML element",
+          "title": "Text",
+          "type": "string"
+        },
+        "that": {
+          "const": "element_text_is",
+          "default": "element_text_is",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "text"
+      ],
+      "title": "Assert Element Text Is",
+      "type": "object"
+    },
+    "element_text_is_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "element_text_is": {
+          "$ref": "#/$defs/base_element_text_is_model",
+          "title": "Assert Element Text Is"
+        }
+      },
+      "required": [
+        "element_text_is"
+      ],
+      "title": "Assert Element Text Is (Nested)",
+      "type": "object"
+    },
+    "element_text_matches_model": {
+      "additionalProperties": false,
+      "description": "Asserts the text of the XML element with the specified XPath-like ``path``\nmatches the regular expression defined by ``expression``.\n\nFor example:\n\n```xml\n<element_text_matches path=\"BlastOutput_version\" expression=\"BLASTP\\s+2\\.2.*\"/>\n```\n\nThe assertion implicitly also asserts that an element matching ``path`` exists.\nWith ``negate`` the result of the assertion (on the matching) can be inverted (the\nimplicit assertion on the existence of the path is not affected).",
+      "properties": {
+        "expression": {
+          "description": "The regular expressions to apply against the target element.",
+          "title": "Expression",
+          "type": "string"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        },
+        "that": {
+          "const": "element_text_matches",
+          "default": "element_text_matches",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "expression"
+      ],
+      "title": "Assert Element Text Matches",
+      "type": "object"
+    },
+    "element_text_matches_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "element_text_matches": {
+          "$ref": "#/$defs/base_element_text_matches_model",
+          "title": "Assert Element Text Matches"
+        }
+      },
+      "required": [
+        "element_text_matches"
+      ],
+      "title": "Assert Element Text Matches (Nested)",
+      "type": "object"
+    },
+    "element_text_model": {
+      "additionalProperties": false,
+      "description": "This tag allows the developer to recurisively specify additional assertions as\nchild elements about just the text contained in the element specified by the\nXPath-like ``path``, e.g.\n\n```xml\n<element_text path=\"BlastOutput_iterations/Iteration/Iteration_hits/Hit/Hit_def\">\n  <not_has_text text=\"EDK72998.1\" />\n</element_text>\n```\n\nThe assertion implicitly also asserts that an element matching ``path`` exists.\nWith ``negate`` the result of the implicit assertions can be inverted.\nThe sub-assertions, which have their own ``negate`` attribute, are not affected\nby ``negate``.",
+      "properties": {
+        "asserts": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Asserts"
+        },
+        "children": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Children"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        },
+        "that": {
+          "const": "element_text",
+          "default": "element_text",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "Assert Element Text",
+      "type": "object"
+    },
+    "element_text_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "element_text": {
+          "$ref": "#/$defs/base_element_text_model",
+          "title": "Assert Element Text"
+        }
+      },
+      "required": [
+        "element_text"
+      ],
+      "title": "Assert Element Text (Nested)",
+      "type": "object"
+    },
+    "has_archive_member_model": {
+      "additionalProperties": false,
+      "description": "This tag allows to check if ``path`` is contained in a compressed file.\n\nThe path is a regular expression that is matched against the full paths of the objects in\nthe compressed file (remember that \"matching\" means it is checked if a prefix of\nthe full path of an archive member is described by the regular expression).\nValid archive formats include ``.zip``, ``.tar``, and ``.tar.gz``. Note that\ndepending on the archive creation method:\n\n- full paths of the members may be prefixed with ``./``\n- directories may be treated as empty files\n\n```xml\n<has_archive_member path=\"./path/to/my-file.txt\"/>\n```\n\nWith ``n`` and ``delta`` (or ``min`` and ``max``) assertions on the number of\narchive members matching ``path`` can be expressed. The following could be used,\ne.g., to assert an archive containing n&plusmn;1 elements out of which at least\n4 need to have a ``txt`` extension.\n\n```xml\n<has_archive_member path=\".*\" n=\"10\" delta=\"1\"/>\n<has_archive_member path=\".*\\.txt\" min=\"4\"/>\n```\n\nIn addition the tag can contain additional assertions as child elements about\nthe first member in the archive matching the regular expression ``path``. For\ninstance\n\n```xml\n<has_archive_member path=\".*/my-file.txt\">\n  <not_has_text text=\"EDK72998.1\"/>\n</has_archive_member>\n```\n\nIf the ``all`` attribute is set to ``true`` then all archive members are subject\nto the assertions. Note that, archive members matching the ``path`` are sorted\nalphabetically.\n\nThe ``negate`` attribute of the ``has_archive_member`` assertion only affects\nthe asserts on the presence and number of matching archive members, but not any\nsub-assertions (which can offer the ``negate`` attribute on their own).  The\ncheck if the file is an archive at all, which is also done by the function, is\nnot affected.",
+      "properties": {
+        "all": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "Check the sub-assertions for all paths matching the path. Default: false, i.e. only the first",
+          "title": "All"
+        },
+        "asserts": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Asserts"
+        },
+        "children": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Children"
+        },
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The regular expression specifying the archive member.",
+          "title": "Path",
+          "type": "string"
+        },
+        "that": {
+          "const": "has_archive_member",
+          "default": "has_archive_member",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "Assert Has Archive Member",
+      "type": "object"
+    },
+    "has_archive_member_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_archive_member": {
+          "$ref": "#/$defs/base_has_archive_member_model",
+          "title": "Assert Has Archive Member"
+        }
+      },
+      "required": [
+        "has_archive_member"
+      ],
+      "title": "Assert Has Archive Member (Nested)",
+      "type": "object"
+    },
+    "has_element_with_path_model": {
+      "additionalProperties": false,
+      "description": "Asserts the XML output contains at least one element (or tag) with the specified\nXPath-like ``path``, e.g.\n\n```xml\n<has_element_with_path path=\"BlastOutput_param/Parameters/Parameters_matrix\" />\n```\n\nWith ``negate`` the result of the assertion can be inverted.",
+      "properties": {
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        },
+        "that": {
+          "const": "has_element_with_path",
+          "default": "has_element_with_path",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "Assert Has Element With Path",
+      "type": "object"
+    },
+    "has_element_with_path_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_element_with_path": {
+          "$ref": "#/$defs/base_has_element_with_path_model",
+          "title": "Assert Has Element With Path"
+        }
+      },
+      "required": [
+        "has_element_with_path"
+      ],
+      "title": "Assert Has Element With Path (Nested)",
+      "type": "object"
+    },
+    "has_h5_attribute_model": {
+      "additionalProperties": false,
+      "description": "Asserts HDF5 output contains the specified ``value`` for an attribute (``key``), e.g.\n\n```xml\n<has_h5_attribute key=\"nchroms\" value=\"15\" />\n```",
+      "properties": {
+        "key": {
+          "description": "HDF5 attribute to check value of.",
+          "title": "Key",
+          "type": "string"
+        },
+        "that": {
+          "const": "has_h5_attribute",
+          "default": "has_h5_attribute",
+          "title": "That",
+          "type": "string"
+        },
+        "value": {
+          "description": "Expected value of HDF5 attribute to check.",
+          "title": "Value",
+          "type": "string"
+        }
+      },
+      "required": [
+        "key",
+        "value"
+      ],
+      "title": "Assert Has H5 Attribute",
+      "type": "object"
+    },
+    "has_h5_attribute_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_h5_attribute": {
+          "$ref": "#/$defs/base_has_h5_attribute_model",
+          "title": "Assert Has H5 Attribute"
+        }
+      },
+      "required": [
+        "has_h5_attribute"
+      ],
+      "title": "Assert Has H5 Attribute (Nested)",
+      "type": "object"
+    },
+    "has_h5_keys_model": {
+      "additionalProperties": false,
+      "description": "Asserts the specified HDF5 output has the given keys.",
+      "properties": {
+        "keys": {
+          "description": "HDF5 attributes to check value of as a comma-separated string.",
+          "title": "Keys",
+          "type": "string"
+        },
+        "that": {
+          "const": "has_h5_keys",
+          "default": "has_h5_keys",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "keys"
+      ],
+      "title": "Assert Has H5 Keys",
+      "type": "object"
+    },
+    "has_h5_keys_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_h5_keys": {
+          "$ref": "#/$defs/base_has_h5_keys_model",
+          "title": "Assert Has H5 Keys"
+        }
+      },
+      "required": [
+        "has_h5_keys"
+      ],
+      "title": "Assert Has H5 Keys (Nested)",
+      "type": "object"
+    },
+    "has_image_center_of_mass_model": {
+      "additionalProperties": false,
+      "description": "Asserts the specified output is an image and has the specified center of mass.\n\nAsserts the output is an image and has a specific center of mass,\nor has an Euclidean distance of ``eps`` or less to that point (e.g.,\n``<has_image_center_of_mass center_of_mass=\"511.07, 223.34\" />``).",
+      "properties": {
+        "center_of_mass": {
+          "description": "The required center of mass of the image intensities (horizontal and vertical coordinate, separated by a comma).",
+          "title": "Center Of Mass",
+          "type": "string"
+        },
+        "channel": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific channel of the image (where ``0`` corresponds to the first image channel).",
+          "title": "Channel"
+        },
+        "eps": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.01,
+          "description": "The maximum allowed Euclidean distance to the required center of mass (defaults to ``0.01``).",
+          "title": "Eps"
+        },
+        "frame": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific frame of the image sequence (where ``0`` corresponds to the first image frame).",
+          "title": "Frame"
+        },
+        "slice": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific slice of the image (where ``0`` corresponds to the first image slice).",
+          "title": "Slice"
+        },
+        "that": {
+          "const": "has_image_center_of_mass",
+          "default": "has_image_center_of_mass",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "center_of_mass"
+      ],
+      "title": "Assert Has Image Center Of Mass",
+      "type": "object"
+    },
+    "has_image_center_of_mass_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_image_center_of_mass": {
+          "$ref": "#/$defs/base_has_image_center_of_mass_model",
+          "title": "Assert Has Image Center Of Mass"
+        }
+      },
+      "required": [
+        "has_image_center_of_mass"
+      ],
+      "title": "Assert Has Image Center Of Mass (Nested)",
+      "type": "object"
+    },
+    "has_image_channels_model": {
+      "additionalProperties": false,
+      "description": "Asserts the output is an image and has a specific number of channels.\n\nThe number of channels is plus/minus ``delta`` (e.g., ``<has_image_channels channels=\"3\" />``).\n\nAlternatively the range of the expected number of channels can be specified by ``min`` and/or ``max``.",
+      "properties": {
+        "channels": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected number of channels of the image.",
+          "title": "Channels"
+        },
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the number of channels (default is 0). The observed number of channels has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed number of channels.",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed number of channels.",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "that": {
+          "const": "has_image_channels",
+          "default": "has_image_channels",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "title": "Assert Has Image Channels",
+      "type": "object"
+    },
+    "has_image_channels_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_image_channels": {
+          "$ref": "#/$defs/base_has_image_channels_model",
+          "title": "Assert Has Image Channels"
+        }
+      },
+      "required": [
+        "has_image_channels"
+      ],
+      "title": "Assert Has Image Channels (Nested)",
+      "type": "object"
+    },
+    "has_image_depth_model": {
+      "additionalProperties": false,
+      "description": "Asserts the output is an image and has a specific depth (number of slices).\n\nThe depth is plus/minus ``delta`` (e.g., ``<has_image_depth depth=\"512\" delta=\"2\" />``).\nAlternatively the range of the expected depth can be specified by ``min`` and/or ``max``.",
+      "properties": {
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the image depth (number of slices, default is 0). The observed depth has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "depth": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected depth of the image (number of slices).",
+          "title": "Depth"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed depth of the image (number of slices).",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed depth of the image (number of slices).",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "that": {
+          "const": "has_image_depth",
+          "default": "has_image_depth",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "title": "Assert Has Image Depth",
+      "type": "object"
+    },
+    "has_image_depth_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_image_depth": {
+          "$ref": "#/$defs/base_has_image_depth_model",
+          "title": "Assert Has Image Depth"
+        }
+      },
+      "required": [
+        "has_image_depth"
+      ],
+      "title": "Assert Has Image Depth (Nested)",
+      "type": "object"
+    },
+    "has_image_frames_model": {
+      "additionalProperties": false,
+      "description": "Asserts the output is an image and has a specific number of frames (number of time steps).\n\nThe number of frames is plus/minus ``delta`` (e.g., ``<has_image_frames depth=\"512\" delta=\"2\" />``).\nAlternatively the range of the expected number of frames can be specified by ``min`` and/or ``max``.",
+      "properties": {
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the number of frames in the image sequence (number of time steps, default is 0). The observed number of frames has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "frames": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected number of frames in the image sequence (number of time steps).",
+          "title": "Frames"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed number of frames in the image sequence (number of time steps).",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed number of frames in the image sequence (number of time steps).",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "that": {
+          "const": "has_image_frames",
+          "default": "has_image_frames",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "title": "Assert Has Image Frames",
+      "type": "object"
+    },
+    "has_image_frames_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_image_frames": {
+          "$ref": "#/$defs/base_has_image_frames_model",
+          "title": "Assert Has Image Frames"
+        }
+      },
+      "required": [
+        "has_image_frames"
+      ],
+      "title": "Assert Has Image Frames (Nested)",
+      "type": "object"
+    },
+    "has_image_height_model": {
+      "additionalProperties": false,
+      "description": "Asserts the output is an image and has a specific height (in pixels).\n\nThe height is plus/minus ``delta`` (e.g., ``<has_image_height height=\"512\" delta=\"2\" />``).\nAlternatively the range of the expected height can be specified by ``min`` and/or ``max``.",
+      "properties": {
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the image height (in pixels, default is 0). The observed height has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "height": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected height of the image (in pixels).",
+          "title": "Height"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed height of the image (in pixels).",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed height of the image (in pixels).",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "that": {
+          "const": "has_image_height",
+          "default": "has_image_height",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "title": "Assert Has Image Height",
+      "type": "object"
+    },
+    "has_image_height_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_image_height": {
+          "$ref": "#/$defs/base_has_image_height_model",
+          "title": "Assert Has Image Height"
+        }
+      },
+      "required": [
+        "has_image_height"
+      ],
+      "title": "Assert Has Image Height (Nested)",
+      "type": "object"
+    },
+    "has_image_mean_intensity_model": {
+      "additionalProperties": false,
+      "description": "Asserts the output is an image and has a specific mean intensity value.\n\nThe mean intensity value is plus/minus ``eps`` (e.g., ``<has_image_mean_intensity mean_intensity=\"0.83\" />``).\nAlternatively the range of the expected mean intensity value can be specified by ``min`` and/or ``max``.",
+      "properties": {
+        "channel": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific channel of the image (where ``0`` corresponds to the first image channel).",
+          "title": "Channel"
+        },
+        "eps": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.01,
+          "description": "The absolute tolerance to be used for ``value`` (defaults to ``0.01``). The observed mean value of the image intensities has to be in the range ``value +- eps``.",
+          "title": "Eps"
+        },
+        "frame": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific frame of the image sequence (where ``0`` corresponds to the first image frame).",
+          "title": "Frame"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "An upper bound of the required mean value of the image intensities.",
+          "title": "Max"
+        },
+        "mean_intensity": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The required mean value of the image intensities.",
+          "title": "Mean Intensity"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A lower bound of the required mean value of the image intensities.",
+          "title": "Min"
+        },
+        "slice": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific slice of the image (where ``0`` corresponds to the first image slice).",
+          "title": "Slice"
+        },
+        "that": {
+          "const": "has_image_mean_intensity",
+          "default": "has_image_mean_intensity",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "title": "Assert Has Image Mean Intensity",
+      "type": "object"
+    },
+    "has_image_mean_intensity_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_image_mean_intensity": {
+          "$ref": "#/$defs/base_has_image_mean_intensity_model",
+          "title": "Assert Has Image Mean Intensity"
+        }
+      },
+      "required": [
+        "has_image_mean_intensity"
+      ],
+      "title": "Assert Has Image Mean Intensity (Nested)",
+      "type": "object"
+    },
+    "has_image_mean_object_size_model": {
+      "additionalProperties": false,
+      "description": "Asserts the output is an image with labeled objects which have the specified mean size (number of pixels),\n\nThe mean size is plus/minus ``eps`` (e.g., ``<has_image_mean_object_size mean_object_size=\"111.87\" exclude_labels=\"0\" />``).\n\nThe labels must be unique.",
+      "properties": {
+        "channel": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific channel of the image (where ``0`` corresponds to the first image channel).",
+          "title": "Channel"
+        },
+        "eps": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.01,
+          "description": "The absolute tolerance to be used for ``value`` (defaults to ``0.01``). The observed mean size of the uniquely labeled objects has to be in the range ``value +- eps``.",
+          "title": "Eps"
+        },
+        "exclude_labels": {
+          "anyOf": [
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "List of labels to be excluded from consideration, separated by a comma. The primary usage of this attribute is to exclude the background of a label image. Cannot be used in combination with ``labels``.",
+          "title": "Exclude Labels"
+        },
+        "frame": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific frame of the image sequence (where ``0`` corresponds to the first image frame).",
+          "title": "Frame"
+        },
+        "labels": {
+          "anyOf": [
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "List of labels, separated by a comma. Labels *not* on this list will be excluded from consideration. Cannot be used in combination with ``exclude_labels``.",
+          "title": "Labels"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "An upper bound of the required mean size of the uniquely labeled objects.",
+          "title": "Max"
+        },
+        "mean_object_size": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The required mean size of the uniquely labeled objects.",
+          "title": "Mean Object Size"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A lower bound of the required mean size of the uniquely labeled objects.",
+          "title": "Min"
+        },
+        "slice": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific slice of the image (where ``0`` corresponds to the first image slice).",
+          "title": "Slice"
+        },
+        "that": {
+          "const": "has_image_mean_object_size",
+          "default": "has_image_mean_object_size",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "title": "Assert Has Image Mean Object Size",
+      "type": "object"
+    },
+    "has_image_mean_object_size_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_image_mean_object_size": {
+          "$ref": "#/$defs/base_has_image_mean_object_size_model",
+          "title": "Assert Has Image Mean Object Size"
+        }
+      },
+      "required": [
+        "has_image_mean_object_size"
+      ],
+      "title": "Assert Has Image Mean Object Size (Nested)",
+      "type": "object"
+    },
+    "has_image_n_labels_model": {
+      "additionalProperties": false,
+      "description": "Asserts the output is an image and has the specified labels.\n\nLabels can be a number of labels or unique values (e.g.,\n``<has_image_n_labels n=\"187\" exclude_labels=\"0\" />``).\n\nThe primary usage of this assertion is to verify the number of objects in images with uniquely labeled objects.",
+      "properties": {
+        "channel": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific channel of the image (where ``0`` corresponds to the first image channel).",
+          "title": "Channel"
+        },
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the number of labels (default is 0). The observed number of labels has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "exclude_labels": {
+          "anyOf": [
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "List of labels to be excluded from consideration, separated by a comma. The primary usage of this attribute is to exclude the background of a label image. Cannot be used in combination with ``labels``.",
+          "title": "Exclude Labels"
+        },
+        "frame": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific frame of the image sequence (where ``0`` corresponds to the first image frame).",
+          "title": "Frame"
+        },
+        "labels": {
+          "anyOf": [
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "List of labels, separated by a comma. Labels *not* on this list will be excluded from consideration. Cannot be used in combination with ``exclude_labels``.",
+          "title": "Labels"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed number of labels.",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed number of labels.",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected number of labels.",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "slice": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific slice of the image (where ``0`` corresponds to the first image slice).",
+          "title": "Slice"
+        },
+        "that": {
+          "const": "has_image_n_labels",
+          "default": "has_image_n_labels",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "title": "Assert Has Image N Labels",
+      "type": "object"
+    },
+    "has_image_n_labels_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_image_n_labels": {
+          "$ref": "#/$defs/base_has_image_n_labels_model",
+          "title": "Assert Has Image N Labels"
+        }
+      },
+      "required": [
+        "has_image_n_labels"
+      ],
+      "title": "Assert Has Image N Labels (Nested)",
+      "type": "object"
+    },
+    "has_image_width_model": {
+      "additionalProperties": false,
+      "description": "Asserts the output is an image and has a specific width (in pixels).\n\nThe width is plus/minus ``delta`` (e.g., ``<has_image_width width=\"512\" delta=\"2\" />``).\nAlternatively the range of the expected width can be specified by ``min`` and/or ``max``.",
+      "properties": {
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the image width (in pixels, default is 0). The observed width has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed width of the image (in pixels).",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed width of the image (in pixels).",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "that": {
+          "const": "has_image_width",
+          "default": "has_image_width",
+          "title": "That",
+          "type": "string"
+        },
+        "width": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected width of the image (in pixels).",
+          "title": "Width"
+        }
+      },
+      "title": "Assert Has Image Width",
+      "type": "object"
+    },
+    "has_image_width_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_image_width": {
+          "$ref": "#/$defs/base_has_image_width_model",
+          "title": "Assert Has Image Width"
+        }
+      },
+      "required": [
+        "has_image_width"
+      ],
+      "title": "Assert Has Image Width (Nested)",
+      "type": "object"
+    },
+    "has_json_property_with_text_model": {
+      "additionalProperties": false,
+      "description": "Asserts the JSON document contains a property or key with the specified text (i.e. string) value.\n\n```xml\n<has_json_property_with_text property=\"color\" text=\"red\" />\n```",
+      "properties": {
+        "property": {
+          "description": "The property name to search the JSON document for.",
+          "title": "Property",
+          "type": "string"
+        },
+        "text": {
+          "description": "The expected text value of the target JSON attribute.",
+          "title": "Text",
+          "type": "string"
+        },
+        "that": {
+          "const": "has_json_property_with_text",
+          "default": "has_json_property_with_text",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "property",
+        "text"
+      ],
+      "title": "Assert Has Json Property With Text",
+      "type": "object"
+    },
+    "has_json_property_with_text_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_json_property_with_text": {
+          "$ref": "#/$defs/base_has_json_property_with_text_model",
+          "title": "Assert Has Json Property With Text"
+        }
+      },
+      "required": [
+        "has_json_property_with_text"
+      ],
+      "title": "Assert Has Json Property With Text (Nested)",
+      "type": "object"
+    },
+    "has_json_property_with_value_model": {
+      "additionalProperties": false,
+      "description": "Asserts the JSON document contains a property or key with the specified JSON value.\n\n```xml\n<has_json_property_with_value property=\"skipped_columns\" value=\"[1, 3, 5]\" />\n```",
+      "properties": {
+        "property": {
+          "description": "The property name to search the JSON document for.",
+          "title": "Property",
+          "type": "string"
+        },
+        "that": {
+          "const": "has_json_property_with_value",
+          "default": "has_json_property_with_value",
+          "title": "That",
+          "type": "string"
+        },
+        "value": {
+          "description": "The expected JSON value of the target JSON attribute (as a JSON encoded string).",
+          "title": "Value",
+          "type": "string"
+        }
+      },
+      "required": [
+        "property",
+        "value"
+      ],
+      "title": "Assert Has Json Property With Value",
+      "type": "object"
+    },
+    "has_json_property_with_value_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_json_property_with_value": {
+          "$ref": "#/$defs/base_has_json_property_with_value_model",
+          "title": "Assert Has Json Property With Value"
+        }
+      },
+      "required": [
+        "has_json_property_with_value"
+      ],
+      "title": "Assert Has Json Property With Value (Nested)",
+      "type": "object"
+    },
+    "has_line_matching_model": {
+      "additionalProperties": false,
+      "description": "Asserts the specified output contains a line matching the\nregular expression specified by the argument expression. If n is given\nthe assertion checks for exactly n occurrences.",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "expression": {
+          "description": "The regular expressions to attempt match in the output.",
+          "title": "Expression",
+          "type": "string"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "that": {
+          "const": "has_line_matching",
+          "default": "has_line_matching",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "expression"
+      ],
+      "title": "Assert Has Line Matching",
+      "type": "object"
+    },
+    "has_line_matching_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_line_matching": {
+          "$ref": "#/$defs/base_has_line_matching_model",
+          "title": "Assert Has Line Matching"
+        }
+      },
+      "required": [
+        "has_line_matching"
+      ],
+      "title": "Assert Has Line Matching (Nested)",
+      "type": "object"
+    },
+    "has_line_model": {
+      "additionalProperties": false,
+      "description": "Asserts the specified output contains the line specified by the\nargument line. The exact number of occurrences can be optionally\nspecified by the argument n",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "line": {
+          "description": "The full line of text to search for in the output.",
+          "title": "Line",
+          "type": "string"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "that": {
+          "const": "has_line",
+          "default": "has_line",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "line"
+      ],
+      "title": "Assert Has Line",
+      "type": "object"
+    },
+    "has_line_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_line": {
+          "$ref": "#/$defs/base_has_line_model",
+          "title": "Assert Has Line"
+        }
+      },
+      "required": [
+        "has_line"
+      ],
+      "title": "Assert Has Line (Nested)",
+      "type": "object"
+    },
+    "has_n_columns_model": {
+      "additionalProperties": false,
+      "description": "Asserts tabular output  contains the specified\nnumber (``n``) of columns.\n\nFor instance, ``<has_n_columns n=\"3\"/>``. The assertion tests only the first line.\nNumber of columns can optionally also be specified with ``delta``. Alternatively the\nrange of expected occurrences can be specified by ``min`` and/or ``max``.\n\nOptionally a column separator (``sep``, default is ``       ``) `and comment character(s)\ncan be specified (``comment``, default is empty string). The first non-comment\nline is used for determining the number of columns.",
+      "properties": {
+        "comment": {
+          "default": "",
+          "description": "Comment character(s) used to skip comment lines (which should not be used for counting columns)",
+          "title": "Comment",
+          "type": "string"
+        },
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "sep": {
+          "default": "\t",
+          "description": "Separator defining columns, default: tab",
+          "title": "Sep",
+          "type": "string"
+        },
+        "that": {
+          "const": "has_n_columns",
+          "default": "has_n_columns",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "title": "Assert Has N Columns",
+      "type": "object"
+    },
+    "has_n_columns_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_n_columns": {
+          "$ref": "#/$defs/base_has_n_columns_model",
+          "title": "Assert Has N Columns"
+        }
+      },
+      "required": [
+        "has_n_columns"
+      ],
+      "title": "Assert Has N Columns (Nested)",
+      "type": "object"
+    },
+    "has_n_elements_with_path_model": {
+      "additionalProperties": false,
+      "description": "Asserts the XML output contains the specified number (``n``, optionally with ``delta``) of elements (or\ntags) with the specified XPath-like ``path``.\n\nFor example:\n\n```xml\n<has_n_elements_with_path n=\"9\" path=\"BlastOutput_iterations/Iteration/Iteration_hits/Hit/Hit_num\" />\n```\n\nAlternatively to ``n`` and ``delta`` also the ``min`` and ``max`` attributes\ncan be used to specify the range of the expected number of occurrences.\nWith ``negate`` the result of the assertion can be inverted.",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        },
+        "that": {
+          "const": "has_n_elements_with_path",
+          "default": "has_n_elements_with_path",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "Assert Has N Elements With Path",
+      "type": "object"
+    },
+    "has_n_elements_with_path_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_n_elements_with_path": {
+          "$ref": "#/$defs/base_has_n_elements_with_path_model",
+          "title": "Assert Has N Elements With Path"
+        }
+      },
+      "required": [
+        "has_n_elements_with_path"
+      ],
+      "title": "Assert Has N Elements With Path (Nested)",
+      "type": "object"
+    },
+    "has_n_lines_model": {
+      "additionalProperties": false,
+      "description": "Asserts the specified output contains ``n`` lines allowing\nfor a difference in the number of lines (delta)\nor relative differebce in the number of lines",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "that": {
+          "const": "has_n_lines",
+          "default": "has_n_lines",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "title": "Assert Has N Lines",
+      "type": "object"
+    },
+    "has_n_lines_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_n_lines": {
+          "$ref": "#/$defs/base_has_n_lines_model",
+          "title": "Assert Has N Lines"
+        }
+      },
+      "required": [
+        "has_n_lines"
+      ],
+      "title": "Assert Has N Lines (Nested)",
+      "type": "object"
+    },
+    "has_size_model": {
+      "additionalProperties": false,
+      "description": "Asserts the specified output has a size of the specified value\n\nAttributes size and value or synonyms though value is considered deprecated.\nThe size optionally allows for absolute (``delta``) difference.",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "size": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired size of the output (in bytes), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Size"
+        },
+        "that": {
+          "const": "has_size",
+          "default": "has_size",
+          "title": "That",
+          "type": "string"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Deprecated alias for `size`",
+          "title": "Value"
+        }
+      },
+      "title": "Assert Has Size",
+      "type": "object"
+    },
+    "has_size_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_size": {
+          "$ref": "#/$defs/base_has_size_model",
+          "title": "Assert Has Size"
+        }
+      },
+      "required": [
+        "has_size"
+      ],
+      "title": "Assert Has Size (Nested)",
+      "type": "object"
+    },
+    "has_text_matching_model": {
+      "additionalProperties": false,
+      "description": "Asserts the specified output contains text matching the\nregular expression specified by the argument expression.\nIf n is given the assertion checks for exactly n (nonoverlapping)\noccurrences.",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "expression": {
+          "description": "The regular expressions to attempt match in the output.",
+          "title": "Expression",
+          "type": "string"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "that": {
+          "const": "has_text_matching",
+          "default": "has_text_matching",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "expression"
+      ],
+      "title": "Assert Has Text Matching",
+      "type": "object"
+    },
+    "has_text_matching_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_text_matching": {
+          "$ref": "#/$defs/base_has_text_matching_model",
+          "title": "Assert Has Text Matching"
+        }
+      },
+      "required": [
+        "has_text_matching"
+      ],
+      "title": "Assert Has Text Matching (Nested)",
+      "type": "object"
+    },
+    "has_text_model": {
+      "additionalProperties": false,
+      "description": "Asserts specified output contains the substring specified by\nthe argument text. The exact number of occurrences can be\noptionally specified by the argument n",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "text": {
+          "description": "The text to search for in the output.",
+          "title": "Text",
+          "type": "string"
+        },
+        "that": {
+          "const": "has_text",
+          "default": "has_text",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "text"
+      ],
+      "title": "Assert Has Text",
+      "type": "object"
+    },
+    "has_text_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_text": {
+          "$ref": "#/$defs/base_has_text_model",
+          "title": "Assert Has Text"
+        }
+      },
+      "required": [
+        "has_text"
+      ],
+      "title": "Assert Has Text (Nested)",
+      "type": "object"
+    },
+    "is_valid_xml_model": {
+      "additionalProperties": false,
+      "description": "Asserts the output is a valid XML file (e.g. ``<is_valid_xml />``).",
+      "properties": {
+        "that": {
+          "const": "is_valid_xml",
+          "default": "is_valid_xml",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "title": "Assert Is Valid Xml",
+      "type": "object"
+    },
+    "is_valid_xml_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "is_valid_xml": {
+          "$ref": "#/$defs/base_is_valid_xml_model",
+          "title": "Assert Is Valid Xml"
+        }
+      },
+      "required": [
+        "is_valid_xml"
+      ],
+      "title": "Assert Is Valid Xml (Nested)",
+      "type": "object"
+    },
+    "not_has_text_model": {
+      "additionalProperties": false,
+      "description": "Asserts specified output does not contain the substring\nspecified by the argument text",
+      "properties": {
+        "text": {
+          "description": "The text to search for in the output.",
+          "title": "Text",
+          "type": "string"
+        },
+        "that": {
+          "const": "not_has_text",
+          "default": "not_has_text",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "text"
+      ],
+      "title": "Assert Not Has Text",
+      "type": "object"
+    },
+    "not_has_text_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "not_has_text": {
+          "$ref": "#/$defs/base_not_has_text_model",
+          "title": "Assert Not Has Text"
+        }
+      },
+      "required": [
+        "not_has_text"
+      ],
+      "title": "Assert Not Has Text (Nested)",
+      "type": "object"
+    },
+    "xml_element_model": {
+      "additionalProperties": false,
+      "description": "Assert if the XML file contains element(s) or tag(s) with the specified\n[XPath-like ``path``](https://lxml.de/xpathxslt.html).  If ``n`` and ``delta``\nor ``min`` and ``max`` are given also the number of occurrences is checked.\n\n```xml\n<assert_contents>\n  <xml_element path=\"./elem\"/>\n  <xml_element path=\"./elem/more[2]\"/>\n  <xml_element path=\".//more\" n=\"3\" delta=\"1\"/>\n</assert_contents>\n```\n\nWith ``negate=\"true\"`` the outcome of the assertions wrt the presence and number\nof ``path`` can be negated. If there are any sub assertions then check them against\n\n- the content of the attribute ``attribute``\n- the element's text if no attribute is given\n\n```xml\n<assert_contents>\n  <xml_element path=\"./elem/more[2]\" attribute=\"name\">\n    <has_text_matching expression=\"foo$\"/>\n  </xml_element>\n</assert_contents>\n```\n\nSub-assertions are not subject to the ``negate`` attribute of ``xml_element``.\nIf ``all`` is ``true`` then the sub assertions are checked for all occurrences.\n\nNote that all other XML assertions can be expressed by this assertion (Galaxy\nalso implements the other assertions by calling this one).",
+      "properties": {
+        "all": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "Check the sub-assertions for all paths matching the path. Default: false, i.e. only the first ",
+          "title": "All"
+        },
+        "asserts": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Asserts"
+        },
+        "attribute": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The XML attribute name to test against from the target XML element.",
+          "title": "Attribute"
+        },
+        "children": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Children"
+        },
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        },
+        "that": {
+          "const": "xml_element",
+          "default": "xml_element",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "Assert Xml Element",
+      "type": "object"
+    },
+    "xml_element_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "xml_element": {
+          "$ref": "#/$defs/base_xml_element_model",
+          "title": "Assert Xml Element"
+        }
+      },
+      "required": [
+        "xml_element"
+      ],
+      "title": "Assert Xml Element (Nested)",
+      "type": "object"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Galaxy workflow tests file — a YAML list of test entries asserting the expected inputs and outputs of a workflow run.",
+  "items": {
+    "$ref": "#/$defs/TestJob"
+  },
+  "title": "GalaxyWorkflowTests",
+  "type": "array"
+}

--- a/content/molds/implement-galaxy-workflow-test/index.md
+++ b/content/molds/implement-galaxy-workflow-test/index.md
@@ -18,6 +18,13 @@ related_notes:
   - "[[tests-format]]"
 summary: "Assemble Galaxy workflow test fixtures and assertions."
 references:
+  - kind: schema
+    ref: "[[tests-format]]"
+    used_at: runtime
+    load: upfront
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "JSON Schema contract for the Galaxy workflow test format. Output of this Mold must validate against it."
   - kind: research
     ref: "[[iwc-test-data-conventions]]"
     used_at: runtime

--- a/content/schemas/tests-format.md
+++ b/content/schemas/tests-format.md
@@ -3,6 +3,7 @@ type: schema
 name: tests-format
 title: Galaxy workflow test format
 package: "@galaxy-tool-util/schema"
+package_export: "testsSchema"
 upstream: "https://github.com/jmchilton/galaxy-tool-util-ts/blob/main/packages/schema/src/test-format/tests.schema.json"
 tags:
   - schema

--- a/meta_schema.yml
+++ b/meta_schema.yml
@@ -186,6 +186,9 @@ properties:
   upstream:
     type: string
     description: "URL to the source-of-truth schema upstream"
+  package_export:
+    type: string
+    description: "For package-vendored schemas: the named runtime export from `package` that returns the JSON Schema object (e.g. `testsSchema`). cast-mold imports and stringifies this when resolving a typed `kind: schema` reference."
 
 allOf:
   # mold requires name + axis

--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.59.1",
     "vitest": "^2.1.0"
+  },
+  "dependencies": {
+    "@galaxy-tool-util/schema": "^1.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@galaxy-tool-util/schema':
+        specifier: ^1.1.0
+        version: 1.1.0
     devDependencies:
       '@changesets/changelog-github':
         specifier: ^0.6.0
@@ -495,6 +499,9 @@ packages:
     resolution: {integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  '@galaxy-tool-util/schema@1.1.0':
+    resolution: {integrity: sha512-D0dMtBaTyRJhoAxH1Djx/42WnxQDAk3yuMhTd3k+MCez1jiGL1kFeYDQEk8yWSgY5Z4d+u24wbhaWG4Q2GTG1w==}
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -682,6 +689,9 @@ packages:
     resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
     cpu: [x64]
     os: [win32]
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
@@ -905,6 +915,9 @@ packages:
     resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
     engines: {node: '>=10'}
 
+  effect@3.21.2:
+    resolution: {integrity: sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg==}
+
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
@@ -986,6 +999,10 @@ packages:
 
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
+
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1300,6 +1317,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
@@ -1896,6 +1916,13 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
+  '@galaxy-tool-util/schema@1.1.0':
+    dependencies:
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      effect: 3.21.2
+      yaml: 2.8.3
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -2023,6 +2050,8 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.60.2':
     optional: true
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@types/esrecurse@4.3.1': {}
 
@@ -2261,6 +2290,11 @@ snapshots:
 
   dotenv@8.6.0: {}
 
+  effect@3.21.2:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 3.23.2
+
   enquirer@2.4.1:
     dependencies:
       ansi-colors: 4.1.3
@@ -2402,6 +2436,10 @@ snapshots:
       is-extendable: 0.1.1
 
   extendable-error@0.1.7: {}
+
+  fast-check@3.23.2:
+    dependencies:
+      pure-rand: 6.1.0
 
   fast-deep-equal@3.1.3: {}
 
@@ -2668,6 +2706,8 @@ snapshots:
   prettier@3.8.3: {}
 
   punycode@2.3.1: {}
+
+  pure-rand@6.1.0: {}
 
   quansync@0.2.11: {}
 

--- a/scripts/cast-mold.ts
+++ b/scripts/cast-mold.ts
@@ -129,6 +129,8 @@ interface ResolvedRef {
   purpose?: string;
   trigger?: string;
   verification?: string;
+  /** Set when src is an npm package export rather than a repo file. */
+  package_source?: { spec: string; exportName: string };
 }
 
 const SUPPORTED_KINDS = new Set(["schema", "research", "pattern", "cli-command"]);
@@ -182,12 +184,34 @@ function resolveMoldRef(
 
   // Resolve src.
   let src: string;
+  let dstOverride: string | undefined;
+  let packageSource: { spec: string; exportName: string } | undefined;
   if (kind === "schema") {
-    if (WIKI_LINK_RE.test(refStr)) return { error: `references[${index}]: schema ref must be a path, not a wiki link` };
-    if (!refStr.startsWith("content/schemas/") || !refStr.endsWith(".schema.json")) {
-      return { error: `references[${index}]: schema ref must be content/schemas/*.schema.json (got ${refStr})` };
+    if (WIKI_LINK_RE.test(refStr)) {
+      // Wiki-link form: resolves to a `type: schema` note. Supports package-vendored
+      // schemas (note has `package` + `package_export`) — caster imports the
+      // runtime export, JSON.stringifies it, and writes to the bundle.
+      const tp = resolveWikiLink(refStr, slugMap);
+      if (!tp) return { error: `references[${index}]: schema ref ${refStr} did not resolve` };
+      const noteMeta = metaByPath.get(tp);
+      if (noteMeta?.type !== "schema") {
+        return { error: `references[${index}]: schema ref ${refStr} resolves to type=${noteMeta?.type ?? "(none)"}, expected schema` };
+      }
+      const pkg = typeof noteMeta.package === "string" ? noteMeta.package : null;
+      const exp = typeof noteMeta.package_export === "string" ? noteMeta.package_export : null;
+      if (!pkg || !exp) {
+        return { error: `references[${index}]: schema ref ${refStr} resolves to a foundry-authored schema note; use the path form (content/schemas/${path.basename(path.dirname(tp))}.schema.json or similar)` };
+      }
+      const noteSlug = path.basename(tp, ".md");
+      src = `package://${pkg}#${exp}`;
+      dstOverride = path.posix.join(kindCfg.dst_dir, `${noteSlug}.schema.json`);
+      packageSource = { spec: pkg, exportName: exp };
+    } else {
+      if (!refStr.startsWith("content/schemas/") || !refStr.endsWith(".schema.json")) {
+        return { error: `references[${index}]: schema ref must be content/schemas/*.schema.json or a [[wiki-link]] to a schema note (got ${refStr})` };
+      }
+      src = refStr;
     }
-    src = refStr;
   } else {
     const tp = resolveWikiLink(refStr, slugMap);
     if (!tp) return { error: `references[${index}]: ${kind} ref ${refStr} did not resolve` };
@@ -199,7 +223,7 @@ function resolveMoldRef(
     src = tp;
   }
 
-  const dst = deriveDst(kind, src, mode, kindCfg);
+  const dst = dstOverride ?? deriveDst(kind, src, mode, kindCfg);
 
   const used_at = (typeof ref.used_at === "string" ? ref.used_at : "runtime") as ResolvedRef["used_at"];
   const load = (typeof ref.load === "string" ? ref.load : "on-demand") as ResolvedRef["load"];
@@ -217,6 +241,7 @@ function resolveMoldRef(
       purpose: typeof ref.purpose === "string" ? ref.purpose : undefined,
       trigger: typeof ref.trigger === "string" ? ref.trigger : undefined,
       verification: typeof ref.verification === "string" ? ref.verification : undefined,
+      package_source: packageSource,
     },
   };
 }
@@ -370,13 +395,63 @@ interface CastPlanResult {
   errors: string[];
 }
 
-function castOneRef(
+async function castOneRef(
   resolved: ResolvedRef,
   repoRoot: string,
   bundleRoot: string,
   prior: Map<string, ProvenanceRefEntry> | undefined,
   check: boolean,
-): { entry: ProvenanceRefEntry; drift?: string; error?: string } {
+): Promise<{ entry: ProvenanceRefEntry; drift?: string; error?: string }> {
+  const dstAbs = path.join(bundleRoot, resolved.dst);
+
+  // Package-vendored schema: import the named export, JSON.stringify, write verbatim.
+  // No file `src` exists; src_hash and dst_hash are both the hash of the synthesized JSON.
+  if (resolved.package_source) {
+    if (resolved.kind !== "schema" || resolved.mode !== "verbatim") {
+      return {
+        entry: { ...skeleton(resolved), src_hash: null, dst_hash: null, source: "deterministic" },
+        error: `package_source ref must be kind=schema mode=verbatim (got ${resolved.kind}/${resolved.mode})`,
+      };
+    }
+    let json: string;
+    try {
+      const mod = (await import(resolved.package_source.spec)) as Record<string, unknown>;
+      const exported = mod[resolved.package_source.exportName];
+      if (exported === undefined) {
+        return {
+          entry: { ...skeleton(resolved), src_hash: null, dst_hash: null, source: "deterministic" },
+          error: `package ${resolved.package_source.spec} has no export '${resolved.package_source.exportName}'`,
+        };
+      }
+      json = JSON.stringify(exported, null, 2) + "\n";
+    } catch (e) {
+      return {
+        entry: { ...skeleton(resolved), src_hash: null, dst_hash: null, source: "deterministic" },
+        error: `failed to import ${resolved.package_source.spec}: ${(e as Error).message}`,
+      };
+    }
+    const expectedHash = sha256OfBuffer(json);
+    const dstExists = existsSync(dstAbs);
+    const dstHash = dstExists ? sha256(dstAbs) : null;
+    let drift: string | undefined;
+    if (dstHash !== expectedHash) {
+      drift = dstExists ? "package schema content drifted" : "package schema missing";
+      if (!check) {
+        mkdirSync(path.dirname(dstAbs), { recursive: true });
+        writeFileSync(dstAbs, json);
+      }
+    }
+    return {
+      entry: {
+        ...skeleton(resolved),
+        src_hash: expectedHash,
+        dst_hash: drift && check ? dstHash : expectedHash,
+        source: "deterministic",
+      },
+      drift,
+    };
+  }
+
   const srcAbs = path.join(repoRoot, resolved.src);
   if (!existsSync(srcAbs)) {
     return {
@@ -385,7 +460,6 @@ function castOneRef(
     };
   }
   const srcHash = sha256(srcAbs);
-  const dstAbs = path.join(bundleRoot, resolved.dst);
 
   if (resolved.mode === "verbatim") {
     const dstExists = existsSync(dstAbs);
@@ -490,7 +564,7 @@ function skeleton(r: ResolvedRef): Omit<ProvenanceRefEntry, "src_hash" | "dst_ha
 
 // ---- main ----
 
-function main(): void {
+async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
   const repoRoot = process.cwd();
 
@@ -533,7 +607,7 @@ function main(): void {
   const drift: Array<{ src: string; reason: string }> = [];
 
   for (const r of resolved) {
-    const result = castOneRef(r, repoRoot, bundleRoot, carry.prior_refs, args.check);
+    const result = await castOneRef(r, repoRoot, bundleRoot, carry.prior_refs, args.check);
     refEntries.push(result.entry);
     if (result.error) errors.push(result.error);
     if (result.drift) drift.push({ src: r.src, reason: result.drift });
@@ -613,4 +687,4 @@ function main(): void {
 void stripBrackets;
 void statSync;
 
-main();
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -280,6 +280,38 @@ function validateTypedReference(
   };
 
   if (ref.kind === "schema") {
+    // Wiki-link form: must resolve to a `type: schema` note that has both
+    // `package` and `package_export` (cast-mold imports the named export).
+    if (WIKI_LINK_RE.test(ref.ref)) {
+      const tp = resolveWikiLink(ref.ref, slugMap);
+      if (!tp) {
+        findings.push({
+          path: filePath,
+          severity: "error",
+          message: `references[${index}]: schema ref ${ref.ref} did not resolve`,
+        });
+        return;
+      }
+      const noteMeta = metaByPath.get(tp);
+      if (noteMeta?.type !== "schema") {
+        findings.push({
+          path: filePath,
+          severity: "error",
+          message: `references[${index}]: schema ref ${ref.ref} resolves to type=${noteMeta?.type ?? "(none)"}, expected schema`,
+        });
+        return;
+      }
+      const pkg = typeof noteMeta.package === "string" ? noteMeta.package : null;
+      const exp = typeof noteMeta.package_export === "string" ? noteMeta.package_export : null;
+      if (!pkg || !exp) {
+        findings.push({
+          path: filePath,
+          severity: "error",
+          message: `references[${index}]: schema wiki-link ref requires the target note to declare both 'package' and 'package_export' (got package=${pkg ?? "(none)"}, package_export=${exp ?? "(none)"})`,
+        });
+      }
+      return;
+    }
     validatePathReference(ref.ref, index, filePath, contentRoot, findings, "content/schemas/", true);
     return;
   }


### PR DESCRIPTION
## Summary
- Add `package_export` frontmatter for schema notes; `kind: schema` references can now use `[[wiki-link]]` form when the target note declares both `package` and `package_export`.
- cast-mold dynamically imports the named export, JSON-stringifies it, and writes verbatim to the bundle. Validator enforces the same shape.
- Wire `tests-format` to `@galaxy-tool-util/schema#testsSchema`, attach the schema as a reference on `implement-galaxy-workflow-test`, and check in the resulting cast.

## Test plan
- [x] `npm run validate`
- [x] `npm run test`
- [x] `npx tsx scripts/cast-mold.ts implement-galaxy-workflow-test --check` (drift detection)
- [x] full cast produces `references/schemas/tests-format.schema.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)