### PR TITLE
Advance Galaxy workflow Mold coverage

### DIFF
--- a/content/Dashboard.md
+++ b/content/Dashboard.md
@@ -16,14 +16,17 @@ Generated from `dashboard_sections.json` and content frontmatter. Do not edit by
 
 | Name | Summary | Status | Revised | Rev |
 | --- | --- | --- | --- | --- |
-| [[compare-against-iwc-exemplar]] | Find nearest IWC exemplar(s) and surface a structural diff against a draft. | draft | 2026-05-02 | 2 |
-| [[debug-galaxy-workflow-output]] | Triage failing Galaxy run outputs; classify failure modes; propose fixes. | draft | 2026-05-02 | 2 |
-| [[implement-galaxy-tool-step]] | Convert an abstract step into a concrete gxformat2 step using a tool summary. | draft | 2026-05-02 | 2 |
+| [[compare-against-iwc-exemplar]] | Find nearest IWC exemplar(s) and surface a structural diff against a draft. | draft | 2026-05-03 | 4 |
+| [[summarize-galaxy-tool]] | Pull JSON schema, container, source, inputs/outputs for a Galaxy tool. | draft | 2026-05-03 | 3 |
+| [[debug-galaxy-workflow-output]] | Triage failing Galaxy run outputs; classify failure modes; propose fixes. | draft | 2026-05-02 | 3 |
+| [[implement-galaxy-tool-step]] | Convert an abstract step into a concrete gxformat2 step using a tool summary. | draft | 2026-05-02 | 3 |
+| [[implement-galaxy-workflow-test]] | Assemble Galaxy workflow test fixtures and assertions. | draft | 2026-05-02 | 3 |
+| [[run-workflow-test]] | Execute a workflow's tests via Planemo; emit structured pass/fail and outputs. | draft | 2026-05-02 | 2 |
 | [[summarize-nextflow]] | Read a Nextflow pipeline source tree and emit a structured per-source summary downstream Molds bind to. | draft | 2026-05-02 | 7 |
 | [[summary-to-galaxy-data-flow]] | Abstract DAG with Galaxy collection / scatter / branching idioms surfaced. | draft | 2026-05-02 | 2 |
 | [[summary-to-galaxy-template]] | gxformat2 skeleton with per-step TODOs from a data-flow summary. | draft | 2026-05-02 | 2 |
-| [[validate-galaxy-step]] | Run gxwf validation on the just-implemented Galaxy step and route failures back to step implementation. | draft | 2026-05-02 | 1 |
-| [[validate-galaxy-workflow]] | Run terminal gxwf validation on an assembled Galaxy workflow and classify workflow-level failures. | draft | 2026-05-02 | 1 |
+| [[validate-galaxy-step]] | Run gxwf validation on the just-implemented Galaxy step and route failures back to step implementation. | draft | 2026-05-02 | 2 |
+| [[validate-galaxy-workflow]] | Run terminal gxwf validation on an assembled Galaxy workflow and classify workflow-level failures. | draft | 2026-05-02 | 2 |
 | [[author-galaxy-tool-wrapper]] | Author a new Galaxy tool wrapper (XML) when discovery yields nothing acceptable. | draft | 2026-04-30 | 1 |
 | [[cwl-test-to-target-tests]] | Translate CWL test fixtures into a target workflow's test format. | draft | 2026-04-30 | 1 |
 | [[debug-cwl-workflow-output]] | Triage failing CWL run outputs; classify failure modes; propose fixes. | draft | 2026-04-30 | 1 |
@@ -31,13 +34,10 @@ Generated from `dashboard_sections.json` and content frontmatter. Do not edit by
 | [[find-test-data]] | Search IWC fixtures and public sources for test data matching a data-flow shape. | draft | 2026-04-30 | 1 |
 | [[implement-cwl-tool-step]] | Convert an abstract step into a concrete CWL CommandLineTool + step. | draft | 2026-04-30 | 1 |
 | [[implement-cwl-workflow-test]] | Assemble CWL job file(s) and expected-output assertions. | draft | 2026-04-30 | 1 |
-| [[implement-galaxy-workflow-test]] | Assemble Galaxy workflow test fixtures and assertions. | draft | 2026-04-30 | 1 |
 | [[nextflow-test-to-target-tests]] | Translate NF test fixtures into a target workflow's test format. | draft | 2026-04-30 | 1 |
 | [[paper-to-test-data]] | Derive workflow test inputs and expected outputs from a paper. | draft | 2026-04-30 | 1 |
-| [[run-workflow-test]] | Execute a workflow's tests via Planemo; emit structured pass/fail and outputs. | draft | 2026-04-30 | 1 |
 | [[summarize-cwl]] | Surface CWL Workflow + CommandLineTool inputs, outputs, scatter, conditionals. | draft | 2026-04-30 | 1 |
 | [[summarize-cwl-tool]] | Derive a CommandLineTool description (container, baseCommand, IO) for a CWL target. | draft | 2026-04-30 | 1 |
-| [[summarize-galaxy-tool]] | Pull JSON schema, container, source, inputs/outputs for a Galaxy tool. | draft | 2026-04-30 | 1 |
 | [[summarize-paper]] | Extract methods, tools, sample data, and references from a paper. | draft | 2026-04-30 | 1 |
 | [[summary-to-cwl-data-flow]] | Abstract DAG with CWL scatter / valueFrom / step idioms surfaced. | draft | 2026-04-30 | 1 |
 | [[summary-to-cwl-template]] | CWL Workflow skeleton with per-step TODOs from a data-flow summary. | draft | 2026-04-30 | 1 |
@@ -54,17 +54,17 @@ Generated from `dashboard_sections.json` and content frontmatter. Do not edit by
 | [[collection-split-identifier-via-rules]] | Use Apply Rules regex columns to split one collection identifier into nested list identifiers. | draft | 2026-05-02 | 1 |
 | [[collection-swap-nesting-with-apply-rules]] | Use Apply Rules to regroup a list:list collection by swapping outer and inner identifier columns. | draft | 2026-05-02 | 1 |
 | [[collection-unbox-singleton]] | Use __EXTRACT_DATASET__ with which: first when a one-element collection must become a dataset. | draft | 2026-05-02 | 1 |
-| [[compose-runtime-text-parameter]] | Use compose_text_param to build connected text expressions from constants plus runtime scalar values. | draft | 2026-05-02 | 1 |
+| [[compose-runtime-text-parameter]] | Use compose_text_param to build connected text expressions from constants plus runtime scalar values. | draft | 2026-05-02 | 2 |
 | [[conditional-gate-on-nonempty-result]] | Derive a boolean from empty or non-empty data, then use when to skip reporting or export steps. | draft | 2026-05-02 | 2 |
 | [[conditional-route-between-alternative-outputs]] | Use when-gated alternatives plus pick_value to merge binary or one-of-N routes into one downstream value. | draft | 2026-05-02 | 2 |
-| [[conditional-run-optional-step]] | Use a workflow boolean connected as inputs.when to skip an optional Galaxy step or branch. | draft | 2026-05-02 | 2 |
+| [[conditional-run-optional-step]] | Use a workflow boolean connected as inputs.when to skip an optional Galaxy step or branch. | draft | 2026-05-02 | 3 |
 | [[conditional-transform-or-pass-through]] | Gate an optional transform, then use pick_value to pass transformed data when present or original data otherwise. | draft | 2026-05-02 | 1 |
-| [[derive-parameter-from-file]] | Read a one-value dataset with param_value_from_file, including count recipes that feed typed parameters. | draft | 2026-05-02 | 1 |
+| [[derive-parameter-from-file]] | Read a one-value dataset with param_value_from_file, including count recipes that feed typed parameters. | draft | 2026-05-02 | 2 |
 | [[galaxy-collection-patterns]] | Use this MOC to choose corpus-grounded Galaxy collection transformation patterns. | draft | 2026-05-02 | 1 |
 | [[galaxy-conditionals-patterns]] | Use this MOC to choose corpus-grounded Galaxy when and pick_value conditional patterns. | draft | 2026-05-02 | 1 |
 | [[galaxy-tabular-patterns]] | Use this MOC to choose corpus-grounded Galaxy tabular transformation patterns. | draft | 2026-05-02 | 1 |
 | [[harmonize-by-sortlist-from-identifiers]] | Use SORTLIST with sort_type:file to reorder one collection by another collection's identifiers. | draft | 2026-05-02 | 1 |
-| [[map-workflow-enum-to-tool-parameter]] | Use map_param_value to translate workflow enum values into downstream tool codes, flags, or snippets. | draft | 2026-05-02 | 1 |
+| [[map-workflow-enum-to-tool-parameter]] | Use map_param_value to translate workflow enum values into downstream tool codes, flags, or snippets. | draft | 2026-05-02 | 2 |
 | [[regex-relabel-via-tabular]] | Derive collection element identifiers in a tabular mapping, then apply them with RELABEL_FROM_FILE. | draft | 2026-05-02 | 1 |
 | [[relabel-via-rules-and-find-replace]] | Use Apply Rules, identifier extraction, find/replace, and relabeling for structural fan-out cleanup. | draft | 2026-05-02 | 1 |
 | [[sync-collections-by-identifier]] | Use collection_element_identifiers with FILTER_FROM_FILE or RELABEL_FROM_FILE to align sibling collections. | draft | 2026-05-02 | 1 |
@@ -87,7 +87,8 @@ Generated from `dashboard_sections.json` and content frontmatter. Do not edit by
 
 | Name | Summary | Status | Revised | Rev |
 | --- | --- | --- | --- | --- |
-| [[validate]] | Validate gxformat2 Galaxy workflow structure and emit diagnostics before runtime execution. | draft | 2026-05-02 | 1 |
+| [[validate-tests]] | Validate Galaxy workflow test files and optionally cross-check labels against their workflow. | draft | 2026-05-03 | 1 |
+| [[validate]] | Validate Galaxy workflow structure, tool state, and optional connection compatibility before runtime execution. | draft | 2026-05-02 | 2 |
 | [[tool-revisions]] | Resolve a Tool Shed tool to changeset revisions for reproducible workflow pinning. Final step in discover-and-pin. | draft | 2026-04-30 | 1 |
 | [[tool-search]] | Free-text Tool Shed search returning candidate tools as JSON; first step in the discover-and-pin sequence. | draft | 2026-04-30 | 1 |
 | [[tool-versions]] | List TRS-published versions of a Tool Shed tool, oldest→newest. Second step in the discover-and-pin sequence. | draft | 2026-04-30 | 1 |
