### PR TITLE
Add pattern IWC exemplar metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@
 - **Frontmatter is contract.** `meta_schema.yml` is JSON Schema Draft 07 with `additionalProperties: false`. Unknown fields are rejected. Add a property declaration in the schema before adding a frontmatter field anywhere.
 - **Tags must be registered.** Every tag a note uses lives in `meta_tags.yml`. Vocabulary changes touch one file.
 - **Wiki-link fields use `[[Target]]`.** Single-value fields (`parent_pattern`) and array fields (`related_notes`, `related_patterns`, `related_molds`, `patterns`, `cli_commands`, `prompts`).
-- **IWC citations should survive corpus churn.** Prefer workflow-path citations plus step label/tool name over brittle line precision when cleaned/converted workflow files are likely to move. Use line ranges only when they clarify a stable local snippet.
+- **Polished IWC references should survive corpus churn.** Pattern pages, Mold pages, and other polished content should cite abstract IWC workflow IDs without generated extensions or fixture roots, e.g. `transcriptomics/rnaseq-pe/rnaseq-pe`, plus step labels or step IDs when needed. Do not cite generated `.ga`/`.gxwf.yml` paths or line numbers in polished pages; reserve those for surveys, ad-hoc research notes, and local debugging evidence.
 - **Validate before commit.** `npm run validate` checks schema + cross-file resolution. Errors block; warnings are advisory.
 - **Don't edit generated files by hand.** `Dashboard.md` and `Index.md` are produced by `scripts/generate-*.ts`. `glossary.md` is hand-curated and skipped by the validator. `log.md` is append-only.
 
@@ -61,8 +61,8 @@ make fixtures-clean    # remove generated fixture dirs
 - `workflow-fixtures/pipelines/` — pinned Nextflow pipeline clones from `workflow-fixtures/fixtures.yaml`.
 - `workflow-fixtures/iwc-src/` — pinned IWC clone.
 - `workflow-fixtures/iwc-cleaned/` — intermediate cleaned Galaxy workflows.
-- `workflow-fixtures/iwc-format2/` — cleaned gxformat2 IWC corpus, cited as `$IWC_FORMAT2/...`.
-- `workflow-fixtures/iwc-skeletons/` — structural-only views, cited as `$IWC_SKELETONS/...`.
+- `workflow-fixtures/iwc-format2/` — cleaned gxformat2 IWC corpus, cited as `$IWC_FORMAT2/...` in surveys and ad-hoc research only.
+- `workflow-fixtures/iwc-skeletons/` — structural-only views, cited as `$IWC_SKELETONS/...` in surveys and ad-hoc research only.
 
 Before launching or acting as a research subagent that needs corpus evidence, check whether the needed generated dirs exist. If they are missing, use the top-level fixture targets above. If you cannot materialize them, stop and report the missing target instead of inventing evidence.
 

--- a/content/patterns/collection-build-list-paired-with-apply-rules.md
+++ b/content/patterns/collection-build-list-paired-with-apply-rules.md
@@ -10,8 +10,8 @@ tags:
   - pattern
 status: draft
 created: 2026-05-02
-revised: 2026-05-02
-revision: 1
+revised: 2026-05-03
+revision: 2
 ai_generated: true
 summary: "Use Apply Rules to promote identifier columns into a list:paired collection, with optional cleanup first."
 related_notes:
@@ -22,6 +22,16 @@ related_patterns:
   - "[[collection-split-identifier-via-rules]]"
 related_molds:
   - "[[implement-galaxy-tool-step]]"
+iwc_exemplars:
+  - workflow: amplicon/dada2/dada2_paired
+    why: "Uses identifier columns, sample sorting, list identifiers, and paired identifiers to promote rows into list:paired structure."
+    confidence: high
+  - workflow: data-fetching/parallel-accession-download/parallel-accession-download
+    why: "Flattens deeper download output into list:paired by promoting an inner identifier to the paired role."
+    confidence: high
+  - workflow: data-fetching/sra-manifest-to-concatenated-fastqs/sra-manifest-to-concatenated-fastqs
+    why: "Shows paired promotion with regex cleanup of transient delimiter text before mapping."
+    confidence: high
 ---
 
 # Collection: build list paired with Apply Rules
@@ -65,12 +75,6 @@ For deeper inputs, add the needed identifier columns and map the innermost paire
 - Use `paired_identifier`, not a second list identifier, when the second axis is read direction.
 - Regex rules append new columns; check column numbers after cleanup.
 - Sorting by the wrong column can separate intended pairs.
-
-## Exemplars (IWC)
-
-- `$IWC_FORMAT2/amplicon/dada2/dada2_paired.gxwf.yml` — "Sort samples" uses `identifier0` and `identifier1`, sorts by sample, then maps `list_identifiers: [0]` plus `paired_identifier: [1]`.
-- `$IWC_FORMAT2/data-fetching/parallel-accession-download/parallel-accession-download.gxwf.yml` — flattens deeper download output into `list:paired` by promoting an inner identifier to paired role.
-- `$IWC_FORMAT2/data-fetching/sra-manifest-to-concatenated-fastqs/sra-manifest-to-concatenated-fastqs.gxwf.yml:12-13` — paired-promotion shape with regex cleanup of transient delimiter text before mapping.
 
 ## Legacy alternative
 

--- a/content/patterns/collection-build-named-bundle.md
+++ b/content/patterns/collection-build-named-bundle.md
@@ -11,8 +11,8 @@ tags:
   - pattern
 status: draft
 created: 2026-05-02
-revised: 2026-05-02
-revision: 1
+revised: 2026-05-03
+revision: 2
 ai_generated: true
 summary: "Use BUILD_LIST to assemble named outputs into a collection bundle for publishing or downstream fan-in."
 related_notes:
@@ -22,6 +22,13 @@ related_patterns:
   - "[[tabular-concatenate-collection-to-table]]"
 related_molds:
   - "[[implement-galaxy-tool-step]]"
+iwc_exemplars:
+  - workflow: amplicon/qiime2/qiime2-III-VI-downsteam/QIIME2-VI-diversity-metrics-and-estimations
+    why: "Groups QIIME2 plots, PCoA results, distance matrices, and richness vectors into named output collections."
+    confidence: high
+  - workflow: microbiome/mags-building/MAGs-generation
+    why: "Assembles bin-table outputs from multiple binners into one collection for binette."
+    confidence: high
 ---
 
 # Collection: build named bundle
@@ -69,11 +76,6 @@ tool_state:
 - Manual bundles group outputs; they do not align rows, merge contents, or validate common keys.
 - Use inherited identifiers only when source names are meaningful.
 - Prefer `__MERGE_COLLECTION__` only when inputs are already collections.
-
-## Exemplars (IWC)
-
-- `$IWC_FORMAT2/amplicon/qiime2/qiime2-III-VI-downsteam/QIIME2-VI-diversity-metrics-and-estimations.gxwf.yml:340` — QIIME2 Emperor plots, PCoA results, distance matrices, and richness vectors grouped into named output collections.
-- `$IWC_FORMAT2/microbiome/mags-building/MAGs-generation.gxwf.yml:961` — bin-table outputs from multiple binners assembled into one collection for `binette`.
 
 ## See also
 

--- a/content/patterns/collection-cleanup-after-mapover-failure.md
+++ b/content/patterns/collection-cleanup-after-mapover-failure.md
@@ -11,8 +11,8 @@ tags:
   - pattern
 status: draft
 created: 2026-05-02
-revised: 2026-05-02
-revision: 1
+revised: 2026-05-03
+revision: 2
 ai_generated: true
 summary: "Use FILTER_EMPTY or FILTER_FAILED after map-over when bad elements would break downstream collection steps."
 related_notes:
@@ -21,6 +21,16 @@ related_patterns:
   - "[[sync-collections-by-identifier]]"
 related_molds:
   - "[[implement-galaxy-tool-step]]"
+iwc_exemplars:
+  - workflow: microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation
+    why: "Shows multiple collection inputs passing through FILTER_FAILED before downstream aggregation."
+    confidence: high
+  - workflow: amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction
+    why: "Uses repeated FILTER_EMPTY steps after awk/search reshapes before the next consumer."
+    confidence: high
+  - workflow: microbiome/metagenomic-raw-reads-amr-analysis/metagenomic-raw-reads-amr-analysis
+    why: "Shows rare replacement form that preserves shape with a sentinel file."
+    confidence: medium
 ---
 
 # Collection: cleanup after map-over failure
@@ -86,12 +96,6 @@ in:
 - Dropping changes collection length. If a downstream zip or sibling comparison assumes one-to-one alignment, resync siblings or use a replacement sentinel.
 - Replacement changes data semantics. The sentinel becomes real downstream input, so choose a value the next tool treats as controlled no-result data.
 - Do not confuse this with `__FILTER_FROM_FILE__`; that tool filters by identifier list and does not inspect dataset state.
