### PR TITLE
Fix summarize-nextflow process discovery for ad-hoc layouts

### DIFF
--- a/content/molds/summarize-nextflow/eval.md
+++ b/content/molds/summarize-nextflow/eval.md
@@ -40,11 +40,48 @@ Fixtures are pinned in `workflow-fixtures/fixtures.yaml`; materialize with
 
 - bucket: fidelity
 - check: deterministic
-- fixture: each pipeline above; ground truth from a shell grep over
-  `main.nf`, `workflows/`, `modules/**`, `subworkflows/**`.
-- expectation: `processes[].length` matches the corpus-observed count
-  modulo aliases (aliases are merged into a single `processes[]` entry
-  with the imports recorded under `aliases[]`).
+- fixture: each tier-tagged fixture in `workflow-fixtures/fixtures.yaml`; ground truth from
+  `grep -c '^process ' <every .nf file>` after excluding generated/vendor dirs
+  (`.git/`, `work/`, `.nextflow/`, known vendored submodules).
+- expectation: `processes[].length` is at least 80% of grep ground truth and
+  ideally exact modulo comments/false-positive grep matches; aliases are merged
+  into a single `processes[]` entry with the imports recorded under `aliases[]`.
+
+## Case: process discovery is layout-agnostic
+
+- bucket: fidelity
+- check: deterministic
+- fixture: every ad-hoc DSL2 fixture in `workflow-fixtures/fixtures.yaml`.
+- expectation: CLI emits non-empty `processes[]` for layouts with root-level
+  `modules.nf`, flat `modules/<name>.nf`, processes inline in `main.nf`, and
+  process files under `workflows/`, `lib/`, or `modules/local/`; no fixture
+  silently succeeds with zero processes when grep sees process blocks. Synthetic
+  package regressions should assert exact counts for each layout class; corpus
+  runs use the 80% threshold above to tolerate grep false positives.
+
+## Case: multi-process-per-file
+
+- bucket: fidelity
+- check: deterministic
+- fixture: `workflow-fixtures/pipelines/CRG-CNAG__CalliNGS-NF`.
+- expectation: summary has 11 `processes[]` entries from root `modules.nf`.
+
+## Case: pipeline-root auto-detect
+
+- bucket: fidelity
+- check: deterministic
+- fixture: `workflow-fixtures/pipelines/biocorecrg__MOP2` and
+  `workflow-fixtures/pipelines/ncbi__egapx`.
+- expectation: CLI exits 0 from the repository root; `warnings[]` surfaces the
+  auto-detected pipeline root so a wrong-root choice is reviewable.
+
+## Case: non-main entrypoint detection
+
+- bucket: fidelity
+- check: deterministic
+- fixture: `workflow-fixtures/pipelines/replikation__What_the_Phage`.
+- expectation: summary exits 0 and `warnings[]` names `phage.nf` as the chosen
+  entrypoint instead of requiring a literal `main.nf`.
 
 ## Case: alias sweep on bacass
 