@@ -97,28 +98,31 @@ Generated from `dashboard_sections.json` and content frontmatter. Do not edit by
 | Name | Summary | Status | Revised | Rev |
 | --- | --- | --- | --- | --- |
 | [[summary-nextflow]] | JSON Schema for the structured summary emitted by the summarize-nextflow Mold. | draft | 2026-05-01 | 3 |
-| [[tests-format]] | JSON Schema for the planemo workflow test format (`<workflow>-tests.yml`), vendored from `@galaxy-tool-util/schema`. | draft | 2026-04-30 | 1 |
+| [[tests-format]] | JSON Schema for the planemo workflow test format (`<workflow>-tests.yml`), vendored from `@galaxy-tool-util/schema`. | draft | 2026-04-30 | 2 |
 
 ## Component Research
 
 | Name | Summary | Status | Revised | Rev |
 | --- | --- | --- | --- | --- |
+| [[component-tool-shed-search]] | Tool Shed's Whoosh repo/tool search and partial GA4GH TRS v2, indexed from hg-walked metadata with no auto-refresh on upload | draft | 2026-05-03 | 2 |
+| [[iwc-nearest-exemplar-selection]] | Defines a feature hierarchy for selecting useful IWC exemplar workflows for structural comparison. | draft | 2026-05-03 | 2 |
 | [[galaxy-apply-rules-dsl]] | Reference for Galaxy's Apply Rules DSL: rule operations, mapping operations, composition patterns, pitfalls. | draft | 2026-05-02 | 2 |
 | [[galaxy-collection-semantics]] | Vendored formal spec of Galaxy dataset-collection mapping/reduction semantics, with labeled examples and pinned test references. | draft | 2026-05-02 | 2 |
 | [[galaxy-collection-tools]] | Catalog of Galaxy's collection-operation tools — purpose, IO, parameters, selection guide. Companion to galaxy-collection-semantics. | draft | 2026-05-02 | 2 |
+| [[galaxy-tool-job-failure-reference]] | Reference for Galaxy tool stdio rules, job failure detection, job states, and job API failure surfaces. | draft | 2026-05-02 | 1 |
+| [[galaxy-workflow-invocation-failure-reference]] | Reference for Galaxy workflow invocation states, messages, failure reasons, and invocation API surfaces. | draft | 2026-05-02 | 1 |
 | [[iwc-conditionals-survey]] | Corpus survey of Galaxy conditional step usage in IWC, covering when-gates, boolean shims, and routed output selection. | draft | 2026-05-02 | 2 |
-| [[iwc-nearest-exemplar-selection]] | Defines a feature hierarchy for selecting useful IWC exemplar workflows for structural comparison. | draft | 2026-05-02 | 1 |
 | [[iwc-parameter-derivation-survey]] | Corpus survey of Galaxy workflow recipes that turn upstream data, metadata, or small files into runtime parameters. | draft | 2026-05-02 | 1 |
 | [[iwc-tabular-operations-survey]] | Corpus survey of tabular tools and operations across IWC workflows; map for the leaf pattern hierarchy on row/column data manipulation. | draft | 2026-05-02 | 2 |
 | [[iwc-test-data-conventions]] | How IWC workflows organize and reference test data — Zenodo-first, SHA-1 integrity, collection shapes, CVMFS gotchas. | draft | 2026-05-02 | 2 |
 | [[iwc-transformations-survey]] | Corpus survey of collection-shape transformations across IWC: built-in collection ops, toolshed transformers, and the multi-step recipes that bracket map-over. | draft | 2026-05-02 | 2 |
 | [[nextflow-operators-to-galaxy-collection-recipes]] | Classifies common Nextflow operators as Galaxy wiring, collection semantics, explicit steps, or review triggers. | draft | 2026-05-02 | 1 |
 | [[nextflow-to-galaxy-channel-shape-mapping]] | Maps common Nextflow channel, tuple, and path shapes to Galaxy dataset and collection shapes. | draft | 2026-05-02 | 1 |
+| [[planemo-asserts-idioms]] | Decision and idiom guide for picking planemo workflow-test assertions: which family per output type, how to size tolerances, when to validate. | draft | 2026-05-02 | 3 |
+| [[planemo-workflow-test-architecture]] | Reference for Planemo workflow test/run architecture, Galaxy modes, API polling, and noisy failure boundaries. | draft | 2026-05-02 | 1 |
 | [[component-nextflow-containers-and-envs]] | Stub. Biocontainers / bioconda equivalence, Docker/Singularity refs, container directive resolution. Grows from cast contact — see issue #17. | draft | 2026-05-01 | 1 |
 | [[component-nextflow-inspect]] | White paper on Nextflow's native introspection subcommands — `nextflow inspect`, `nextflow config`, and adjacent tooling. Survey, not decision. | draft | 2026-05-01 | 1 |
 | [[component-nextflow-pipeline-anatomy]] | Stub. DSL2 layout, channel idioms, operator-chain reading rules. Grows from cast contact with rnaseq/sarek/ad-hoc — see issue #17. | draft | 2026-05-01 | 1 |
 | [[component-nextflow-testing]] | Stub. conf/test.config, nf-core/test-datasets, nf-test idioms, samplesheet conventions. Grows from cast contact — see issue #17. | draft | 2026-05-01 | 1 |
 | [[component-nf-core-tools]] | White paper on nf-core/tools — conventions, CLI surface, schema universe, container resolution. Survey, not decision. | draft | 2026-05-01 | 1 |
-| [[component-tool-shed-search]] | Tool Shed's Whoosh repo/tool search and partial GA4GH TRS v2, indexed from hg-walked metadata with no auto-refresh on upload | draft | 2026-04-30 | 1 |
 | [[iwc-shortcuts-anti-patterns]] | What IWC test suites cut corners on (accepted) vs what's a code smell — existence-only probes, sim_size deltas, image dim checks, label coupling. | draft | 2026-04-30 | 1 |
-| [[planemo-asserts-idioms]] | Decision and idiom guide for picking planemo workflow-test assertions: which family per output type, how to size tolerances, when to validate. | draft | 2026-04-30 | 1 |

--- a/content/Index.md
+++ b/content/Index.md
@@ -82,7 +82,8 @@ Generated from content frontmatter. Do not edit by hand.
 - [[tool-revisions]] — Resolve a Tool Shed tool to changeset revisions for reproducible workflow pinning. Final step in discover-and-pin.
 - [[tool-search]] — Free-text Tool Shed search returning candidate tools as JSON; first step in the discover-and-pin sequence.
 - [[tool-versions]] — List TRS-published versions of a Tool Shed tool, oldest→newest. Second step in the discover-and-pin sequence.
-- [[validate]] — Validate gxformat2 Galaxy workflow structure and emit diagnostics before runtime execution.
+- [[validate]] — Validate Galaxy workflow structure, tool state, and optional connection compatibility before runtime execution.
+- [[validate-tests]] — Validate Galaxy workflow test files and optionally cross-check labels against their workflow.
 
 ## Schemas
 
@@ -100,6 +101,8 @@ Generated from content frontmatter. Do not edit by hand.
 - [[galaxy-apply-rules-dsl]] — Reference for Galaxy's Apply Rules DSL: rule operations, mapping operations, composition patterns, pitfalls.
 - [[galaxy-collection-semantics]] — Vendored formal spec of Galaxy dataset-collection mapping/reduction semantics, with labeled examples and pinned test references.
 - [[galaxy-collection-tools]] — Catalog of Galaxy's collection-operation tools — purpose, IO, parameters, selection guide. Companion to galaxy-collection-semantics.
+- [[galaxy-tool-job-failure-reference]] — Reference for Galaxy tool stdio rules, job failure detection, job states, and job API failure surfaces.
+- [[galaxy-workflow-invocation-failure-reference]] — Reference for Galaxy workflow invocation states, messages, failure reasons, and invocation API surfaces.
 - [[iwc-conditionals-survey]] — Corpus survey of Galaxy conditional step usage in IWC, covering when-gates, boolean shims, and routed output selection.
 - [[iwc-nearest-exemplar-selection]] — Defines a feature hierarchy for selecting useful IWC exemplar workflows for structural comparison.
 - [[iwc-parameter-derivation-survey]] — Corpus survey of Galaxy workflow recipes that turn upstream data, metadata, or small files into runtime parameters.
@@ -110,7 +113,10 @@ Generated from content frontmatter. Do not edit by hand.
 - [[nextflow-operators-to-galaxy-collection-recipes]] — Classifies common Nextflow operators as Galaxy wiring, collection semantics, explicit steps, or review triggers.
 - [[nextflow-to-galaxy-channel-shape-mapping]] — Maps common Nextflow channel, tuple, and path shapes to Galaxy dataset and collection shapes.
 - [[planemo-asserts-idioms]] — Decision and idiom guide for picking planemo workflow-test assertions: which family per output type, how to size tolerances, when to validate.
+- [[planemo-workflow-test-architecture]] — Reference for Planemo workflow test/run architecture, Galaxy modes, API polling, and noisy failure boundaries.
 
 ## Design Specs
 
 - [[galaxy-data-flow-draft-contract]] — Defines the proposed boundary between Galaxy data-flow drafts, gxformat2 templates, and concrete step implementation.
+- [[galaxy-tool-summary-input-source]] — Decides that summarize-galaxy-tool reads cached ParsedTool JSON as its v1 input source.
+- [[iwc-exemplar-runtime-discovery]] — Resolves runtime IWC exemplar discovery through live IWC URLs plus gxwf processing.