-
-## Exemplars (IWC)
-
-- `$IWC_FORMAT2/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation.gxwf.yml:10-14` — five collection inputs pass through `__FILTER_FAILED_DATASETS__` before downstream aggregation.
-- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction.gxwf.yml` — repeated `__FILTER_EMPTY_DATASETS__` uses after awk/search reshapes before the next consumer.
-- `$IWC_FORMAT2/microbiome/metagenomic-raw-reads-amr-analysis/metagenomic-raw-reads-amr-analysis.gxwf.yml:225` — rare replacement form, preserving shape with a sentinel file.
 
 ## See also
 

--- a/content/patterns/collection-flatten-after-fanout.md
+++ b/content/patterns/collection-flatten-after-fanout.md
@@ -11,8 +11,8 @@ tags:
   - pattern
 status: draft
 created: 2026-05-02
-revised: 2026-05-02
-revision: 1
+revised: 2026-05-03
+revision: 2
 ai_generated: true
 summary: "Use FLATTEN to collapse nested collection outputs to a flat list once the outer axis no longer matters."
 related_notes:
@@ -22,6 +22,16 @@ related_patterns:
   - "[[harmonize-by-sortlist-from-identifiers]]"
 related_molds:
   - "[[implement-galaxy-tool-step]]"
+iwc_exemplars:
+  - workflow: microbiome/mags-building/MAGs-generation
+    why: "Flattens a list:list of bins from all samples for pool-level processing."
+    confidence: high
+  - workflow: transcriptomics/rnaseq-pe/rnaseq-pe
+    why: "Flattens a paired collection to a flat list for MultiQC."
+    confidence: high
+  - workflow: microbiome/metagenomic-raw-reads-amr-analysis/metagenomic-raw-reads-amr-analysis
+    why: "Flattens list:list output from sylph_profile before relabeling."
+    confidence: high
 ---
 
 # Collection: flatten after fan-out
@@ -56,12 +66,6 @@ The useful authoring decision is input collection type and whether the outer axi
 - Flatten only after the outer axis is done.
 - If flattened identifiers collide or become unreadable, add an explicit relabel step.
 - Do not use Apply Rules for plain flattening; the survey found `__FLATTEN__` dominates simple cases.
-
-## Exemplars (IWC)
-
-- `$IWC_FORMAT2/microbiome/mags-building/MAGs-generation.gxwf.yml` — "Pool Bins from all samples" flattens a `list:list` of bins for pool-level processing.
-- `$IWC_FORMAT2/transcriptomics/rnaseq-pe/rnaseq-pe.gxwf.yml:11` — flattens a paired collection to a flat list for MultiQC.
-- `$IWC_FORMAT2/microbiome/metagenomic-raw-reads-amr-analysis/metagenomic-raw-reads-amr-analysis.gxwf.yml:15` — flattens `list:list` output from `sylph_profile` before relabeling.
 
 ## See also
 

--- a/content/patterns/collection-split-identifier-via-rules.md
+++ b/content/patterns/collection-split-identifier-via-rules.md
@@ -10,8 +10,8 @@ tags:
   - pattern
 status: draft
 created: 2026-05-02
-revised: 2026-05-02
-revision: 1
+revised: 2026-05-03
+revision: 2
 ai_generated: true
 summary: "Use Apply Rules regex columns to split one collection identifier into nested list identifiers."
 related_notes:
@@ -22,6 +22,10 @@ related_patterns:
   - "[[collection-build-list-paired-with-apply-rules]]"
 related_molds:
   - "[[implement-galaxy-tool-step]]"
+iwc_exemplars:
+  - workflow: epigenetics/average-bigwig-between-replicates/average-bigwig-between-replicates
+    why: "Splits flat bigWig identifiers into sample-prefix and replicate-suffix nesting with two regex-derived columns."
+    confidence: high
 ---
 
 # Collection: split identifier via rules
@@ -68,10 +72,6 @@ tool_state:
 - Target the original identifier column both times.
 - `^(.*)_([^_]*)$` splits on the last underscore; use a stricter regex if identifiers can contain multiple separators.
 - Validate unmatched behavior instead of silently creating empty nesting keys.
-
-## Exemplars (IWC)
-
-- `$IWC_FORMAT2/epigenetics/average-bigwig-between-replicates/average-bigwig-between-replicates.gxwf.yml` — splits flat bigWig identifiers into sample-prefix and replicate-suffix nesting with two regex-derived columns.
 
 ## See also
 

--- a/content/patterns/collection-swap-nesting-with-apply-rules.md
+++ b/content/patterns/collection-swap-nesting-with-apply-rules.md
@@ -10,8 +10,8 @@ tags:
   - pattern
 status: draft
 created: 2026-05-02
-revised: 2026-05-02
-revision: 1
+revised: 2026-05-03
+revision: 2
 ai_generated: true
 summary: "Use Apply Rules to regroup a list:list collection by swapping outer and inner identifier columns."
 related_notes:
@@ -23,6 +23,12 @@ related_patterns:
   - "[[relabel-via-rules-and-find-replace]]"
 related_molds:
   - "[[implement-galaxy-tool-step]]"
+iwc_exemplars:
+  - workflow: virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping
+    steps:
+      - label: "Regroup influenza BAM collections between sample and segment axes"
+    why: "Shows repeated pure regrouping of list:list collections by swapping outer and inner identifier columns."
+    confidence: high
 ---
 
 # Collection: swap nesting with Apply Rules
@@ -69,10 +75,6 @@ Treat this as the logical shape, not a complete serialized workflow API blob.
 - Check that the input is actually `list:list`; `identifier1` exists only when there is an inner list level.
 - Keep pure regrouping separate from relabeling unless noisy identifiers force the heavier recipe.
 - Downstream map-over behavior changes after the swap; tools now iterate by the former inner axis.
-
-## Exemplars (IWC)
-
-- `$IWC_FORMAT2/virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping.gxwf.yml` steps 14, 34, 39, 43 — repeated regrouping of influenza BAM collections between sample and segment axes.
 
 Footnote: the same workflow uses `__DUPLICATE_FILE_TO_COLLECTION__` before one Apply Rules step as a broadcast setup. That broadcast is barely attested and should not be treated as the main pattern.
 

--- a/content/patterns/collection-unbox-singleton.md
+++ b/content/patterns/collection-unbox-singleton.md
@@ -10,14 +10,24 @@ tags:
   - pattern
 status: draft
 created: 2026-05-02
-revised: 2026-05-02
-revision: 1
+revised: 2026-05-03
+revision: 2
 ai_generated: true
 summary: "Use __EXTRACT_DATASET__ with which: first when a one-element collection must become a dataset."
 related_notes:
   - "[[iwc-transformations-survey]]"
 related_molds:
   - "[[implement-galaxy-tool-step]]"
+iwc_exemplars:
+  - workflow: VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8
+    why: "Repeatedly unboxes singleton QC/report outputs such as alignment scores, alignment stats, and snapshots."
+    confidence: high
+  - workflow: VGP-assembly-v2/Assembly-Hifi-HiC-phasing-VGP4/Assembly-Hifi-HiC-phasing-VGP4
+    why: "Shows repeated singleton extraction for Merqury and PNG outputs."
+    confidence: high
+  - workflow: VGP-assembly-v2/Purge-duplicates-one-haplotype-VGP6b/Purging-duplicates-one-haplotype-VGP6b
+    why: "Uses the same VGP reporting and QC singleton extraction shape."
+    confidence: high
 ---
 
 # Collection: unbox singleton
@@ -60,12 +70,6 @@ Read this as an assertion: this collection has exactly one useful element here.
 - Do not use it as collection filtering; selecting a named element is a different operation.
 - Check conditional branches. Singleton extraction often follows single-sample vs multi-sample routing.
 - Once unboxed, collection element identifiers are no longer available as collection metadata.
-
-## Exemplars (IWC)
-
-- `$IWC_FORMAT2/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8.gxwf.yml:27,29,48,58,60` — repeated unboxing of singleton QC/report outputs such as alignment scores, alignment stats, and snapshots.
-- `$IWC_FORMAT2/VGP-assembly-v2/Assembly-Hifi-HiC-phasing-VGP4/Assembly-Hifi-HiC-phasing-VGP4.gxwf.yml` — repeated singleton extraction for Merqury and PNG outputs.
-- `$IWC_FORMAT2/VGP-assembly-v2/Purge-duplicates-one-haplotype-VGP6b/Purging-duplicates-one-haplotype-VGP6b.gxwf.yml` — same VGP reporting/QC shape.
 
 ## See also
 

--- a/content/patterns/compose-runtime-text-parameter.md
+++ b/content/patterns/compose-runtime-text-parameter.md
@@ -12,8 +12,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-05-02
-revised: 2026-05-02
-revision: 2
+revised: 2026-05-03
+revision: 3
 ai_generated: true
 summary: "Use compose_text_param to build connected text expressions from constants plus runtime scalar values."
 related_notes:
@@ -27,6 +27,19 @@ related_molds:
   - "[[implement-galaxy-tool-step]]"
 verification_paths:
   - verification/workflows/compose-runtime-text-parameter/compose-runtime-text.gxwf-test.yml
+iwc_exemplars:
+  - workflow: epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun
+    why: "Composes a Filter1 predicate from a literal comparison and a workflow integer input."
+    confidence: high
+  - workflow: data-fetching/sra-manifest-to-concatenated-fastqs/sra-manifest-to-concatenated-fastqs
+    why: "Composes dynamic Cut1 column lists from connected column identifiers."
+    confidence: high
+  - workflow: computational-chemistry/gromacs-dctmd/gromacs-dctmd
+    why: "Composes GROMACS config lines from float and integer parameters for add_line_to_file."
+    confidence: high
+  - workflow: virology/pox-virus-amplicon/pox-virus-half-genome
+    why: "Composes genomic range and pool suffix strings for downstream regions and read-group parameters."
+    confidence: high
 ---
 
 # Parameter: compose runtime text parameter
@@ -99,13 +112,6 @@ These snippets are conceptual; use the gxformat2 exemplars for exact serialized 
 - Connected text is not a dataset. Connect `out1` to a tool parameter, not a dataset input.
 - Do not replace [[map-workflow-enum-to-tool-parameter]]. If the operation is mapping `stranded` to a flag or snippet, map first; compose only when the final task is concatenation.
 - Do not confuse row-wise string construction with runtime parameter composition. If each input row needs a computed string, use tabular tools.
-
-## Exemplars (IWC)
-
-- `$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:102-128`, `$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:318-336` — composes `c4 >= ` plus a workflow integer input, then connects `out1` to `Filter1.cond`.
-- `$IWC_FORMAT2/data-fetching/sra-manifest-to-concatenated-fastqs/sra-manifest-to-concatenated-fastqs.gxwf.yml:61-113` — composes `c<id>,c<id>` and connects it to `Cut1.columnList`.
-- `$IWC_FORMAT2/computational-chemistry/gromacs-dctmd/gromacs-dctmd.gxwf.yml:553-654`, `$IWC_FORMAT2/computational-chemistry/gromacs-dctmd/gromacs-dctmd.gxwf.yml:720-999` — composes GROMACS config lines from float/integer parameters and feeds them into `add_line_to_file.text_input`.
-- `$IWC_FORMAT2/virology/pox-virus-amplicon/pox-virus-half-genome.gxwf.yml:560-669`, `$IWC_FORMAT2/virology/pox-virus-amplicon/pox-virus-half-genome.gxwf.yml:680-819` — composes genomic ranges and pool suffix strings for EMBOSS `regions` and BWA read-group IDs.
 
 ## See Also
 

--- a/content/patterns/conditional-gate-on-nonempty-result.md
+++ b/content/patterns/conditional-gate-on-nonempty-result.md
@@ -12,8 +12,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-05-02
-revised: 2026-05-02
-revision: 2
+revised: 2026-05-03
+revision: 3
 ai_generated: true
 summary: "Derive a boolean from empty or non-empty data, then use when to skip reporting or export steps."
 related_notes:
@@ -27,6 +27,17 @@ related_molds:
   - "[[implement-galaxy-tool-step]]"
 verification_paths:
   - verification/workflows/conditional-gate-on-nonempty-result/gate-on-nonempty.gxwf-test.yml
+iwc_exemplars:
+  - workflow: amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction
+    steps:
+      - label: "Map empty/not empty collection to boolean"
+      - label: "Gate Krona output generation"
+      - label: "Gate BIOM conversion and export steps"
+    why: "Shows the verified collection-to-boolean shim feeding downstream when gates."
+    confidence: high
+  - workflow: VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation
+    why: "Shows text-like dataset content mapped to a boolean before gating Pretext graph steps."
+    confidence: high
 ---
 
 # Conditional: gate on non-empty result
@@ -58,7 +69,7 @@ This is not a generic user toggle. If the user chooses whether to run an optiona
 
 This is not map-over cleanup. If the need is to drop empty or failed elements inside a collection before the next collection consumer, use [[collection-cleanup-after-mapover-failure]].
 
-This is not `__FILTER_NULL__`. The conditionals survey found zero `__FILTER_NULL__` usage in `$IWC_FORMAT2`, but zero uptake alone is not an anti-pattern call.
+This is not `__FILTER_NULL__`. The conditionals survey found zero `__FILTER_NULL__` usage in the IWC corpus, but zero uptake alone is not an anti-pattern call.
 
 ## Operation Boundary
 
@@ -133,13 +144,6 @@ These snippets summarize observed and verified shapes. Do not simplify the MGnif
 - Do not use this when the choice is user-controlled. Direct boolean `when` gates are simpler.
 - Do not replace collection cleanup with a workflow gate. Cleanup changes collection members; this pattern skips whole downstream steps.
 - Do not cite `__FILTER_NULL__` as an IWC-backed conditional pattern. Survey found no corpus uptake.
-
-## Exemplars (IWC)
-
-- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction.gxwf.yml:1358-1483` — embedded subworkflow labeled `Map empty/not empty collection to boolean`; uses `collection_element_identifiers -> wc_gnu -> column_maker -> param_value_from_file`.
-- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction.gxwf.yml:1330-1357` — boolean gates Krona output generation.
-- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction.gxwf.yml:1484-1659` — same boolean gates BIOM conversion/export steps.
-- `$IWC_FORMAT2/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation.gxwf.yml:3057-3218`, `$IWC_FORMAT2/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation.gxwf.yml:3289-3346`, `$IWC_FORMAT2/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation.gxwf.yml:3458-3510` — text-like dataset-content variant: telomere BED text is mapped to a boolean before gating Pretext graph steps.
 
 ## Verification
 

--- a/content/patterns/conditional-route-between-alternative-outputs.md
+++ b/content/patterns/conditional-route-between-alternative-outputs.md
@@ -12,8 +12,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-05-02
-revised: 2026-05-02
-revision: 2
+revised: 2026-05-03
+revision: 3
 ai_generated: true
 summary: "Use when-gated alternatives plus pick_value to merge binary or one-of-N routes into one downstream value."
 related_notes:
@@ -26,6 +26,16 @@ related_patterns:
   - "[[collection-cleanup-after-mapover-failure]]"
 related_molds:
   - "[[implement-galaxy-tool-step]]"
+iwc_exemplars:
+  - workflow: scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy
+    why: "Shows a binary 10x import route with legacy and v3 AnnData branches merged by pick_value."
+    confidence: high
+  - workflow: genome_annotation/functional-annotation/functional-annotation-of-sequences/Functional_annotation_of_sequences
+    why: "Shows one enum input mapped into mode booleans, fan-out across eggNOG modes, then pick_value merge."
+    confidence: high
+  - workflow: microbiome/mags-building/MAGs-generation
+    why: "Routes among individual, co-assembly, and custom assembly alternatives, including an embedded subworkflow branch."
+    confidence: high
 ---
 
 # Conditional: route between alternative outputs
@@ -147,14 +157,6 @@ These snippets are conceptual. Use the cited gxformat2 exemplars for exact seria
 - Hiding the route in one wrapper. IWC evidence favors graph-visible `when` branches plus merge for these route operations.
 - Duplicating enum comparisons inside every downstream tool. Normalize once with `map_param_value`, then connect the resulting boolean to `id: when`.
 - Confusing route merge with collection cleanup. `__FILTER_EMPTY_DATASETS__` and `__FILTER_FAILED_DATASETS__` clean mapped collection elements; they are not the observed IWC mechanism for one-of-N conditional routing.
-
-## Exemplars (IWC)
-
-- `$IWC_FORMAT2/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy.gxwf.yml:180-211`, `$IWC_FORMAT2/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy.gxwf.yml:337-399` — binary 10x import route: legacy vs v3 `anndata_import`, then `pick_value` selects the present AnnData output.
-- `$IWC_FORMAT2/genome_annotation/functional-annotation/functional-annotation-of-sequences/Functional_annotation_of_sequences.gxwf.yml:244-395`, `$IWC_FORMAT2/genome_annotation/functional-annotation/functional-annotation-of-sequences/Functional_annotation_of_sequences.gxwf.yml:396-429` — one-of-N eggNOG mapper mode fan-out, then `pick_value` collapses the selected annotation output.
-- `$IWC_FORMAT2/microbiome/mags-building/MAGs-generation.gxwf.yml:295-410`, `$IWC_FORMAT2/microbiome/mags-building/MAGs-generation.gxwf.yml:411-439` — alternative assembly route including an embedded subworkflow branch, then `pick_value` chooses among individual, co-assembly, or custom assemblies.
-- `$IWC_FORMAT2/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy.gxwf.yml:173-241` — binary route uses direct boolean for one branch and `map_param_value` inversion for the other.
-- `$IWC_FORMAT2/genome_annotation/functional-annotation/functional-annotation-of-sequences/Functional_annotation_of_sequences.gxwf.yml:55-195` — one enum input maps into one boolean per eggNOG mode before the gated branches.
 
 ## See Also
 

--- a/content/patterns/conditional-run-optional-step.md
+++ b/content/patterns/conditional-run-optional-step.md
@@ -12,8 +12,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-05-02
-revised: 2026-05-02
-revision: 3
+revised: 2026-05-03
+revision: 4
 ai_generated: true
 summary: "Use a workflow boolean connected as inputs.when to skip an optional Galaxy step or branch."
 related_notes:
@@ -28,6 +28,24 @@ related_molds:
   - "[[implement-galaxy-tool-step]]"
 verification_paths:
   - verification/workflows/conditional-run-optional-step/run-optional-step.gxwf-test.yml
+iwc_exemplars:
+  - workflow: genome_annotation/annotation-braker3/Genome_annotation_with_braker3
+    steps:
+      - label: "Gate BUSCO on predicted protein sequences"
+      - label: "Gate genome BUSCO from the same user boolean"
+    why: "Shows repeated optional assessment branches controlled by one workflow boolean."
+    confidence: high
+  - workflow: transcriptomics/rnaseq-pe/rnaseq-pe
+    steps:
+      - label: "Gate optional StringTie FPKM branch"
+      - label: "Gate optional Cufflinks FPKM branch"
+    why: "Shows peer optional quantification branches gated by workflow choices."
+    confidence: high
+  - workflow: VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation
+    steps:
+      - label: "Gate multi-step suffixing branch"
+    why: "Shows a multi-step optional branch where downstream fallback belongs to a separate transform-or-pass-through pattern."
+    confidence: high
 ---
 
 # Conditional: run optional step
@@ -118,16 +136,7 @@ The second shape is conceptual, derived from the VGP Hi-C suffixing branch. The 
 - Consuming a missing optional output unconditionally. If downstream requires a value regardless of the boolean, add an explicit merge/fallback with `pick_value`.
 - Confusing user choice with data-derived choice. Empty/non-empty result checks need a separate boolean-producing shim before `when:`.
 - Duplicating normalization logic inside optional tools. If the gate depends on a derived boolean, compute it once and connect that boolean as `id: when`.