--- a/packages/summarize-nextflow/src/resolver.ts
+++ b/packages/summarize-nextflow/src/resolver.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
-import { basename, dirname, join, relative, resolve } from "node:path";
+import { basename, dirname, join, relative, resolve, sep } from "node:path";
 import YAML from "yaml";
 
 interface Summary {
@@ -124,15 +124,14 @@ export async function resolveNextflowSummary(
   pipelineRoot: string,
   options: ResolveOptions,
 ): Promise<Summary> {
-  if (!existsSync(join(pipelineRoot, "nextflow.config"))) {
-    throw new Error(`not a Nextflow pipeline root: ${pipelineRoot}`);
-  }
+  const root = detectPipelineRoot(pipelineRoot);
+  pipelineRoot = root.path;
 
-  const config = readText(join(pipelineRoot, "nextflow.config"));
+  const configPath = join(pipelineRoot, "nextflow.config");
+  const config = existsSync(configPath) ? readText(configPath) : "";
   const workflowName = parseWorkflowName(config);
-  const processes = discoverProcessFiles(pipelineRoot).map((path) =>
-    parseProcessFile(pipelineRoot, path),
-  );
+  const processFiles = discoverProcessFiles(pipelineRoot);
+  const processes = processFiles.flatMap((path) => parseProcessFile(pipelineRoot, path));
   const aliases = discoverProcessAliases(pipelineRoot);
   const tools = buildTools(pipelineRoot, processes);
   const workflows = parseWorkflows(
@@ -176,8 +175,11 @@ export async function resolveNextflowSummary(
     },
     test_fixtures: parseTestFixtures(pipelineRoot, options.profile),
     nf_tests: parseNfTests(pipelineRoot),
-    warnings,
+    warnings: [...root.warnings, ...warnings],
   };
+
+  const entrypoint = selectEntrypoint(pipelineRoot);
+  if (entrypoint) summary.warnings.push(`selected Nextflow entrypoint: ${entrypoint}`);
 
   if (options.withNextflow) mergeNextflowInspect(summary, pipelineRoot, options.profile);
   if (options.fetchTestData) await fetchTestData(summary, options.testDataDir);
@@ -186,7 +188,7 @@ export async function resolveNextflowSummary(
 
 function buildWarnings(processes: Process[], workflows: ParsedWorkflow[]): string[] {
   const warnings = ["workflow graph extraction is intentionally partial in resolver v1"];
-  if (processes.length === 0) {
+  if (!processes.some((process) => process.module_path.startsWith(`modules${sep}`))) {
     warnings.push(
       "no module process files found under modules/; process extraction may be incomplete",
     );
@@ -303,45 +305,154 @@ function parseParams(pipelineRoot: string): Param[] {
   return [...params.values()];
 }
 
-function discoverProcessFiles(pipelineRoot: string): string[] {
-  return walk(join(pipelineRoot, "modules")).filter((path) => basename(path) === "main.nf");
+function detectPipelineRoot(path: string): { path: string; warnings: string[] } {
+  const requestedRoot = resolve(path);
+  if (existsSync(join(requestedRoot, "nextflow.config"))) {
+    return { path: requestedRoot, warnings: [] };
+  }
+
+  const configRoots = walk(requestedRoot, { maxDepth: 2 })
+    .filter((candidate) => basename(candidate) === "nextflow.config")
+    .map(dirname)
+    .sort((left, right) =>
+      relative(requestedRoot, left).localeCompare(relative(requestedRoot, right)),
+    );
+  if (configRoots[0]) {
+    const sharedProcessFiles = discoverProcessFiles(requestedRoot).filter(
+      (path) => !configRoots.some((configRoot) => path.startsWith(`${configRoot}${sep}`)),
+    );
+    if (sharedProcessFiles.length > 0) {
+      return {
+        path: requestedRoot,
+        warnings: [
+          `detected child Nextflow configs but kept repository root because shared process files exist outside child roots`,
+          `multiple Nextflow pipeline roots found; selected .`,
+        ],
+      };
+    }
+
+    const warnings = [
+      `auto-detected Nextflow pipeline root: ${relative(requestedRoot, configRoots[0]) || "."}`,
+    ];
+    if (configRoots.length > 1) {
+      warnings.push(
+        `multiple Nextflow pipeline roots found; selected ${relative(requestedRoot, configRoots[0]) || "."}`,
+      );
+    }
+    return {
+      path: configRoots[0],
+      warnings,
+    };
+  }
+
+  const workflowFiles = walk(requestedRoot)
+    .filter(isNextflowSourceFile)
+    .filter((candidate) => extractWorkflowBlocks(readText(candidate)).length > 0)
+    .sort((left, right) => compareEntrypointCandidates(requestedRoot, left, right));
+  if (workflowFiles[0]) {
+    const detectedRoot = dirname(workflowFiles[0]);
+    return {
+      path: detectedRoot,
+      warnings: [
+        `auto-detected Nextflow pipeline root from workflow block: ${relative(requestedRoot, detectedRoot) || "."}`,
+      ],
+    };
+  }
+
+  throw new Error(`not a Nextflow pipeline root: ${path}`);
 }
 
-function walk(root: string): string[] {
+function discoverProcessFiles(pipelineRoot: string): string[] {
+  return walk(pipelineRoot)
+    .filter(isNextflowSourceFile)
+    .filter((path) => /\bprocess\s+[A-Za-z0-9_]+\s*\{/u.test(readText(path)));
+}
+
+function walk(root: string, options: { maxDepth?: number } = {}, depth = 0): string[] {
   if (!existsSync(root)) return [];
   const paths: string[] = [];
-  for (const entry of readdirSync(root)) {
+  for (const entry of readdirSync(root).sort()) {
     const path = join(root, entry);
-    if (statSync(path).isDirectory()) paths.push(...walk(path));
-    else paths.push(path);
+    if (statSync(path).isDirectory()) {
+      if (!shouldSkipDir(entry) && (options.maxDepth === undefined || depth < options.maxDepth)) {
+        paths.push(...walk(path, options, depth + 1));
+      }
+    } else paths.push(path);
   }
   return paths;
 }
 
-function parseProcessFile(pipelineRoot: string, path: string): Process {
+function shouldSkipDir(name: string): boolean {
+  return [
+    ".git",
+    ".nextflow",
+    "work",
+    "node_modules",
+    "BioNextflow",
+    "external-modules",
+    "vendor",
+    "vendors",
+    "third_party",
+  ].includes(name);
+}
+
+function isNextflowSourceFile(path: string): boolean {
+  return path.endsWith(".nf");
+}
+
+function parseProcessFile(pipelineRoot: string, path: string): Process[] {
   const text = readText(path);
-  const name =
-    matchOne(text, /process\s+([A-Za-z0-9_]+)\s*\{/u) ?? basename(dirname(path)).toUpperCase();
-  const container = normalizeDirective(
-    matchOne(
-      text,
-      /container\s+"([\s\S]*?)"\s*(?:\n\s*input:|\n\s*output:|\n\s*when:|\n\s*script:)/u,
-    ),
+  return [...text.matchAll(/\bprocess\s+([A-Za-z0-9_]+)\s*\{/gu)].flatMap((match) => {
+    const openIndex = match.index + match[0].lastIndexOf("{");
+    const body = extractBlockAt(text, openIndex);
+    if (body === null) return [];
+    const name = match[1]!;
+    const container = normalizeDirective(
+      matchOne(
+        body,
+        /container\s+"([\s\S]*?)"\s*(?:\n\s*input:|\n\s*output:|\n\s*when:|\n\s*script:)/u,
+      ) ?? matchOne(body, /container\s+([^\n]+)/u),
+    );
+    const conda = normalizeDirective(matchOne(body, /conda\s+"([\s\S]*?)"/u));
+    return {
+      name,
+      aliases: [],
+      module_path: relative(pipelineRoot, path),
+      tool: null,
+      container,
+      conda,
+      inputs: parseIoBlock(body, "input"),
+      outputs: parseIoBlock(body, "output"),
+      when: normalizeDirective(matchOne(body, /when:\s*\n([\s\S]*?)\n\s*script:/u)),
+      script_summary: summarizeScript(name),
+      publish_dir: normalizeDirective(matchOne(body, /publishDir\s+([^\n]+)/u)),
+    };
+  });
+}
+
+function selectEntrypoint(pipelineRoot: string): string | null {
+  const candidates = walk(pipelineRoot)
+    .filter(isNextflowSourceFile)
+    .filter((candidate) => extractWorkflowBlocks(readText(candidate)).length > 0)
+    .sort((left, right) => compareEntrypointCandidates(pipelineRoot, left, right));
+  return candidates[0] ? relative(pipelineRoot, candidates[0]) : null;
+}
+
+function compareEntrypointCandidates(root: string, left: string, right: string): number {
+  const leftBlocks = extractWorkflowBlocks(readText(left));
+  const rightBlocks = extractWorkflowBlocks(readText(right));
+  const leftAnonymousScore = leftBlocks.some((block) => block.name === null) ? 0 : 1;
+  const rightAnonymousScore = rightBlocks.some((block) => block.name === null) ? 0 : 1;
+  const leftNameScore = basename(left) === "main.nf" ? 0 : 1;
+  const rightNameScore = basename(right) === "main.nf" ? 0 : 1;
+  const leftDepth = relative(root, dirname(left)).split(sep).filter(Boolean).length;
+  const rightDepth = relative(root, dirname(right)).split(sep).filter(Boolean).length;
+  return (
+    leftAnonymousScore - rightAnonymousScore ||
+    leftNameScore - rightNameScore ||
+    leftDepth - rightDepth ||
+    relative(root, left).localeCompare(relative(root, right))
   );
-  const conda = normalizeDirective(matchOne(text, /conda\s+"([\s\S]*?)"/u));
-  return {
-    name,
-    aliases: [],
-    module_path: relative(pipelineRoot, path),
-    tool: null,
-    container,
-    conda,
-    inputs: parseIoBlock(text, "input"),
-    outputs: parseIoBlock(text, "output"),
-    when: normalizeDirective(matchOne(text, /when:\s*\n([\s\S]*?)\n\s*script:/u)),
-    script_summary: summarizeScript(name),
-    publish_dir: normalizeDirective(matchOne(text, /publishDir\s+([^\n]+)/u)),
-  };
 }
 
 function discoverProcessAliases(pipelineRoot: string): Map<string, string[]> {
@@ -724,7 +835,9 @@ function parseTestFixtures(pipelineRoot: string, profile: string): Summary["test
   const configPath = join(pipelineRoot, "conf", `${profile}.config`);
   const text = existsSync(configPath) ? readText(configPath) : "";
   const baseParams = parseParamAssignments(
-    readText(join(pipelineRoot, "nextflow.config")),
+    existsSync(join(pipelineRoot, "nextflow.config"))
+      ? readText(join(pipelineRoot, "nextflow.config"))
+      : "",
     new Map(),
   );
   const profileParams = parseParamAssignments(text, baseParams);

--- a/packages/summarize-nextflow/test/resolver.test.ts
+++ b/packages/summarize-nextflow/test/resolver.test.ts
@@ -1,0 +1,201 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { buildSummary } from "../src/index.js";
+
+interface SummaryLike {
+  processes: { name: string; module_path: string; inputs: unknown[]; outputs: unknown[] }[];
+  warnings: string[];
+}
+
+const roots: string[] = [];
+
+afterEach(() => {
+  roots.length = 0;
+});
+
+describe("resolveNextflowSummary", () => {
+  test("discovers multiple processes in a single root-level module file", async () => {
+    const root = tempPipelineRoot();
+    write(root, "nextflow.config", "manifest { name = 'adhoc/callings' }\n");
+    write(
+      root,
+      "modules.nf",
+      `process FIRST {
+  input:
+  path reads
+  output:
+  path "first.txt", emit: first
+  script:
+  "first"
+}
+
+process SECOND {
+  input:
+  val sample
+  output:
+  path "second.txt", emit: second
+  script:
+  "second"
+}
+`,
+    );
+    write(root, "main.nf", "workflow { FIRST(Channel.of('x')); SECOND('sample') }\n");
+
+    const summary = await summarize(root);
+
+    expect(summary.processes.map((process) => process.name)).toEqual(["FIRST", "SECOND"]);
+    expect(summary.processes.every((process) => process.module_path === "modules.nf")).toBe(true);
+    expect(summary.processes[0]?.inputs).toHaveLength(1);
+    expect(summary.processes[1]?.outputs).toHaveLength(1);
+  });
+
+  test("discovers flat module files that are not named main.nf", async () => {
+    const root = tempPipelineRoot();
+    write(root, "nextflow.config", "manifest { name = 'adhoc/flat' }\n");
+    write(root, "modules/align.nf", "process ALIGN {\n  script:\n  'align'\n}\n");
+    write(root, "modules/qc.nf", "process QC {\n  script:\n  'qc'\n}\n");
+    write(root, "main.nf", "workflow { ALIGN(); QC() }\n");
+
+    const summary = await summarize(root);
+
+    expect(summary.processes.map((process) => process.name)).toEqual(["ALIGN", "QC"]);
+    expect(summary.processes.map((process) => process.module_path)).toEqual([
+      "modules/align.nf",
+      "modules/qc.nf",
+    ]);
+  });
+
+  test("discovers inline, workflow, and lib process blocks", async () => {
+    const root = tempPipelineRoot();
+    write(root, "nextflow.config", "manifest { name = 'adhoc/spread' }\n");
+    write(root, "main.nf", "process INLINE {\n  script:\n  'inline'\n}\nworkflow { INLINE() }\n");
+    write(root, "workflows/assemble.nf", "process ASSEMBLE {\n  script:\n  'assemble'\n}\n");
+    write(root, "lib/annotate.nf", "process ANNOTATE {\n  script:\n  'annotate'\n}\n");
+
+    const summary = await summarize(root);
+
+    expect(summary.processes.map((process) => process.name)).toEqual([
+      "ANNOTATE",
+      "INLINE",
+      "ASSEMBLE",
+    ]);
+    expect(summary.processes.map((process) => process.module_path)).toEqual([
+      "lib/annotate.nf",
+      "main.nf",
+      "workflows/assemble.nf",
+    ]);
+  });
+
+  test("skips known vendored and generated directories", async () => {
+    const root = tempPipelineRoot();
+    write(root, "nextflow.config", "manifest { name = 'adhoc/vendor-skip' }\n");
+    write(root, "main.nf", "process REAL {\n  script:\n  'real'\n}\nworkflow { REAL() }\n");
+    write(root, "external-modules/noise.nf", "process VENDORED {\n  script:\n  'vendored'\n}\n");
+    write(root, "work/noise.nf", "process WORKDIR {\n  script:\n  'workdir'\n}\n");
+
+    const summary = await summarize(root);
+
+    expect(summary.processes.map((process) => process.name)).toEqual(["REAL"]);
+  });
+
+  test("auto-detects a child pipeline root with nextflow.config", async () => {
+    const repo = tempPipelineRoot();
+    write(repo, "mop_preprocess/nextflow.config", "manifest { name = 'adhoc/mop_preprocess' }\n");
+    write(
+      repo,
+      "mop_preprocess/local_modules.nf",
+      "process BASECALL {\n  script:\n  'basecall'\n}\n",
+    );
+    write(repo, "mop_preprocess/main.nf", "workflow { BASECALL() }\n");
+
+    const summary = await summarize(repo);
+
+    expect(summary.processes.map((process) => process.name)).toEqual(["BASECALL"]);
+    expect(summary.warnings).toContain("auto-detected Nextflow pipeline root: mop_preprocess");
+  });
+
+  test("surfaces ambiguous child pipeline roots", async () => {
+    const repo = tempPipelineRoot();
+    write(repo, "mop_mod/nextflow.config", "manifest { name = 'adhoc/mop_mod' }\n");
+    write(repo, "mop_mod/main.nf", "workflow { MOD() }\nprocess MOD {\n  script:\n  'mod'\n}\n");
+    write(repo, "mop_preprocess/nextflow.config", "manifest { name = 'adhoc/mop_preprocess' }\n");
+    write(
+      repo,
+      "mop_preprocess/main.nf",
+      "workflow { PREPROCESS() }\nprocess PREPROCESS {\n  script:\n  'preprocess'\n}\n",
+    );
+
+    const summary = await summarize(repo);
+
+    expect(summary.processes.map((process) => process.name)).toEqual(["MOD"]);
+    expect(summary.warnings).toContain("multiple Nextflow pipeline roots found; selected mop_mod");
+  });
+
+  test("keeps monorepo root when child configs share root-level process files", async () => {
+    const repo = tempPipelineRoot();
+    write(repo, "local_modules.nf", "process SHARED {\n  script:\n  'shared'\n}\n");
+    write(repo, "mop_mod/nextflow.config", "manifest { name = 'adhoc/mop_mod' }\n");
+    write(repo, "mop_mod/mop_mod.nf", "workflow { SHARED() }\n");
+    write(repo, "mop_preprocess/nextflow.config", "manifest { name = 'adhoc/mop_preprocess' }\n");
+    write(repo, "mop_preprocess/mop_preprocess.nf", "workflow { SHARED() }\n");
+
+    const summary = await summarize(repo);
+
+    expect(summary.processes.map((process) => process.name)).toEqual(["SHARED"]);
+    expect(summary.processes.map((process) => process.module_path)).toEqual(["local_modules.nf"]);
+    expect(summary.warnings).toContain(
+      "detected child Nextflow configs but kept repository root because shared process files exist outside child roots",
+    );
+  });
+
+  test("auto-detects a source directory from a workflow block without config", async () => {
+    const repo = tempPipelineRoot();
+    write(repo, "nf/phage.nf", "workflow { PHAGE() }\n");
+    write(repo, "nf/modules/phage.nf", "process PHAGE {\n  script:\n  'phage'\n}\n");
+
+    const summary = await summarize(repo);
+
+    expect(summary.processes.map((process) => process.name)).toEqual(["PHAGE"]);
+    expect(summary.warnings).toContain(
+      "auto-detected Nextflow pipeline root from workflow block: nf",
+    );
+    expect(summary.warnings).toContain("selected Nextflow entrypoint: phage.nf");
+  });
+
+  test("prefers shallow anonymous workflow entrypoints over nested named workflows", async () => {
+    const repo = tempPipelineRoot();
+    write(repo, "nf/ui.nf", "workflow { UI() }\n");
+    write(repo, "nf/subworkflows/nested/main.nf", "workflow NESTED { UI() }\n");
+    write(repo, "nf/modules/ui.nf", "process UI {\n  script:\n  'ui'\n}\n");
+
+    const summary = await summarize(repo);
+
+    expect(summary.warnings).toContain(
+      "auto-detected Nextflow pipeline root from workflow block: nf",
+    );
+    expect(summary.warnings).toContain("selected Nextflow entrypoint: ui.nf");
+  });
+});
+
+async function summarize(root: string): Promise<SummaryLike> {
+  return (await buildSummary(root, {
+    profile: "test",
+    withNextflow: false,
+    fetchTestData: false,
+    validate: false,
+  })) as SummaryLike;
+}
+
+function tempPipelineRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "summarize-nextflow-"));
+  roots.push(root);
+  return root;
+}
+
+function write(root: string, path: string, content: string): void {
+  const target = join(root, path);
+  mkdirSync(join(target, ".."), { recursive: true });
+  writeFileSync(target, content);
+}


### PR DESCRIPTION
## Summary
- Add ad-hoc Nextflow fixtures and eval notes that expose nf-core layout overfitting.
- Update summarize-nextflow resolver to walk all `.nf` process files, parse multiple processes per file, auto-detect non-standard roots, and surface selected entrypoints.
- Add resolver regressions for flat modules, root-level `modules.nf`, shared monorepo process files, and non-main entrypoints.

## Validation
- `make fixtures-nextflow`
- ad-hoc fixture sweep: all 8 ad-hoc fixtures matched grep process counts exactly
- `npm run packages-test`
- `npm run packages-typecheck`
- `npm run packages-format`
- `npm run validate`
- `npm run test`

Fixes #111