--- a/content/cli/gxwf/validate-tests.md
+++ b/content/cli/gxwf/validate-tests.md
@@ -1,0 +1,68 @@
+---
+type: cli-command
+tool: gxwf
+command: validate-tests
+tags:
+  - cli-command
+  - cli/gxwf
+status: draft
+created: 2026-05-03
+revised: 2026-05-03
+revision: 1
+ai_generated: true
+summary: "Validate Galaxy workflow test files and optionally cross-check labels against their workflow."
+related_notes:
+  - "[[tests-format]]"
+  - "[[planemo-asserts-idioms]]"
+---
+
+# `gxwf validate-tests`
+
+Validate a Galaxy workflow test file (`*-tests.yml` or `*.gxwf-tests.yml`) against the Galaxy tests schema. Optionally cross-check the test file against a workflow so missing input labels, missing output labels, and type mismatches fail before a slow Planemo run.
+
+## Install
+
+Use the Foundry-supported `gxwf` CLI from `@galaxy-tool-util/cli` or the Python package with the matching interface. Prefer the project-local executable when running inside a checked-out Foundry or galaxy-tool-util workspace.
+
+## Synopsis
+
+```bash
+gxwf validate-tests <file> [options]
+```
+
+`<file>` is a workflow test YAML file, usually named `<workflow>-tests.yml` or `<workflow>.gxwf-tests.yml`.
+
+## Options
+
+| Option | Description |
+|---|---|
+| `--json` | Emit a structured JSON validation report. Preferred for cast skills and harness routing. |
+| `--workflow <path>` | Cross-check job inputs and output assertions against a Galaxy workflow (`.ga` or `.gxwf.yml`). |
+
+## Output
+
+Default output is human-readable validation diagnostics.
+
+With `--json`, the command emits a structured report describing schema errors and, when `--workflow` is supplied, workflow-coherence errors such as missing labels or incompatible input values.
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Test file is schema-valid and any requested workflow cross-check passed. |
+| non-zero | The test file is invalid, the workflow cross-check failed, or an input file could not be loaded. |
+
+## Examples
+
+```bash
+gxwf validate-tests workflow-tests.yml
+gxwf validate-tests workflow-tests.yml --json
+gxwf validate-tests workflow-tests.yml --workflow workflow.gxwf.yml --json
+```
+
+## Gotchas
+
+- This is the cheap static gate before Planemo. It does not execute the workflow and does not prove assertions pass on real outputs.
+- Use `--workflow` whenever the workflow file is available. Schema-valid tests can still reference stale input/output labels after workflow edits.
+- Run this before `planemo workflow_test_on_invocation` or full `planemo test`; it catches authoring mistakes without starting Galaxy.
+- The assertion vocabulary itself comes from `[[tests-format]]`; strategy for choosing assertions lives in `[[planemo-asserts-idioms]]`.

--- a/content/cli/gxwf/validate.md
+++ b/content/cli/gxwf/validate.md
@@ -8,9 +8,9 @@ tags:
 status: draft
 created: 2026-05-02
 revised: 2026-05-02
-revision: 1
+revision: 2
 ai_generated: true
-summary: "Validate gxformat2 Galaxy workflow structure and emit diagnostics before runtime execution."
+summary: "Validate Galaxy workflow structure, tool state, and optional connection compatibility before runtime execution."
 ---
 
 # `gxwf validate`
@@ -24,32 +24,44 @@ Use the Foundry-supported `gxwf` CLI from `@galaxy-tool-util/cli` or the Python 
 ## Synopsis
 
 ```bash
-gxwf validate <workflow> [options]
+gxwf validate <file> [options]
 ```
 
 ## Options
 
 | Option | Description |
 |---|---|
-| `--json` | Emit machine-readable diagnostics when available. |
-| `--format <format>` | Select workflow format when the CLI cannot infer it from the file extension. |
+| `--format <fmt>` | Force source format: `native` or `format2`; otherwise auto-detected from file extension/content. |
+| `--json` | Emit a structured JSON validation report. Preferred for cast skills and harness routing. |
+| `--report-html [file]` | Write an HTML validation report to `file`, or stdout when the optional file value is omitted. |
+| `--no-tool-state` | Skip tool-state validation. Use only when tool metadata is unavailable and structural checks are still useful. |
+| `--cache-dir <dir>` | Tool cache directory used for tool-state validation. |
+| `--mode <mode>` | Validation backend. Upstream default is `effect`; `json-schema` is available for schema-backed/offline cases. |
+| `--tool-schema-dir <dir>` | Directory of pre-exported per-tool JSON Schemas for offline `json-schema` mode. |
+| `--connections` | Validate connection-type compatibility, including collection algebra and map-over/reduction compatibility. |
+| `--strict` | Shorthand for `--strict-structure --strict-encoding --strict-state`. |
+| `--strict-structure` | Reject unknown envelope/step keys. |
+| `--strict-encoding` | Reject legacy JSON-string `tool_state` and format2 field misuse. |
+| `--strict-state` | Require every tool step to validate; no skipped tool-state checks. |
 
 ## Output
 
-Default output is human-readable diagnostics. JSON output should be treated as the preferred cast-skill interface when available; free-text diagnostics are a fallback.
+Default output is human-readable diagnostics. JSON output should be treated as the preferred cast-skill interface; free-text diagnostics are a fallback for humans.
 
 ## Exit codes
 
 | Code | Meaning |
 |---|---|
 | `0` | Workflow validation passed. |
-| non-zero | Validation failed or the workflow could not be loaded. |
+| non-zero | Validation failed, the workflow could not be loaded, or a selected validation backend could not complete. |
 
 ## Examples
 
 ```bash
 gxwf validate workflow.ga
 gxwf validate workflow.gxwf.yml --json
+gxwf validate workflow.gxwf.yml --json --connections --strict
+gxwf validate workflow.ga --mode json-schema --tool-schema-dir ./tool-schemas --json
 ```
 
 ## Gotchas
@@ -57,3 +69,6 @@ gxwf validate workflow.gxwf.yml --json
 - Validation is design-time structure checking. It does not prove that a workflow test will pass under Planemo.
 - Run after each generated Galaxy step when the harness can still attribute failures to the fresh step.
 - Run again after assembly to catch cross-step or workflow-level issues before runtime testing.
+- Prefer `--json` whenever a cast skill or harness needs to classify diagnostics.
+- Use `--connections` when tool cache metadata is available and data-shape compatibility matters, especially around collections and map-over.
+- `--no-tool-state` weakens validation. If used, record why tool metadata was unavailable and rerun without it before final runtime testing.

--- a/content/molds/author-galaxy-tool-wrapper/eval.md
+++ b/content/molds/author-galaxy-tool-wrapper/eval.md
@@ -1,0 +1,19 @@
+# author-galaxy-tool-wrapper eval
+
+## Case: conda-only Nextflow process
+
+- check: deterministic
+- fixture: Nextflow process summary with a bioconda-only environment directive, explicit command, declared inputs, declared outputs, and minimal test fixture evidence.
+- expectation: authors a Galaxy tool XML wrapper whose `requirements` package entries match the conda spec, whose command preserves the process command intent, and whose wrapper passes `planemo lint`.
+
+## Case: biocontainers Docker URI
+
+- check: llm-judged
+- fixture: Nextflow process summary with a BioContainers Docker URI, command stanza, input/output declarations, and no acceptable Tool Shed discovery hit.
+- expectation: derives a plausible conda-equivalent requirement set, preserves command-stanza fidelity, and records uncertainty where container-to-conda mapping is not directly evidenced.
+
+## Case: discovery fallthrough against IWC-wrapped tools
+
+- check: llm-judged
+- fixture: process needs corresponding to IWC-wrapped tools such as fastp and samtools where wrapper discovery should normally succeed.
+- expectation: does not author a duplicate wrapper unless discovery evidence is unacceptable; explains why the fallthrough was justified and compares the authored XML shape against the existing IWC wrapper.

--- a/content/molds/compare-against-iwc-exemplar/eval.md
+++ b/content/molds/compare-against-iwc-exemplar/eval.md
@@ -1,0 +1,25 @@
+# compare-against-iwc-exemplar eval
+
+## Case: nf-core rnaseq nearest exemplar
+
+- check: deterministic + llm-judged
+- fixture: Galaxy draft or data-flow template derived from nf-core/rnaseq after the exemplar-discovery mechanism is resolved.
+- expectation: selects an IWC transcriptomics RNA-seq exemplar such as `transcriptomics/rnaseq-pe` with high confidence, emits schema-valid structural diff JSON, and explains alignment on domain, collection topology, tool families, outputs, and tests.
+
+## Case: nf-core viralrecon nearest exemplar
+
+- check: deterministic + llm-judged
+- fixture: Galaxy draft or data-flow template derived from nf-core/viralrecon after the exemplar-discovery mechanism is resolved.
+- expectation: selects an IWC SARS-CoV-2 variation-reporting exemplar with medium confidence, emits schema-valid structural diff JSON, and explains both shared variation-analysis structure and mismatched workflow scope.
+
+## Case: nf-core mag nearest exemplar
+
+- check: deterministic + llm-judged
+- fixture: Galaxy draft or data-flow template derived from nf-core/mag after the exemplar-discovery mechanism is resolved.
+- expectation: selects an IWC microbiome MAG-generation exemplar with high confidence, emits schema-valid structural diff JSON, and identifies collection, binning, annotation, and report-assembly structure differences.
+
+## Case: no acceptable exemplar
+
+- check: deterministic + llm-judged
+- fixture: Galaxy draft whose domain, tool families, topology, or output intent has no close IWC match in the configured exemplar source.
+- expectation: returns a low-confidence or no-match result instead of forcing a nearest exemplar, records the top weak candidates, and scopes which structural findings are speculative.

--- a/content/molds/compare-against-iwc-exemplar/index.md
+++ b/content/molds/compare-against-iwc-exemplar/index.md
@@ -8,11 +8,19 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-05-02
-revision: 2
+revised: 2026-05-03
+revision: 4
 ai_generated: true
 summary: "Find nearest IWC exemplar(s) and surface a structural diff against a draft."
 references:
+  - kind: research
+    ref: "[[iwc-exemplar-runtime-discovery]]"
+    used_at: runtime
+    load: upfront
+    mode: verbatim
+    evidence: hypothesis
+    purpose: "Discover IWC exemplar candidates from live IWC GitHub URLs and normalize selected workflows with gxwf."
+    verification: "Run exemplar discovery for nf-core/rnaseq, viralrecon, and mag cases and confirm selected candidates match eval expectations."
   - kind: research
     ref: "[[iwc-nearest-exemplar-selection]]"
     used_at: runtime
@@ -65,4 +73,131 @@ references:
 ---
 # compare-against-iwc-exemplar
 