-- Leading with `__FILTER_NULL__` as conditional cleanup. The survey found zero `__FILTER_NULL__` hits in `$IWC_FORMAT2`; keep it as catalog knowledge, not the corpus-backed authoring path.
-
-## Exemplars (IWC)
-
-- `$IWC_FORMAT2/genome_annotation/annotation-braker3/Genome_annotation_with_braker3.gxwf.yml:110-141` — BRAKER3 gates BUSCO on predicted protein sequences with the `Include BUSCO` boolean connected as `when`.
-- `$IWC_FORMAT2/genome_annotation/annotation-braker3/Genome_annotation_with_braker3.gxwf.yml:341-385` — same workflow gates genome BUSCO from the same user-facing boolean, showing repeated optional assessment branches.
-- `$IWC_FORMAT2/transcriptomics/rnaseq-pe/rnaseq-pe.gxwf.yml:1082-1140` — RNA-seq gates the optional StringTie FPKM branch with `Compute StringTie FPKM`.
-- `$IWC_FORMAT2/transcriptomics/rnaseq-pe/rnaseq-pe.gxwf.yml:1141-1214` — RNA-seq gates the optional Cufflinks FPKM branch separately with `Compute Cufflinks FPKM`.
-- `$IWC_FORMAT2/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation.gxwf.yml:338-459` — VGP Hi-C gates a multi-step suffixing branch with a user boolean; downstream fallback uses `pick_value`, marking the boundary with [[conditional-transform-or-pass-through]].
-- `$IWC_FORMAT2/VGP-assembly-v2/Assembly-decontamination-VGP9/Assembly-decontamination-VGP9.gxwf.yml:205-305` — integer-derived value is normalized with `map_param_value`, then the boolean gates optional filtering steps.
+- Leading with `__FILTER_NULL__` as conditional cleanup. The survey found zero `__FILTER_NULL__` hits in the IWC corpus; keep it as catalog knowledge, not the corpus-backed authoring path.
 
 ## See Also
 

--- a/content/patterns/conditional-transform-or-pass-through.md
+++ b/content/patterns/conditional-transform-or-pass-through.md
@@ -12,8 +12,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-05-02
-revised: 2026-05-02
-revision: 1
+revised: 2026-05-03
+revision: 2
 ai_generated: true
 summary: "Gate an optional transform, then use pick_value to pass transformed data when present or original data otherwise."
 related_notes:
@@ -25,6 +25,13 @@ related_patterns:
   - "[[collection-cleanup-after-mapover-failure]]"
 related_molds:
   - "[[implement-galaxy-tool-step]]"
+iwc_exemplars:
+  - workflow: VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation
+    why: "Runs optional haplotype suffixing only when requested, then pick_value selects suffixed or original haplotype output."
+    confidence: high
+  - workflow: VGP-assembly-v2/Assembly-decontamination-VGP9/Assembly-decontamination-VGP9
+    why: "Uses a mapped boolean to gate adaptor filtering/masking/report rewrite, then falls back to the original report when masking does not run."
+    confidence: high
 ---
 
 # Conditional: transform or pass through
@@ -107,11 +114,6 @@ Read this as preserving a downstream contract: later steps consume one value reg
 - Do not duplicate the whole downstream workflow after the optional transform. Merge once with `pick_value`, then continue with one path.
 - Do not model pass-through as a fake transform step. The unmodified value should be connected directly as the fallback candidate.
 - Do not cite `__FILTER_NULL__` as the IWC idiom for this. The survey found zero `__FILTER_NULL__` hits.
-
-## Exemplars (IWC)
-
-- `$IWC_FORMAT2/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation.gxwf.yml:338-479` — optional haplotype suffixing branch runs only when requested; `pick_value` selects the suffixed haplotype when present or the original haplotype otherwise.
-- `$IWC_FORMAT2/VGP-assembly-v2/Assembly-decontamination-VGP9/Assembly-decontamination-VGP9.gxwf.yml:243-409` — mapped boolean gates adaptor filtering/masking/report-rewrite branch; `pick_value` later falls back to the original `Adaptor Action report` when masking does not run.
 
 ## See Also
 

--- a/content/patterns/derive-parameter-from-file.md
+++ b/content/patterns/derive-parameter-from-file.md
@@ -13,8 +13,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-05-02
-revised: 2026-05-02
-revision: 2
+revised: 2026-05-03
+revision: 3
 ai_generated: true
 summary: "Read a one-value dataset with param_value_from_file, including count recipes that feed typed parameters."
 related_notes:
@@ -26,6 +26,19 @@ related_molds:
   - "[[implement-galaxy-tool-step]]"
 verification_paths:
   - verification/workflows/derive-parameter-from-file/derive-integer-from-file.gxwf-test.yml
+iwc_exemplars:
+  - workflow: VGP-assembly-v2/kmer-profiling-hifi-VGP1/kmer-profiling-hifi-VGP1
+    why: "Reads homozygous read coverage as a float and estimated genome size as an integer parameter."
+    confidence: high
+  - workflow: epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun
+    why: "Converts table-derived minima and replicate counts through text and integer parameter ports before downstream subsampling."
+    confidence: high
+  - workflow: virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping
+    why: "Turns line counts into integer parameters used as collection duplication counts."
+    confidence: high
+  - workflow: amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction
+    why: "Counts collection identifiers, converts the count to a boolean, then reads it through boolean_param."
+    confidence: high
 ---
 
 # Parameter: derive from file
@@ -137,14 +150,6 @@ collection -> collection_element_identifiers -> wc_gnu -> column_maker(c1 != 0) 
 - Do not bury the operation under `wc_gnu`; counts are just one upstream scalar-producing recipe.
 - Do not duplicate [[conditional-gate-on-nonempty-result]]. If the user story is "skip when empty," the conditional page owns the recommendation.
 - Do not present MGnify's four-step boolean shim as best. It is corpus-backed but clunky and pending verified-pattern issue #84.
-
-## Exemplars (IWC)
-
-- `$IWC_FORMAT2/VGP-assembly-v2/kmer-profiling-hifi-VGP1/kmer-profiling-hifi-VGP1.gxwf.yml:1022-1038` — reads homozygous read coverage as `float_param`.
-- `$IWC_FORMAT2/VGP-assembly-v2/kmer-profiling-hifi-VGP1/kmer-profiling-hifi-VGP1.gxwf.yml:1042-1088` — reads estimated genome size as `integer_param` and connects it to `rdeval.expected_gsize`.
-- `$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:263-318`, `$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:372-423`, `$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:467-499` — table minimum and replicate count are converted through text/integer parameter ports before downstream subsampling.
-- `$IWC_FORMAT2/virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping.gxwf.yml:198-287`, `$IWC_FORMAT2/virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping.gxwf.yml:287-346` — line counts become integer parameters used as collection duplication counts.
-- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction.gxwf.yml:1358-1463` — collection identifiers are counted, converted with `column_maker(c1 != 0)`, then read as `boolean_param`.
 
 ## See Also
 

--- a/content/patterns/harmonize-by-sortlist-from-identifiers.md
+++ b/content/patterns/harmonize-by-sortlist-from-identifiers.md
@@ -11,8 +11,8 @@ tags:
   - pattern
 status: draft
 created: 2026-05-02
-revised: 2026-05-02
-revision: 1
+revised: 2026-05-03
+revision: 2
 ai_generated: true
 summary: "Use SORTLIST with sort_type:file to reorder one collection by another collection's identifiers."
 related_notes:
@@ -22,6 +22,13 @@ related_patterns:
   - "[[collection-flatten-after-fanout]]"
 related_molds:
   - "[[implement-galaxy-tool-step]]"
+iwc_exemplars:
+  - workflow: virology/pox-virus-amplicon/pox-virus-half-genome
+    why: "Uses identifiers from Pool1 to drive SORTLIST ordering of Pool2."
+    confidence: high
+  - workflow: VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8
+    why: "Uses multiple file-driven SORTLIST steps to align sibling collections by identifier order."
+    confidence: high
 ---
 
 # Collection: harmonize by sortlist from identifiers
@@ -62,11 +69,6 @@ The `sort_file` must be the identifiers of the collection whose order should be 
 - The reference collection defines truth. If the identifier file comes from the wrong sibling, downstream pairing silently follows the wrong axis.
 - Extract identifiers after upstream relabel, filter, or flatten operations, not before.
 - Mention `__HARMONIZELISTS__` only as the absent catalog alternative; do not recommend it from corpus evidence.
-
-## Exemplars (IWC)
-
-- `$IWC_FORMAT2/virology/pox-virus-amplicon/pox-virus-half-genome.gxwf.yml:541-562` — identifiers from Pool1 drive `__SORTLIST__` on Pool2.
-- `$IWC_FORMAT2/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8.gxwf.yml` — subworkflow uses multiple file-driven `__SORTLIST__` steps to align sibling collections by identifier order.
 
 ## See also
 

--- a/content/patterns/map-workflow-enum-to-tool-parameter.md
+++ b/content/patterns/map-workflow-enum-to-tool-parameter.md
@@ -12,8 +12,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-05-02
-revised: 2026-05-02
-revision: 2
+revised: 2026-05-03
+revision: 3
 ai_generated: true
 summary: "Use map_param_value to translate workflow enum values into downstream tool codes, flags, or snippets."
 related_notes:
@@ -28,6 +28,24 @@ related_molds:
   - "[[implement-galaxy-tool-step]]"
 verification_paths:
   - verification/workflows/map-workflow-enum-to-tool-parameter/map-enum-to-text.gxwf-test.yml
+iwc_exemplars:
+  - workflow: transcriptomics/rnaseq-pe/rnaseq-pe
+    steps:
+      - label: "Strandedness to featureCounts codes"
+      - label: "Strandedness to Cufflinks library types"
+      - label: "Strandedness to StringTie flags"
+    why: "Shows one workflow enum normalized into several downstream tool dialects with separate mapper steps."
+    confidence: high
+  - workflow: VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8
+    steps:
+      - label: "Map haplotype labels to suffix abbreviations"
+    why: "Shows label-to-fragment mapping consumed later by runtime text composition."
+    confidence: high
+  - workflow: amplicon/amplicon-mgnify/taxonomic-rank-abundance-summary-table/taxonomic-rank-abundance-summary-table
+    steps:
+      - label: "Map taxonomic rank to awk program text"
+    why: "Shows enum mapping into executable text for a downstream text-processing parameter."
+    confidence: high
 ---
 
 # Parameter: map workflow enum to tool parameter
@@ -113,15 +131,6 @@ The same workflow enum maps through sibling `map_param_value` steps into Cufflin
 - Do not silently change quoted numeric codes into numeric output types unless the downstream parameter expects a numeric type.
 - Do not use one mapper output for incompatible tool dialects. One workflow value may need several mapper steps.
 - Treat long generated snippets as brittle. The taxonomy awk examples prove the mechanism, but a clearer wrapper or smaller expression is easier to maintain when available.
-
-## Exemplars (IWC)
-
-- `$IWC_FORMAT2/transcriptomics/rnaseq-pe/rnaseq-pe.gxwf.yml:270-299` — `Strandedness` to `featureCounts` codes `1`, `2`, `0` with `unmapped.on_unmapped: fail`.
-- `$IWC_FORMAT2/transcriptomics/rnaseq-pe/rnaseq-pe.gxwf.yml:303-332` — same workflow enum mapped to Cufflinks library types `fr-secondstrand`, `fr-firststrand`, `fr-unstranded`.
-- `$IWC_FORMAT2/transcriptomics/rnaseq-pe/rnaseq-pe.gxwf.yml:336-365` — same workflow enum mapped to StringTie flags `--fr`, `--rf`, and empty string.
-- `$IWC_FORMAT2/transcriptomics/rnaseq-pe/rnaseq-pe.gxwf.yml:1017-1081`, `$IWC_FORMAT2/transcriptomics/rnaseq-pe/rnaseq-pe.gxwf.yml:1082-1140`, `$IWC_FORMAT2/transcriptomics/rnaseq-pe/rnaseq-pe.gxwf.yml:1141-1152` — mapped outputs connected into `featureCounts`, StringTie, and Cufflinks parameters.
-- `$IWC_FORMAT2/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8.gxwf.yml:276-313`, `$IWC_FORMAT2/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8.gxwf.yml:1497-1522` — haplotype labels mapped to suffix abbreviations, then consumed by `compose_text_param`.
-- `$IWC_FORMAT2/amplicon/amplicon-mgnify/taxonomic-rank-abundance-summary-table/taxonomic-rank-abundance-summary-table.gxwf.yml:35-72`, `$IWC_FORMAT2/amplicon/amplicon-mgnify/taxonomic-rank-abundance-summary-table/taxonomic-rank-abundance-summary-table.gxwf.yml:118-139` — taxonomic rank mapped to awk program text and connected as `tp_awk_tool.code`.
 
 ## See Also
 

--- a/content/patterns/regex-relabel-via-tabular.md
+++ b/content/patterns/regex-relabel-via-tabular.md
@@ -11,8 +11,8 @@ tags:
   - pattern
 status: draft
 created: 2026-05-02
-revised: 2026-05-02
-revision: 1
+revised: 2026-05-03
+revision: 2
 ai_generated: true
 summary: "Derive collection element identifiers in a tabular mapping, then apply them with RELABEL_FROM_FILE."
 related_notes:
@@ -22,6 +22,16 @@ related_patterns:
   - "[[sync-collections-by-identifier]]"
 related_molds:
   - "[[implement-galaxy-tool-step]]"
+iwc_exemplars:
+  - workflow: data-fetching/sra-manifest-to-concatenated-fastqs/sra-manifest-to-concatenated-fastqs
+    why: "Uses a generated relabel table to restore paired and unpaired fasterq_dump output collection labels."
+    confidence: high
+  - workflow: microbiome/metagenomic-raw-reads-amr-analysis/metagenomic-raw-reads-amr-analysis
+    why: "Uses original read identifiers to relabel a downstream collection."
+    confidence: high
+  - workflow: virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping
+    why: "Shows the heavier sibling chain with identifier extraction and find/replace before relabeling."
+    confidence: high
 ---
 
 # Collection: regex relabel via tabular
@@ -80,12 +90,6 @@ tool_state:
 - `collection_element_identifiers` has no header; skipping the first line drops a real identifier.
 - Relabeling does not reorder or filter. Use a filter or sort pattern when membership or order changes.
 - Keep regex cleanup narrow enough that distinct elements do not collapse to the same identifier.
-
-## Exemplars (IWC)
-
-- `$IWC_FORMAT2/data-fetching/sra-manifest-to-concatenated-fastqs/sra-manifest-to-concatenated-fastqs.gxwf.yml` — generated relabel table feeds `__RELABEL_FROM_FILE__` for paired and unpaired `fasterq_dump` output collections.
-- `$IWC_FORMAT2/microbiome/metagenomic-raw-reads-amr-analysis/metagenomic-raw-reads-amr-analysis.gxwf.yml:11-19` — original read identifiers drive relabeling of a downstream collection.
-- `$IWC_FORMAT2/virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping.gxwf.yml:35-38` — heavier sibling chain uses identifier extraction plus `tp_find_and_replace` before relabeling.
 
 ## See also
 

--- a/content/patterns/relabel-via-rules-and-find-replace.md
+++ b/content/patterns/relabel-via-rules-and-find-replace.md
@@ -11,8 +11,8 @@ tags:
   - pattern
 status: draft
 created: 2026-05-02
-revised: 2026-05-02
-revision: 1
+revised: 2026-05-03
+revision: 2
 ai_generated: true
 summary: "Use Apply Rules, identifier extraction, find/replace, and relabeling for structural fan-out cleanup."
 related_notes:
@@ -23,6 +23,13 @@ related_patterns:
   - "[[collection-swap-nesting-with-apply-rules]]"
 related_molds:
   - "[[implement-galaxy-tool-step]]"
+iwc_exemplars:
+  - workflow: virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping
+    steps:
+      - label: "BAM split by reference relabel chain"
+      - label: "Repeated Apply Rules swap-nesting around sample and segment collections"
+    why: "Shows the dense chain of Apply Rules, identifier extraction, find/replace, relabeling, and Apply Rules regrouping."
+    confidence: high
 ---
 
 # Collection: relabel via rules and find/replace
@@ -71,11 +78,6 @@ Conceptual chain:
 - Extract identifiers at the right level; extracting before the first Apply Rules step can capture the wrong labels.
 - Rewrite only tool-added noise. A broad regex can merge distinct segment/sample identifiers.
 - `__RELABEL_FROM_FILE__` changes names only. Apply Rules carries the shape change.
-
-## Exemplars (IWC)
-
-- `$IWC_FORMAT2/virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping.gxwf.yml:34-38` — canonical dense segment: `bamtools_split_ref` output goes through Apply Rules, identifier extraction, find/replace, relabeling, then Apply Rules again.
-- `$IWC_FORMAT2/virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping.gxwf.yml:14,39,43` — same workflow repeatedly uses the Apply Rules swap-nesting shape around sample/segment collections.
 
 ## See also
 

--- a/content/patterns/sync-collections-by-identifier.md
+++ b/content/patterns/sync-collections-by-identifier.md
@@ -11,8 +11,8 @@ tags:
   - pattern
 status: draft
 created: 2026-05-02
-revised: 2026-05-02
-revision: 1
+revised: 2026-05-03
+revision: 2
 ai_generated: true
 summary: "Use collection_element_identifiers with FILTER_FROM_FILE or RELABEL_FROM_FILE to align sibling collections."
 related_notes:
@@ -22,6 +22,16 @@ related_patterns:
   - "[[harmonize-by-sortlist-from-identifiers]]"
 related_molds:
   - "[[implement-galaxy-tool-step]]"
+iwc_exemplars:
+  - workflow: amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction
+    why: "Cleaned SSU and LSU BED identifiers drive filtering of processed sequence collections."
+    confidence: high
+  - workflow: amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-its/mgnify-amplicon-pipeline-v5-its
+    why: "Shows a compact clean, identify, and filter sibling collection shape."
+    confidence: high
+  - workflow: microbiome/metagenomic-raw-reads-amr-analysis/metagenomic-raw-reads-amr-analysis
+    why: "Uses identifier extraction and relabeling to restore per-sample identity downstream."
+    confidence: high
 ---
 
 # Collection: sync collections by identifier
@@ -76,12 +86,6 @@ tool_state:
 - Extract identifiers from the collection that represents truth after cleanup. In MGnify examples, BED hits drive filtering of processed sequences, not the reverse.
 - Relabeling can hide mismatches when strict checks are off. Use only when the upstream shape guarantees correspondence.
 - `__FILTER_FROM_FILE__` filters by names in a file; it does not inspect whether files are empty or failed.
-
-## Exemplars (IWC)
-
-- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction.gxwf.yml:12-18` — cleaned SSU/LSU BED identifiers drive filtering of processed sequence collections.
-- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-its/mgnify-amplicon-pipeline-v5-its.gxwf.yml:2-4` — compact version of the same clean, identify, filter sibling shape.
-- `$IWC_FORMAT2/microbiome/metagenomic-raw-reads-amr-analysis/metagenomic-raw-reads-amr-analysis.gxwf.yml:11,19` — identifier extraction and relabel variant used to restore per-sample identity downstream.
 
 ## See also
 

--- a/content/patterns/tabular-compute-new-column.md
+++ b/content/patterns/tabular-compute-new-column.md
@@ -8,8 +8,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-05-02
-revision: 2
+revised: 2026-05-03
+revision: 3
 ai_generated: true
 summary: "Use column_maker (Add_a_column1) with strict error_handling to insert/replace a computed column. Per-expression-kind auto_col_types rule."
 related_notes:
@@ -21,6 +21,19 @@ related_patterns:
   - "[[derive-parameter-from-file]]"
 related_molds:
   - "[[implement-galaxy-tool-step]]"
+iwc_exemplars:
+  - workflow: sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting
+    steps:
+      - label: "Raw cN arithmetic with auto_col_types true"
+      - label: "String concatenation with auto_col_types false"
+    why: "Shows the key auto_col_types split between arithmetic and string concatenation expressions."
+    confidence: high
+  - workflow: sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation
+    why: "Shows explicit-cast arithmetic with auto_col_types false and skip-non-computable handling."
+    confidence: high
+  - workflow: amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction
+    why: "Computes c1 != 0 before reading the result as a boolean parameter for a non-empty gate."
+    confidence: high
 ---
 
 # Tabular: compute a new column
@@ -76,9 +89,9 @@ Rationale: with `true`, `c5 + c6` performs numeric addition (silently turning a 
 
 Canonical exemplars to memorize:
 
-- Arithmetic on raw `cN`, `auto_col_types: true` — `variation-reporting.gxwf.yml:316-329` (`AF = round((c18 + c19) / c6, 6)` replace at position 7; `AFcaller` insert at position 8).
-- String concat, `auto_col_types: false` — `variation-reporting.gxwf.yml:438-475` (`c5 + '>' + c6` named `change`, `c3 + ':' + c19` named `change_with_pos`; both `mode: ""` append).
-- Explicit-cast arithmetic, `auto_col_types: false` — `consensus-from-variation.gxwf.yml:343-378` (`int(c2) - (len(c3) == 1)` and `int(c2) + ((len(c3) - 1) or 1)`, replace at positions 2 and 3; uses `--skip-non-computable`).
+- Arithmetic on raw `cN`, `auto_col_types: true` — the SARS-CoV-2 variation reporting workflow computes `AF = round((c18 + c19) / c6, 6)` and inserts `AFcaller`.
+- String concat, `auto_col_types: false` — the same workflow appends `change` and `change_with_pos` from string concatenation expressions.
+- Explicit-cast arithmetic, `auto_col_types: false` — the SARS-CoV-2 consensus-from-variation workflow uses `int(...)` expressions with `--skip-non-computable`.
 
 ## Idiomatic shapes
 
@@ -107,7 +120,7 @@ tool_state:
         new_column_name: AF
 ```
 
