### PR TITLE
Expand Nextflow graph extraction

### DIFF
--- a/packages/summarize-nextflow/src/resolver.ts
+++ b/packages/summarize-nextflow/src/resolver.ts
@@ -11,7 +11,7 @@ interface Summary {
   tools: Tool[];
   processes: Process[];
   subworkflows: Subworkflow[];
-  workflow: { name: string; channels: Channel[]; edges: Edge[]; conditionals: unknown[] };
+  workflow: { name: string; channels: Channel[]; edges: Edge[]; conditionals: Conditional[] };
   test_fixtures: { profile: string; inputs: TestDataRef[]; outputs: unknown[] };
   nf_tests: NfTest[];
   warnings: string[];
@@ -40,6 +40,12 @@ interface Edge {
   from: string;
   to: string;
   via?: string[];
+}
+
+interface Conditional {
+  guard: string;
+  branch: "default" | "alternate";
+  affects: string[];
 }
 
 interface Param {
@@ -134,6 +140,7 @@ export async function resolveNextflowSummary(
     processes.map((process) => process.name),
   );
   const primaryWorkflow = selectPrimaryWorkflow(workflows);
+  const warnings = buildWarnings(processes, workflows);
 
   const summary: Summary = {
     source: {
@@ -163,16 +170,31 @@ export async function resolveNextflowSummary(
       name: primaryWorkflow?.name ?? workflowName.split("/").at(-1)?.toUpperCase() ?? "WORKFLOW",
       channels: primaryWorkflow ? parseWorkflowChannels(primaryWorkflow.body) : [],
       edges: primaryWorkflow ? parseWorkflowEdges(primaryWorkflow.body, primaryWorkflow.calls) : [],
-      conditionals: [],
+      conditionals: primaryWorkflow
+        ? parseWorkflowConditionals(primaryWorkflow.body, primaryWorkflow.calls)
+        : [],
     },
     test_fixtures: parseTestFixtures(pipelineRoot, options.profile),
     nf_tests: parseNfTests(pipelineRoot),
-    warnings: ["workflow graph extraction is intentionally minimal in resolver v0"],
+    warnings,
   };
 
   if (options.withNextflow) mergeNextflowInspect(summary, pipelineRoot, options.profile);
   if (options.fetchTestData) await fetchTestData(summary, options.testDataDir);
   return summary;
+}
+
+function buildWarnings(processes: Process[], workflows: ParsedWorkflow[]): string[] {
+  const warnings = ["workflow graph extraction is intentionally partial in resolver v1"];
+  if (processes.length === 0) {
+    warnings.push(
+      "no module process files found under modules/; process extraction may be incomplete",
+    );
+  }
+  if (workflows.length === 0) {
+    warnings.push("no named workflow blocks found; summary uses manifest-derived workflow name");
+  }
+  return warnings;
 }
 
 function readText(path: string): string {
@@ -400,23 +422,98 @@ function parseWorkflowCalls(body: string, knownNames: Set<string>): string[] {
 
 function parseWorkflowChannels(body: string): Channel[] {
   const channels = new Map<string, Channel>();
-  for (const match of body.matchAll(/^\s*(ch_[A-Za-z0-9_]+)\s*=\s*([^\n]+)/gmu)) {
-    channels.set(match[1]!, {
-      name: match[1]!,
-      source: match[2]!.trim(),
-      shape: "channel",
-    });
+  for (const assignment of extractChannelAssignments(body)) {
+    setPreferredChannel(channels, channelFromSource(assignment.name, assignment.source));
   }
-  for (const match of body.matchAll(
-    /([A-Za-z0-9_.()\s]+)\s*\.set\s*\{\s*(ch_[A-Za-z0-9_]+)\s*\}/gu,
-  )) {
-    channels.set(match[2]!, {
-      name: match[2]!,
-      source: match[1]!.replace(/\s+/gu, " ").trim(),
-      shape: "channel",
-    });
+  for (const setChain of extractSetChains(body)) {
+    setPreferredChannel(channels, channelFromSource(setChain.name, setChain.source));
   }
   return [...channels.values()].sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function setPreferredChannel(channels: Map<string, Channel>, candidate: Channel): void {
+  const existing = channels.get(candidate.name);
+  if (
+    !existing ||
+    parseOperators(candidate.source).length > parseOperators(existing.source).length
+  ) {
+    channels.set(candidate.name, candidate);
+  }
+}
+
+function extractChannelAssignments(body: string): { name: string; source: string }[] {
+  const assignments: { name: string; source: string }[] = [];
+  const lines = body.split("\n");
+  for (let index = 0; index < lines.length; index += 1) {
+    const start = /^\s*(ch_[A-Za-z0-9_]+)\s*=\s*(.+)$/u.exec(lines[index]!);
+    if (!start) continue;
+    const sourceLines = [start[2]!];
+    for (let next = index + 1; next < lines.length; next += 1) {
+      const line = lines[next]!;
+      if (!/^\s*\./u.test(line)) break;
+      sourceLines.push(line.trim());
+      index = next;
+    }
+    assignments.push({
+      name: start[1]!,
+      source: normalizeWorkflowExpression(sourceLines.join(" ")),
+    });
+  }
+  return assignments;
+}
+
+function extractSetChains(body: string): { name: string; source: string }[] {
+  const chains: { name: string; source: string }[] = [];
+  const lines = body.split("\n");
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!/^\s*(?:ch_|Channel\.)/u.test(lines[index]!)) continue;
+    const sourceLines: string[] = [];
+    for (let next = index; next < lines.length; next += 1) {
+      const line = lines[next]!;
+      if (
+        next > index &&
+        (/^\s*(?:take|main|emit):/u.test(line) ||
+          /^\s*(?:if|else|[A-Z][A-Z0-9_]+\s*\()/u.test(line))
+      ) {
+        break;
+      }
+      sourceLines.push(line.trim());
+      const setMatch = /\.set\s*\{\s*(ch_[A-Za-z0-9_]+)\s*\}/u.exec(line);
+      if (setMatch) {
+        const rawSource = sourceLines
+          .join(" ")
+          .replace(/\.set\s*\{\s*ch_[A-Za-z0-9_]+\s*\}.*/u, "");
+        chains.push({ name: setMatch[1]!, source: normalizeWorkflowExpression(rawSource) });
+        index = next;
+        break;
+      }
+      if (next - index > 80) break;
+    }
+  }
+  return chains;
+}
+
+function channelFromSource(name: string, source: string): Channel {
+  const operators = parseOperators(source);
+  return {
+    name,
+    source,
+    shape: operators.length > 0 ? operators.join("|") : "channel",
+  };
+}
+
+function parseOperators(source: string): string[] {
+  return [...source.matchAll(/\.(branch|cross|dump|filter|join|map|mix|multiMap)\b/gu)].map(
+    (match) => match[1]!,
+  );
+}
+
+function normalizeWorkflowExpression(source: string): string {
+  return source
+    .replace(/\s+/gu, " ")
+    .replace(/\s+\./gu, ".")
+    .replace(/\s*,\s*/gu, ", ")
+    .trim();
 }
 
 function parseWorkflowEdges(body: string, calls: string[]): Edge[] {
@@ -429,6 +526,42 @@ function parseWorkflowEdges(body: string, calls: string[]): Edge[] {
     }
   }
   return edges;
+}
+
+function parseWorkflowConditionals(body: string, calls: string[]): Conditional[] {
+  const conditionals: Conditional[] = [];
+  const callNames = new Set(calls);
+  for (const block of extractIfBlocks(body)) {
+    const defaultAffects = parseWorkflowCalls(block.defaultBody, callNames);
+    if (defaultAffects.length > 0) {
+      conditionals.push({ guard: block.guard, branch: "default", affects: defaultAffects });
+    }
+    const alternateAffects = block.alternateBody
+      ? parseWorkflowCalls(block.alternateBody, callNames)
+      : [];
+    if (alternateAffects.length > 0) {
+      conditionals.push({ guard: block.guard, branch: "alternate", affects: alternateAffects });
+    }
+  }
+  return conditionals;
+}
+
+function extractIfBlocks(
+  body: string,
+): { guard: string; defaultBody: string; alternateBody: string | null }[] {
+  const blocks: { guard: string; defaultBody: string; alternateBody: string | null }[] = [];
+  for (const match of body.matchAll(/\bif\s*\(([^\n)]+)\)\s*\{/gu)) {
+    const openIndex = match.index + match[0].lastIndexOf("{");
+    const defaultBody = extractBlockAt(body, openIndex);
+    if (defaultBody === null) continue;
+    const closeIndex = openIndex + defaultBody.length + 1;
+    const elseMatch = /^\s*else\s*\{/u.exec(body.slice(closeIndex + 1));
+    const alternateBody = elseMatch
+      ? extractBlockAt(body, closeIndex + 1 + elseMatch[0].lastIndexOf("{"))
+      : null;
+    blocks.push({ guard: normalizeWorkflowExpression(match[1]!), defaultBody, alternateBody });
+  }
+  return blocks;
 }
 
 function extractCallInvocations(body: string): { name: string; arguments: string[] }[] {

--- a/packages/summarize-nextflow/test/integration/cli.test.ts
+++ b/packages/summarize-nextflow/test/integration/cli.test.ts
@@ -381,6 +381,149 @@ workflow SYNTHETIC {
     expect(prep?.inputs).toHaveLength(1);
     expect(prep?.outputs).toHaveLength(1);
   });
+
+  itIfBuilt("emits valid JSON with warnings for off-template anonymous workflows", async () => {
+    const root = mkdtempSync(join(os.tmpdir(), "foundry-ad-hoc-nextflow-"));
+    writeFileSync(
+      join(root, "nextflow.config"),
+      `manifest { name = 'example/ad-hoc' }
+profiles { test {} }
+`,
+    );
+    writeFileSync(
+      join(root, "main.nf"),
+      `process SAY_HELLO {
+  output:
+  path "hello.txt", emit: txt
+  script:
+  """
+  printf hello > hello.txt
+  """
+}
+
+workflow {
+  Channel.of('hello').set { ch_words }
+  SAY_HELLO(ch_words)
+}
+`,
+    );
+
+    const { buildSummary } = (await import("../../dist/index.js")) as {
+      buildSummary: typeof import("../../src/index.js").buildSummary;
+    };
+    const summary = await buildSummary(root, {
+      profile: "test",
+      withNextflow: false,
+      fetchTestData: false,
+      validate: false,
+    });
+    const validation = validateSummary(summary);
+    expect(validation.valid).toBe(true);
+
+    const data = summary as { workflow: { name: string }; warnings: string[] };
+    expect(data.workflow.name).toBe("AD-HOC");
+    expect(data.warnings).toEqual(
+      expect.arrayContaining([
+        "no named workflow blocks found; summary uses manifest-derived workflow name",
+        "no module process files found under modules/; process extraction may be incomplete",
+      ]),
+    );
+  });
+
+  itIfBuilt("extracts operator channels and conditionals from workflow bodies", async () => {
+    const root = mkdtempSync(join(os.tmpdir(), "foundry-synthetic-nextflow-"));
+    mkdirSync(join(root, "modules", "local", "align"), { recursive: true });
+    mkdirSync(join(root, "modules", "local", "qc"), { recursive: true });
+    mkdirSync(join(root, "workflows"), { recursive: true });
+    writeFileSync(
+      join(root, "nextflow.config"),
+      `manifest { name = 'nf-core/synthetic' }
+profiles { test {} }
+`,
+    );
+    writeFileSync(
+      join(root, "modules", "local", "align", "main.nf"),
+      `process ALIGN { script: "align" }
+`,
+    );
+    writeFileSync(
+      join(root, "modules", "local", "qc", "main.nf"),
+      `process QC { script: "qc" }
+`,
+    );
+    writeFileSync(
+      join(root, "workflows", "synthetic.nf"),
+      `include { ALIGN } from '../modules/local/align'
+include { QC } from '../modules/local/qc'
+workflow SYNTHETIC {
+  take:
+  ch_reads
+  main:
+  ch_reads
+    .filter { meta, reads -> meta.keep }
+    .map { meta, reads -> tuple(meta, reads) }
+    .set { ch_filtered }
+  ch_filtered.join(ch_reference).set { ch_joined }
+  ch_joined.mix(ch_extra).set { ch_mixed }
+  ch_mixed.branch { meta, reads -> pass: true }.set { ch_branched }
+  if (params.run_qc) {
+    QC(ch_filtered)
+  } else {
+    ALIGN(ch_joined)
+  }
+  ALIGN(ch_branched.pass)
+}
+`,
+    );
+
+    const { buildSummary } = (await import("../../dist/index.js")) as {
+      buildSummary: typeof import("../../src/index.js").buildSummary;
+    };
+    const summary = await buildSummary(root, {
+      profile: "test",
+      withNextflow: false,
+      fetchTestData: false,
+      validate: false,
+    });
+    const validation = validateSummary(summary);
+    expect(validation.valid).toBe(true);
+
+    const data = summary as {
+      workflow: {
+        channels: { name: string; source: string; shape: string }[];
+        edges: { from: string; to: string; via: string[] }[];
+        conditionals: { guard: string; branch: string; affects: string[] }[];
+      };
+    };
+    expect(data.workflow.channels).toEqual(
+      expect.arrayContaining([
+        {
+          name: "ch_filtered",
+          source:
+            "ch_reads.filter { meta, reads -> meta.keep }.map { meta, reads -> tuple(meta, reads) }",
+          shape: "filter|map",
+        },
+        { name: "ch_joined", source: "ch_filtered.join(ch_reference)", shape: "join" },
+        { name: "ch_mixed", source: "ch_joined.mix(ch_extra)", shape: "mix" },
+        {
+          name: "ch_branched",
+          source: "ch_mixed.branch { meta, reads -> pass: true }",
+          shape: "branch",
+        },
+      ]),
+    );
+    expect(data.workflow.edges).toEqual(
+      expect.arrayContaining([
+        { from: "ch_filtered", to: "QC", via: [] },
+        { from: "ch_joined", to: "ALIGN", via: [] },
+        { from: "ch_branched.pass", to: "ALIGN", via: [] },
+      ]),
+    );
+    expect(data.workflow.conditionals).toEqual([
+      { guard: "params.run_qc", branch: "default", affects: ["QC"] },
+      { guard: "params.run_qc", branch: "alternate", affects: ["ALIGN"] },
+    ]);
+  });
 });
 
 describe("summarize-nextflow CLI — real pipeline tree (nf-core/demo)", () => {
@@ -559,6 +702,36 @@ describe("summarize-nextflow CLI — real pipeline tree (nf-core/bacass)", () =>
     expect(trim?.path).toBe("subworkflows/nf-core/fastq_trim_fastp_fastqc/main.nf");
     expect(trim?.kind).toBe("pipeline");
     expect(trim?.calls).toEqual(["FASTP", "FASTQC_RAW", "FASTQC_TRIM"]);
+  });
+
+  itIfBacassFixture("extracts bacass graph operators and conditionals", () => {
+    const r = spawnSync("node", [CLI, BACASS_PIPELINE, "--no-with-nextflow", "--no-validate"], {
+      encoding: "utf8",
+    });
+    expect(r.status).toBe(0);
+
+    const data = JSON.parse(r.stdout);
+    expect(data.workflow.channels).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "ch_shortreads_fastqs", shape: "branch" }),
+        expect.objectContaining({ name: "ch_shortreads_concat", shape: "mix" }),
+        expect.objectContaining({ name: "ch_for_assembly", shape: "dump|cross|map|dump" }),
+      ]),
+    );
+    expect(data.workflow.conditionals).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          guard: "params.assembly_type in ['short', 'hybrid']",
+          branch: "default",
+          affects: ["CAT_FASTQ_SHORT"],
+        }),
+        expect.objectContaining({
+          guard: "params.assembly_type != 'long'",
+          branch: "default",
+          affects: ["FASTQ_TRIM_FASTP_FASTQC"],
+        }),
+      ]),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- Extract richer workflow channel operator chains, including `filter`, `map`, `join`, `mix`, `branch`, `cross`, and `dump` shapes.
- Emit workflow conditional summaries for guarded process/subworkflow calls.
- Add synthetic and bacass coverage for graph extraction plus off-template anonymous workflow warnings.

## Tests
- `pnpm --filter @galaxy-foundry/summarize-nextflow typecheck`
- `pnpm --filter @galaxy-foundry/summarize-nextflow build`
- `pnpm --filter @galaxy-foundry/summarize-nextflow test`

Closes part of #26.