-Stub. Replace with real Mold content per MOLD_SPEC once first walks are done.
+Find the nearest IWC exemplar workflow(s) for a Galaxy draft and emit a structural diff that can guide authoring before more effort is spent on concrete step implementation.
+
+This Mold is the corpus-first check in Galaxy-targeting pipelines. It does not retrieve exemplars as a separate Mold; discovery, ranking, and comparison are one action. Runtime discovery uses live IWC GitHub URLs plus `gxwf` normalization per [[iwc-exemplar-runtime-discovery]], and ranking uses [[iwc-nearest-exemplar-selection]].
+
+## Inputs
+
+The Mold expects a Galaxy draft from `[[summary-to-galaxy-template]]` or a later implemented workflow. The draft should include:
+
+- Workflow/domain intent and source summary context.
+- Workflow inputs, outputs, and collection topology.
+- Abstract or concrete step labels.
+- Tool-family hints, even when exact Tool Shed wrappers are unresolved.
+- Placeholder transformations such as collection cleanup, Apply Rules reshaping, tabular bridges, and optional branches.
+- Test or fixture hints when available.
+
+The caller may also provide:
+
+- An IWC branch, tag, or commit SHA. Default is the live `main` branch.
+- A local IWC checkout path for offline development. This is an override, not a cast dependency.
+- A maximum candidate count for fetched workflows.
+
+## Outputs
+
+A structural comparison object conforming to the future structural-diff schema. Sketch shape:
+
+```jsonc
+{
+  "query_features": {
+    "domain": "transcriptomics/rna-seq",
+    "input_topology": ["list:paired fastq"],
+    "tool_families": ["fastp", "star", "featurecounts", "multiqc"],
+    "dag_motifs": ["qc branch", "alignment branch", "report aggregation"],
+    "outputs": ["counts table", "multiqc report"]
+  },
+  "nearest": {
+    "path": "workflows/transcriptomics/rnaseq-pe/rnaseq-pe.ga",
+    "url": "https://github.com/galaxyproject/iwc/.../rnaseq-pe.ga",
+    "confidence": "high",
+    "rationale": "same domain, paired FASTQ topology, align/count/report shape"
+  },
+  "alternates": [],
+  "diff": {
+    "aligned_patterns": [],
+    "draft_missing": [],
+    "draft_extra": [],
+    "ordering_differences": [],
+    "test_differences": [],
+    "speculative_findings": []
+  }
+}
+```
+
+Confidence labels are the labels from [[iwc-nearest-exemplar-selection]]: `high`, `medium`, `low`, or `no nearest exemplar`.
+
+## Procedure
+
+### 1. Extract draft features
+
+Read the draft at the abstraction level it currently supports. Do not force unresolved template TODOs into concrete tools.
+
+Extract the feature hierarchy from [[iwc-nearest-exemplar-selection]]:
+
+1. Domain or analysis intent.
+2. Input collection topology.
+3. Primary tool families.
+4. DAG motifs and structural recipes.
+5. Output types and report shape.
+6. Test style and fixture topology.
+
+Keep missing features explicit. A draft with no domain signal should not produce a high-confidence exemplar even if it shares generic tools.
+
+### 2. Discover candidate IWC workflows
+
+Use the IWC GitHub tree or contents API under `https://github.com/galaxyproject/iwc/tree/main/workflows/` to list candidate workflow paths. Start with path/domain narrowing, then fetch only a small ranked set.
+
+Preserve URLs as provenance. Do not cite Foundry `workflow-fixtures/` paths in runtime output, and do not require a prebuilt Foundry exemplar index.
+
+### 3. Normalize candidates
+
+For each fetched candidate, use `gxwf` to normalize the workflow into a structural representation suitable for comparison. Prefer skeleton-level structure for topology, labels, tool order, workflow inputs/outputs, and collection shapes. Use more detailed gxformat2 or native workflow content only when parameter-level evidence matters.
+
+If `gxwf` cannot normalize a candidate, keep the URL in alternates with a failure reason instead of silently dropping a promising domain match.
+
+### 4. Rank candidates
+
+Rank by the feature hierarchy, not by a single global similarity score. Domain and topology outrank generic tool overlap. Common tools such as `MultiQC`, `fastp`, `awk`, and `datamash` are weak signals by themselves.
+
+Select one nearest exemplar when a clear candidate exists. Return weak alternates when they explain ambiguity or when the nearest confidence is only medium or low.
+
+If no candidate aligns on domain or topology, return `no nearest exemplar` and compare only against known pattern pages when useful.
+
+### 5. Produce the structural diff
+
+Compare the draft to the nearest exemplar at the level appropriate to the draft:
+
+- Workflow input and output shapes.
+- Collection mapping, reduction, reshaping, relabeling, and synchronization motifs.
+- Tabular bridges, joins, filters, aggregation, and report assembly.
+- Conditional or optional paths.
+- Tool-family ordering and missing pre/post-processing steps.
+- Test fixture shape and assertion style when test evidence exists.
+
+Separate findings into:
+
+- `aligned_patterns` — draft matches a corpus-observed structure.
+- `draft_missing` — IWC consistently has structure absent from the draft.
+- `draft_extra` — draft has structure not reflected in the nearest exemplar.
+- `ordering_differences` — same parts, materially different order.
+- `test_differences` — fixture/assertion differences.
+- `speculative_findings` — low-confidence suggestions that need human review.
+
+### 6. Route findings back to authoring
+
+Each finding should name the authoring surface most likely to own the fix:
+
+- Template/data-flow issue: missing node, wrong collection shape, wrong branch, placeholder too vague.
+- Pattern issue: recurring Galaxy idiom should become or update a pattern page.
+- Tool-step issue: exact wrapper or parameterization will be handled later.
+- Test issue: defer to `nextflow-test-to-target-tests` or `implement-galaxy-workflow-test`.
+
+Do not block downstream authoring on low-confidence exemplar mismatches. Report them as review guidance.
+
+## Non-goals
+
+- **No corpus mirroring.** Runtime output cites IWC URLs; Foundry fixtures are research aids only.
+- **No tool discovery.** Do not replace `[[discover-shed-tool]]`.
+- **No automatic rewrite.** This Mold emits structural diff guidance; the harness or user decides which changes to apply.
+- **No forced nearest.** A no-match result is valid when IWC lacks a close exemplar.

--- a/content/molds/implement-galaxy-workflow-test/eval.md
+++ b/content/molds/implement-galaxy-workflow-test/eval.md
@@ -1,0 +1,25 @@
+# implement-galaxy-workflow-test eval
+
+## Case: tests-format schema gate
+
+- check: deterministic
+- fixture: Galaxy workflow test plan for an IWC-style workflow such as SARS-CoV-2 variant calling, ChIPseq-SR, or RNAseq.
+- expectation: authored `-tests.yml` validates against the tests-format schema before any Planemo invocation.
+
+## Case: workflow/test cross-check gate
+
+- check: deterministic
+- fixture: authored `-tests.yml` plus the target Galaxy workflow in gxformat2 or native Galaxy workflow format.
+- expectation: `checkTestsAgainstWorkflow` reports zero missing input labels, zero missing output labels, and no collection/datatype mismatches.
+
+## Case: static CLI validation
+
+- check: deterministic
+- fixture: authored `-tests.yml` and workflow fixture for a representative IWC workflow.
+- expectation: gxwf or Planemo static validation reaches a clean result, or emits only explicitly documented warnings that do not block runtime testing.
+
+## Case: managed Galaxy runtime green
+
+- check: deterministic
+- fixture: authored workflow test for a representative IWC workflow with staged test data and tools available.
+- expectation: `planemo test` passes on a managed Galaxy, and the result preserves enough invocation, job, and assertion artifact context for debugging if the run fails.

--- a/content/molds/implement-galaxy-workflow-test/index.md
+++ b/content/molds/implement-galaxy-workflow-test/index.md
@@ -9,15 +9,25 @@ tags:
 status: draft
 created: 2026-04-30
 revised: 2026-05-02
-revision: 2
+revision: 3
 ai_generated: true
 related_notes:
   - "[[iwc-test-data-conventions]]"
   - "[[iwc-shortcuts-anti-patterns]]"
   - "[[planemo-asserts-idioms]]"
   - "[[tests-format]]"
+cli_commands:
+  - "[[validate-tests]]"
 summary: "Assemble Galaxy workflow test fixtures and assertions."
 references:
+  - kind: cli-command
+    ref: "[[validate-tests]]"
+    used_at: runtime
+    load: on-demand
+    mode: sidecar
+    evidence: corpus-observed
+    purpose: "Run the cheap static workflow-test validation and workflow-label cross-check before Planemo execution."
+    trigger: "After authoring or editing a Galaxy workflow test file and before Planemo invocation."
   - kind: schema
     ref: "[[tests-format]]"
     used_at: runtime
@@ -67,5 +77,6 @@ Stub. Replace with real Mold content per MOLD_SPEC once first walks are done.
 - **Test-format JSON Schema** — `@galaxy-tool-util/schema` exports `tests.schema.json` (auto-generated from `galaxy.tool_util_models.Tests`). Cast skill should ship the schema verbatim under `references/schemas/tests-format.schema.json` and validate every authored `-tests.yml` against it before any planemo invocation. See `docs/COMPILATION_PIPELINE.md` § *Schema artifacts in casts*.
 - **`validateTestsFile(yaml)`** — pure-JS schema validator from the same package. First gate in the inner authoring loop.
 - **`checkTestsAgainstWorkflow(workflow, tests)`** — pure-JS cross-checker that reports missing input/output labels and type mismatches between a `.ga` (or format2) workflow and its tests file. Catches the most common authoring failure (renamed output → broken test) without a full planemo run. Second gate in the inner loop. See [[planemo-asserts-idioms]] §6.
+- **`gxwf validate-tests <tests.yml> --workflow <workflow> --json`** — CLI form of the same static gates for cast skills that operate through subprocesses. See [[validate-tests]].
 - **`planemo workflow_test_init --from_invocation <id>`** — preferred bootstrap for new test files; reviewer convention. See [[planemo-asserts-idioms]] §7.
 - **`planemo workflow_test_on_invocation <tests.yml> <id>`** — fast assertion-iteration loop without re-running the workflow.

--- a/content/molds/nextflow-test-to-target-tests/eval.md
+++ b/content/molds/nextflow-test-to-target-tests/eval.md
@@ -1,0 +1,25 @@
+# nextflow-test-to-target-tests eval
+
+## Case: schema-valid translated test plan
+
+- check: deterministic
+- fixture: nf-core/bacass or minimal demo Nextflow summary containing nf-test profiles, params, input fixtures, expected outputs, and snapshot evidence.
+- expectation: emits a target test plan that validates against the handoff schema selected for Galaxy workflow tests.
+
+## Case: workflow cross-check compatibility
+
+- check: deterministic
+- fixture: translated Galaxy workflow test plan plus matching draft Galaxy workflow skeleton.
+- expectation: `checkTestsAgainstWorkflow` reports zero missing input labels, zero missing output labels, and no collection or datatype shape mismatches introduced by the translation.
+
+## Case: Planemo-runnable assertions
+
+- check: deterministic
+- fixture: translated tests materialized as Galaxy workflow tests for the demo or bacass cast.
+- expectation: Planemo can load the tests and run or lint them far enough to prove the assertions are syntactically valid for Galaxy workflow testing.
+
+## Case: nf-test snapshot fidelity
+
+- check: llm-judged
+- fixture: nf-test snapshot evidence covering outputs such as `succeeded_task_count`, `versions.yml`, stable named files, and directory outputs with ignore globs.
+- expectation: translated Planemo assertions exercise the same output intent using suitable assertions such as `has_text`, `has_n_lines`, `has_size`, stable-name checks, or tolerated omissions for intentionally unstable files.