-Cited at `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:307-329`.
+Anchored by the SARS-CoV-2 variation reporting IWC exemplar.
 
 String-concat new columns (append), `auto_col_types: false`:
 
@@ -134,7 +147,7 @@ tool_state:
         new_column_name: change_with_pos
 ```
 
-Cited at `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:438-475`.
+Anchored by the SARS-CoV-2 variation reporting IWC exemplar.
 
 ## Pitfalls
 
@@ -145,14 +158,6 @@ Cited at `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting
 - **Skipping `error_handling`.** Wrapper defaults differ from corpus defaults; without explicit `fail_on_non_existent_columns: true`, non-existent column refs may pass through depending on `non_computable.action`.
 - **`add_column.mode` / `pos`.** `I` (insert) and `R` (replace) take a 1-indexed integer `pos`; append uses `mode: ""` and `pos: ""`. Off-by-one in `pos` shifts every downstream `cN` reference in subsequent expressions in the same step.
 - **`Add a column` (`addValue/1.0.1`)** — a different, legacy tool that adds a *constant* column only. Do not confuse with `column_maker/Add_a_column1`.
-
-## Exemplars (IWC)
-
-
-- `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:307-329` — raw-`cN` arithmetic, `auto_col_types: true`, insert + replace pair.
-- `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:438-475` — string concat, `auto_col_types: false`, append (`mode: ""`).
-- `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation.gxwf.yml:343-378` — explicit-cast arithmetic (`int(c2) - …`), `auto_col_types: false`, `--skip-non-computable`. Counter-example to "arithmetic always implies `auto_col_types: true`."
-- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction.gxwf.yml:1396-1463` — computes `c1 != 0`, then reads the result as a boolean parameter for a non-empty gate.
 
 ## Legacy alternative
 

--- a/content/patterns/tabular-concatenate-collection-to-table.md
+++ b/content/patterns/tabular-concatenate-collection-to-table.md
@@ -12,8 +12,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-05-02
-revised: 2026-05-02
-revision: 1
+revised: 2026-05-03
+revision: 2
 ai_generated: true
 summary: "Use collapse_dataset to row-bind a collection of tabulars into one table, with optional element IDs and header dedupe."
 related_notes:
@@ -24,6 +24,19 @@ related_patterns:
   - "[[tabular-group-and-aggregate-with-datamash]]"
 related_molds:
   - "[[implement-galaxy-tool-step]]"
+iwc_exemplars:
+  - workflow: sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting
+    why: "Shows the canonical row-provenance triad with add_name, same_multiple, and one_header."
+    confidence: high
+  - workflow: amplicon/amplicon-mgnify/mapseq-to-ampvis2/mapseq-to-ampvis2
+    why: "Shows collection concatenation without element-name or header handling."
+    confidence: high
+  - workflow: virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping
+    why: "Shows headerless outputs with per-row provenance and repeated bridge use before filtering."
+    confidence: high
+  - workflow: microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation
+    why: "Shows the same collection-to-tabular bridge in a pathogen aggregation workflow."
+    confidence: high
 ---
 
 # Tabular: concatenate collection to table
@@ -70,7 +83,7 @@ tool_state:
   one_header: true
 ```
 
-Cited at `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:414-433`.
+Anchored by the SARS-CoV-2 variation reporting IWC exemplar.
 
 Collection concat with no element identifier:
 
@@ -82,7 +95,7 @@ tool_state:
   one_header: false
 ```
 
-Cited at `$IWC_FORMAT2/amplicon/amplicon-mgnify/mapseq-to-ampvis2/mapseq-to-ampvis2.gxwf.yml:178-198`.
+Anchored by the MAPseq-to-ampvis2 IWC exemplar.
 
 Headerless outputs with row provenance:
 
@@ -95,7 +108,7 @@ tool_state:
   one_header: false
 ```
 
-Cited at `$IWC_FORMAT2/virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping.gxwf.yml:715-734`.
+Anchored by the influenza consensus and subtyping IWC exemplar.
 
 ## Pitfalls
 
@@ -105,14 +118,6 @@ Cited at `$IWC_FORMAT2/virology/influenza-isolates-consensus-and-subtyping/influ
 - **`place_name: same_multiple` is the row-provenance idiom.** It repeats the element name so each output row carries identity.
 - **`same_once` is a different shape.** Use it only when downstream expects block labels, not per-row identity.
 - **This is row-bind, not wide pivot.** If each collection element should become a column, use [[tabular-pivot-collection-to-wide]].
-
-## Exemplars (IWC)
-
-- `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:414-433` — canonical triad: `add_name: true`, `place_name: same_multiple`, `one_header: true`.
-- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mapseq-to-ampvis2/mapseq-to-ampvis2.gxwf.yml:178-198` — concat without name/header handling: `add_name: false`, `one_header: false`.
-- `$IWC_FORMAT2/virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping.gxwf.yml:715-734` — `add_name: true`, `same_multiple`, `one_header: false`.
-- `$IWC_FORMAT2/virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping.gxwf.yml:1195-1240` — repeated bridge pattern before tabular filtering.
-- `$IWC_FORMAT2/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation.gxwf.yml:509-548` — collection bridge in a pathogen workflow.
 
 ## Legacy alternative
 

--- a/content/patterns/tabular-cut-and-reorder-columns.md
+++ b/content/patterns/tabular-cut-and-reorder-columns.md
@@ -8,8 +8,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-04-30
-revision: 1
+revised: 2026-05-03
+revision: 2
 ai_generated: true
 summary: "Use Cut1 with a comma-separated cN list to project — and reorder — columns. Listing out of order is the canonical reorder idiom."
 related_notes:
@@ -19,6 +19,16 @@ related_patterns:
   - "[[tabular-sql-query]]"
 related_molds:
   - "[[implement-galaxy-tool-step]]"
+iwc_exemplars:
+  - workflow: sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting
+    steps:
+      - label: "Long projection and reorder with c20 last"
+      - label: "Sibling Cut1 steps with different column lists"
+    why: "Shows pure projection and reordering with long explicit column lists."
+    confidence: high
+  - workflow: genome_annotation/functional-annotation/functional-annotation-of-sequences/Functional_annotation_of_sequences
+    why: "Shows a legacy Paste1 plus Cut1 chain that should usually be replaced by column_maker for new work."
+    confidence: medium
 ---
 
 # Tabular: cut and reorder columns
@@ -59,7 +69,7 @@ tool_state:
   delimiter: T
 ```
 
-Cited at `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:782`.
+Anchored by the SARS-CoV-2 variation reporting IWC exemplar.
 
 ## Pitfalls
 
@@ -68,13 +78,6 @@ Cited at `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting
 - **Cut breaks Galaxy column metadata.** The wrapper warns: re-cutting may invalidate column-assignment metadata (chrom/start/end for interval/BED). Re-establish via the dataset's "edit attributes" if downstream tools need it.
 - **Reorder-then-rename** is *not* `Cut1`'s job. Renaming columns means rewriting the header row — handle that with [[tabular-compute-new-column]] or with a `tp_replace_in_line` pass.
 - **Adding a constant column** belongs to [[tabular-compute-new-column]] (`column_maker/Add_a_column1`), not `Cut1` + `Paste1`. The latter is legacy.
-
-## Exemplars (IWC)
-
-
-- `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:782` — long projection + reorder (17 columns, `c20` last).
-- `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:830`, `:878` — sibling Cut1 steps in the same workflow, different column lists.
-- `$IWC_FORMAT2/genome_annotation/functional-annotation/functional-annotation-of-sequences/Functional_annotation_of_sequences.gxwf.yml:733` — `Paste1`+`Cut1` chain (legacy idiom; prefer [[tabular-compute-new-column]] today).
 
 ## Legacy alternative
 

--- a/content/patterns/tabular-filter-by-column-value.md
+++ b/content/patterns/tabular-filter-by-column-value.md
@@ -8,8 +8,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-04-30
-revision: 1
+revised: 2026-05-03
+revision: 2
 ai_generated: true
 summary: "Use Filter1 with a Python expression over cN columns to drop rows. Highest-frequency tabular row filter in IWC."
 related_notes:
@@ -19,6 +19,16 @@ related_patterns:
   - "[[tabular-sql-query]]"
 related_molds:
   - "[[implement-galaxy-tool-step]]"
