### PR TITLE
summarize-nextflow eval.md + ad-hoc fixture corpus + overfitting findings

### DIFF
--- a/casts/claude/skills/summarize-nextflow/_provenance.json
+++ b/casts/claude/skills/summarize-nextflow/_provenance.json
@@ -6,11 +6,11 @@
     "path": "content/molds/summarize-nextflow/index.md",
     "revision": 7,
     "content_hash": "e35e59ed138365803fd6f70a5831bc199452b4c1dc271cd466fcda9ca5c3b0d3",
-    "commit": "5e65ff5a673463e5ee86e6de6946baa1a0255b2b"
+    "commit": "4be9b4fbb5bc46ffbef6e3b3484f9482c6f8df73"
   },
   "cast_method": "hand-cast",
   "cast_agent": "claude (manual transcription, no LLM cast prompt)",
-  "cast_at": "2026-05-02T22:44:00.546Z",
+  "cast_at": "2026-05-03T01:58:37.428Z",
   "cast_date": "2026-05-01",
   "cast_revision": 3,
   "cast_history": [

--- a/content/log.md
+++ b/content/log.md
@@ -105,3 +105,27 @@ Re-cast both pipelines:
 
 Of the 17 bacass gaps logged in the prior entry, 4 are now structurally captured (process aliasing, multi-test-profile enumeration, snapshot helper extraction, snapshot ignore-globs). 13 remain (mulled containers, multi-dep envs, racon env bug, multiMap/.branch/.cross, meta-mutation closures, conditional channel construction, .mix-then-reassign, .dump pervasiveness, exit/log.error, subworkflow-typed-value-inputs, empty-list-literal channel inputs, params runtime concatenation, params runtime existence checks). These hold for the third pipeline.
 
+
+## 2026-05-02 — summarize-nextflow eval.md + 7-fixture sweep
+
+Added `content/molds/summarize-nextflow/eval.md` (14 cases: schema/fidelity/utility/regression buckets). Ran `@galaxy-foundry/summarize-nextflow` against all seven pinned fixtures (demo, fetchngs, hlatyping, bacass, rnaseq, sarek, taxprofiler) for the first time end-to-end.
+
+**Schema-conformance (eval bucket "schema"): PASS for all 7.** Every fixture exits 0 with `--validate` enabled. `additionalProperties: false` holds.
+
+**Fidelity findings (eval bucket "fidelity"):**
+
+- **process counts diverge upward on large pipelines.** demo/fetchngs/hlatyping match a naive `grep -c '^process '` (3/10/12 == fs); bacass/rnaseq/sarek/taxprofiler emit MORE than the naive count (34>31, 76>66, 123>90, 61>51). Two candidate causes: the resolver counts process declarations the regex misses (multi-line, indented), or it includes processes from un-imported modules. Worth confirming before tightening the eval case.
+- **nf_tests is severely under-enumerated.** Spec says "every `tests/*.nf.test`" (top-level) but corpus has many more under `modules/nf-core/*/tests/`, `subworkflows/nf-core/*/tests/`. Counts: demo 1/9, fetchngs 1/29, hlatyping 7/21, bacass 9/36, rnaseq 47/130, sarek 59/62, taxprofiler 8/72. Open question: should nf_tests capture module/subworkflow-level tests too, or is pipeline-level the contract? If the latter, eval case wording needs to say "pipeline-level tests" and add a separate fidelity case for module-level tests if/when they matter.
+- **tools count looks plausible** for the size of pipeline (demo 3, bacass 26, rnaseq 42, sarek 37, taxprofiler 35) but not ground-truthed yet.
+- **warnings count is 2 across every fixture** — suspiciously uniform. Likely the same boilerplate warnings (DSL2-required-version + something else) are emitted unconditionally; the pipeline-specific warnings the mold §"Caveats" predicted (meta.yml-disagreement, low-confidence operator chains) are not surfacing.
+
+**Regression (eval bucket "regression"): FAIL on both committed runs.** demo diff 822 lines, bacass diff 4624 lines. Sampling the head of demo: committed run has hand-curated param descriptions ("Path to a samplesheet CSV.") while the CLI emits the verbatim `nextflow_schema.json` text ("Path to a metadata file containing information about the samples in the experiment."). The committed runs predate the strict-deterministic CLI; they are no longer the right regression baseline. Either re-baseline (commit the new CLI outputs as the canonical run) or drop the regression cases until a "v1 frozen" reference run is established.
+
+**Utility (eval bucket "utility"): not exercised.** Requires running `summary-to-galaxy-data-flow` and `author-galaxy-tool-wrapper` against the new outputs. Open as next step.
+
+Recommended next steps:
+1. Re-baseline `runs/nf-core__{demo,bacass}/summary.json` with the current CLI output, after deciding on the nf_tests scoping question (module-level in or out).
+2. Add the 5 new fixtures (fetchngs, hlatyping, rnaseq, sarek, taxprofiler) as runs under `runs/` if they are intended baselines.
+3. Investigate process-count divergence on bacass (34 vs naive 31) before declaring the fidelity case authoritative.
+4. Investigate the uniform 2-warning count — either the warnings system is under-sampling or the corpus genuinely doesn't trigger §"Caveats" predicates.
+5. Run the utility cases (data-flow Mold + tool-wrapper Mold consumers) against bacass output to surface missing fields / open gaps.

--- a/content/log.md
+++ b/content/log.md
@@ -129,3 +129,78 @@ Recommended next steps:
 3. Investigate process-count divergence on bacass (34 vs naive 31) before declaring the fidelity case authoritative.
 4. Investigate the uniform 2-warning count — either the warnings system is under-sampling or the corpus genuinely doesn't trigger §"Caveats" predicates.
 5. Run the utility cases (data-flow Mold + tool-wrapper Mold consumers) against bacass output to surface missing fields / open gaps.
+
+## 2026-05-03 — summarize-nextflow ad-hoc fixture sweep (overfitting check)
+
+Issue #110 raised, then 8 ad-hoc DSL2 pipelines added to `workflow-fixtures/fixtures.yaml` (`flavor: adhoc` field new; existing 7 nf-core entries marked `flavor: nf-core`). Stress-test goal: confirm the resolver doesn't silently degrade against pipelines that don't follow the nf-core template.
+
+**Result: severe overfitting. The resolver works only on nf-core layouts.**
+
+### Hard failures (2/8)
+
+- **biocorecrg/MOP2** — multi-pipeline monorepo; no `nextflow.config` at repo root. Resolver throws `not a Nextflow pipeline root`.
+- **ncbi/egapx** — sources under `nf/`, no `nextflow.config` at repo root. Same throw.
+
+Pipeline-root detection (`packages/summarize-nextflow/src/resolver.ts:121`) requires `<root>/nextflow.config` and offers no fallback for nested-pipeline or non-standard-root layouts.
+
+### Silent degradation (6/8)
+
+The other six exit 0 and emit *schema-valid but empty* summaries. Process counts (resolver-emitted vs filesystem grep `^process `):
+
+| pipeline | emitted | fs | gap reason |
+| - | - | - | - |
+| CalliNGS-NF | 0 | 11 | 11 processes in single `modules.nf` file at root |
+| mcmicro | 0 | 17 | flat `modules/<name>.nf` (one file per module, not nf-core's per-dir) |
+| nf-demos | 0 | 9 | no `modules/` dir; processes in `<dir>/<file>.nf` |
+| crispr-process-nf | 0 | 12 | processes inline in `main.nf` itself |
+| What_the_Phage | 0 | 94 | flat `modules/<tool>.nf` + custom `phage.nf` entrypoint |
+| wf-human-variation | 0 | 99 | processes spread across `workflows/`, `lib/`, `modules/local/<name>.nf` |
+
+### Root cause
+
+`discoverProcessFiles()` (resolver.ts:284-286):
+
+```ts
+function discoverProcessFiles(pipelineRoot: string): string[] {
+  return walk(join(pipelineRoot, "modules")).filter((path) => basename(path) === "main.nf");
+}
+```
+
+Two hardcoded nf-core assumptions:
+
+1. **`<root>/modules/` exists.** Half the ad-hoc pipelines have processes elsewhere (`<root>/main.nf`, `<root>/<custom-name>.nf`, `<root>/workflows/`, `<root>/lib/`, flat `<root>/modules/<x>.nf`).
+2. **One process per `main.nf` file.** CalliNGS-NF puts 11 processes in one `modules.nf`; ad-hoc pipelines routinely put multiple processes in a single file. `parseProcessFile` uses `matchOne(/process\s+(...)\{/u)` — single match — so even if the file were found, only the first process would be parsed.
+
+### Surviving fields
+
+- `params` — works for pipelines with `nextflow_schema.json` (nf-core, mcmicro, wf-human-variation). Returns `[]` for pipelines without it. Acceptable; the schema is optional in NF.
+- `profiles` — works (parses `nextflow.config` `profiles { ... }` block). Captured 8/13/10/3/26/0 across the six.
+- `subworkflows` — partial. Picked up some (10 mcmicro, 21 What_the_Phage, 13 wf-human-variation) but missed others. Not yet ground-truthed.
+- `tools` — 0 across all six (downstream of empty `processes[]`).
+- `nf_tests` — 0 across all six (correctly; none use nf-test).
+- `warnings` — uniform 2 across every fixture (same finding as 2026-05-02; warnings appear boilerplate-only).
+
+### Implications for the resolver
+
+The fix-list, ordered by impact:
+
+1. **Walk all `.nf` files** under the pipeline root (excluding `.git/`, `work/`, `.nextflow/`, vendored submodules) and grep each for `^[ \t]*process [A-Z_][A-Z0-9_]*[ \t]*\{`. This single change unblocks 5 of the 6 silent-degradation cases.
+2. **Multi-process-per-file support.** Replace `matchOne` with `matchAll`; emit one `processes[]` entry per match. Each gets its own `module_path` (the file) plus a span/offset into the file for IO/script extraction.
+3. **Pipeline-root auto-detect.** When `<path>/nextflow.config` is absent, walk down looking for one (handles MOP2's `mop_preprocess/`); when none found anywhere, fall back to the nearest dir containing a `.nf` file with a `workflow {` block (handles egapx's `nf/`). Surface the chosen root in `source` or `warnings`.
+4. **Entrypoint detection beyond `main.nf`.** What_the_Phage uses `phage.nf`; egapx uses `ui/main.nf` or similar. The resolver should pick the .nf file containing `workflow { ... }` (named or anonymous) at the chosen root, not require a literal `main.nf`.
+5. **Local-module IO inference.** Once 5/6 pipelines start emitting processes, every one of those processes will be a "local" module without `meta.yml`. The resolver currently leans on `meta.yml` for IO docs; it'll need a script-block IO inference path (already noted in mold §4 but not implemented).
+
+### Implications for the schema
+
+Probably none from this sweep alone — `additionalProperties: false` holds, and the schema's required fields are all already satisfiable as empty arrays. The schema isn't overfit; the **resolver** is.
+
+### Implications for the eval
+
+Two new fidelity cases to add to `content/molds/summarize-nextflow/eval.md`:
+
+- **process-discovery is layout-agnostic** (deterministic): for every fixture, `processes[].length` >= 80% of `grep -c '^process ' <every .nf file>` ground truth. (80% rather than exact to allow for genuine false-positive grep matches in comment blocks.)
+- **pipeline-root auto-detect** (deterministic): MOP2 and egapx are summarized successfully, with the chosen root surfaced in the JSON.
+
+### Recommended next step
+
+File a follow-up issue: "summarize-nextflow resolver: walk all .nf files, support multi-process-per-file, auto-detect pipeline root." This is independent of issue #110 (per-module tests + meta.yml) and should land first — there's no point capturing per-module tests while the resolver finds zero modules.

--- a/content/molds/summarize-nextflow/eval.md
+++ b/content/molds/summarize-nextflow/eval.md
@@ -1,0 +1,142 @@
+# summarize-nextflow eval
+
+Evaluation plan for the `summarize-nextflow` Mold and its CLI implementation
+(`@galaxy-foundry/summarize-nextflow`). Cases are tagged by bucket:
+
+- **schema** — does the emitted JSON validate?
+- **fidelity** — does the JSON faithfully reflect the source pipeline?
+- **utility** — can downstream Molds bind to the output without holes?
+- **regression** — does a re-cast reproduce the prior committed run?
+
+Fixtures are pinned in `workflow-fixtures/fixtures.yaml`; materialize with
+`make fixtures-nextflow` before running.
+
+## Case: schema-validates against every tier-tagged fixture
+
+- bucket: schema
+- check: deterministic
+- fixture: `workflow-fixtures/pipelines/nf-core__{demo,fetchngs,hlatyping,bacass,rnaseq,sarek,taxprofiler}`
+- expectation: CLI exits 0 and the emitted JSON validates against
+  `content/schemas/summary-nextflow.schema.json` with `additionalProperties: false`.
+
+## Case: schema-validation failure surfaces, does not silently emit
+
+- bucket: schema
+- check: deterministic
+- fixture: a pipeline (or synthetic tree) that drives the resolver into a
+  shape the schema rejects (e.g. missing required `source.workflow`).
+- expectation: CLI exits 3 (schema validation failure) and prints the AJV
+  error path; nothing partial is written to `--out`.
+
+## Case: DSL1 short-circuit
+
+- bucket: schema
+- check: deterministic
+- fixture: a synthetic tree without a `workflow { ... }` block.
+- expectation: emits the `source` block plus a `warnings[]` entry naming
+  DSL1; does not invent processes/channels.
+
+## Case: process inventory matches grep ground truth
+
+- bucket: fidelity
+- check: deterministic
+- fixture: each pipeline above; ground truth from a shell grep over
+  `main.nf`, `workflows/`, `modules/**`, `subworkflows/**`.
+- expectation: `processes[].length` matches the corpus-observed count
+  modulo aliases (aliases are merged into a single `processes[]` entry
+  with the imports recorded under `aliases[]`).
+
+## Case: alias sweep on bacass
+
+- bucket: fidelity
+- check: deterministic
+- fixture: `nf-core__bacass` (known to import `MINIMAP2_ALIGN` three times
+  under aliases like `MINIMAP2_CONSENSUS`, `MINIMAP2_POLISH`).
+- expectation: `processes[].aliases[]` contains every `include { X as Y }`
+  rename for `MINIMAP2_ALIGN` and `FASTQC`.
+
+## Case: tool registry covers every container directive
+
+- bucket: fidelity
+- check: deterministic
+- fixture: each pipeline's resolved per-process container directives.
+- expectation: every `processes[].tool` is a foreign key into a `tools[]`
+  entry; every container/conda directive resolves to at least one of
+  `biocontainer`, `bioconda`, `singularity`, `docker`, or `wave`. Unresolved
+  directives appear in `warnings[]` with the directive verbatim.
+
+## Case: nf-test enumeration matches filesystem
+
+- bucket: fidelity
+- check: deterministic
+- fixture: each pipeline's `tests/*.nf.test` file tree.
+- expectation: `nf_tests[].length` equals the file count; each entry has
+  `path`, `profiles[]`, and a `snapshot` block when the file contains
+  `assert snapshot(...).match()`.
+
+## Case: test-fixture localization round-trip
+
+- bucket: fidelity
+- check: deterministic
+- fixture: any pipeline run with `--fetch-test-data --test-data-dir=<tmp>`.
+- expectation: every remote `test_fixtures.inputs[].url` has a corresponding
+  on-disk `path`; SHA-1 hashes are stable across two runs.
+
+## Case: ad-hoc DSL2 fallback
+
+- bucket: fidelity
+- check: llm-judged
+- fixture: a non-nf-core DSL2 pipeline lacking `nextflow_schema.json` and
+  per-module `meta.yml` (placeholder; corpus addition pending).
+- expectation: process IO is inferred from `script:` blocks rather than
+  invented from absent metadata; `warnings[]` notes the missing nf-core
+  affordances.
+
+## Case: data-flow Mold can bind without holes
+
+- bucket: utility
+- check: llm-judged
+- fixture: a `summarize-nextflow` output for a non-trivial pipeline
+  (e.g. bacass).
+- expectation: `summary-to-galaxy-data-flow`'s cast skill consumes the JSON
+  and produces a draft without "field missing" errors. Any field it
+  consults that proves underspecified gets logged in `content/log.md`
+  under `gap:` and triggers an Open-gaps note update.
+
+## Case: tool-wrapper Mold can resolve every tools row
+
+- bucket: utility
+- check: llm-judged
+- fixture: same JSON.
+- expectation: `author-galaxy-tool-wrapper` can produce a Galaxy
+  `<requirements>` block for every `tools[]` row; rows that don't yield
+  a wrapper-shaped requirement are surfaced as evaluation gaps, not
+  silently dropped.
+
+## Case: nf-test to Planemo assertions translation
+
+- bucket: utility
+- check: llm-judged
+- fixture: a pipeline with a representative `nf_tests[]` entry containing
+  `snapshot.captures[]`.
+- expectation: `nextflow-test-to-target-tests` (or its successor) maps each
+  capture to a Planemo assertion or to an explicit "untranslatable" entry;
+  no captures are silently elided.
+
+## Case: bacass hand-cast diff is reproduced
+
+- bucket: regression
+- check: deterministic
+- fixture: `casts/claude/summarize-nextflow/runs/nf-core__bacass/summary.json`
+  (current committed run).
+- expectation: re-running the CLI against the pinned bacass fixture
+  produces a JSON whose normalized form (sorted keys, stable ordering)
+  is byte-identical to the committed run, or the diff is intentional and
+  recorded as a schema/mold revision bump.
+
+## Case: demo hand-cast diff is reproduced
+
+- bucket: regression
+- check: deterministic
+- fixture: `casts/claude/summarize-nextflow/runs/nf-core__demo/summary.json`.
+- expectation: same contract as bacass.

--- a/workflow-fixtures/README.md
+++ b/workflow-fixtures/README.md
@@ -53,19 +53,34 @@ Each skeleton is ~5–20KB instead of ~100KB–1MB; all 120 fit in agent context
 
 ## Adding a Nextflow fixture
 
-1. Append an entry to `fixtures.yaml` with `name`, `tier`, `repo`, `tag`, `sha`, `notes`.
-2. Resolve the SHA for the tag:
+1. Append an entry to `fixtures.yaml` with `name`, `flavor`, `tier`, `repo`, `sha`, `notes`. Add `tag` if the upstream has a release; omit for HEAD-pinned pipelines.
+2. Resolve the SHA:
+
+   For tagged releases:
 
    ```sh
-   gh api repos/<org>/<name>/git/ref/tags/<tag> --jq '.object.sha'
-   # if object.type is "tag" (annotated), dereference:
-   gh api repos/<org>/<name>/git/tags/<sha> --jq '.object.sha'
+   git ls-remote https://github.com/<org>/<name> refs/tags/<tag>
+   # if the tag is annotated, peel it:
+   git ls-remote https://github.com/<org>/<name> refs/tags/<tag>^{}
+   ```
+
+   For HEAD-pinned (no releases):
+
+   ```sh
+   git ls-remote https://github.com/<org>/<name> HEAD
    ```
 
 3. Run `scripts/fetch.sh <org>/<name>` to verify.
 
+## Flavors (Nextflow)
+
+- `nf-core` — follows the nf-core template (`modules/nf-core/`, `subworkflows/nf-core/`, `nextflow_schema.json`, per-module `meta.yml`, nf-test under `tests/`).
+- `adhoc` — any DSL2 pipeline that does not follow the nf-core template. Used to stress-test `summarize-nextflow` against non-nf-core conventions: custom layouts, missing schema/meta, non-`main.nf` entrypoints, alternate test conventions, non-bio domains.
+
 ## Tiers (Nextflow)
+
+Rough size buckets, both flavors:
 
 - `tiny` — minimal, bootstrap / smoke tests
 - `small` — mostly linear, clean patterns
-- `large` — many profiles, complex config; edge-case stress
+- `large` — many processes/profiles or heavy config; edge-case stress

--- a/workflow-fixtures/fixtures.yaml
+++ b/workflow-fixtures/fixtures.yaml
@@ -1,15 +1,27 @@
-# Nextflow fixture corpus for review-nextflow / gxwf skill research.
+# Nextflow fixture corpus for summarize-nextflow / gxwf skill research.
 #
 # Each entry pins a pipeline at a specific commit SHA so research results
 # are reproducible. Update `tag` + `sha` together when bumping.
 #
-# Tiers:
+# Required fields: name, repo, sha, flavor, tier, notes.
+# Optional fields: tag (omit for HEAD-pinned pipelines without releases).
+#
+# Flavors:
+#   nf-core - follows the nf-core template (modules/nf-core/, subworkflows/nf-core/,
+#             nextflow_schema.json, per-module meta.yml, nf-test under tests/).
+#   adhoc   - any DSL2 pipeline that does not follow the nf-core template.
+#             Used to stress-test summarize-nextflow against non-nf-core
+#             conventions (custom layouts, missing schema/meta, non-`main.nf`
+#             entrypoints, alternate test conventions, non-bio domains).
+#
+# Tiers (rough size buckets, both flavors):
 #   tiny    - minimal, fast to fully review; bootstrap / smoke tests
-#   small   - mostly linear, few branches; clean params/containers/test patterns
-#   large   - many profiles, complex modules.config; stresses edge cases
+#   small   - mostly linear, few branches; clean patterns
+#   large   - many processes/profiles or heavy config; stresses edge cases
 
 pipelines:
   - name: nf-core/demo
+    flavor: nf-core
     tier: tiny
     repo: https://github.com/nf-core/demo.git
     tag: 1.1.0
@@ -19,6 +31,7 @@ pipelines:
       bootstrapping the review skill and regression-testing output format.
 
   - name: nf-core/fetchngs
+    flavor: nf-core
     tier: small
     repo: https://github.com/nf-core/fetchngs.git
     tag: 1.12.0
@@ -28,6 +41,7 @@ pipelines:
       exercises remote data handling and param surface.
 
   - name: nf-core/rnaseq
+    flavor: nf-core
     tier: large
     repo: https://github.com/nf-core/rnaseq.git
     tag: 3.24.0
@@ -37,6 +51,7 @@ pipelines:
       modules.config, many profiles. Hard mode for the review skill.
 
   - name: nf-core/bacass
+    flavor: nf-core
     tier: small
     repo: https://github.com/nf-core/bacass.git
     tag: 2.5.0
@@ -46,6 +61,7 @@ pipelines:
       structure, good mid-tier example between demo and rnaseq.
 
   - name: nf-core/hlatyping
+    flavor: nf-core
     tier: small
     repo: https://github.com/nf-core/hlatyping.git
     tag: 2.2.0
@@ -55,6 +71,7 @@ pipelines:
       for exercising param surface + container mapping without branching.
 
   - name: nf-core/sarek
+    flavor: nf-core
     tier: large
     repo: https://github.com/nf-core/sarek.git
     tag: 3.8.1
@@ -64,6 +81,7 @@ pipelines:
       aligners, heavy config, distinct flavor from rnaseq hard-mode.
 
   - name: nf-core/taxprofiler
+    flavor: nf-core
     tier: large
     repo: https://github.com/nf-core/taxprofiler.git
     tag: 2.0.0
@@ -72,6 +90,104 @@ pipelines:
       Metagenomic taxonomic profiling across many profilers. Heavy
       branching, different domain from rnaseq/sarek — stresses the
       incompatibility report on parallel-tool patterns.
+
+  # ----- ad-hoc DSL2 pipelines (non-nf-core) -----
+  # Pinned to stress-test summarize-nextflow against pipelines that lack
+  # nf-core conventions: no nextflow_schema.json, no per-module meta.yml,
+  # custom layouts, alternate test conventions, non-`main.nf` entrypoints,
+  # non-bio domains.
+
+  - name: CRG-CNAG/CalliNGS-NF
+    flavor: adhoc
+    tier: tiny
+    repo: https://github.com/CRG-CNAG/CalliNGS-NF.git
+    sha: 9e7ebf04455a24877a92c87216b9629ee2b6088d
+    notes: >
+      CRG-authored GATK RNA-seq variant caller. Single-author style, no
+      nextflow_schema.json, no per-module meta.yml, no nf-test, no
+      modules/nf-core/. Stresses the minimal-pipeline path. HEAD-pinned
+      (no upstream releases).
+
+  - name: labsyspharm/mcmicro
+    flavor: adhoc
+    tier: small
+    repo: https://github.com/labsyspharm/mcmicro.git
+    sha: c06c56deb7b87c80e172d38e9321051728cf77f0
+    notes: >
+      Whole-slide microscopy pipeline (image domain, not NGS). Has a
+      nextflow_schema.json but no nf-core module layout, no meta.yml,
+      no nf-test. Multi-entrypoint (roadie.nf, exemplar.nf alongside
+      main.nf). HEAD-pinned.
+
+  - name: JaneliaSciComp/nf-demos
+    flavor: adhoc
+    tier: tiny
+    repo: https://github.com/JaneliaSciComp/nf-demos.git
+    sha: 0c447f1b401b7f43dc3916129448530842e00d4b
+    notes: >
+      Janelia n5/zarr image-processing pipelines. Non-bioinformatics
+      domain. No schema, no modules/nf-core, no meta.yml, no tests.
+      Uses git submodules (external-modules/). HEAD-pinned.
+
+  - name: ZuberLab/crispr-process-nf
+    flavor: adhoc
+    tier: small
+    repo: https://github.com/ZuberLab/crispr-process-nf.git
+    tag: v2.0.0
+    sha: c88efe7486b2667f9c80de787a68ad40c6c7a950
+    notes: >
+      CRISPR screening pipeline (IMP Vienna). Custom test/ dir (not
+      tests/), no schema, no meta.yml, no nf-test. Tag-released.
+
+  - name: biocorecrg/MOP2
+    flavor: adhoc
+    tier: small
+    repo: https://github.com/biocorecrg/MOP2.git
+    sha: 91aea3fd94cd27095a839a3db96c6620a27c06d8
+    notes: >
+      CRG Master-of-Pores 2 ONT pipeline. Multi-pipeline monorepo
+      (mop_preprocess, mop_mod, mop_tail, mop_consensus). Uses git
+      submodule (BioNextflow/), Singularity-first, local_modules.nf
+      pattern. No schema, no meta.yml. Stresses non-`main.nf`-rooted
+      layouts. HEAD-pinned.
+
+  - name: replikation/What_the_Phage
+    flavor: adhoc
+    tier: large
+    repo: https://github.com/replikation/What_the_Phage.git
+    tag: v1.2.4
+    sha: aeb341738c31dabf2129e7d6ce2ed0b9c4cabe83
+    notes: >
+      Phage identification pipeline. Custom phage.nf entrypoint (no
+      main.nf). workflows/ + flat modules/ (not nf-core layout).
+      Per-tool Dockerfiles in phage-tool-Dockerfiles/. ~111 .nf files;
+      large process count. Stresses non-`main.nf` entrypoint detection.
+
+  - name: epi2me-labs/wf-human-variation
+    flavor: adhoc
+    tier: small
+    repo: https://github.com/epi2me-labs/wf-human-variation.git
+    tag: v2.8.0
+    sha: bb8b526d97e0bbb169ba0fa3596eb5d844b927a8
+    notes: >
+      Oxford Nanopore (epi2me-labs) human variant-calling pipeline.
+      Has a nextflow_schema.json plus epi2me-specific
+      output_definition.json, but no nf-core module layout, no
+      meta.yml, no nf-test. Different schema dialect than nf-core —
+      good schema-handling stress.
+
+  - name: ncbi/egapx
+    flavor: adhoc
+    tier: large
+    repo: https://github.com/ncbi/egapx.git
+    tag: v0.5.2
+    sha: 40ec7362576e4b93fa9c5bf0a6c400d9502b8a63
+    notes: >
+      NCBI eukaryotic genome annotation. Sources live under nf/ not
+      project root (entrypoint not at top level). Uses subworkflows/
+      without subworkflows/nf-core/. No schema, no meta.yml, no
+      nf-test. Stresses non-standard root layout from non-academic
+      provenance.
 
 # IWC corpus — single rolling repo, no tag. Pin SHA from main.
 # Materialized into iwc-src/ then cleaned + converted to format2 under iwc-format2/


### PR DESCRIPTION
## Summary

Bootstraps evaluation for the `summarize-nextflow` Mold and validates the resolver against non-nf-core pipelines.

- New `content/molds/summarize-nextflow/eval.md` — 14 cases across schema / fidelity / utility / regression buckets.
- `workflow-fixtures/fixtures.yaml` gains a `flavor: nf-core | adhoc` field and 8 ad-hoc DSL2 pipelines (CalliNGS-NF, mcmicro, nf-demos, crispr-process-nf, MOP2, What_the_Phage, wf-human-variation, egapx). README updated.
- `content/log.md` — full sweep findings: 7-fixture nf-core baseline, 8-fixture ad-hoc stress, resolver overfitting analysis.
- Cast bundle re-cast against the new mold-source commit.

## Findings (full detail in `content/log.md`)

**nf-core baseline (7 fixtures):** schema validates everywhere; surfaced an `nf_tests` scoping question, process-count drift on large pipelines, and uniform-2-warnings smell. Regression cases fail vs committed runs because the committed runs predate the strict-deterministic CLI.

**Ad-hoc sweep (8 fixtures):** the resolver works only on nf-core layouts.

| Outcome | Count |
| --- | --- |
| Hard failure | 2/8 (MOP2, egapx — no root `nextflow.config`) |
| Silent degradation (schema-valid, 0 processes) | 6/8 |

Process counts emitted vs filesystem grep: 0/11, 0/17, 0/9, 0/12, 0/94, 0/99 across the six. The schema isn't overfit; the resolver is — `discoverProcessFiles` only walks `<root>/modules/**/main.nf`, and even when files are found, only the first process per file is parsed.

## Follow-up issues opened

- #111 — resolver: walk all .nf files, multi-process-per-file, pipeline-root auto-detect. **Should land before #110.**
- #110 — capture per-module tests and meta.yml in the schema (depends on #111).

## Test plan

- [x] `npm run validate` clean (0 errors, 78 warnings — all pre-existing)
- [x] `npm run test` 47/47
- [x] `make fixtures-nextflow` materializes all 15 fixtures (7 nf-core + 8 adhoc)
- [x] CLI exits 0 against all 7 nf-core fixtures and 6/8 ad-hoc fixtures
- [x] Cast verifier passes (`scripts/cast-skill-verify.ts summarize-nextflow`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)