--- a/content/molds/summarize-galaxy-tool/eval.md
+++ b/content/molds/summarize-galaxy-tool/eval.md
@@ -1,0 +1,19 @@
+# summarize-galaxy-tool eval
+
+## Case: FastQC simple wrapper
+
+- check: deterministic
+- fixture: chosen Galaxy tool input source for FastQC after the input-source decision is resolved.
+- expectation: emits a Galaxy tool summary that validates against the future `summary-galaxy-tool` schema and includes tool id, version, owner/source context, command shape, inputs, outputs, requirements, citations, and tests when present.
+
+## Case: bwa_mem2 conditional inputs
+
+- check: llm-judged
+- fixture: chosen Galaxy tool input source for a bwa_mem2 wrapper with conditional `when` branches.
+- expectation: reconstructs conditional parameter structure clearly enough for downstream step implementation to bind the correct branch-specific inputs without flattening away branch ownership.
+
+## Case: samtools_sort data-table reference
+
+- check: llm-judged
+- fixture: chosen Galaxy tool input source for a samtools_sort wrapper with data-table-backed parameters or reference-genome selection.
+- expectation: records data-table reference inputs, allowed fallback behavior, and unresolved runtime dependencies so downstream implementation can distinguish user parameters from Galaxy instance configuration.

--- a/content/molds/summarize-galaxy-tool/index.md
+++ b/content/molds/summarize-galaxy-tool/index.md
@@ -8,11 +8,19 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-04-30
-revision: 1
+revised: 2026-05-03
+revision: 3
 ai_generated: true
 summary: "Pull JSON schema, container, source, inputs/outputs for a Galaxy tool."
 references:
+  - kind: research
+    ref: "[[galaxy-tool-summary-input-source]]"
+    used_at: runtime
+    load: upfront
+    mode: verbatim
+    evidence: hypothesis
+    purpose: "Treat cached ParsedTool JSON from galaxy-tool-cache as the v1 input source for Galaxy tool summaries."
+    verification: "Summarize FastQC, bwa_mem2, and samtools_sort from cached ParsedTool JSON and confirm downstream step implementation can bind inputs and outputs."
   - kind: research
     ref: "[[component-tool-shed-search]]"
     used_at: runtime
@@ -24,4 +32,140 @@ references:
 ---
 # summarize-galaxy-tool
 
-Stub. Replace with real Mold content per MOLD_SPEC once first walks are done.
+Read a cached Galaxy `ParsedTool` object for an existing wrapper and emit a compact tool summary that downstream step implementation can bind to. This Mold runs after `[[discover-shed-tool]]` has selected a Tool Shed pin and after the caller has populated `galaxy-tool-cache` for that pin.
+
+This Mold owns the **wrapper summarization** step only. It does not search the Tool Shed, choose a version, author XML, or decide how a workflow step should use the wrapper. Its job is to preserve the wrapper's executable contract: identity, command shape, inputs, outputs, requirements, tests, and any conditional or data-table behavior that could affect binding.
+
+The v1 input-source decision is [[galaxy-tool-summary-input-source]]: read cached ParsedTool JSON, using raw XML only as supporting evidence when the cache object is lossy or ambiguous.
+
+## Inputs
+
+The Mold expects:
+
+- A Tool Shed pin from `[[discover-shed-tool]]`: `tool_shed_url`, `owner`, `repo`, `tool_id`, `version`, and `changeset_revision`.
+- A `galaxy-tool-cache` directory containing the cached ParsedTool JSON for that pin.
+- Optional raw XML source for ambiguity checks, normally fetched through cache metadata rather than treated as the primary input.
+- Optional step intent from the caller, used only to prioritize which wrapper details to explain; it must not change the wrapper facts.
+
+## Outputs
+
+A single JSON document conforming to the future `summary-galaxy-tool` schema. Sketch shape:
+
+```jsonc
+{
+  "source": {
+    "kind": "toolshed",
+    "tool_shed_url": "https://toolshed.g2.bx.psu.edu",
+    "owner": "devteam",
+    "repo": "fastqc",
+    "tool_id": "fastqc",
+    "version": "0.74+galaxy0",
+    "changeset_revision": "5ec9f6bceaee"
+  },
+  "tool": {
+    "id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.74+galaxy0",
+    "name": "FastQC",
+    "description": "Read quality reports",
+    "profile": "22.05",
+    "version_command": "fastqc --version"
+  },
+  "requirements": [
+    { "type": "package", "name": "fastqc", "version": "0.74" }
+  ],
+  "command": {
+    "template": "fastqc ...",
+    "strict_shell": true,
+    "stdio": [],
+    "environment": []
+  },
+  "inputs": [
+    { "name": "input_file", "type": "data", "format": ["fastq", "fastqsanger"], "optional": false }
+  ],
+  "outputs": [
+    { "name": "html_file", "type": "data", "format": "html", "from_work_dir": null }
+  ],
+  "conditionals": [],
+  "data_tables": [],
+  "tests": [],
+  "warnings": []
+}
+```
+
+Field-name parity with `summary-nextflow.tools[]` should be preserved where concepts match (`name`, `version`, container/package evidence), but Galaxy wrapper-specific structure belongs here rather than being forced into the Nextflow schema.
+
+## Procedure
+
+### 1. Load the cached wrapper
+
+Locate the ParsedTool JSON in the configured `galaxy-tool-cache` directory using the Tool Shed pin. Fail early if the cache entry is missing; do not silently re-search the Tool Shed.
+
+Confirm the cached identity matches the requested pin. If the cache exposes a tool id or version that conflicts with the pin, emit a hard failure rather than summarizing the wrong wrapper.
+
+### 2. Capture identity and provenance
+
+Populate `source` from the discovery pin and cache metadata. Populate `tool` from the parsed wrapper identity fields, not from the search hit. Search hits can omit version and changeset detail.
+
+Keep both forms when they differ:
+
+- Short XML `id` for human matching.
+- Fully qualified installed Tool Shed id for gxformat2 step binding.
+
+### 3. Extract executable requirements
+
+Read `<requirements>` into structured package/container requirements. Preserve requirement `type`, `name`, `version`, and any container URI or resolver hints exposed by the cache.
+
+Do not invent Bioconda equivalences here. Equivalence inference belongs to `[[author-galaxy-tool-wrapper]]` when authoring a new XML wrapper. Existing wrapper summaries report what the wrapper declares.
+
+### 4. Summarize command and failure behavior
+
+Preserve the command template enough for downstream binding to understand which inputs and parameters are consumed. Record strict-shell, stdio regexes, exit-code handling, environment variables, and dynamic output behavior when present.
+
+The command summary should be readable, but lossy prose is not enough. Keep template fragments and wrapper flags where they affect required inputs, output discovery, or runtime failure classification.
+
+### 5. Enumerate inputs
+
+For every wrapper input parameter, emit:
+
+- `name` and label/help text when available.
+- Parameter kind (`data`, `data_collection`, `select`, `integer`, `float`, `boolean`, `text`, conditional section, repeat, section).
+- Required/optional/default semantics.
+- Datatypes, collection types, and multiple-value behavior.
+- Select choices and dynamic options when statically available.
+- Data-table references separately from user-provided parameters.
+
+Nested conditionals must preserve branch ownership. Do not flatten `when` branches into independent parameters without recording the controlling selector and branch value.
+
+### 6. Enumerate outputs
+
+For every output and collection output, emit:
+
+- Output name, datatype, label, and `from_work_dir` or discovery rule when available.
+- Conditional output ownership.
+- Dynamic output collection shape and naming rules.
+- Relationship to input collections when the wrapper maps over or preserves identifiers.
+
+If output discovery depends on runtime filenames, record that as a warning for downstream test and debug Molds.
+
+### 7. Capture tests and citations
+
+Summarize wrapper tests into input fixture expectations, parameter settings, and output assertions. Do not treat wrapper tests as workflow tests; they are evidence about legal parameter combinations and output behavior.
+
+Preserve citations, help text, and upstream URLs when present because they help resolve ambiguous wrappers during review.
+
+### 8. Emit warnings
+
+Warnings should identify missing or lossy surfaces, especially:
+
+- ParsedTool JSON omits raw XML behavior that affects binding.
+- Conditional inputs cannot be reconstructed completely.
+- Dynamic data-table options require Galaxy instance configuration.
+- Output discovery is runtime-dependent.
+- Tests are absent or too thin to confirm key outputs.
+
+## Non-goals
+
+- **Tool discovery.** Use `[[discover-shed-tool]]` before this Mold.
+- **Wrapper authoring.** Use `[[author-galaxy-tool-wrapper]]` when no acceptable wrapper exists.
+- **Step implementation.** `[[implement-galaxy-tool-step]]` binds abstract workflow intent to this summary.
+- **Installed-Galaxy-only wrappers.** Deferred until a Galaxy API discovery/input path exists.
+- **Schema invention at runtime.** The generated skill should validate against `summary-galaxy-tool` once that schema is authored; until then, keep output shape close to this body and eval expectations.

--- a/content/research/component-tool-shed-search.md
+++ b/content/research/component-tool-shed-search.md
@@ -6,11 +6,12 @@ tags:
 component: "Tool Shed Search and Indexing"
 status: draft
 created: 2026-04-30
-revised: 2026-04-30
-revision: 1
+revised: 2026-05-03
+revision: 2
 ai_generated: true
 summary: "Tool Shed's Whoosh repo/tool search and partial GA4GH TRS v2, indexed from hg-walked metadata with no auto-refresh on upload"
 related_notes:
+  - "[[galaxy-tool-summary-input-source]]"
   - "[[tool-search]]"
   - "[[tool-versions]]"
   - "[[tool-revisions]]"

--- a/content/research/galaxy-data-flow-draft-contract.md
+++ b/content/research/galaxy-data-flow-draft-contract.md
@@ -7,10 +7,11 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-05-02
-revised: 2026-05-02
-revision: 1
+revised: 2026-05-03
+revision: 2
 ai_generated: true
 related_notes:
+  - "[[iwc-exemplar-runtime-discovery]]"
   - "[[nextflow-to-galaxy-channel-shape-mapping]]"
   - "[[nextflow-operators-to-galaxy-collection-recipes]]"
   - "[[iwc-nearest-exemplar-selection]]"