+iwc_exemplars:
+  - workflow: sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting
+    why: "Shows a literal Filter1 predicate over a string status column with one header line."
+    confidence: high
+  - workflow: sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation
+    why: "Shows a connected predicate generated upstream with header_lines set independently."
+    confidence: high
+  - workflow: epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun
+    why: "Shows another connected predicate shape where the filter rule is supplied at runtime."
+    confidence: high
 ---
 
 # Tabular: filter rows by column value
@@ -50,7 +60,7 @@ tool_state:
   header_lines: '1'
 ```
 
-Cited at `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:545`.
+Anchored by the SARS-CoV-2 variation reporting IWC exemplar.
 
 Predicate produced upstream and wired in via `ConnectedValue` (lets a workflow author parameterize the predicate without a runtime parameter). Note that this corpus example has `header_lines: "0"` because the upstream rule already accounts for the header — the `header_lines` setting is independent of the `cond` source:
 
@@ -61,7 +71,7 @@ tool_state:
   header_lines: '0'
 ```
 
-Cited at `$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:320-336`.
+Anchored by the consensus peaks ATAC/CUT&RUN IWC exemplar.
 
 ## Pitfalls
 
@@ -70,13 +80,6 @@ Cited at `$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-atac-cutandru
 - **Uppercase operators.** `cond: c1=='X' OR c1=='Y'` — `OR` is treated as a name (`NameError`), not a boolean op. Use lowercase `and`, `or`, `not`.
 - **No new columns.** `Filter1` is a *filter*; new or computed columns belong in [[tabular-compute-new-column]].
 - **Implicit column-type coercion.** `cN` values are strings until an operator forces int/float; coercion failures skip the row (counted in the dataset metadata, not surfaced in the output stream). If silent-from-data drops are unacceptable, pre-clean upstream or use [[tabular-sql-query]].
-
-## Exemplars (IWC)
-
-
-- `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:545` — literal predicate `c4=='PASS' or c4=='.'`, `header_lines: "1"`.
-- `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation.gxwf.yml:276` — `ConnectedValue` predicate, `header_lines: "0"` (rule generated upstream).
-- `$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:320-336` — `ConnectedValue` predicate, `header_lines: "0"`.
 
 All three corpus filters are equality / disjunction over a string column, or a `ConnectedValue` rule. Numeric-range predicates are unattested — if you reach for `cN > X`, you're slightly off the corpus path; verify behavior on a sample.
 

--- a/content/patterns/tabular-filter-by-regex.md
+++ b/content/patterns/tabular-filter-by-regex.md
@@ -8,8 +8,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-04-30
-revision: 1
+revised: 2026-05-03
+revision: 2
 ai_generated: true
 summary: "Use tp_grep_tool for whole-line regex row filters on tabular input. Grep1 is the legacy alternative."
 related_notes:
@@ -19,6 +19,19 @@ related_patterns:
   - "[[tabular-sql-query]]"
 related_molds:
   - "[[implement-galaxy-tool-step]]"
+iwc_exemplars:
+  - workflow: epigenetics/atacseq/atacseq
+    why: "Drops comment lines from a fragment-length histogram with tp_grep_tool and invert mode."
+    confidence: high
+  - workflow: epigenetics/chipseq-sr/chipseq-sr
+    why: "Keeps MACS2 summary header lines and changes datatype for downstream rendering."
+    confidence: high
+  - workflow: VGP-assembly-v2/Purge-duplicates-one-haplotype-VGP6b/Purging-duplicates-one-haplotype-VGP6b
+    why: "Drops BED rows containing REPEAT with inverted grep."
+    confidence: high
+  - workflow: comparative_genomics/hyphy/capheine-core-and-compare
+    why: "Shows the legacy Grep1 path for keeping FASTA header lines."
+    confidence: medium
 ---
 
 # Tabular: filter rows by regex
@@ -66,7 +79,7 @@ tool_state:
   color: NOCOLOR
 ```
 
-Cited at `$IWC_FORMAT2/epigenetics/atacseq/atacseq.gxwf.yml:469` ("remove comments lines") and `$IWC_FORMAT2/epigenetics/chipseq-sr/chipseq-sr.gxwf.yml:305` (same shape, `invert: ""` to *keep* `^#` summary lines into a MACS2 report).
+Anchored by the ATAC-seq and ChIP-seq single-read IWC exemplars.
 
 Drop rows containing a literal token:
 
@@ -83,7 +96,7 @@ tool_state:
   color: NOCOLOR
 ```
 
-Cited at `$IWC_FORMAT2/VGP-assembly-v2/Purge-duplicates-one-haplotype-VGP6b/Purging-duplicates-one-haplotype-VGP6b.gxwf.yml:983` ("Remove REPEATs from BED").
+Anchored by the VGP purge-duplicates IWC exemplar.
 
 ## Pitfalls
 
@@ -93,13 +106,6 @@ Cited at `$IWC_FORMAT2/VGP-assembly-v2/Purge-duplicates-one-haplotype-VGP6b/Purg
 - **PCRE vs ERE.** `regex_type: -P` is the corpus default and matches `Grep1`'s flavor. ERE / BRE are available but unattested in the survey; switching flavors mid-workflow makes patterns harder to reason about.
 - **No column awareness.** A pattern like `\tPASS\t` is the closest you can get to "column 4 equals PASS" — and it's brittle (depends on tab counts, breaks on the first/last column). Use [[tabular-filter-by-column-value]] for column predicates.
 - **Version pin sprawl.** Four pins coexist in the corpus (`1.1.1`, `9.3+galaxy1`, `9.5+galaxy2`, `9.5+galaxy3` — `9.5+galaxy3` dominates) with the same parameter shape. Pick the highest pin already present in the workflow you're touching; do not block PRs for older pins on cleanup grounds.
-
-## Exemplars (IWC)
-
-- `$IWC_FORMAT2/epigenetics/atacseq/atacseq.gxwf.yml:469` — drop `^#` comment lines from a fragment-length histogram (`invert: -v`).
-- `$IWC_FORMAT2/epigenetics/chipseq-sr/chipseq-sr.gxwf.yml:305` — keep `^#` MACS2 summary header lines (`invert: ""`); change_datatype to `txt` for downstream rendering.
-- `$IWC_FORMAT2/VGP-assembly-v2/Purge-duplicates-one-haplotype-VGP6b/Purging-duplicates-one-haplotype-VGP6b.gxwf.yml:983` — drop BED rows containing `REPEAT` (`invert: -v`).
-- `$IWC_FORMAT2/comparative_genomics/hyphy/capheine-core-and-compare.gxwf.yml:687` — `Grep1` (legacy) keeping FASTA header lines (`pattern: ^>`, `invert: ""`, `keep_header: false`).
 
 ## Legacy alternative
 

--- a/content/patterns/tabular-group-and-aggregate-with-datamash.md
+++ b/content/patterns/tabular-group-and-aggregate-with-datamash.md
@@ -8,8 +8,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-05-02
-revised: 2026-05-02
-revision: 1
+revised: 2026-05-03
+revision: 2
 ai_generated: true
 summary: "Use datamash_ops for grouped tabular aggregation: multi-column grouping, collapse, countunique, min/max, and reductions."
 related_notes:
@@ -20,6 +20,20 @@ related_patterns:
   - "[[tabular-join-on-key]]"
 related_molds:
   - "[[implement-galaxy-tool-step]]"
+iwc_exemplars:
+  - workflow: sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting
+    steps:
+      - label: "Grouped collapse with regex cleanup"
+      - label: "Grouped countunique, min, and max"
+      - label: "Single countunique operation"
+    why: "Shows multi-column grouping, grouped summaries, and cleanup after collapsed datamash output."
+    confidence: high
+  - workflow: VGP-assembly-v2/Purge-duplicates-one-haplotype-VGP6b/Purging-duplicates-one-haplotype-VGP6b
+    why: "Shows whole-file absmax reduction with no grouping."
+    confidence: high
+  - workflow: microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation
+    why: "Shows legacy Grouping1 occurrences preserved as inherited workflow context."
+    confidence: medium
 ---
 
 # Tabular: group and aggregate
@@ -78,7 +92,7 @@ tool_state:
   print_full_line: false
 ```
 
-Cited at `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:333-373`.
+Anchored by the SARS-CoV-2 variation reporting IWC exemplar.
 
 Grouped multi-stat summary in one pass:
 
@@ -106,7 +120,7 @@ tool_state:
   print_full_line: false
 ```
 
-Cited at `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:562-596`.
+Anchored by the SARS-CoV-2 variation reporting IWC exemplar.
 
 ## Pitfalls
 
@@ -118,21 +132,13 @@ Cited at `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting
 - **Empty `grouping: ""` is a whole-file aggregate.** Valid, but a different operation than grouped summary.
 - **Version pins vary.** Prefer the newest available pin in the workflow context; do not downgrade just to match an old exemplar.
 
-## Exemplars (IWC)
-
-- `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:333-373` — 10-column grouping with 7 `collapse` operations.
-- `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:375-407` — regex cleanup after collapsed datamash output.
-- `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:562-596` — `countunique`, `min`, and `max` in one grouped step.
-- `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:632-657` — single `countunique` operation.
-- `$IWC_FORMAT2/VGP-assembly-v2/Purge-duplicates-one-haplotype-VGP6b/Purging-duplicates-one-haplotype-VGP6b.gxwf.yml:601-626` — `1.9+galaxy0`, whole-file `absmax` reduction with no grouping.
-
 ## Legacy alternative
 
 `Grouping1` (Galaxy core; display name "Group data by a column") survives in older microbiome workflows. Preserve it when reading old workflows, but prefer `datamash_ops` for new authoring.
 
 Distinguishing fields: `groupcol`, `ignorecase`, `ignorelines`, `operations[].optype`, `operations[].opcol`, `operations[].opround`, and `operations[].opdefault`. Do not translate `Grouping1.operations[].optype` directly into datamash without checking names; datamash uses `op_name`.
 
-Cited at `$IWC_FORMAT2/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation.gxwf.yml:324-340` and `:1087-1103`.
+Anchored by the PathoGFAIR sample aggregation IWC exemplar.
 
 ## See also
 

--- a/content/patterns/tabular-join-on-key.md
+++ b/content/patterns/tabular-join-on-key.md
@@ -8,8 +8,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-05-02
-revised: 2026-05-02
-revision: 1
+revised: 2026-05-03
+revision: 2
 ai_generated: true
 summary: "Use tp_easyjoin_tool for two-tabular key joins; use tp_multijoin_tool for many files and query_tabular for SQL joins."
 related_notes:
@@ -20,6 +20,25 @@ related_patterns:
   - "[[tabular-pivot-collection-to-wide]]"
 related_molds:
   - "[[implement-galaxy-tool-step]]"
+iwc_exemplars:
+  - workflow: sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting
+    why: "Shows canonical and repeated tp_easyjoin_tool fan-in joins with headered inputs and zero fill."
+    confidence: high
+  - workflow: VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8
+    why: "Shows a newer tp_easyjoin_tool pin joining key 1 to key 1 with dot fill."
+    confidence: high
+  - workflow: microbiome/metagenomic-genes-catalogue/metagenomic-genes-catalogue
+    why: "Shows a headerless easyjoin labeled Join Prodigal to AMR."
+    confidence: high
+  - workflow: microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation
+    why: "Shows tp_multijoin_tool for many same-shaped key/value files."
+    confidence: high
+  - workflow: proteomics/clinicalmp/clinicalmp-verification/clinicalmp-verification
+    why: "Shows query_tabular used for a two-table SQL inner join."
+    confidence: high
+  - workflow: proteomics/clinicalmp/clinicalmp-discovery/iwc-clinicalmp-discovery-workflow
+    why: "Shows SQL anti-join with load filters and indexes."
+    confidence: high
 ---
 
 # Tabular: join on key
@@ -73,7 +92,7 @@ tool_state:
   jointype: " "
 ```
 
-Cited at `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:601-627`.
+Anchored by the SARS-CoV-2 variation reporting IWC exemplar.
 
 Many two-column files joined by a shared key:
 
@@ -90,7 +109,7 @@ tool_state:
   ignore_dups: false
 ```
 
-Cited at `$IWC_FORMAT2/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation.gxwf.yml:796-819`.
+Anchored by the PathoGFAIR sample aggregation IWC exemplar.
 
 SQL join when SQL semantics matter:
 
@@ -115,7 +134,7 @@ tool_state:
         col_names: pep,prot
 ```
 
-Cited at `$IWC_FORMAT2/proteomics/clinicalmp/clinicalmp-verification/clinicalmp-verification.gxwf.yml:359-415`.
+Anchored by the clinical metaproteomics verification IWC exemplar.
 
 ## Pitfalls
 
@@ -126,16 +145,6 @@ Cited at `$IWC_FORMAT2/proteomics/clinicalmp/clinicalmp-verification/clinicalmp-
 - **`tp_easyjoin_tool` is not SQL.** Compound predicates, anti-joins, named-column projection, or indexed joins belong in [[tabular-sql-query]].
 - **`tp_multijoin_tool` assumes uniform shape.** It fits many same-shaped key/value files, not arbitrary heterogeneous tables.
 - **Do not substitute collection joins.** `collection_column_join` is for the collection-to-wide-table idiom, not ordinary two-file joins.
-
-## Exemplars (IWC)
-
-- `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:601-627` — canonical `tp_easyjoin_tool` with `column1: "20"`, `column2: "1"`, `empty_string_filler: "0"`, `header: true`, `jointype: " "`.
-- `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:722-747`, `:752-777`, `:799-825` — repeated fan-in joins with the same easyjoin shape.
-- `$IWC_FORMAT2/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8.gxwf.yml:3452-3477` — newer `tp_easyjoin_tool/9.5+galaxy3`, key `1` to `1`, filler `"."`.
-- `$IWC_FORMAT2/microbiome/metagenomic-genes-catalogue/metagenomic-genes-catalogue.gxwf.yml:1013-1041` — headerless easyjoin, labeled "Join Prodigal to AMR".
-- `$IWC_FORMAT2/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation.gxwf.yml:796-819` — `tp_multijoin_tool`, key column `"1"`, value column `"2"`, filler `"0"`.
-- `$IWC_FORMAT2/proteomics/clinicalmp/clinicalmp-verification/clinicalmp-verification.gxwf.yml:359-415` — `query_tabular` `INNER JOIN`.
-- `$IWC_FORMAT2/proteomics/clinicalmp/clinicalmp-discovery/iwc-clinicalmp-discovery-workflow.gxwf.yml:724-814` — SQL anti-join using `WHERE ... NOT IN (SELECT ... JOIN ...)`.
 
 ## Legacy alternative
 

--- a/content/patterns/tabular-pivot-collection-to-wide.md
+++ b/content/patterns/tabular-pivot-collection-to-wide.md
@@ -10,8 +10,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-05-02
-revised: 2026-05-02
-revision: 1
+revised: 2026-05-03
+revision: 2
 ai_generated: true
 summary: "Use collection_column_join to outer-join a collection of 2-column id/value tables into one wide table."
 related_notes:
@@ -21,6 +21,19 @@ related_patterns:
   - "[[tabular-concatenate-collection-to-table]]"
 related_molds:
   - "[[implement-galaxy-tool-step]]"
+iwc_exemplars:
+  - workflow: amplicon/amplicon-mgnify/mapseq-to-ampvis2/mapseq-to-ampvis2
+    why: "Pivots a headerless id/value collection to a wide table with zero fill and element identity in headers."
+    confidence: high
+  - workflow: microbiome/mags-building/MAGs-generation
+    why: "Shows repeated metric pivots over headered inputs with missing values represented as dots."
+    confidence: high
+  - workflow: microbiome/mag-genome-annotation-parallel/MAG-Genome-Annotation-Parallel
+    why: "Merges Bakta output through collection_column_join with headered input and element identity in headers."
+    confidence: high
+  - workflow: microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation
+    why: "Shows defensive empty-dataset filtering upstream of collection_column_join."
+    confidence: high
 ---
 
 # Tabular: pivot collection to wide
@@ -59,7 +72,7 @@ tool_state:
   old_col_in_header: true
 ```
 