--- a/content/research/galaxy-tool-summary-input-source.md
+++ b/content/research/galaxy-tool-summary-input-source.md
@@ -1,0 +1,50 @@
+---
+type: research
+subtype: design-spec
+title: "Galaxy tool summary input source"
+tags:
+  - research/design-spec
+  - target/galaxy
+status: draft
+created: 2026-05-03
+revised: 2026-05-03
+revision: 2
+ai_generated: true
+related_notes:
+  - "[[component-tool-shed-search]]"
+related_molds:
+  - "[[discover-shed-tool]]"
+  - "[[summarize-galaxy-tool]]"
+summary: "Decides that summarize-galaxy-tool reads cached ParsedTool JSON as its v1 input source."
+---
+
+# Galaxy Tool Summary Input Source
+
+## Decision
+
+`summarize-galaxy-tool` reads `galaxy-tool-cache` ParsedTool JSON populated from the Tool Shed pin emitted by `discover-shed-tool`.
+
+The v1 handoff is:
+
+1. `discover-shed-tool` emits `(tool_shed_url, owner, repo, tool_id, version, changeset_revision)` plus confidence evidence.
+2. The harness or caller runs `galaxy-tool-cache add toolshed.g2.bx.psu.edu/repos/<owner>/<repo>/<tool_id> --version <version>` using the chosen pin.
+3. `summarize-galaxy-tool` loads the cached ParsedTool JSON and emits the Foundry-owned Galaxy tool summary schema once that schema exists.
+
+## Rationale
+
+This source is already implied by the discovery chain and avoids making `summarize-galaxy-tool` repeat Tool Shed search, version selection, or Mercurial materialization.
+
+ParsedTool JSON is better than raw XML as the primary input because it exposes a normalized parse surface for inputs, outputs, requirements, tests, and command/source metadata. Raw XML remains supporting evidence only when the parsed object is lossy or ambiguous.
+
+Galaxy API input is deferred. It is useful for installed-only tools and instance-local wrappers, but it changes the trust and availability model: the result depends on a configured Galaxy instance instead of the Tool Shed pin selected by `discover-shed-tool`.
+
+## Non-Goals
+
+- Do not summarize directly from a Tool Shed search hit; hits do not include enough version or changeset detail.
+- Do not make raw Tool Shed tarball XML the normal input; use it only to resolve ambiguity in the cached parse.
+- Do not support installed-Galaxy-only tools in v1; add a sibling discovery/input path when a pipeline needs it.
+
+## Open Work
+
+- Add `content/schemas/summary-galaxy-tool.schema.json` and a companion schema note.
+- Seed the `galaxy-tool-cache add` CLI manual page if Molds begin referencing it directly.

--- a/content/research/iwc-exemplar-runtime-discovery.md
+++ b/content/research/iwc-exemplar-runtime-discovery.md
@@ -1,0 +1,55 @@
+---
+type: research
+subtype: design-spec
+title: "IWC exemplar runtime discovery"
+tags:
+  - research/design-spec
+  - target/galaxy
+status: draft
+created: 2026-05-03
+revised: 2026-05-03
+revision: 1
+ai_generated: true
+related_notes:
+  - "[[iwc-nearest-exemplar-selection]]"
+  - "[[galaxy-data-flow-draft-contract]]"
+related_molds:
+  - "[[compare-against-iwc-exemplar]]"
+summary: "Resolves runtime IWC exemplar discovery through live IWC URLs plus gxwf processing."
+---
+
+# IWC Exemplar Runtime Discovery
+
+## Decision
+
+`compare-against-iwc-exemplar` discovers candidates at runtime from the live IWC GitHub tree, then uses `gxwf` to normalize fetched workflow files for structural comparison.
+
+The v1 procedure is:
+
+1. Load draft features from the data-flow/template handoff: domain intent, input topology, tool families, DAG motifs, output/report shape, and test hints.
+2. Query the IWC GitHub tree or contents API under `https://github.com/galaxyproject/iwc/tree/main/workflows/` for candidate workflow paths.
+3. Narrow candidates by path/domain keywords first, then by fetched workflow labels, input types, output labels, and tool ids.
+4. Fetch only the ranked candidate workflows as URLs.
+5. Normalize each fetched workflow with `gxwf` into the comparison representation needed by the Mold.
+6. Rank with `[[iwc-nearest-exemplar-selection]]` and emit one nearest exemplar plus weak alternates when useful.
+
+The caller may provide a local IWC path as an override for offline development, but cast artifacts must not depend on Foundry `workflow-fixtures/` or a bundled exemplar index.
+
+## Rationale
+
+This keeps IWC as a cited external corpus instead of a mirrored Foundry runtime dependency. It also avoids a pre-cast index that can drift from IWC before the generated skill runs.
+
+`gxwf` is the normalizer, not the retriever of record. GitHub URLs remain the durable provenance surface; `gxwf` turns selected candidates into comparable structure after retrieval.
+
+## Rejected Options
+
+- Foundry-hosted pre-cast exemplar index: faster, but violates the URL-not-mirror posture and creates drift.
+- Generated fixtures under `workflow-fixtures/`: useful for research evidence, not runtime cast artifacts.
+- Mandatory user-supplied path: good fallback, but too manual for default harness behavior.
+- Pure `gxwf` listing without IWC URL provenance: hides the corpus source and makes citation weaker.
+
+## Open Work
+
+- Specify the structural-diff JSON schema.
+- Decide whether the output schema requires one nearest exemplar or a ranked list.
+- Add CLI manual pages if the exact `gxwf` normalization commands become Mold references.

--- a/content/research/iwc-nearest-exemplar-selection.md
+++ b/content/research/iwc-nearest-exemplar-selection.md
@@ -7,10 +7,11 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-05-02
-revised: 2026-05-02
-revision: 1
+revised: 2026-05-03
+revision: 2
 ai_generated: true
 related_notes:
+  - "[[iwc-exemplar-runtime-discovery]]"
   - "[[galaxy-data-flow-draft-contract]]"
   - "[[iwc-transformations-survey]]"
   - "[[iwc-tabular-operations-survey]]"
@@ -80,9 +81,13 @@ Use `$IWC_FORMAT2/...` for parameter-level evidence and exact `tool_state`. Use 
 - [[compare-against-iwc-exemplar]] should use this as the selection procedure for finding and ranking exemplar candidates.
 - [[summary-to-galaxy-template]] should use this on demand when a skeleton is mature enough to pick comparison targets.
 
+## Runtime Discovery
+
+The default runtime discovery mechanism is defined by [[iwc-exemplar-runtime-discovery]]: live IWC GitHub URLs for retrieval and provenance, with `gxwf` used to normalize selected workflows for structural comparison.
+
 ## TODOs
 
 - Decide whether exemplar comparison should emit one nearest workflow or two to three ranked exemplars.
 - Decide whether confidence should be a single label or a per-axis vector.
 - Decide whether output schema should require source URL plus local fixture citation pairs.
-- Decide whether runtime retrieval uses local fixtures, live IWC listings, `gxwf`, or a user-supplied corpus path.
+- Specify the exact `gxwf` normalization command sequence once CLI manual pages cover it.

--- a/content/research/planemo-asserts-idioms.md
+++ b/content/research/planemo-asserts-idioms.md
@@ -7,7 +7,7 @@ tags:
 status: draft
 created: 2026-04-30
 revised: 2026-05-02
-revision: 2
+revision: 3
 ai_generated: true
 related_notes:
   - "[[iwc-test-data-conventions]]"
@@ -15,6 +15,7 @@ related_notes:
   - "[[implement-galaxy-workflow-test]]"
   - "[[tests-format]]"
   - "[[planemo-workflow-test-architecture]]"
+  - "[[validate-tests]]"
 summary: "Decision and idiom guide for picking planemo workflow-test assertions: which family per output type, how to size tolerances, when to validate."
 ---
 

--- a/content/schemas/tests-format.md
+++ b/content/schemas/tests-format.md
@@ -11,13 +11,14 @@ tags:
 status: draft
 created: 2026-04-30
 revised: 2026-04-30
-revision: 1
+revision: 2
 ai_generated: true
 related_notes:
   - "[[implement-galaxy-workflow-test]]"
   - "[[planemo-asserts-idioms]]"
   - "[[iwc-test-data-conventions]]"
   - "[[iwc-shortcuts-anti-patterns]]"
+  - "[[validate-tests]]"
 summary: "JSON Schema for the planemo workflow test format (`<workflow>-tests.yml`), vendored from `@galaxy-tool-util/schema`."
 ---
 

--- a/docs/CLI_META_INTEGRATION.md
+++ b/docs/CLI_META_INTEGRATION.md
@@ -1,9 +1,10 @@
 # CLI metadata integration
 
-**Status: ready for Foundry activation.** The upstream CLI metadata work has landed in
-`@galaxy-tool-util/cli` 1.1.0. The Foundry site has the empty registry and renderer shape in
-place; the remaining work is to add the package dependency, populate the registry, and convert the
-first CLI note.
+**Status: Foundry adapter wired; blocked on a follow-up package release.** The local
+`galaxy-tool-util-ts` worktree exposes `@galaxy-tool-util/cli/meta`, but the published
+`@galaxy-tool-util/cli` 1.1.0 package does not export the `./meta` subpath or ship `spec/` files.
+Foundry now pins the package and attempts to load the metadata subpath at site build time. Until a
+release exposes it, the registry remains empty and CLI notes render from their markdown bodies.
 
 ## Goal
 
@@ -20,48 +21,30 @@ The data side is now available upstream:
 
 - [galaxy-tool-util-ts#86](https://github.com/jmchilton/galaxy-tool-util-ts/pull/86) merged on 2026-05-01 and inverted the CLI source of truth so specs drive Commander.
 - [galaxy-tool-util-ts#87](https://github.com/jmchilton/galaxy-tool-util-ts/issues/87) closed with the same change.
-- `@galaxy-tool-util/cli` 1.1.0 is published with the metadata subpath.
+- `@galaxy-tool-util/cli` 1.1.0 is published, but its `exports` only include `.`. It does not expose `./meta` yet.
 
 This document is now an activation checklist for the Foundry repo, not an upstream tracking note.
 
 ## What's already in place
 
-- `site/src/lib/cli-registry.ts` — empty registry with the typed shape `CliCommandView` ready to receive data.
+- `site/src/lib/cli-registry.ts` — registry loader with the typed shape `CliCommandView`. It dynamically imports `@galaxy-tool-util/cli/meta` and falls back to `{}` when the package release does not expose that subpath.
 - `site/src/components/CliCommandBody.astro` — upgraded to render synopsis / args / options / defaults / negatable / per-option anchor IDs from the registry. Falls back to "no metadata registered" banner + raw markdown body when the entry is absent, so the existing prose stubs (`content/cli/gxwf/tool-search.md`, etc.) keep rendering on `main` and on this branch.
+- `site/src/lib/package-version.ts` — shared package-version lookup used by schema and CLI registries.
 
 ## Activation checklist
 
-1. **Pin the package.** Add `"@galaxy-tool-util/cli": "^1.1.0"` to `site/package.json`. Run the site package manager and commit the lockfile change.
-2. **Populate the registry.** In `site/src/lib/cli-registry.ts`:
-   ```ts
-   import { gxwfCliMeta, galaxyToolCacheCliMeta } from '@galaxy-tool-util/cli/meta';
-
-   function indexProgram(program: CliProgramSpec, pkg: string, version: string): Record<string, CliRegistryEntry> {
-     const out: Record<string, CliRegistryEntry> = {};
-     for (const c of program.commands) {
-       out[`${program.name}/${c.name}`] = { command: c, package: pkg, version };
-     }
-     return out;
-   }
-
-   const version = readVendoredPackageVersion('@galaxy-tool-util/cli'); // copy helper from schema-registry.ts
-   export const cliRegistry: Record<string, CliRegistryEntry> = {
-     ...indexProgram(gxwfCliMeta, '@galaxy-tool-util/cli', version),
-     ...indexProgram(galaxyToolCacheCliMeta, '@galaxy-tool-util/cli', version),
-   };
-   ```
-   Lift `readVendoredPackageVersion` into a shared module (`site/src/lib/vendored-version.ts`) so schema-registry and cli-registry both use it — currently lives only in schema-registry.
+1. **Publish/export upstream metadata.** Release a package where `@galaxy-tool-util/cli/package.json` exports `./meta` and includes the built metadata files.
+2. **Verify activation.** Run the site build and confirm `cliRegistry` contains `gxwf/validate`, `gxwf/validate-tests`, and the Tool Shed discovery commands.
 3. **Convert one note end-to-end as the proof.** Pick `content/cli/gxwf/tool-revisions.md` (richest existing prose; best stress test). Drop the Synopsis / Options / Exit codes tables, keep the framing prose and the *Gotchas* / *Pairs with* sections — those are the parts the registry can't carry. Add `package` and `upstream` frontmatter fields to mirror `tests-format.md`.
-4. **Decide on `package` / `upstream` frontmatter for cli-command.** Add to `meta_schema.yml` under the cli-command branch (these fields exist already for the `schema` type — same semantics, copy the property declarations).
-5. **Convert remaining notes.** `tool-search.md`, `tool-versions.md`. Replace synopsis/option tables with framing-only bodies.
-6. **Seed missing notes.** The walked metadata covers the full surface (gxwf has 19 commands, galaxy-tool-cache has 7); only 3 have framing notes today. Decide policy: framing note required for every command? Or only for commands a Mold references? Probably the latter — Mold-referenced commands get framing notes, the rest are reachable via a per-program index page that lists every registered command (parallel to `tests-format`'s "All definitions" nav).
-7. **Update `docs/COMPILATION_PIPELINE.md`.** The cli-command row already says "Cast to structured JSON sidecar"; clarify that the sidecar is now sourced from the registry rather than parsed from the markdown body.
-8. **Drift safety.** Once notes are converted, add a validator check: cli-command notes whose `<tool>/<command>` doesn't appear in `cliRegistry` should warn (or error). Catches typos and removed-upstream commands.
+4. **Decide on `package` / `upstream` frontmatter for cli-command.** The properties already exist globally in `meta_schema.yml`; decide whether CLI notes should require them once converted.
+5. **Convert remaining notes.** `validate.md`, `validate-tests.md`, `tool-search.md`, `tool-versions.md`. Replace synopsis/option tables with framing-only bodies after registry-backed rendering is visible.
+6. **Seed missing notes.** The metadata should cover the full surface; only Mold-referenced commands need framing notes in `content/cli/` unless a whole-program index page lands.
+7. **Update `docs/COMPILATION_PIPELINE.md`.** The cli-command row already says "Cast to structured JSON sidecar"; clarify that the sidecar is sourced from registry metadata plus markdown framing, not parsed from markdown tables.
+8. **Drift safety.** Once notes are converted, add a validator check: cli-command notes whose `<tool>/<command>` doesn't appear in loaded package metadata should warn (or error). Catches typos and removed-upstream commands.
 
 ## Things deliberately left out so far
 
-- No `package.json` change. This can now land because `@galaxy-tool-util/cli` 1.1.0 is published.
-- No note conversions. Without the registry populated, converting a note loses the option tables on render. The conversions land in the activation PR alongside the registry data.
+- No note conversions. Without the registry populated from a published metadata subpath, converting a note loses the option tables on render. The conversions land after upstream package activation.
 - No new `meta_schema.yml` fields. They land with the first note conversion so the schema change is reviewed against an example.
 
 ## Risks to track

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "vitest": "^2.1.0"
   },
   "dependencies": {
+    "@galaxy-tool-util/cli": "^1.1.0",
     "@galaxy-tool-util/schema": "^1.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@galaxy-tool-util/cli':
+        specifier: ^1.1.0
+        version: 1.1.0
       '@galaxy-tool-util/schema':
         specifier: ^1.1.0
         version: 1.1.0
@@ -499,8 +502,18 @@ packages:
     resolution: {integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  '@galaxy-tool-util/cli@1.1.0':
+    resolution: {integrity: sha512-eTOR1uzm5tM3wyf2C3PTZMGEy3BVEkhtsMRUkrvnM2I/qub/XZcK64GVqwq0O6SFM5cBL8kBOLAXCcVzQB5frA==}
+    hasBin: true
+
+  '@galaxy-tool-util/core@1.1.0':
+    resolution: {integrity: sha512-aOCt4s3bW8OYRrt2JPjtkS8pn2yTPJy86eED6lh3Nfy/KaFWMDUcXBjTm+5/7BgmcfW9x/d/6FVazsekH07OVg==}
+
   '@galaxy-tool-util/schema@1.1.0':
     resolution: {integrity: sha512-D0dMtBaTyRJhoAxH1Djx/42WnxQDAk3yuMhTd3k+MCez1jiGL1kFeYDQEk8yWSgY5Z4d+u24wbhaWG4Q2GTG1w==}
+
+  '@galaxy-tool-util/search@1.1.0':
+    resolution: {integrity: sha512-VSLDCUE68u/2+zKWH8J+wf0N080vOUDJd/nVFr5v7F81TJURjdC4oHRsl2YYs2Uwb8JkpWIvs9EAbtSB2rzF2g==}
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -799,6 +812,9 @@ packages:
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
+  a-sync-waterfall@1.0.1:
+    resolution: {integrity: sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -841,6 +857,9 @@ packages:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
 
+  asap@2.0.6:
+    resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -879,6 +898,14 @@ packages:
   commander@12.1.0:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
+
+  commander@5.1.0:
+    resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
+    engines: {node: '>= 6'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1222,6 +1249,16 @@ packages:
       encoding: ^0.1.0
     peerDependenciesMeta:
       encoding:
+        optional: true
+
+  nunjucks@3.2.4:
+    resolution: {integrity: sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==}
+    engines: {node: '>= 6.9.0'}
+    hasBin: true
+    peerDependencies:
+      chokidar: ^3.3.0
+    peerDependenciesMeta:
+      chokidar:
         optional: true
 
   optionator@0.9.4:
@@ -1916,12 +1953,36 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
+  '@galaxy-tool-util/cli@1.1.0':
+    dependencies:
+      '@galaxy-tool-util/core': 1.1.0
+      '@galaxy-tool-util/schema': 1.1.0
+      '@galaxy-tool-util/search': 1.1.0
+      ajv: 8.20.0
+      commander: 14.0.3
+      effect: 3.21.2
+      nunjucks: 3.2.4
+      yaml: 2.8.3
+    transitivePeerDependencies:
+      - chokidar
+
+  '@galaxy-tool-util/core@1.1.0':
+    dependencies:
+      '@galaxy-tool-util/schema': 1.1.0
+      effect: 3.21.2
+      yaml: 2.8.3
+
   '@galaxy-tool-util/schema@1.1.0':
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       effect: 3.21.2
       yaml: 2.8.3
+
+  '@galaxy-tool-util/search@1.1.0':
+    dependencies:
+      '@galaxy-tool-util/core': 1.1.0
+      '@galaxy-tool-util/schema': 1.1.0
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -2198,6 +2259,8 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 1.2.0
 
+  a-sync-waterfall@1.0.1: {}
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -2234,6 +2297,8 @@ snapshots:
 
   array-union@2.1.0: {}
 
+  asap@2.0.6: {}
+
   assertion-error@2.0.1: {}
 
   balanced-match@4.0.4: {}
@@ -2265,6 +2330,10 @@ snapshots:
   check-error@2.1.3: {}
 
   commander@12.1.0: {}
+
+  commander@14.0.3: {}
+
+  commander@5.1.0: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -2635,6 +2704,12 @@ snapshots:
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+
+  nunjucks@3.2.4:
+    dependencies:
+      a-sync-waterfall: 1.0.1
+      asap: 2.0.6
+      commander: 5.1.0
 
   optionator@0.9.4:
     dependencies:

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@fontsource/atkinson-hyperlegible": "^5.2.8",
+        "@galaxy-tool-util/cli": "^1.1.0",
         "@galaxy-tool-util/schema": "^1.1.0",
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.1.18",
@@ -612,6 +613,80 @@
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
+    "node_modules/@galaxy-tool-util/cli": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@galaxy-tool-util/cli/-/cli-1.1.0.tgz",
+      "integrity": "sha512-eTOR1uzm5tM3wyf2C3PTZMGEy3BVEkhtsMRUkrvnM2I/qub/XZcK64GVqwq0O6SFM5cBL8kBOLAXCcVzQB5frA==",
+      "license": "MIT",
+      "dependencies": {
+        "@galaxy-tool-util/core": "1.1.0",
+        "@galaxy-tool-util/schema": "1.1.0",
+        "@galaxy-tool-util/search": "1.1.0",
+        "ajv": "^8.18.0",
+        "commander": "^14.0.0",
+        "effect": "^3.21.0",
+        "nunjucks": "^3.2.4",
+        "yaml": "^2.8.3"
+      },
+      "bin": {
+        "galaxy-tool-cache": "dist/bin/galaxy-tool-cache.js",
+        "gxwf": "dist/bin/gxwf.js"
+      }
+    },
+    "node_modules/@galaxy-tool-util/cli/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@galaxy-tool-util/cli/node_modules/nunjucks": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.4.tgz",
+      "integrity": "sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "a-sync-waterfall": "^1.0.0",
+        "asap": "^2.0.3",
+        "commander": "^5.1.0"
+      },
+      "bin": {
+        "nunjucks-precompile": "bin/precompile"
+      },
+      "engines": {
+        "node": ">= 6.9.0"
+      },
+      "peerDependencies": {
+        "chokidar": "^3.3.0"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@galaxy-tool-util/cli/node_modules/nunjucks/node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@galaxy-tool-util/core": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@galaxy-tool-util/core/-/core-1.1.0.tgz",
+      "integrity": "sha512-aOCt4s3bW8OYRrt2JPjtkS8pn2yTPJy86eED6lh3Nfy/KaFWMDUcXBjTm+5/7BgmcfW9x/d/6FVazsekH07OVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@galaxy-tool-util/schema": "1.1.0",
+        "effect": "^3.21.0",
+        "yaml": "^2.8.3"
+      }
+    },
     "node_modules/@galaxy-tool-util/schema": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@galaxy-tool-util/schema/-/schema-1.1.0.tgz",
@@ -622,6 +697,16 @@
         "ajv-formats": "^3.0.1",
         "effect": "^3.21.0",
         "yaml": "^2.8.3"
+      }
+    },
+    "node_modules/@galaxy-tool-util/search": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@galaxy-tool-util/search/-/search-1.1.0.tgz",
+      "integrity": "sha512-VSLDCUE68u/2+zKWH8J+wf0N080vOUDJd/nVFr5v7F81TJURjdC4oHRsl2YYs2Uwb8JkpWIvs9EAbtSB2rzF2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@galaxy-tool-util/core": "1.1.0",
+        "@galaxy-tool-util/schema": "1.1.0"
       }
     },
     "node_modules/@img/colour": {
@@ -2317,6 +2402,12 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
     },