-Cited at `$IWC_FORMAT2/amplicon/amplicon-mgnify/mapseq-to-ampvis2/mapseq-to-ampvis2.gxwf.yml:202-222`.
+Anchored by the MAPseq-to-ampvis2 IWC exemplar.
 
 Headered metric-table pivot:
 
@@ -74,7 +87,7 @@ tool_state:
   old_col_in_header: false
 ```
 
-Cited at `$IWC_FORMAT2/microbiome/mags-building/MAGs-generation.gxwf.yml:1483-1505`, `:1544-1565`, and `:1656-1677`.
+Anchored by the MAGs generation IWC exemplar.
 
 ## Pitfalls
 
@@ -84,14 +97,6 @@ Cited at `$IWC_FORMAT2/microbiome/mags-building/MAGs-generation.gxwf.yml:1483-15
 - **Fill value has meaning.** `"0"` means absent is zero; `.` means missing/unknown. Match downstream semantics.
 - **Header semantics matter.** `old_col_in_header: true` preserves element identity in headers; `false` appears in MAG metric pivots.
 - **Guard empties when plausible.** The transformations survey flags upstream `__FILTER_EMPTY_DATASETS__` as a defensive guard when per-element outputs may be empty, especially small-N or filter-heavy paths. Do not apply it as universal boilerplate; several IWC pivots do not filter first.
-
-## Exemplars (IWC)
-
-- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mapseq-to-ampvis2/mapseq-to-ampvis2.gxwf.yml:202-222` — headerless id/value collection to wide table, `fill_char: "0"`, `old_col_in_header: true`.
-- `$IWC_FORMAT2/microbiome/mags-building/MAGs-generation.gxwf.yml:1483-1505`, `:1544-1565`, `:1656-1677` — three metric pivots in one workflow, headered inputs, `fill_char: .`.
-- `$IWC_FORMAT2/microbiome/mag-genome-annotation-parallel/MAG-Genome-Annotation-Parallel.gxwf.yml:811-833` — "Merge Bakta Output", headered input, `old_col_in_header: true`.
-- `$IWC_FORMAT2/microbiome/pathogen-identification/nanopore-pre-processing/Nanopore-Pre-Processing.gxwf.yml:823-843` — upstream tabular sources joined into wide output.
-- `$IWC_FORMAT2/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation.gxwf.yml:444-455`, `:552-571` — defensive `__FILTER_EMPTY_DATASETS__` upstream of `collection_column_join`.
 
 ## Legacy alternative
 

--- a/content/patterns/tabular-prepend-header.md
+++ b/content/patterns/tabular-prepend-header.md
@@ -8,8 +8,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-05-02
-revised: 2026-05-02
-revision: 1
+revised: 2026-05-03
+revision: 2
 ai_generated: true
 summary: "Use tp_awk_tool to prepend a constant header line, optionally skipping or reformatting an existing first row."
 related_notes:
@@ -19,6 +19,16 @@ related_patterns:
   - "[[tabular-concatenate-collection-to-table]]"
 related_molds:
   - "[[implement-galaxy-tool-step]]"
+iwc_exemplars:
+  - workflow: microbiome/mags-building/MAGs-generation
+    why: "Uses multiline awk to prepend genome/completeness/contamination, skip the old first row, and normalize genome suffixes."
+    confidence: high
+  - workflow: VGP-assembly-v2/Purge-duplicates-one-haplotype-VGP6b/Purging-duplicates-one-haplotype-VGP6b
+    why: "Shows one-line awk header injection for alternate and primary metrics."
+    confidence: high
+  - workflow: VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8
+    why: "Shows one-line awk header injection for contig metrics and notes."
+    confidence: high
 ---
 
 # Tabular: prepend header
@@ -55,7 +65,7 @@ tool_state:
   variables: []
 ```
 
-Cited at `$IWC_FORMAT2/VGP-assembly-v2/Purge-duplicates-one-haplotype-VGP6b/Purging-duplicates-one-haplotype-VGP6b.gxwf.yml:846-858`.
+Anchored by the VGP purge-duplicates IWC exemplar.
 
 Prepend a header, skip the old first row, and normalize rows:
 
@@ -73,7 +83,7 @@ tool_state:
   variables: []
 ```
 
-Cited at `$IWC_FORMAT2/microbiome/mags-building/MAGs-generation.gxwf.yml:1078-1099`.
+Anchored by the MAGs generation IWC exemplar.
 
 ## Pitfalls
 
@@ -82,13 +92,6 @@ Cited at `$IWC_FORMAT2/microbiome/mags-building/MAGs-generation.gxwf.yml:1078-10
 - **Quoted and multiline `code` both occur.** Use one-line quoted strings only for simple pass-through. Use multiline `|-` for `NR > 1`, conditionals, or field rewriting.
 - **Do not name this awk.** The page is operation-named per the survey decision. Sibling awk recipes get their own operation pages.
 - **Header injection is not collection header dedupe.** Collection-wide header dedupe belongs to [[tabular-concatenate-collection-to-table]].
-
-## Exemplars (IWC)
-
-- `$IWC_FORMAT2/microbiome/mags-building/MAGs-generation.gxwf.yml:1078-1099` — multiline awk, prepends `genome\tcompleteness\tcontamination`, skips existing first row, appends `.fasta` when missing.
-- `$IWC_FORMAT2/VGP-assembly-v2/Purge-duplicates-one-haplotype-VGP6b/Purging-duplicates-one-haplotype-VGP6b.gxwf.yml:846-858` — one-liner `Metric\tAlternate`.
-- `$IWC_FORMAT2/VGP-assembly-v2/Purge-duplicates-one-haplotype-VGP6b/Purging-duplicates-one-haplotype-VGP6b.gxwf.yml:1622-1634` — sibling one-liner `Metric\tPrimary`.
-- `$IWC_FORMAT2/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8.gxwf.yml:2150-2161` — one-liner `Metric\tContigs\tNotes`.
 
 ## Legacy alternative
 

--- a/content/patterns/tabular-relabel-by-row-counter.md
+++ b/content/patterns/tabular-relabel-by-row-counter.md
@@ -11,8 +11,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-05-02
-revised: 2026-05-02
-revision: 1
+revised: 2026-05-03
+revision: 2
 ai_generated: true
 summary: "Use tp_awk_tool to replace each row or label with deterministic sample_N values from awk NR."
 related_notes:
@@ -23,6 +23,10 @@ related_patterns:
   - "[[tabular-concatenate-collection-to-table]]"
 related_molds:
   - "[[implement-galaxy-tool-step]]"
+iwc_exemplars:
+  - workflow: microbiome/binning-evaluation/MAGs-binning-evaluation
+    why: "Uses tp_awk_tool to replace each row with zero-based sample_N labels derived from NR."
+    confidence: high
 ---
 
 # Tabular: relabel by row counter
@@ -57,7 +61,7 @@ tool_state:
   variables: []
 ```
 
-Cited at `$IWC_FORMAT2/microbiome/binning-evaluation/MAGs-binning-evaluation.gxwf.yml:420-436`.
+Anchored by the MAGs binning evaluation IWC exemplar.
 
 Clearer equivalent for new whole-row replacement:
 
@@ -94,10 +98,6 @@ tool_state:
 - **Whole-row replacement destroys original columns.** Only use when downstream wants labels only.
 - **Row order becomes semantic.** Any upstream sort or filter changes assigned sample numbers.
 - **No collection provenance.** If labels should come from element identifiers, do not synthesize them from row order.
-
-## Exemplars (IWC)
-
-- `$IWC_FORMAT2/microbiome/binning-evaluation/MAGs-binning-evaluation.gxwf.yml:420-436` — `tp_awk_tool/9.5+galaxy3`, `code: '{gsub( $0 ,"sample_" (NR-1)); print}'`.
 
 ## See also
 

--- a/content/patterns/tabular-split-taxonomy-string.md
+++ b/content/patterns/tabular-split-taxonomy-string.md
@@ -8,8 +8,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-05-02
-revised: 2026-05-02
-revision: 1
+revised: 2026-05-03
+revision: 2
 ai_generated: true
 summary: "Use tp_awk_tool to split semicolon-delimited taxonomy strings into explicit rank columns with missing-rank handling."
 related_notes:
@@ -20,6 +20,16 @@ related_patterns:
   - "[[tabular-cut-and-reorder-columns]]"
 related_molds:
   - "[[implement-galaxy-tool-step]]"
+iwc_exemplars:
+  - workflow: amplicon/amplicon-mgnify/mapseq-to-ampvis2/mapseq-to-ampvis2
+    why: "Shows canonical eight-rank prefix dispatch from taxonomy strings into explicit rank columns."
+    confidence: high
+  - workflow: amplicon/amplicon-mgnify/mgnify-amplicon-taxonomic-summary-tables/mgnify-amplicon-summary-tables
+    why: "Shows fixed-depth rank splitting, rank cleanup, unassigned filling, and abundance-column preservation."
+    confidence: high
+  - workflow: amplicon/amplicon-mgnify/taxonomic-rank-abundance-summary-table/taxonomic-rank-abundance-summary-table
+    why: "Shows rank-depth variants from superkingdom through species."
+    confidence: high
 ---
 
 # Tabular: split taxonomy string
@@ -74,7 +84,7 @@ tool_state:
   variables: []
 ```
 
-Cited at `$IWC_FORMAT2/amplicon/amplicon-mgnify/mapseq-to-ampvis2/mapseq-to-ampvis2.gxwf.yml:101-135`.
+Anchored by the MAPseq-to-ampvis2 IWC exemplar.
 
 Fixed-depth split when upstream guarantees positional ranks:
 