+    "node_modules/a-sync-waterfall": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
+      "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2485,6 +2576,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "license": "MIT"
     },
     "node_modules/astro": {
       "version": "5.18.1",

--- a/site/package.json
+++ b/site/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@fontsource/atkinson-hyperlegible": "^5.2.8",
+    "@galaxy-tool-util/cli": "^1.1.0",
     "@galaxy-tool-util/schema": "^1.1.0",
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.1.18",
@@ -23,8 +24,8 @@
     "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {
-    "@types/mdast": "^4.0.4",
     "@types/js-yaml": "^4.0.9",
+    "@types/mdast": "^4.0.4",
     "astro-pagefind": "^1.8.6",
     "pagefind": "^1.5.2"
   }

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -129,6 +129,7 @@ const schemaNoteSchema = z.object({
   title: z.string(),
   package: z.string().optional(),
   upstream: z.string().optional(),
+  package_export: z.string().optional(),
   ...baseFields,
 }).strict();
 

--- a/site/src/lib/cli-registry.ts
+++ b/site/src/lib/cli-registry.ts
@@ -1,19 +1,8 @@
 // Registry of CLI command metadata, keyed by `<tool>/<command>`.
-//
-// Mirrors `schema-registry.ts`: in-repo CLI command notes are thin
-// framing stubs; the structured data (synopsis, args, options,
-// defaults) lives in the upstream package's `meta` subpath and is
-// wired in here for the `CliCommandBody.astro` component to render.
-//
-// STATUS: ready for activation. `@galaxy-tool-util/cli` now ships metadata;
-// the registry stays empty until the site pins the package and wires the
-// imports. See `docs/CLI_META_INTEGRATION.md` for the activation checklist.
-//
-// Once activated:
-//   import { gxwfCliMeta, galaxyToolCacheCliMeta } from '@galaxy-tool-util/cli/meta';
-//   const gxwf = Object.fromEntries(
-//     gxwfCliMeta.commands.map(c => [`gxwf/${c.name}`, { command: c, ... }])
-//   );
+// Mirrors `schema-registry.ts`: in-repo CLI command notes are framing stubs;
+// synopsis, args, options, and defaults come from upstream package metadata.
+
+import { readInstalledPackageVersion } from './package-version';
 
 export interface CliCommandOption {
   flags: string;
@@ -54,6 +43,64 @@ export interface CliRegistryEntry {
   upstream?: string;
 }
 
-// Keyed by `<tool>/<command>`, e.g. `gxwf/validate`, `galaxy-tool-cache/add`.
-// Empty until activation — see docs/CLI_META_INTEGRATION.md.
-export const cliRegistry: Record<string, CliRegistryEntry> = {};
+export interface CliProgramView {
+  name: string;
+  description: string;
+  version?: string;
+  commands: CliCommandView[];
+}
+
+interface CliMetaModule {
+  gxwfCliMeta?: CliProgramView;
+  galaxyToolCacheCliMeta?: CliProgramView;
+}
+
+export function indexProgram(
+  program: CliProgramView,
+  packageName: string,
+  packageVersion: string,
+  upstream?: string,
+): Record<string, CliRegistryEntry> {
+  const out: Record<string, CliRegistryEntry> = {};
+  for (const command of program.commands) {
+    out[`${program.name}/${command.name}`] = {
+      command,
+      package: packageName,
+      version: packageVersion,
+      upstream,
+    };
+  }
+  return out;
+}
+
+export async function loadCliRegistry(): Promise<Record<string, CliRegistryEntry>> {
+  const packageName = '@galaxy-tool-util/cli';
+  const packageVersion = readInstalledPackageVersion(packageName);
+  try {
+    const spec = `${packageName}/meta`;
+    const meta = (await import(/* @vite-ignore */ spec)) as CliMetaModule;
+    return {
+      ...(meta.gxwfCliMeta
+        ? indexProgram(
+            meta.gxwfCliMeta,
+            packageName,
+            packageVersion,
+            'https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/gxwf.json',
+          )
+        : {}),
+      ...(meta.galaxyToolCacheCliMeta
+        ? indexProgram(
+            meta.galaxyToolCacheCliMeta,
+            packageName,
+            packageVersion,
+            'https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/galaxy-tool-cache.json',
+          )
+        : {}),
+    };
+  } catch {
+    // Published 1.1.0 lacks the meta subpath; keep raw markdown pages rendering.
+    return {};
+  }
+}
+
+export const cliRegistry: Record<string, CliRegistryEntry> = await loadCliRegistry();

--- a/site/src/lib/package-version.ts
+++ b/site/src/lib/package-version.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export function readInstalledPackageVersion(packageName: string): string {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    let dir = here;
+    for (let i = 0; i < 8; i++) {
+      const candidate = resolve(dir, 'node_modules', packageName, 'package.json');
+      try {
+        const pkg = JSON.parse(readFileSync(candidate, 'utf-8')) as { version?: string };
+        if (pkg.version) return pkg.version;
+      } catch {
+        // Try parent.
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  } catch {
+    // Fall through.
+  }
+  return '';
+}

--- a/site/src/lib/schema-registry.ts
+++ b/site/src/lib/schema-registry.ts
@@ -3,37 +3,10 @@
 //
 // Each entry: { schema: <JSON Schema object>, version: <package version string> }.
 
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { dirname, resolve } from 'node:path';
 import { testsSchema } from '@galaxy-tool-util/schema';
 import summaryNextflowSchema from '../../../content/schemas/summary-nextflow.schema.json';
 import summaryNextflowSchemaPkg from '../../../packages/summary-nextflow-schema/package.json';
-
-// For schemas vendored from external npm packages (e.g. `@galaxy-tool-util/schema`),
-// the published `exports` field doesn't expose `package.json`, so we read the
-// version by walking node_modules. Lockfile-pinning makes the on-disk path stable.
-// Foundry-authored schemas shipped from this monorepo (e.g. summary-nextflow) read
-// the version directly from the workspace package.json instead.
-function readVendoredPackageVersion(packageName: string): string {
-  try {
-    const here = dirname(fileURLToPath(import.meta.url));
-    // here is .../site/src/lib (dev) or .../site/dist/... (build) — walk up
-    // until we hit a directory that has node_modules/<package>.
-    let dir = here;
-    for (let i = 0; i < 6; i++) {
-      const candidate = resolve(dir, 'node_modules', packageName, 'package.json');
-      try {
-        const pkg = JSON.parse(readFileSync(candidate, 'utf-8')) as { version?: string };
-        if (pkg.version) return pkg.version;
-      } catch { /* try parent */ }
-      const parent = dirname(dir);
-      if (parent === dir) break;
-      dir = parent;
-    }
-  } catch { /* fall through */ }
-  return '';
-}
+import { readInstalledPackageVersion } from './package-version';
 
 export interface SchemaEntry {
   schema: Record<string, unknown>;
@@ -43,7 +16,7 @@ export interface SchemaEntry {
 export const schemaRegistry: Record<string, SchemaEntry> = {
   'tests-format': {
     schema: testsSchema as unknown as Record<string, unknown>,
-    version: readVendoredPackageVersion('@galaxy-tool-util/schema'),
+    version: readInstalledPackageVersion('@galaxy-tool-util/schema'),
   },
   'summary-nextflow': {
     schema: summaryNextflowSchema as unknown as Record<string, unknown>,

--- a/tests/cli-registry.test.ts
+++ b/tests/cli-registry.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { indexProgram, loadCliRegistry, type CliProgramView } from "../site/src/lib/cli-registry";
+
+describe("cli metadata registry", () => {
+  it("indexes commands by tool and command name", () => {
+    const program: CliProgramView = {
+      name: "gxwf",
+      description: "Galaxy workflow operations",
+      commands: [
+        {
+          name: "validate",
+          fullName: "gxwf validate",
+          description: "Validate Galaxy workflow files",
+          synopsis: "gxwf validate [options] <file>",
+          args: [{ raw: "file", name: "file", required: true, variadic: false }],
+          options: [
+            {
+              flags: "--json",
+              name: "json",
+              description: "Output structured JSON report",
+              takesArgument: false,
+              optionalArgument: false,
+              negatable: false,
+            },
+          ],
+        },
+      ],
+    };
+
+    const registry = indexProgram(program, "@galaxy-tool-util/cli", "1.2.3", "https://example.test/spec.json");
+
+    expect(Object.keys(registry)).toEqual(["gxwf/validate"]);
+    expect(registry["gxwf/validate"]?.command.synopsis).toBe("gxwf validate [options] <file>");
+    expect(registry["gxwf/validate"]?.package).toBe("@galaxy-tool-util/cli");
+    expect(registry["gxwf/validate"]?.version).toBe("1.2.3");
+  });
+
+  it("tolerates package releases without the metadata subpath", async () => {
+    const registry = await loadCliRegistry();
+    expect(registry).toBeTypeOf("object");
+  });
+});


### PR DESCRIPTION
## Summary
- Wire gxwf CLI metadata fallback and add validate-tests reference plumbing for workflow-test validation surfaces.
- Add eval plans for five thin Galaxy/Nextflow-to-Galaxy Molds to make pass criteria explicit.
- Resolve two blocker decisions for Galaxy tool summaries and IWC exemplar discovery, then replace the unblocked Mold body stubs.

## Validation
- npm run validate