@@ -97,13 +107,6 @@ NR > 1 {
 - **Handle missing ranks explicitly.** Corpus examples use empty strings or `unassigned` depending on downstream contract.
 - **`for (i in array)` order is undefined.** It is fine for prefix dispatch, not for positional rank emission.
 - **Avoid `class` as a new example variable.** Corpus-style awk may use it, but `tax_class` avoids confusing readers.
-
-## Exemplars (IWC)
-
-- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mapseq-to-ampvis2/mapseq-to-ampvis2.gxwf.yml:101-135` — canonical 8-rank prefix dispatch from `$3`, emits OTU id plus rank columns.
-- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-taxonomic-summary-tables/mgnify-amplicon-summary-tables.gxwf.yml:101-120` — fixed-depth merge of first three ranks, strips `__`, fills `unassigned`.
-- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-taxonomic-summary-tables/mgnify-amplicon-summary-tables.gxwf.yml:336-367` — splits first column into superkingdom/kingdom/phylum and preserves abundance columns.
-- `$IWC_FORMAT2/amplicon/amplicon-mgnify/taxonomic-rank-abundance-summary-table/taxonomic-rank-abundance-summary-table.gxwf.yml:97-111` — rank-depth variants from superkingdom through species.
 
 ## See also
 

--- a/content/patterns/tabular-sql-query.md
+++ b/content/patterns/tabular-sql-query.md
@@ -8,8 +8,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-05-02
-revised: 2026-05-02
-revision: 1
+revised: 2026-05-03
+revision: 2
 ai_generated: true
 summary: "Use query_tabular when SQL semantics justify it: windows, joins, anti-joins, or fused project+compute over tabulars."
 related_notes:
@@ -22,6 +22,19 @@ related_patterns:
   - "[[tabular-join-on-key]]"
 related_molds:
   - "[[implement-galaxy-tool-step]]"
+iwc_exemplars:
+  - workflow: amplicon/amplicon-mgnify/mapseq-to-ampvis2/mapseq-to-ampvis2
+    why: "Uses a single-table query with SUM window function for relative abundance."
+    confidence: high
+  - workflow: amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction
+    why: "Shows one input with main query plus multiple addqueries outputs."
+    confidence: high
+  - workflow: proteomics/clinicalmp/clinicalmp-verification/clinicalmp-verification
+    why: "Shows a two-table INNER JOIN with named tables."
+    confidence: high
+  - workflow: proteomics/clinicalmp/clinicalmp-discovery/iwc-clinicalmp-discovery-workflow
+    why: "Shows a three-table anti-join with load filters and indexes."
+    confidence: high
 ---
 
 # Tabular: SQL query
@@ -81,7 +94,7 @@ tool_state:
   workdb: workdb.sqlite
 ```
 
-Cited at `$IWC_FORMAT2/amplicon/amplicon-mgnify/mapseq-to-ampvis2/mapseq-to-ampvis2.gxwf.yml:33-82`.
+Anchored by the MAPseq-to-ampvis2 IWC exemplar.
 
 Multi-table SQL join with named tables:
 
@@ -117,7 +130,7 @@ tool_state:
   workdb: workdb.sqlite
 ```
 
-Cited at `$IWC_FORMAT2/proteomics/clinicalmp/clinicalmp-verification/clinicalmp-verification.gxwf.yml:359-415`.
+Anchored by the clinical metaproteomics verification IWC exemplar.
 
 ## Pitfalls
 
@@ -128,13 +141,6 @@ Cited at `$IWC_FORMAT2/proteomics/clinicalmp/clinicalmp-verification/clinicalmp-
 - **`comment_char: "35"` means `#`.** The corpus YAML uses the ASCII code string, not the literal `#`.
 - **Extra outputs can hide in `addqueries`.** Some workflows emit multiple query results from one step.
 - **Version pins vary.** `3.3.0` and `3.3.2` appear in corpus. Prefer the newest available pin unless preserving an existing workflow.
-
-## Exemplars (IWC)
-
-- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mapseq-to-ampvis2/mapseq-to-ampvis2.gxwf.yml:33-82` — single-table relative abundance with `SUM(c3) OVER()`.
-- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction.gxwf.yml:137-201` — one input, main query plus three `addqueries` outputs.
-- `$IWC_FORMAT2/proteomics/clinicalmp/clinicalmp-verification/clinicalmp-verification.gxwf.yml:359-415` — two-table `INNER JOIN` with named tables.
-- `$IWC_FORMAT2/proteomics/clinicalmp/clinicalmp-discovery/iwc-clinicalmp-discovery-workflow.gxwf.yml:724-814` — three-table anti-join with load filters and indexes.
 
 ## See also
 

--- a/content/patterns/tabular-synthesize-bed-from-3col.md
+++ b/content/patterns/tabular-synthesize-bed-from-3col.md
@@ -8,8 +8,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-05-02
-revised: 2026-05-02
-revision: 1
+revised: 2026-05-03
+revision: 2
 ai_generated: true
 summary: "Use tp_awk_tool to convert chrom/start/end rows into 6-column BED, subtracting 1 from start and setting constants."
 related_notes:
@@ -19,6 +19,13 @@ related_patterns:
   - "[[tabular-compute-new-column]]"
 related_molds:
   - "[[implement-galaxy-tool-step]]"
+iwc_exemplars:
+  - workflow: amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction
+    why: "Synthesizes SSU and LSU forward/reverse BED files from three-column interval outputs."
+    confidence: high
+  - workflow: amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/mgnify-amplicon-pipeline-v5-complete
+    why: "Uses the same BED synthesis idiom embedded in the complete workflow with an older text-processing pin."
+    confidence: high
 ---
 
 # Tabular: synthesize BED from 3-column input
@@ -88,12 +95,6 @@ out:
 - **BED datatype matters.** Corpus sets `change_datatype: bed`; do not leave the output as generic tabular if downstream expects BED.
 - **Name and score are constants.** This pattern does not derive BED name or score from input columns.
 - **Forward and reverse are separate steps.** Do not emit both strands from one row unless downstream expects duplicate intervals in one file.
-
-## Exemplars (IWC)
-
-- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction.gxwf.yml:205-245` — SSU forward/reverse BED.
-- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction.gxwf.yml:251-291` — LSU forward/reverse BED.
-- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/mgnify-amplicon-pipeline-v5-complete.gxwf.yml:2084-2170` — same idiom embedded in the complete workflow with older `9.3+galaxy1` pin.
 
 ## See also
 

--- a/content/patterns/tabular-to-collection-by-row.md
+++ b/content/patterns/tabular-to-collection-by-row.md
@@ -11,8 +11,8 @@ tags:
   - pattern
 status: draft
 created: 2026-05-02
-revised: 2026-05-02
-revision: 1
+revised: 2026-05-03
+revision: 2
 ai_generated: true
 summary: "Use split_file_to_collection split_by:col to fan a tabular into collection elements by row/key."
 related_notes:
@@ -22,6 +22,16 @@ related_patterns:
   - "[[sync-collections-by-identifier]]"
 related_molds:
   - "[[implement-galaxy-tool-step]]"
+iwc_exemplars:
+  - workflow: data-fetching/sra-manifest-to-concatenated-fastqs/sra-manifest-to-concatenated-fastqs
+    why: "Splits one-column SRA accessions so fasterq_dump can run once per accession."
+    confidence: high
+  - workflow: sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting
+    why: "Splits a combined per-clade VCF table into per-clade collection elements."
+    confidence: high
+  - workflow: epigenetics/consensus-peaks/consensus-peaks-chip-sr
+    why: "Turns a sample-list tabular into a collection-shaped input for downstream processing."
+    confidence: high
 ---
 
 # Tabular: to collection by row
@@ -63,13 +73,6 @@ tool_state:
 - Pick a stable, unique identifier column; duplicate values produce ambiguous collection elements.
 - Regex cleanup is downstream metadata cleanup, not cosmetic only.
 - Headers matter. Ensure each split element gets the header behavior the downstream tool expects.
-
-## Exemplars (IWC)
-
-- `$IWC_FORMAT2/data-fetching/sra-manifest-to-concatenated-fastqs/sra-manifest-to-concatenated-fastqs.gxwf.yml` — splits one-column SRA accessions so `fasterq_dump` runs once per accession.
-- `$IWC_FORMAT2/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:895` — splits a combined per-clade VCF table into per-clade elements.
-- `$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-chip-sr.gxwf.yml:415` — turns a sample-list tabular into a collection-shaped input.
-- `$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:440` — same row-fan-out shape in the ATAC/CUT&RUN variant.
 
 ## See also
 

--- a/meta_schema.yml
+++ b/meta_schema.yml
@@ -79,6 +79,40 @@ properties:
     type: array
     items:
       type: string
+  iwc_exemplars:
+    type: array
+    items:
+      type: object
+      required: [workflow, why, confidence]
+      additionalProperties: false
+      properties:
+        workflow:
+          type: string
+          minLength: 1
+        steps:
+          type: array
+          minItems: 1
+          items:
+            type: object
+            additionalProperties: false
+            anyOf:
+              - required: [label]
+              - required: [id]
+            properties:
+              label:
+                type: string
+                minLength: 1
+              id:
+                oneOf:
+                  - type: string
+                    minLength: 1
+                  - type: integer
+        why:
+          type: string
+          minLength: 1
+        confidence:
+          type: string
+          enum: [high, medium, low]
 
   # --- Mold fields ---
   name:

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -613,9 +613,38 @@ function validatePatternVerificationEvidence(files: FileMeta[]): CrossFileFindin
   for (const f of files) {
     if (f.meta.type === "pattern") {
       validatePatternVerificationPaths(f, findings);
+      validatePatternIwcExemplars(f, findings);
     }
   }
   return findings;
+}
+
+const GENERATED_IWC_REF_RE = /(?:^|\/)(?:\$IWC_FORMAT2|\$IWC_SKELETONS|workflow-fixtures\/iwc-(?:format2|skeletons)|iwc-(?:format2|skeletons)\/)|\.(?:ga|gxwf\.ya?ml)$/;
+const LINE_REF_RE = /:\d+(?:-\d+)?$/;
+
+function validatePatternIwcExemplars(file: FileMeta, findings: CrossFileFinding[]): void {
+  const exemplars = Array.isArray(file.meta.iwc_exemplars) ? file.meta.iwc_exemplars : [];
+  if (file.meta.pattern_kind === "leaf" && exemplars.length === 0) {
+    findings.push({
+      path: file.path,
+      severity: "warning",
+      message: "leaf pattern should declare iwc_exemplars metadata",
+    });
+  }
+
+  exemplars.forEach((raw, index) => {
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return;
+    const exemplar = raw as Record<string, unknown>;
+    if (typeof exemplar.workflow !== "string") return;
+    const workflow = exemplar.workflow;
+    if (GENERATED_IWC_REF_RE.test(workflow) || LINE_REF_RE.test(workflow)) {
+      findings.push({
+        path: file.path,
+        severity: "error",
+        message: `iwc_exemplars[${index}].workflow must use an abstract IWC workflow ID, not a generated path or line citation: ${workflow}`,
+      });
+    }
+  });
 }
 
 function validatePatternVerificationPaths(file: FileMeta, findings: CrossFileFinding[]): void {

--- a/site/src/components/HealthPanel.astro
+++ b/site/src/components/HealthPanel.astro
@@ -1,0 +1,113 @@
+---
+interface HealthItem {
+  label: string;
+  state: 'ok' | 'warn' | 'error';
+  detail: string;
+}
+
+interface Props {
+  title: string;
+  items: HealthItem[];
+}
+
+const { title, items } = Astro.props;
+const stateRank = { ok: 0, warn: 1, error: 2 } as const;
+const overall = items.reduce<'ok' | 'warn' | 'error'>((state, item) => stateRank[item.state] > stateRank[state] ? item.state : state, 'ok');
+const headingId = `${title.toLowerCase().replace(/[^a-z0-9]+/g, '-')}-heading`;
+---
+<section class={`health-panel health-panel-${overall}`} aria-labelledby={headingId}>
+  <div class="health-panel-head">
+    <h2 id={headingId}>{title}</h2>
+    <span class={`health-pill health-${overall}`}>{overall}</span>
+  </div>
+  <ul class="health-grid">
+    {items.map(item => (
+      <li class={`health-item health-${item.state}`}>
+        <span class="health-dot" aria-hidden="true"></span>
+        <div>
+          <strong>{item.label}</strong>
+          <p>{item.detail}</p>
+        </div>
+      </li>
+    ))}
+  </ul>
+</section>
+
+<style>
+  .health-panel {
+    margin: 0 0 1.5rem;
+    padding: 1rem;
+    border: 1px solid var(--color-border);
+    border-radius: 1rem;
+    background: var(--color-surface-raised);
+  }
+  .health-panel-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 0.75rem;
+  }
+  .health-panel h2 {
+    margin: 0;
+    font-size: 0.8rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+  }
+  .health-pill {
+    border-radius: 999px;
+    padding: 0.2rem 0.55rem;
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    text-transform: uppercase;
+  }
+  .health-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
+    gap: 0.55rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+  .health-item {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.5rem;
+    padding: 0.7rem;
+    border: 1px solid color-mix(in srgb, var(--color-border) 80%, transparent);
+    border-radius: 0.75rem;
+    background: var(--color-surface);
+  }
+  .health-dot {
+    width: 0.55rem;
+    height: 0.55rem;
+    margin-top: 0.35rem;
+    border-radius: 50%;
+    background: var(--color-text-muted);
+  }
+  .health-item strong {
+    display: block;
+    font-size: 0.85rem;
+  }
+  .health-item p {
+    margin: 0.15rem 0 0;
+    font-size: 0.78rem;
+    color: var(--color-text-muted);
+  }
+  .health-ok .health-dot,
+  .health-pill.health-ok {
+    background: #18794e;
+    color: white;
+  }
+  .health-warn .health-dot,
+  .health-pill.health-warn {
+    background: #b7791f;
+    color: white;
+  }
+  .health-error .health-dot,
+  .health-pill.health-error {
+    background: #c53030;
+    color: white;
+  }
+</style>

--- a/site/src/components/MoldHealth.astro
+++ b/site/src/components/MoldHealth.astro
@@ -2,6 +2,7 @@
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import type { CollectionEntry } from 'astro:content';
+import HealthPanel from './HealthPanel.astro';
 import { resolveWikiLinkId, type WikiLinkTarget } from '../lib/wiki-links';
 
 interface Props {
@@ -117,102 +118,5 @@ const items: HealthItem[] = [
   },
 ];
 
-const stateRank = { ok: 0, warn: 1, error: 2 } as const;
-const overall = items.reduce<'ok' | 'warn' | 'error'>((state, item) => stateRank[item.state] > stateRank[state] ? item.state : state, 'ok');
 ---
-<section class={`mold-health mold-health-${overall}`} aria-labelledby="mold-health-heading">
-  <div class="mold-health-head">
-    <h2 id="mold-health-heading">Mold health</h2>
-    <span class={`health-pill health-${overall}`}>{overall}</span>
-  </div>
-  <ul class="health-grid">
-    {items.map(item => (
-      <li class={`health-item health-${item.state}`}>
-        <span class="health-dot" aria-hidden="true"></span>
-        <div>
-          <strong>{item.label}</strong>
-          <p>{item.detail}</p>
-        </div>
-      </li>
-    ))}
-  </ul>
-</section>
-
-<style>
-  .mold-health {
-    margin: 0 0 1.5rem;
-    padding: 1rem;
-    border: 1px solid var(--color-border);
-    border-radius: 1rem;
-    background: var(--color-surface-raised);
-  }
-  .mold-health-head {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 1rem;
-    margin-bottom: 0.75rem;
-  }
-  .mold-health h2 {
-    margin: 0;
-    font-size: 0.8rem;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    color: var(--color-text-muted);
-  }
-  .health-pill {
-    border-radius: 999px;
-    padding: 0.2rem 0.55rem;
-    font-family: var(--font-mono);
-    font-size: 0.68rem;
-    text-transform: uppercase;
-  }
-  .health-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
-    gap: 0.55rem;
-    margin: 0;
-    padding: 0;
-    list-style: none;
-  }
-  .health-item {
-    display: grid;
-    grid-template-columns: auto 1fr;
-    gap: 0.5rem;
-    padding: 0.7rem;
-    border: 1px solid color-mix(in srgb, var(--color-border) 80%, transparent);
-    border-radius: 0.75rem;
-    background: var(--color-surface);
-  }
-  .health-dot {
-    width: 0.55rem;
-    height: 0.55rem;
-    margin-top: 0.35rem;
-    border-radius: 50%;
-    background: var(--color-text-muted);
-  }
-  .health-item strong {
-    display: block;
-    font-size: 0.85rem;
-  }
-  .health-item p {
-    margin: 0.15rem 0 0;
-    font-size: 0.78rem;
-    color: var(--color-text-muted);
-  }
-  .health-ok .health-dot,
-  .health-pill.health-ok {
-    background: #18794e;
-    color: white;
-  }
-  .health-warn .health-dot,
-  .health-pill.health-warn {
-    background: #b7791f;
-    color: white;
-  }
-  .health-error .health-dot,
-  .health-pill.health-error {
-    background: #c53030;
-    color: white;
-  }
-</style>
+<HealthPanel title="Mold health" items={items} />

--- a/site/src/components/PatternBody.astro
+++ b/site/src/components/PatternBody.astro
@@ -5,18 +5,21 @@ import { resolveWikiLink, type WikiLinkTarget } from '../lib/wiki-links';
 interface Props {
   entry: CollectionEntry<'content'>;
   linkMap: Map<string, WikiLinkTarget>;
+  placement?: 'before' | 'after';
 }
 
-const { entry, linkMap } = Astro.props;
+const { entry, linkMap, placement = 'before' } = Astro.props;
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const data = entry.data as any;
 const isMap = data.pattern_kind === 'moc';
+const isLeaf = data.pattern_kind === 'leaf';
+const exemplars = Array.isArray(data.iwc_exemplars) ? data.iwc_exemplars : [];
 const relatedPatterns = (data.related_patterns ?? [])
   .map((link: string) => resolveWikiLink(link, linkMap, base))
   .filter((link: ReturnType<typeof resolveWikiLink>) => link.href);
 ---
 
-{isMap && (
+{placement === 'before' && isMap && (
   <aside class="pattern-map-panel" aria-labelledby="pattern-map-heading">
     <div class="pattern-map-panel-top">
       <span class="badge badge-draft">pattern map</span>
@@ -38,6 +41,37 @@ const relatedPatterns = (data.related_patterns ?? [])
       </div>
     )}
   </aside>
+)}
+
+{placement === 'after' && isLeaf && exemplars.length > 0 && (
+  <section class="iwc-exemplars" aria-labelledby="iwc-exemplars-heading">
+    <div class="iwc-exemplars-top">
+      <span class="badge badge-draft">IWC exemplars</span>
+      <span class="iwc-exemplars-count font-mono">{exemplars.length} anchor{exemplars.length === 1 ? '' : 's'}</span>
+    </div>
+    <h2 id="iwc-exemplars-heading">IWC Exemplars</h2>
+    <div class="iwc-exemplar-list">
+      {exemplars.map((exemplar: any) => (
+        <article class="iwc-exemplar-card">
+          <div class="iwc-exemplar-card-head">
+            <code>{exemplar.workflow}</code>
+            <span class={`confidence confidence-${exemplar.confidence}`}>{exemplar.confidence}</span>
+          </div>
+          <p>{exemplar.why}</p>
+          {Array.isArray(exemplar.steps) && exemplar.steps.length > 0 && (
+            <ul>
+              {exemplar.steps.map((step: any) => (
+                <li>
+                  {step.label && <span>{step.label}</span>}
+                  {step.id !== undefined && <code>step {step.id}</code>}
+                </li>
+              ))}
+            </ul>
+          )}
+        </article>
+      ))}
+    </div>
+  </section>
 )}
 
 <style>
@@ -95,5 +129,78 @@ const relatedPatterns = (data.related_patterns ?? [])
     color: var(--color-text-muted);
     font-size: 0.78rem;
     line-height: 1.35;
+  }
+  .iwc-exemplars {
+    margin: 1.5rem 0;
+    padding: 1rem;
+    border: 1px solid var(--color-border-subtle);
+    border-radius: 0.85rem;
+    background: var(--color-surface-raised);
+  }
+  .iwc-exemplars-top,
+  .iwc-exemplar-card-head {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+  .iwc-exemplars-count {
+    color: var(--color-text-muted);
+    font-size: 0.75rem;
+  }
+  .iwc-exemplars h2 {
+    margin: 0.7rem 0 0.75rem;
+    color: var(--color-text-primary);
+    font-size: 1.15rem;
+  }
+  .iwc-exemplar-list {
+    display: grid;
+    gap: 0.65rem;
+  }
+  .iwc-exemplar-card {
+    padding: 0.8rem;
+    border: 1px solid color-mix(in srgb, var(--color-border) 80%, transparent);
+    border-radius: 0.7rem;
+    background: var(--color-surface);
+  }
+  .iwc-exemplar-card code {
+    min-width: 0;
+    color: var(--color-text-primary);
+    font-size: 0.78rem;
+    overflow-wrap: anywhere;
+  }
+  .iwc-exemplar-card p {
+    margin: 0.55rem 0 0;
+    color: var(--color-text-secondary);
+    font-size: 0.9rem;
+    line-height: 1.5;
+  }
+  .iwc-exemplar-card ul {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin: 0.65rem 0 0;
+    padding: 0;
+    list-style: none;
+  }
+  .iwc-exemplar-card li {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.25rem 0.45rem;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--color-accent) 8%, transparent);
+    color: var(--color-text-secondary);
+    font-size: 0.78rem;
+  }
+  .confidence {
+    border-radius: 999px;
+    padding: 0.18rem 0.5rem;
+    background: color-mix(in srgb, var(--color-galaxy-primary) 12%, transparent);
+    color: var(--color-text-secondary);
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    text-transform: uppercase;
   }
 </style>

--- a/site/src/components/PatternHealth.astro
+++ b/site/src/components/PatternHealth.astro
@@ -1,0 +1,78 @@
+---
+import type { CollectionEntry } from 'astro:content';
+import HealthPanel from './HealthPanel.astro';
+import { resolveWikiLinkId, type WikiLinkTarget } from '../lib/wiki-links';
+
+interface Props {
+  entry: CollectionEntry<'content'>;
+  linkMap: Map<string, WikiLinkTarget>;
+  entryById: Map<string, CollectionEntry<'content'>>;
+}
+
+interface HealthItem {
+  label: string;
+  state: 'ok' | 'warn' | 'error';
+  detail: string;
+}
+
+const { entry, linkMap, entryById } = Astro.props;
+const data = entry.data as any;
+const exemplars = Array.isArray(data.iwc_exemplars) ? data.iwc_exemplars : [];
+const verificationPaths = Array.isArray(data.verification_paths) ? data.verification_paths : [];
+const generatedRefPattern = /(?:^|\/)(?:\$IWC_FORMAT2|\$IWC_SKELETONS|workflow-fixtures\/iwc-(?:format2|skeletons)|iwc-(?:format2|skeletons)\/)|\.(?:ga|gxwf\.ya?ml)$/;
+const lineRefPattern = /:\d+(?:-\d+)?$/;
+
+function exemplarState(): HealthItem {
+  const bad = exemplars.filter((exemplar: any) => {
+    const workflow = exemplar?.workflow;
+    return typeof workflow === 'string' && (generatedRefPattern.test(workflow) || lineRefPattern.test(workflow));
+  });
+  if (bad.length > 0) {
+    return { label: 'IWC exemplar anchors', state: 'error', detail: `${bad.length} generated path or line citation${bad.length === 1 ? '' : 's'} in metadata.` };
+  }
+  if (exemplars.length === 0) {
+    return { label: 'IWC exemplar anchors', state: 'warn', detail: 'No structured IWC exemplars yet.' };
+  }
+  return { label: 'IWC exemplar anchors', state: 'ok', detail: `${exemplars.length} abstract workflow anchor${exemplars.length === 1 ? '' : 's'} declared.` };
+}
+
+function verificationState(): HealthItem {
+  if (data.evidence === 'corpus-and-verified' || data.evidence === 'structurally-verified') {
+    return verificationPaths.length > 0
+      ? { label: 'Foundry verification fixture', state: 'ok', detail: `${verificationPaths.length} verification path${verificationPaths.length === 1 ? '' : 's'} declared.` }
+      : { label: 'Foundry verification fixture', state: 'error', detail: `${data.evidence} evidence needs a verification path.` };
+  }
+  return verificationPaths.length === 0
+    ? { label: 'Foundry verification fixture', state: 'warn', detail: 'No structural verification fixture yet.' }
+    : { label: 'Foundry verification fixture', state: 'error', detail: `${data.evidence} should not declare verification paths.` };
+}
+
+function mapCoverageState(): HealthItem {
+  const mocs = Array.from(entryById.values()).filter(candidate => {
+    const candidateData = candidate.data as any;
+    if (candidateData.type !== 'pattern' || candidateData.pattern_kind !== 'moc') return false;
+    const related = Array.isArray(candidateData.related_patterns) ? candidateData.related_patterns : [];
+    return related.some((link: string) => resolveWikiLinkId(link, linkMap) === entry.id);
+  });
+  if (mocs.length === 0) {
+    return { label: 'Pattern map coverage', state: 'warn', detail: 'No pattern map links to this leaf yet.' };
+  }
+  return { label: 'Pattern map coverage', state: 'ok', detail: `${mocs.length} pattern map${mocs.length === 1 ? '' : 's'} link here.` };
+}
+
+function metadataState(): HealthItem {
+  const missing = ['title', 'summary', 'evidence', 'pattern_kind'].filter(field => !data[field]);
+  if (missing.length > 0) {
+    return { label: 'Metadata contract', state: 'error', detail: `Missing ${missing.join(', ')}.` };
+  }
+  return { label: 'Metadata contract', state: 'ok', detail: 'Pattern frontmatter matches the site contract.' };
+}
+
+const items: HealthItem[] = [
+  exemplarState(),
+  verificationState(),
+  mapCoverageState(),
+  metadataState(),
+];
+---
+<HealthPanel title="Pattern health" items={items} />

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -34,6 +34,20 @@ const typedReference = z.object({
   }
 });
 
+const iwcExemplarStep = z.object({
+  label: z.string().min(1).optional(),
+  id: z.union([z.string().min(1), z.number().int()]).optional(),
+}).strict().refine((step: any) => step.label || step.id !== undefined, {
+  message: 'step needs `label` or `id`',
+});
+
+const iwcExemplar = z.object({
+  workflow: z.string().min(1),
+  steps: z.array(iwcExemplarStep).min(1).optional(),
+  why: z.string().min(1),
+  confidence: z.enum(['high', 'medium', 'low']),
+}).strict();
+
 const baseFields = {
   tags: z.array(z.string()).min(1),
   status: z.enum(['draft', 'reviewed', 'revised', 'stale', 'archived']),
@@ -99,6 +113,7 @@ const patternSchema = z.object({
   title: z.string(),
   parent_pattern: wikiLink.optional(),
   verification_paths: z.array(z.string()).optional(),
+  iwc_exemplars: z.array(iwcExemplar).optional(),
   ...baseFields,
 }).strict();
 
@@ -129,6 +144,7 @@ const schemaNoteSchema = z.object({
   title: z.string(),
   package: z.string().optional(),
   upstream: z.string().optional(),
+  package_export: z.string().optional(),
   ...baseFields,
 }).strict();
 

--- a/site/src/pages/[...slug].astro
+++ b/site/src/pages/[...slug].astro
@@ -5,6 +5,7 @@ import NoteHeader from '../components/NoteHeader.astro';
 import NoteMeta from '../components/NoteMeta.astro';
 import IncomingRefs from '../components/IncomingRefs.astro';
 import MoldHealth from '../components/MoldHealth.astro';
+import PatternHealth from '../components/PatternHealth.astro';
 import MoldBody from '../components/MoldBody.astro';
 import PipelineBody from '../components/PipelineBody.astro';
 import PatternBody from '../components/PatternBody.astro';
@@ -75,9 +76,10 @@ const metaMode: 'full' | 'related-only' = data.type === 'mold' ? 'related-only' 
     {showMeta && <NoteMeta entry={entry} linkMap={linkMap} mode={metaMode} />}
 
     {data.type === 'mold' && <MoldHealth entry={entry} linkMap={linkMap} entryById={entryMap} />}
+    {data.type === 'pattern' && data.pattern_kind === 'leaf' && <PatternHealth entry={entry} linkMap={linkMap} entryById={entryMap} />}
     {data.type === 'mold' && <MoldBody entry={entry} linkMap={linkMap} />}
     {data.type === 'pipeline' && <PipelineBody entry={entry} linkMap={linkMap} />}
-    {data.type === 'pattern' && <PatternBody entry={entry} linkMap={linkMap} />}
+    {data.type === 'pattern' && <PatternBody entry={entry} linkMap={linkMap} placement="before" />}
     {data.type === 'cli-command' && <CliCommandBody entry={entry} />}
     {data.type === 'research' && <ResearchBody entry={entry} />}
     {data.type === 'schema' && <SchemaBody entry={entry} />}
@@ -85,6 +87,8 @@ const metaMode: 'full' | 'related-only' = data.type === 'mold' ? 'related-only' 
     <article class="prose prose-slate max-w-none dark:prose-invert">
       <Content />
     </article>
+
+    {data.type === 'pattern' && <PatternBody entry={entry} linkMap={linkMap} placement="after" />}
 
     <IncomingRefs incoming={incoming} />
   </div>

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -174,6 +174,34 @@ describe("validateData (per-file)", () => {
     const r = validateData(patternRequired({ tags: ["mold"] }), schema);
     expect(r.warnings.some((w) => /expected 'pattern'/.test(w))).toBe(true);
   });
+
+  it("accepts iwc_exemplars metadata", () => {
+    const r = validateData(patternRequired({
+      iwc_exemplars: [
+        {
+          workflow: "transcriptomics/rnaseq-pe/rnaseq-pe",
+          steps: [{ label: "Map strandedness", id: 12 }],
+          why: "Shows workflow enum values mapped into downstream tool dialect.",
+          confidence: "high",
+        },
+      ],
+    }), schema);
+    expect(r.errors).toEqual([]);
+  });
+
+  it("requires label or id for iwc_exemplars steps", () => {
+    const r = validateData(patternRequired({
+      iwc_exemplars: [
+        {
+          workflow: "transcriptomics/rnaseq-pe/rnaseq-pe",
+          steps: [{}],
+          why: "Shows workflow enum values mapped into downstream tool dialect.",
+          confidence: "high",
+        },
+      ],
+    }), schema);
+    expect(r.errors.length).toBeGreaterThan(0);
+  });
 });
 
 // ---- Cross-file integration ----
@@ -274,6 +302,55 @@ describe("validateDirectory (cross-file)", () => {
       tagsPath: TAGS_PATH,
     });
     expect(r.errors).toBeGreaterThanOrEqual(1);
+  });
+
+  it("accepts abstract IWC workflow IDs in iwc_exemplars", () => {
+    writeFm(path.join(dir, "patterns/pattern-x.md"), patternRequired({
+      title: "Pattern X",
+      iwc_exemplars: [{
+        workflow: "transcriptomics/rnaseq-pe/rnaseq-pe",
+        steps: [{ label: "Map strandedness", id: "12" }],
+        why: "Shows workflow enum values mapped into downstream tool dialect.",
+        confidence: "high",
+      }],
+    }));
+
+    const r = validateDirectory({
+      directory: dir,
+      schemaPath: SCHEMA_PATH,
+      tagsPath: TAGS_PATH,
+    });
+    expect(r.errors).toBe(0);
+  });
+
+  it("rejects generated IWC paths in iwc_exemplars", () => {
+    writeFm(path.join(dir, "patterns/pattern-x.md"), patternRequired({
+      title: "Pattern X",
+      iwc_exemplars: [{
+        workflow: "$IWC_FORMAT2/transcriptomics/rnaseq-pe/rnaseq-pe.gxwf.yml:270-299",
+        why: "Shows workflow enum values mapped into downstream tool dialect.",
+        confidence: "high",
+      }],
+    }));
+
+    const r = validateDirectory({
+      directory: dir,
+      schemaPath: SCHEMA_PATH,
+      tagsPath: TAGS_PATH,
+    });
+    expect(r.errors).toBeGreaterThanOrEqual(1);
+  });
+
+  it("warns when leaf patterns omit iwc_exemplars during migration", () => {
+    writeFm(path.join(dir, "patterns/pattern-x.md"), patternRequired({ title: "Pattern X" }));
+
+    const r = validateDirectory({
+      directory: dir,
+      schemaPath: SCHEMA_PATH,
+      tagsPath: TAGS_PATH,
+    });
+    expect(r.errors).toBe(0);
+    expect(r.warnings).toBeGreaterThanOrEqual(1);
   });
 
   it("flags pipeline phase resolving to non-Mold", () => {


### PR DESCRIPTION
## Summary
- Add structured `iwc_exemplars` metadata to the frontmatter schema, Astro content schema, and validator.
- Render generated IWC exemplar cards for leaf patterns and add shared health-panel UI with pattern health indicators.
- Migrate leaf pattern exemplar sections from generated fixture citations to abstract IWC workflow anchors.

## Validation
- `npm run validate`
- `npm run test`
- `npm run site:build`

Closes #115