### PR TITLE
Capture Nextflow module evidence

### DIFF
--- a/casts/claude/skills/summarize-nextflow/runs/nf-core__bacass/summary.json
+++ b/casts/claude/skills/summarize-nextflow/runs/nf-core__bacass/summary.json
@@ -592,7 +592,9 @@
       "aliases": [
         "FASTQC_RAW",
         "FASTQC_TRIM"
-      ]
+      ],
+      "meta": null,
+      "module_tests": []
     },
     {
       "name": "FASTP",
@@ -664,7 +666,9 @@
           "topic": null
         }
       ],
-      "aliases": []
+      "aliases": [],
+      "meta": null,
+      "module_tests": []
     },
     {
       "name": "CAT_FASTQ",
@@ -694,7 +698,9 @@
       "aliases": [
         "CAT_FASTQ_SHORT",
         "CAT_FASTQ_LONG"
-      ]
+      ],
+      "meta": null,
+      "module_tests": []
     },
     {
       "name": "PORECHOP_PORECHOP",
@@ -726,7 +732,9 @@
           "topic": null
         }
       ],
-      "aliases": []
+      "aliases": [],
+      "meta": null,
+      "module_tests": []
     },
     {
       "name": "FILTLONG",
@@ -758,7 +766,9 @@
           "topic": null
         }
       ],
-      "aliases": []
+      "aliases": [],
+      "meta": null,
+      "module_tests": []
     },
     {
       "name": "UNICYCLER",
@@ -795,7 +805,9 @@
           "topic": null
         }
       ],
-      "aliases": []
+      "aliases": [],
+      "meta": null,
+      "module_tests": []
     },
     {
       "name": "CANU",
@@ -837,7 +849,9 @@
           "topic": null
         }
       ],
-      "aliases": []
+      "aliases": [],
+      "meta": null,
+      "module_tests": []
     },
     {
       "name": "MINIMAP2_ALIGN",
@@ -892,7 +906,9 @@
       "aliases": [
         "MINIMAP2_CONSENSUS",
         "MINIMAP2_POLISH"
-      ]
+      ],
+      "meta": null,
+      "module_tests": []
     },
     {
       "name": "MINIASM",
@@ -919,7 +935,9 @@
           "topic": null
         }
       ],
-      "aliases": []
+      "aliases": [],
+      "meta": null,
+      "module_tests": []
     },
     {
       "name": "DRAGONFLYE",
@@ -951,7 +969,9 @@
           "topic": null
         }
       ],
-      "aliases": []
+      "aliases": [],
+      "meta": null,
+      "module_tests": []
     },
     {
       "name": "RACON",
@@ -978,7 +998,9 @@
           "topic": null
         }
       ],
-      "aliases": []
+      "aliases": [],
+      "meta": null,
+      "module_tests": []
     },
     {
       "name": "SAMTOOLS_SORT",
@@ -1010,7 +1032,9 @@
           "topic": null
         }
       ],
-      "aliases": []
+      "aliases": [],
+      "meta": null,
+      "module_tests": []
     },
     {
       "name": "SAMTOOLS_INDEX",
@@ -1042,7 +1066,9 @@
           "topic": null
         }
       ],
-      "aliases": []
+      "aliases": [],
+      "meta": null,
+      "module_tests": []
     },
     {
       "name": "KRAKEN2_KRAKEN2",
@@ -1092,7 +1118,9 @@
       "aliases": [
         "KRAKEN2",
         "KRAKEN2_LONG"
-      ]
+      ],
+      "meta": null,
+      "module_tests": []
     },
     {
       "name": "QUAST",
@@ -1136,7 +1164,9 @@
       ],
       "aliases": [
         "QUAST_BYREFSEQID"
-      ]
+      ],
+      "meta": null,
+      "module_tests": []
     },
     {
       "name": "BUSCO_BUSCO",
@@ -1193,7 +1223,9 @@
           "topic": null
         }
       ],
-      "aliases": []
+      "aliases": [],
+      "meta": null,
+      "module_tests": []
     },
     {
       "name": "GUNZIP",
@@ -1220,7 +1252,9 @@
           "topic": null
         }
       ],
-      "aliases": []
+      "aliases": [],
+      "meta": null,
+      "module_tests": []
     },
     {
       "name": "PROKKA",
@@ -1267,7 +1301,9 @@
           "topic": null
         }
       ],
-      "aliases": []
+      "aliases": [],
+      "meta": null,
+      "module_tests": []
     },
     {
       "name": "BAKTA_BAKTA",
@@ -1314,7 +1350,9 @@
           "topic": null
         }
       ],
-      "aliases": []
+      "aliases": [],
+      "meta": null,
+      "module_tests": []
     },
     {
       "name": "BAKTA_BAKTADBDOWNLOAD",
@@ -1335,7 +1373,9 @@
           "topic": null
         }
       ],
-      "aliases": []
+      "aliases": [],
+      "meta": null,
+      "module_tests": []
     },
     {
       "name": "DFAST",
@@ -1367,7 +1407,9 @@
           "topic": null
         }
       ],
-      "aliases": []
+      "aliases": [],
+      "meta": null,
+      "module_tests": []
     },
     {
       "name": "LIFTOFF",
@@ -1404,7 +1446,9 @@
           "topic": null
         }
       ],
-      "aliases": []
+      "aliases": [],
+      "meta": null,
+      "module_tests": []
     },
     {
       "name": "NANOPLOT",
@@ -1436,7 +1480,9 @@
           "topic": null
         }
       ],
-      "aliases": []
+      "aliases": [],
+      "meta": null,
+      "module_tests": []
     },
     {
       "name": "TOULLIGQC",
@@ -1463,7 +1509,9 @@
           "topic": null
         }
       ],
-      "aliases": []
+      "aliases": [],
+      "meta": null,
+      "module_tests": []
     },
     {
       "name": "PYCOQC",
@@ -1490,7 +1538,9 @@
           "topic": null
         }
       ],
-      "aliases": []
+      "aliases": [],
+      "meta": null,
+      "module_tests": []
     },
     {
       "name": "MEDAKA",
@@ -1517,7 +1567,9 @@
           "topic": null
         }
       ],
-      "aliases": []
+      "aliases": [],
+      "meta": null,
+      "module_tests": []
     },
     {
       "name": "NANOPOLISH",
@@ -1544,7 +1596,9 @@
           "topic": null
         }
       ],
-      "aliases": []
+      "aliases": [],
+      "meta": null,
+      "module_tests": []
     },
     {
       "name": "KRAKEN2_DB_PREPARATION",
@@ -1571,7 +1625,9 @@
           "topic": null
         }
       ],
-      "aliases": []
+      "aliases": [],
+      "meta": null,
+      "module_tests": []
     },
     {
       "name": "KMERFINDER_KMERFINDER",
@@ -1603,7 +1659,9 @@
           "topic": null
         }
       ],
-      "aliases": []
+      "aliases": [],
+      "meta": null,
+      "module_tests": []
     },
     {
       "name": "KMERFINDER_SUMMARY",
@@ -1630,7 +1688,9 @@
           "topic": null
         }
       ],
-      "aliases": []
+      "aliases": [],
+      "meta": null,
+      "module_tests": []
     },
     {
       "name": "KMERFINDER_DOWNLOAD_REFERENCE",
@@ -1657,7 +1717,9 @@
           "topic": null
         }
       ],
-      "aliases": []
+      "aliases": [],
+      "meta": null,
+      "module_tests": []
     },
     {
       "name": "CUSTOM_MULTIQC",
@@ -1694,7 +1756,9 @@
           "topic": null
         }
       ],
-      "aliases": []
+      "aliases": [],
+      "meta": null,
+      "module_tests": []
     },
     {
       "name": "UNTAR",
@@ -1721,7 +1785,9 @@
           "topic": null
         }
       ],
-      "aliases": []
+      "aliases": [],
+      "meta": null,
+      "module_tests": []
     }
   ],
   "subworkflows": [
@@ -1797,7 +1863,8 @@
           "shape": "path",
           "topic": null
         }
-      ]
+      ],
+      "tests": []
     },
     {
       "name": "QC_NANOPLOT_TOULLIGQC",
@@ -1840,7 +1907,8 @@
           "shape": "path",
           "topic": null
         }
-      ]
+      ],
+      "tests": []
     },
     {
       "name": "KMERFINDER_SUMMARY_DOWNLOAD",
@@ -1880,7 +1948,8 @@
           "shape": "path",
           "topic": null
         }
-      ]
+      ],
+      "tests": []
     },
     {
       "name": "BAKTA_DBDOWNLOAD_RUN",
@@ -1919,7 +1988,8 @@
           "shape": "path",
           "topic": null
         }
-      ]
+      ],
+      "tests": []
     },
     {
       "name": "PIPELINE_INITIALISATION",
@@ -1934,7 +2004,8 @@
           "description": "5-column TSV samplesheet validated via samplesheetToList.",
           "topic": null
         }
-      ]
+      ],
+      "tests": []
     },
     {
       "name": "PIPELINE_COMPLETION",
@@ -1942,7 +2013,8 @@
       "kind": "utility",
       "calls": [],
       "inputs": [],
-      "outputs": []
+      "outputs": [],
+      "tests": []
     },
     {
       "name": "NFCORE_BACASS",
@@ -1958,7 +2030,8 @@
           "shape": "path",
           "topic": null
         }
-      ]
+      ],
+      "tests": []
     }
   ],
   "workflow": {

--- a/casts/claude/skills/summarize-nextflow/runs/nf-core__demo/summary.json
+++ b/casts/claude/skills/summarize-nextflow/runs/nf-core__demo/summary.json
@@ -8,43 +8,268 @@
     "slug": "nf-core-demo"
   },
   "params": [
-    { "name": "input",                       "type": "string",  "default": null,                                          "description": "Path to a samplesheet CSV.",                                "required": true },
-    { "name": "outdir",                      "type": "string",  "default": null,                                          "description": "Output directory.",                                         "required": true },
-    { "name": "genome",                      "type": "string",  "default": null,                                          "description": "iGenomes reference key.",                                   "required": false },
-    { "name": "fasta",                       "type": "string",  "default": null,                                          "description": "Reference FASTA. Computed dynamically in main.nf via getGenomeAttribute('fasta'); not declared in nextflow_schema.json.", "required": false },
-    { "name": "igenomes_base",               "type": "string",  "default": "s3://ngi-igenomes/igenomes/",                 "description": "iGenomes S3 base path.",                                    "required": false },
-    { "name": "igenomes_ignore",             "type": "boolean", "default": false,                                         "description": "Skip iGenomes lookups.",                                    "required": false },
-    { "name": "skip_trim",                   "type": "boolean", "default": false,                                         "description": "Skip the SEQTK_TRIM step.",                                 "required": false },
-    { "name": "multiqc_config",              "type": "string",  "default": null,                                          "description": "Custom MultiQC config.",                                    "required": false },
-    { "name": "multiqc_title",               "type": "string",  "default": null,                                          "description": "Custom MultiQC report title.",                              "required": false },
-    { "name": "multiqc_logo",                "type": "string",  "default": null,                                          "description": "Custom MultiQC logo.",                                      "required": false },
-    { "name": "max_multiqc_email_size",      "type": "string",  "default": "25.MB",                                       "description": "Max size of MultiQC email attachment.",                     "required": false },
-    { "name": "multiqc_methods_description", "type": "string",  "default": null,                                          "description": "Custom MultiQC methods description text.",                  "required": false },
-    { "name": "publish_dir_mode",            "type": "string",  "default": "copy",                                        "description": "How files are published to outdir.",                        "required": false },
-    { "name": "email",                       "type": "string",  "default": null,                                          "description": "Email address for completion summary.",                     "required": false },
-    { "name": "email_on_fail",               "type": "string",  "default": null,                                          "description": "Email address for failure notifications.",                  "required": false },
-    { "name": "plaintext_email",             "type": "boolean", "default": false,                                         "description": "Send plaintext rather than HTML email.",                    "required": false },
-    { "name": "monochrome_logs",             "type": "boolean", "default": false,                                         "description": "Disable ANSI color in logs.",                               "required": false },
-    { "name": "hook_url",                    "type": "string",  "default": null,                                          "description": "Webhook URL (Slack/MS Teams) for completion notifications.", "required": false },
-    { "name": "help",                        "type": "boolean", "default": false,                                         "description": "Show help and exit.",                                       "required": false },
-    { "name": "help_full",                   "type": "boolean", "default": false,                                         "description": "Show full help and exit.",                                  "required": false },
-    { "name": "show_hidden",                 "type": "boolean", "default": false,                                         "description": "Show hidden parameters in help.",                           "required": false },
-    { "name": "version",                     "type": "boolean", "default": false,                                         "description": "Show pipeline version and exit.",                           "required": false },
-    { "name": "validate_params",             "type": "boolean", "default": true,                                          "description": "Validate parameters against the JSON schema.",              "required": false },
-    { "name": "pipelines_testdata_base_path","type": "string",  "default": "https://raw.githubusercontent.com/nf-core/test-datasets/", "description": "Base URL for pipeline test data.",                "required": false },
-    { "name": "trace_report_suffix",         "type": "string",  "default": "<runtime-timestamp>",                         "description": "Suffix appended to trace report filenames.",                "required": false },
-    { "name": "config_profile_name",         "type": "string",  "default": null,                                          "description": "Profile name (set by config profiles).",                    "required": false },
-    { "name": "config_profile_description",  "type": "string",  "default": null,                                          "description": "Profile description (set by config profiles).",            "required": false },
-    { "name": "config_profile_contact",      "type": "string",  "default": null,                                          "description": "Profile contact (set by config profiles).",                "required": false },
-    { "name": "config_profile_url",          "type": "string",  "default": null,                                          "description": "Profile URL (set by config profiles).",                    "required": false },
-    { "name": "custom_config_version",       "type": "string",  "default": "master",                                      "description": "Version of nf-core/configs to load.",                       "required": false },
-    { "name": "custom_config_base",          "type": "string",  "default": "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}", "description": "Base URL for nf-core/configs.",          "required": false }
+    {
+      "name": "input",
+      "type": "string",
+      "default": null,
+      "description": "Path to a samplesheet CSV.",
+      "required": true
+    },
+    {
+      "name": "outdir",
+      "type": "string",
+      "default": null,
+      "description": "Output directory.",
+      "required": true
+    },
+    {
+      "name": "genome",
+      "type": "string",
+      "default": null,
+      "description": "iGenomes reference key.",
+      "required": false
+    },
+    {
+      "name": "fasta",
+      "type": "string",
+      "default": null,
+      "description": "Reference FASTA. Computed dynamically in main.nf via getGenomeAttribute('fasta'); not declared in nextflow_schema.json.",
+      "required": false
+    },
+    {
+      "name": "igenomes_base",
+      "type": "string",
+      "default": "s3://ngi-igenomes/igenomes/",
+      "description": "iGenomes S3 base path.",
+      "required": false
+    },
+    {
+      "name": "igenomes_ignore",
+      "type": "boolean",
+      "default": false,
+      "description": "Skip iGenomes lookups.",
+      "required": false
+    },
+    {
+      "name": "skip_trim",
+      "type": "boolean",
+      "default": false,
+      "description": "Skip the SEQTK_TRIM step.",
+      "required": false
+    },
+    {
+      "name": "multiqc_config",
+      "type": "string",
+      "default": null,
+      "description": "Custom MultiQC config.",
+      "required": false
+    },
+    {
+      "name": "multiqc_title",
+      "type": "string",
+      "default": null,
+      "description": "Custom MultiQC report title.",
+      "required": false
+    },
+    {
+      "name": "multiqc_logo",
+      "type": "string",
+      "default": null,
+      "description": "Custom MultiQC logo.",
+      "required": false
+    },
+    {
+      "name": "max_multiqc_email_size",
+      "type": "string",
+      "default": "25.MB",
+      "description": "Max size of MultiQC email attachment.",
+      "required": false
+    },
+    {
+      "name": "multiqc_methods_description",
+      "type": "string",
+      "default": null,
+      "description": "Custom MultiQC methods description text.",
+      "required": false
+    },
+    {
+      "name": "publish_dir_mode",
+      "type": "string",
+      "default": "copy",
+      "description": "How files are published to outdir.",
+      "required": false
+    },
+    {
+      "name": "email",
+      "type": "string",
+      "default": null,
+      "description": "Email address for completion summary.",
+      "required": false
+    },
+    {
+      "name": "email_on_fail",
+      "type": "string",
+      "default": null,
+      "description": "Email address for failure notifications.",
+      "required": false
+    },
+    {
+      "name": "plaintext_email",
+      "type": "boolean",
+      "default": false,
+      "description": "Send plaintext rather than HTML email.",
+      "required": false
+    },
+    {
+      "name": "monochrome_logs",
+      "type": "boolean",
+      "default": false,
+      "description": "Disable ANSI color in logs.",
+      "required": false
+    },
+    {
+      "name": "hook_url",
+      "type": "string",
+      "default": null,
+      "description": "Webhook URL (Slack/MS Teams) for completion notifications.",
+      "required": false
+    },
+    {
+      "name": "help",
+      "type": "boolean",
+      "default": false,
+      "description": "Show help and exit.",
+      "required": false
+    },
+    {
+      "name": "help_full",
+      "type": "boolean",
+      "default": false,
+      "description": "Show full help and exit.",
+      "required": false
+    },
+    {
+      "name": "show_hidden",
+      "type": "boolean",
+      "default": false,
+      "description": "Show hidden parameters in help.",
+      "required": false
+    },
+    {
+      "name": "version",
+      "type": "boolean",
+      "default": false,
+      "description": "Show pipeline version and exit.",
+      "required": false
+    },
+    {
+      "name": "validate_params",
+      "type": "boolean",
+      "default": true,
+      "description": "Validate parameters against the JSON schema.",
+      "required": false
+    },
+    {
+      "name": "pipelines_testdata_base_path",
+      "type": "string",
+      "default": "https://raw.githubusercontent.com/nf-core/test-datasets/",
+      "description": "Base URL for pipeline test data.",
+      "required": false
+    },
+    {
+      "name": "trace_report_suffix",
+      "type": "string",
+      "default": "<runtime-timestamp>",
+      "description": "Suffix appended to trace report filenames.",
+      "required": false
+    },
+    {
+      "name": "config_profile_name",
+      "type": "string",
+      "default": null,
+      "description": "Profile name (set by config profiles).",
+      "required": false
+    },
+    {
+      "name": "config_profile_description",
+      "type": "string",
+      "default": null,
+      "description": "Profile description (set by config profiles).",
+      "required": false
+    },
+    {
+      "name": "config_profile_contact",
+      "type": "string",
+      "default": null,
+      "description": "Profile contact (set by config profiles).",
+      "required": false
+    },
+    {
+      "name": "config_profile_url",
+      "type": "string",
+      "default": null,
+      "description": "Profile URL (set by config profiles).",
+      "required": false
+    },
+    {
+      "name": "custom_config_version",
+      "type": "string",
+      "default": "master",
+      "description": "Version of nf-core/configs to load.",
+      "required": false
+    },
+    {
+      "name": "custom_config_base",
+      "type": "string",
+      "default": "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}",
+      "description": "Base URL for nf-core/configs.",
+      "required": false
+    }
   ],
-  "profiles": ["debug", "conda", "mamba", "docker", "singularity", "podman", "shifter", "charliecloud", "apptainer", "wave", "arm64", "gpu", "test", "test_full"],
+  "profiles": [
+    "debug",
+    "conda",
+    "mamba",
+    "docker",
+    "singularity",
+    "podman",
+    "shifter",
+    "charliecloud",
+    "apptainer",
+    "wave",
+    "arm64",
+    "gpu",
+    "test",
+    "test_full"
+  ],
   "tools": [
-    { "name": "fastqc",  "version": "0.12.1", "biocontainer": "biocontainers/fastqc:0.12.1--hdfd78af_0",                          "bioconda": "bioconda::fastqc=0.12.1",  "docker": null,                                                                              "singularity": "https://depot.galaxyproject.org/singularity/fastqc:0.12.1--hdfd78af_0",                                              "wave": null },
-    { "name": "seqtk",   "version": "1.4",    "biocontainer": "biocontainers/seqtk:1.4--he4a0461_1",                              "bioconda": "bioconda::seqtk=1.4",      "docker": null,                                                                              "singularity": "https://depot.galaxyproject.org/singularity/seqtk:1.4--he4a0461_1",                                                  "wave": null },
-    { "name": "multiqc", "version": "1.33",   "biocontainer": null,                                                                "bioconda": "bioconda::multiqc=1.33",   "docker": null,                                                                              "singularity": "https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/34/34e733a9ae16a27e80fe00f863ea1479c96416017f24a907996126283e7ecd4d/data", "wave": "community.wave.seqera.io/library/multiqc:1.33--ee7739d47738383b" }
+    {
+      "name": "fastqc",
+      "version": "0.12.1",
+      "biocontainer": "biocontainers/fastqc:0.12.1--hdfd78af_0",
+      "bioconda": "bioconda::fastqc=0.12.1",
+      "docker": null,
+      "singularity": "https://depot.galaxyproject.org/singularity/fastqc:0.12.1--hdfd78af_0",
+      "wave": null
+    },
+    {
+      "name": "seqtk",
+      "version": "1.4",
+      "biocontainer": "biocontainers/seqtk:1.4--he4a0461_1",
+      "bioconda": "bioconda::seqtk=1.4",
+      "docker": null,
+      "singularity": "https://depot.galaxyproject.org/singularity/seqtk:1.4--he4a0461_1",
+      "wave": null
+    },
+    {
+      "name": "multiqc",
+      "version": "1.33",
+      "biocontainer": null,
+      "bioconda": "bioconda::multiqc=1.33",
+      "docker": null,
+      "singularity": "https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/34/34e733a9ae16a27e80fe00f863ea1479c96416017f24a907996126283e7ecd4d/data",
+      "wave": "community.wave.seqera.io/library/multiqc:1.33--ee7739d47738383b"
+    }
   ],
   "processes": [
     {
@@ -55,16 +280,38 @@
       "container": "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ? 'https://depot.galaxyproject.org/singularity/fastqc:0.12.1--hdfd78af_0' : 'biocontainers/fastqc:0.12.1--hdfd78af_0' }",
       "conda": "${moduleDir}/environment.yml",
       "inputs": [
-        { "name": "reads", "shape": "tuple(val(meta), path(reads))", "description": "Input FASTQ files (single-end or paired-end). meta is a Groovy map with id and single_end keys.", "topic": null }
+        {
+          "name": "reads",
+          "shape": "tuple(val(meta), path(reads))",
+          "description": "Input FASTQ files (single-end or paired-end). meta is a Groovy map with id and single_end keys.",
+          "topic": null
+        }
       ],
       "outputs": [
-        { "name": "html",            "shape": "tuple(val(meta), path(\"*.html\"))",                                                "description": "FastQC HTML report per sample.",                                "topic": null },
-        { "name": "zip",             "shape": "tuple(val(meta), path(\"*.zip\"))",                                                 "description": "FastQC report archive per sample.",                             "topic": null },
-        { "name": "versions_fastqc", "shape": "tuple(val(\"${task.process}\"), val('fastqc'), eval('fastqc --version | sed ...'))", "description": "Tool version triple emitted to the 'versions' channel topic.", "topic": "versions" }
+        {
+          "name": "html",
+          "shape": "tuple(val(meta), path(\"*.html\"))",
+          "description": "FastQC HTML report per sample.",
+          "topic": null
+        },
+        {
+          "name": "zip",
+          "shape": "tuple(val(meta), path(\"*.zip\"))",
+          "description": "FastQC report archive per sample.",
+          "topic": null
+        },
+        {
+          "name": "versions_fastqc",
+          "shape": "tuple(val(\"${task.process}\"), val('fastqc'), eval('fastqc --version | sed ...'))",
+          "description": "Tool version triple emitted to the 'versions' channel topic.",
+          "topic": "versions"
+        }
       ],
       "when": "task.ext.when == null || task.ext.when",
       "script_summary": "Symlink reads to prefix-renamed names, then run fastqc with --threads and --memory derived from task resources.",
-      "publish_dir": null
+      "publish_dir": null,
+      "meta": null,
+      "module_tests": []
     },
     {
       "name": "SEQTK_TRIM",
@@ -74,15 +321,32 @@
       "container": "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ? 'https://depot.galaxyproject.org/singularity/seqtk:1.4--he4a0461_1' : 'biocontainers/seqtk:1.4--he4a0461_1' }",
       "conda": "${moduleDir}/environment.yml",
       "inputs": [
-        { "name": "reads", "shape": "tuple(val(meta), path(reads))", "description": "Input FASTQ files.", "topic": null }
+        {
+          "name": "reads",
+          "shape": "tuple(val(meta), path(reads))",
+          "description": "Input FASTQ files.",
+          "topic": null
+        }
       ],
       "outputs": [
-        { "name": "reads",          "shape": "tuple(val(meta), path(\"*.fastq.gz\"))",                                              "description": "Trimmed gzipped FASTQ output.",                              "topic": null },
-        { "name": "versions_seqtk", "shape": "tuple(val(\"${task.process}\"), val('seqtk'), eval('seqtk 2>&1 | sed ...'))",         "description": "Tool version triple emitted to the 'versions' channel topic.", "topic": "versions" }
+        {
+          "name": "reads",
+          "shape": "tuple(val(meta), path(\"*.fastq.gz\"))",
+          "description": "Trimmed gzipped FASTQ output.",
+          "topic": null
+        },
+        {
+          "name": "versions_seqtk",
+          "shape": "tuple(val(\"${task.process}\"), val('seqtk'), eval('seqtk 2>&1 | sed ...'))",
+          "description": "Tool version triple emitted to the 'versions' channel topic.",
+          "topic": "versions"
+        }
       ],
       "when": "task.ext.when == null || task.ext.when",
       "script_summary": "Pipe each input read file through `seqtk trimfq` and gzip-write to a prefixed output.",
-      "publish_dir": null
+      "publish_dir": null,
+      "meta": null,
+      "module_tests": []
     },
     {
       "name": "MULTIQC",
@@ -92,22 +356,74 @@
       "container": "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/34/34e733a9ae16a27e80fe00f863ea1479c96416017f24a907996126283e7ecd4d/data' : 'community.wave.seqera.io/library/multiqc:1.33--ee7739d47738383b' }",
       "conda": "${moduleDir}/environment.yml",
       "inputs": [
-        { "name": "multiqc_files",        "shape": "path(stageAs:\"?/*\")", "description": "All accumulated reports and version YAMLs.", "topic": null },
-        { "name": "multiqc_config",       "shape": "path",                  "description": "Default MultiQC config from assets/.",        "topic": null },
-        { "name": "extra_multiqc_config", "shape": "path",                  "description": "Optional --multiqc_config override.",         "topic": null },
-        { "name": "multiqc_logo",         "shape": "path",                  "description": "Optional custom logo.",                       "topic": null },
-        { "name": "replace_names",        "shape": "path",                  "description": "Optional sample-name replacement table.",     "topic": null },
-        { "name": "sample_names",         "shape": "path",                  "description": "Optional sample-name table.",                 "topic": null }
+        {
+          "name": "multiqc_files",
+          "shape": "path(stageAs:\"?/*\")",
+          "description": "All accumulated reports and version YAMLs.",
+          "topic": null
+        },
+        {
+          "name": "multiqc_config",
+          "shape": "path",
+          "description": "Default MultiQC config from assets/.",
+          "topic": null
+        },
+        {
+          "name": "extra_multiqc_config",
+          "shape": "path",
+          "description": "Optional --multiqc_config override.",
+          "topic": null
+        },
+        {
+          "name": "multiqc_logo",
+          "shape": "path",
+          "description": "Optional custom logo.",
+          "topic": null
+        },
+        {
+          "name": "replace_names",
+          "shape": "path",
+          "description": "Optional sample-name replacement table.",
+          "topic": null
+        },
+        {
+          "name": "sample_names",
+          "shape": "path",
+          "description": "Optional sample-name table.",
+          "topic": null
+        }
       ],
       "outputs": [
-        { "name": "report",   "shape": "path(\"*.html\")",                                                              "description": "MultiQC HTML report.",                                                                                                "topic": null },
-        { "name": "data",     "shape": "path(\"*_data\")",                                                              "description": "MultiQC data directory.",                                                                                             "topic": null },
-        { "name": "plots",    "shape": "path(\"*_plots\") optional",                                                    "description": "MultiQC plots directory (optional).",                                                                                 "topic": null },
-        { "name": "versions", "shape": "tuple(val(\"${task.process}\"), val('multiqc'), eval('multiqc --version ...'))", "description": "Tool version triple. Deliberately NOT emitted to the versions topic — multiqc consumes versions and would deadlock.", "topic": null }
+        {
+          "name": "report",
+          "shape": "path(\"*.html\")",
+          "description": "MultiQC HTML report.",
+          "topic": null
+        },
+        {
+          "name": "data",
+          "shape": "path(\"*_data\")",
+          "description": "MultiQC data directory.",
+          "topic": null
+        },
+        {
+          "name": "plots",
+          "shape": "path(\"*_plots\") optional",
+          "description": "MultiQC plots directory (optional).",
+          "topic": null
+        },
+        {
+          "name": "versions",
+          "shape": "tuple(val(\"${task.process}\"), val('multiqc'), eval('multiqc --version ...'))",
+          "description": "Tool version triple. Deliberately NOT emitted to the versions topic — multiqc consumes versions and would deadlock.",
+          "topic": null
+        }
       ],
       "when": "task.ext.when == null || task.ext.when",
       "script_summary": "Run multiqc on the staged inputs, optionally with a custom config, logo, and sample-name replacements.",
-      "publish_dir": null
+      "publish_dir": null,
+      "meta": null,
+      "module_tests": []
     }
   ],
   "subworkflows": [
@@ -118,8 +434,14 @@
       "calls": [],
       "inputs": [],
       "outputs": [
-        { "name": "samplesheet", "shape": "tuple(val(meta), path(reads))", "description": "Validated samplesheet read from --input via plugin/nf-schema's samplesheetToList.", "topic": null }
-      ]
+        {
+          "name": "samplesheet",
+          "shape": "tuple(val(meta), path(reads))",
+          "description": "Validated samplesheet read from --input via plugin/nf-schema's samplesheetToList.",
+          "topic": null
+        }
+      ],
+      "tests": []
     },
     {
       "name": "PIPELINE_COMPLETION",
@@ -127,36 +449,96 @@
       "kind": "utility",
       "calls": [],
       "inputs": [],
-      "outputs": []
+      "outputs": [],
+      "tests": []
     },
     {
       "name": "NFCORE_DEMO",
       "path": "main.nf",
       "kind": "pipeline",
-      "calls": ["DEMO"],
+      "calls": [
+        "DEMO"
+      ],
       "inputs": [],
       "outputs": [
-        { "name": "multiqc_report", "shape": "path", "description": "MultiQC HTML report.", "topic": null }
-      ]
+        {
+          "name": "multiqc_report",
+          "shape": "path",
+          "description": "MultiQC HTML report.",
+          "topic": null
+        }
+      ],
+      "tests": []
     }
   ],
   "workflow": {
     "name": "DEMO",
     "channels": [
-      { "name": "ch_samplesheet",      "source": "PIPELINE_INITIALISATION.out.samplesheet",                                              "shape": "tuple(val(meta), path(reads))" },
-      { "name": "ch_versions",         "source": "channel.empty()",                                                                     "shape": "path" },
-      { "name": "ch_multiqc_files",    "source": "channel.empty() then accumulated via .mix(FASTQC.out.zip, ch_workflow_summary, ch_methods_description, ch_collated_versions)", "shape": "path" },
-      { "name": "ch_multiqc_config",   "source": "channel.fromPath(\"$projectDir/assets/multiqc_config.yml\")",                          "shape": "path" },
-      { "name": "ch_collated_versions","source": "softwareVersionsToYAML(ch_versions.mix(channel.topic('versions').versions_file)).mix(...).collectFile(...)", "shape": "path" }
+      {
+        "name": "ch_samplesheet",
+        "source": "PIPELINE_INITIALISATION.out.samplesheet",
+        "shape": "tuple(val(meta), path(reads))"
+      },
+      {
+        "name": "ch_versions",
+        "source": "channel.empty()",
+        "shape": "path"
+      },
+      {
+        "name": "ch_multiqc_files",
+        "source": "channel.empty() then accumulated via .mix(FASTQC.out.zip, ch_workflow_summary, ch_methods_description, ch_collated_versions)",
+        "shape": "path"
+      },
+      {
+        "name": "ch_multiqc_config",
+        "source": "channel.fromPath(\"$projectDir/assets/multiqc_config.yml\")",
+        "shape": "path"
+      },
+      {
+        "name": "ch_collated_versions",
+        "source": "softwareVersionsToYAML(ch_versions.mix(channel.topic('versions').versions_file)).mix(...).collectFile(...)",
+        "shape": "path"
+      }
     ],
     "edges": [
-      { "from": "ch_samplesheet",   "to": "FASTQC",      "via": [],                          "notes": "" },
-      { "from": "ch_samplesheet",   "to": "SEQTK_TRIM",  "via": [],                          "notes": "Gated by !params.skip_trim conditional." },
-      { "from": "FASTQC.out.zip",   "to": "MULTIQC",     "via": ["collect", "mix"],          "notes": "Mixed into ch_multiqc_files alongside workflow_summary, methods_description, and collated versions." },
-      { "from": "ch_multiqc_files", "to": "MULTIQC",     "via": ["collect"],                 "notes": "" }
+      {
+        "from": "ch_samplesheet",
+        "to": "FASTQC",
+        "via": [],
+        "notes": ""
+      },
+      {
+        "from": "ch_samplesheet",
+        "to": "SEQTK_TRIM",
+        "via": [],
+        "notes": "Gated by !params.skip_trim conditional."
+      },
+      {
+        "from": "FASTQC.out.zip",
+        "to": "MULTIQC",
+        "via": [
+          "collect",
+          "mix"
+        ],
+        "notes": "Mixed into ch_multiqc_files alongside workflow_summary, methods_description, and collated versions."
+      },
+      {
+        "from": "ch_multiqc_files",
+        "to": "MULTIQC",
+        "via": [
+          "collect"
+        ],
+        "notes": ""
+      }
     ],
     "conditionals": [
-      { "guard": "!params.skip_trim", "branch": "default", "affects": ["SEQTK_TRIM"] }
+      {
+        "guard": "!params.skip_trim",
+        "branch": "default",
+        "affects": [
+          "SEQTK_TRIM"
+        ]
+      }
     ]
   },
   "test_fixtures": {
@@ -189,14 +571,29 @@
     {
       "name": "-profile test",
       "path": "tests/default.nf.test",
-      "profiles": ["test"],
-      "params_overrides": { "outdir": "$outputDir" },
+      "profiles": [
+        "test"
+      ],
+      "params_overrides": {
+        "outdir": "$outputDir"
+      },
       "assert_workflow_success": true,
       "snapshot": {
-        "captures": ["versions_yml", "stable_names", "stable_paths"],
-        "helpers":  ["getAllFilesFromDir", "removeNextflowVersion"],
-        "ignore_files": ["tests/.nftignore"],
-        "ignore_globs": ["pipeline_info/*.{html,json,txt}"],
+        "captures": [
+          "versions_yml",
+          "stable_names",
+          "stable_paths"
+        ],
+        "helpers": [
+          "getAllFilesFromDir",
+          "removeNextflowVersion"
+        ],
+        "ignore_files": [
+          "tests/.nftignore"
+        ],
+        "ignore_globs": [
+          "pipeline_info/*.{html,json,txt}"
+        ],
         "snap_path": "tests/default.nf.test.snap"
       },
       "prose_assertions": []

--- a/content/molds/summarize-nextflow/eval.md
+++ b/content/molds/summarize-nextflow/eval.md
@@ -92,6 +92,28 @@ Fixtures are pinned in `workflow-fixtures/fixtures.yaml`; materialize with
 - expectation: `processes[].aliases[]` contains every `include { X as Y }`
   rename for `MINIMAP2_ALIGN` and `FASTQC`.
 
+## Case: nf-core module metadata and unit tests are process-local
+
+- bucket: fidelity
+- check: deterministic
+- fixture: `workflow-fixtures/pipelines/nf-core__bacass`.
+- expectation: every `processes[]` row with `module_path` under
+  `modules/nf-core/` has `meta != null`; `meta.tools[]`, `meta.input[]`,
+  and `meta.output[]` are normalized from the vendored `meta.yml`; and
+  `module_tests[].length` equals the count of `*.nf.test` files under that
+  module's `tests/` directory. Every `processes[]` row under
+  `modules/local/` has `meta == null` and `module_tests == []`.
+
+## Case: subworkflow unit tests are enumerated without semantics
+
+- bucket: fidelity
+- check: deterministic
+- fixture: `workflow-fixtures/pipelines/nf-core__bacass`.
+- expectation: every `subworkflows[]` row whose `path` lives under
+  `subworkflows/nf-core/` has `tests[].length` matching on-disk
+  `*.nf.test` files under that subworkflow directory; local or untested
+  subworkflows emit `tests == []`. No snapshot contents are inlined.
+
 ## Case: tool registry covers every container directive
 
 - bucket: fidelity
@@ -149,6 +171,17 @@ Fixtures are pinned in `workflow-fixtures/fixtures.yaml`; materialize with
   `<requirements>` block for every `tools[]` row; rows that don't yield
   a wrapper-shaped requirement are surfaced as evaluation gaps, not
   silently dropped.
+
+## Case: tool-wrapper Mold can consume one process row standalone
+
+- bucket: utility
+- check: llm-judged
+- fixture: `processes[]` row for `MINIMAP2_ALIGN` from a bacass summary.
+- expectation: `author-galaxy-tool-wrapper` produces a Galaxy tool wrapper
+  using only that process object (`meta`, `module_tests`, `container`,
+  `conda`, declared IO); it does not consult summary-level `tools[]`,
+  `workflow`, or `params`. Missing fields become logged gaps rather than
+  implicit lookups into the parent summary.
 
 ## Case: nf-test to Galaxy test-plan translation
 

--- a/content/schemas/summary-nextflow.schema.json
+++ b/content/schemas/summary-nextflow.schema.json
@@ -98,11 +98,13 @@
       "description": "One Nextflow `process { ... }` block.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "module_path", "inputs", "outputs"],
+      "required": ["name", "module_path", "meta", "module_tests", "inputs", "outputs"],
       "properties": {
         "name":            { "type": "string", "description": "Canonical process name (uppercase NF convention) as declared by the `process <NAME>` line in `module_path`." },
         "aliases":         { "type": "array", "items": { "type": "string" }, "description": "Alias names this process is imported as in workflow scopes via `include { <NAME> as <ALIAS> }`. Real nf-core pipelines re-import a single module multiple times under different aliases to invoke it with distinct runtime args (e.g. `MINIMAP2_ALIGN as MINIMAP2_CONSENSUS`, `MINIMAP2_ALIGN as MINIMAP2_POLISH`). Each alias appears in `workflow.edges[].from`/`.to` exactly as written; the canonical `name` does not appear in edges unless an unaliased import exists. Default `[]` when the process is only imported under its canonical name." },
         "module_path":     { "type": "string", "description": "Relative path from the pipeline root to the file declaring the process." },
+        "meta":            { "anyOf": [{ "$ref": "#/$defs/ModuleMeta" }, { "type": "null" }], "description": "Normalized `meta.yml` from the module directory when present. Null for local/ad-hoc processes without module metadata." },
+        "module_tests":    { "type": "array", "items": { "$ref": "#/$defs/NfTest" }, "description": "Module-scoped nf-test files under the module's `tests/` directory. Empty for local/ad-hoc modules without unit tests." },
         "tool":            { "type": ["string", "null"], "description": "Foreign key into `tools[].name` when the process runs a single recognizable tool; null for multi-tool or pure-Groovy processes." },
         "container":       { "type": ["string", "null"], "description": "Verbatim text of the process's `container` directive (or null). Modern nf-core modules use a ternary expression `\"${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ? '<singularity-uri>' : '<docker-uri>' }\"` — keep that text intact here. The two resolved branches are split out into `tools[].docker` / `tools[].singularity` (and `tools[].wave` / `tools[].biocontainer` as appropriate)." },
         "conda":           { "type": ["string", "null"], "description": "Verbatim text of the process's `conda` directive (or null). Two common shapes: a literal `bioconda::<name>=<version>` (legacy) or a file reference `${moduleDir}/environment.yml` (modern nf-core convention). Either way the resolved bioconda spec lands in `tools[].bioconda`." },
@@ -114,19 +116,57 @@
       }
     },
 
+    "ModuleMeta": {
+      "title": "ModuleMeta",
+      "description": "Normalized subset of nf-core module `meta.yml`, captured next to a process so module-scoped downstream Molds can consume `processes[i]` without reading the full pipeline summary.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["keywords", "authors", "maintainers", "tools", "input", "output"],
+      "properties": {
+        "description": { "type": "string" },
+        "keywords":    { "type": "array", "items": { "type": "string" } },
+        "authors":     { "type": "array", "items": { "type": "string" } },
+        "maintainers": { "type": "array", "items": { "type": "string" } },
+        "tools":       { "type": "array", "items": { "$ref": "#/$defs/ModuleMetaEntry" } },
+        "input":       { "type": "array", "items": { "$ref": "#/$defs/ModuleMetaEntry" } },
+        "output":      { "type": "array", "items": { "$ref": "#/$defs/ModuleMetaEntry" } }
+      }
+    },
+
+    "ModuleMetaEntry": {
+      "title": "ModuleMetaEntry",
+      "description": "One named entry from a module `meta.yml` section, normalized from nf-core's single-key YAML maps into `{ name, ...fields }` objects.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name":          { "type": "string" },
+        "description":   { "type": "string" },
+        "homepage":      { "type": "string" },
+        "documentation": { "type": "string" },
+        "tool_dev_url":  { "type": "string" },
+        "doi":           { "type": "string" },
+        "licence":       { "type": "array", "items": { "type": "string" } },
+        "identifier":    { "type": "string" },
+        "type":          { "type": "string" },
+        "pattern":       { "type": "string" }
+      }
+    },
+
     "Subworkflow": {
       "title": "Subworkflow",
       "description": "One named `workflow <NAME> { ... }` block other than the primary workflow. Includes nf-core utility wrappers (PIPELINE_INITIALISATION, PIPELINE_COMPLETION, UTILS_NFCORE_PIPELINE) which exist to compose helper-function calls rather than to invoke processes.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "path", "kind", "calls"],
+      "required": ["name", "path", "kind", "calls", "tests"],
       "properties": {
         "name":    { "type": "string" },
         "path":    { "type": "string", "description": "Relative path from the pipeline root." },
         "kind":    { "type": "string", "enum": ["pipeline", "utility"], "description": "`pipeline` when the subworkflow invokes pipeline processes (data-flow contributor). `utility` when it composes helper functions only — common nf-core template subworkflows like PIPELINE_INITIALISATION (which calls `paramsHelp`, `samplesheetToList`, `UTILS_NFSCHEMA_PLUGIN`) and PIPELINE_COMPLETION (`completionEmail`, `completionSummary`). Utility subworkflows have empty `calls[]` for processes but may still expose channel outputs the primary workflow consumes." },
         "calls":   { "type": "array", "items": { "type": "string" }, "description": "Names of processes and nested subworkflows this subworkflow invokes. Free-function calls (e.g. `paramsHelp`, `completionEmail`) are NOT recorded here; they're implied by `kind = utility`." },
         "inputs":  { "type": "array", "items": { "$ref": "#/$defs/ChannelIO" } },
-        "outputs": { "type": "array", "items": { "$ref": "#/$defs/ChannelIO" } }
+        "outputs": { "type": "array", "items": { "$ref": "#/$defs/ChannelIO" } },
+        "tests":   { "type": "array", "items": { "$ref": "#/$defs/NfTest" }, "description": "Subworkflow-scoped nf-test files under the subworkflow's `tests/` directory. Empty when absent." }
       }
     },
 

--- a/packages/summarize-nextflow/src/resolver.ts
+++ b/packages/summarize-nextflow/src/resolver.ts
@@ -24,6 +24,7 @@ interface Subworkflow {
   calls: string[];
   inputs?: ChannelIO[];
   outputs?: ChannelIO[];
+  tests: NfTest[];
 }
 
 interface ParsedWorkflow extends Subworkflow {
@@ -78,6 +79,8 @@ interface Process {
   name: string;
   aliases: string[];
   module_path: string;
+  meta: ModuleMeta | null;
+  module_tests: NfTest[];
   tool: string | null;
   container: string | null;
   conda: string | null;
@@ -86,6 +89,29 @@ interface Process {
   when: string | null;
   script_summary: string;
   publish_dir: string | null;
+}
+
+interface ModuleMeta {
+  description?: string;
+  keywords: string[];
+  authors: string[];
+  maintainers: string[];
+  tools: ModuleMetaEntry[];
+  input: ModuleMetaEntry[];
+  output: ModuleMetaEntry[];
+}
+
+interface ModuleMetaEntry {
+  name: string;
+  description?: string;
+  homepage?: string;
+  documentation?: string;
+  tool_dev_url?: string;
+  doi?: string;
+  licence?: string[];
+  identifier?: string;
+  type?: string;
+  pattern?: string;
 }
 
 interface TestDataRef {
@@ -407,6 +433,9 @@ function parseProcessFile(pipelineRoot: string, path: string): Process[] {
     const body = extractBlockAt(text, openIndex);
     if (body === null) return [];
     const name = match[1]!;
+    const moduleDir = dirname(path);
+    const modulePath = relative(pipelineRoot, path);
+    const isLocalModule = modulePath.startsWith(`modules${sep}local${sep}`);
     const container = normalizeDirective(
       matchOne(
         body,
@@ -417,7 +446,9 @@ function parseProcessFile(pipelineRoot: string, path: string): Process[] {
     return {
       name,
       aliases: [],
-      module_path: relative(pipelineRoot, path),
+      module_path: modulePath,
+      meta: isLocalModule ? null : parseModuleMeta(join(moduleDir, "meta.yml")),
+      module_tests: isLocalModule ? [] : parseNfTestsInDir(pipelineRoot, join(moduleDir, "tests")),
       tool: null,
       container,
       conda,
@@ -428,6 +459,53 @@ function parseProcessFile(pipelineRoot: string, path: string): Process[] {
       publish_dir: normalizeDirective(matchOne(body, /publishDir\s+([^\n]+)/u)),
     };
   });
+}
+
+function parseModuleMeta(path: string): ModuleMeta | null {
+  if (!existsSync(path)) return null;
+  const data = YAML.parse(readText(path)) as Record<string, unknown> | null;
+  if (!data || typeof data !== "object") return null;
+  return {
+    description: typeof data.description === "string" ? data.description : undefined,
+    keywords: stringArray(data.keywords),
+    authors: stringArray(data.authors),
+    maintainers: stringArray(data.maintainers),
+    tools: parseNamedMetaEntries(data.tools),
+    input: parseNamedMetaEntries(data.input),
+    output: parseNamedMetaEntries(data.output),
+  };
+}
+
+function parseNamedMetaEntries(value: unknown): ModuleMetaEntry[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => {
+    if (!item || typeof item !== "object" || Array.isArray(item)) return [];
+    return Object.entries(item as Record<string, unknown>).flatMap(([name, details]) => {
+      if (!details || typeof details !== "object" || Array.isArray(details)) return [];
+      const record = details as Record<string, unknown>;
+      return {
+        name,
+        description: stringValue(record.description),
+        homepage: stringValue(record.homepage),
+        documentation: stringValue(record.documentation),
+        tool_dev_url: stringValue(record.tool_dev_url),
+        doi: stringValue(record.doi),
+        licence: stringArray(record.licence),
+        identifier: stringValue(record.identifier),
+        type: stringValue(record.type),
+        pattern: stringValue(record.pattern),
+      };
+    });
+  });
+}
+
+function stringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
 }
 
 function selectEntrypoint(pipelineRoot: string): string | null {
@@ -486,6 +564,7 @@ function parseWorkflows(pipelineRoot: string, processNames: string[]): ParsedWor
         calls,
         inputs: parseWorkflowIoBlock(block.body, "take"),
         outputs: parseWorkflowIoBlock(block.body, "emit"),
+        tests: parseNfTestsInDir(pipelineRoot, join(dirname(path), "tests")),
         body: block.body,
       });
     }
@@ -1019,7 +1098,10 @@ function formatError(err: unknown): string {
 }
 
 function parseNfTests(pipelineRoot: string): NfTest[] {
-  const testsRoot = join(pipelineRoot, "tests");
+  return parseNfTestsInDir(pipelineRoot, join(pipelineRoot, "tests"));
+}
+
+function parseNfTestsInDir(pipelineRoot: string, testsRoot: string): NfTest[] {
   return walk(testsRoot)
     .filter((path) => path.endsWith(".nf.test"))
     .flatMap((path) => {

--- a/packages/summarize-nextflow/test/resolver.test.ts
+++ b/packages/summarize-nextflow/test/resolver.test.ts
@@ -196,8 +196,16 @@ process SECOND {
   test("captures module meta.yml and module nf-tests on canonical process", async () => {
     const root = tempPipelineRoot();
     write(root, "nextflow.config", "manifest { name = 'nf-core/module-meta' }\n");
-    write(root, "main.nf", "include { ALIGN } from './modules/nf-core/minimap2/align'\nworkflow MODULE_META { ALIGN() }\n");
-    write(root, "modules/nf-core/minimap2/align/main.nf", "process ALIGN {\n  script:\n  'align'\n}\n");
+    write(
+      root,
+      "main.nf",
+      "include { ALIGN } from './modules/nf-core/minimap2/align'\nworkflow MODULE_META { ALIGN() }\n",
+    );
+    write(
+      root,
+      "modules/nf-core/minimap2/align/main.nf",
+      "process ALIGN {\n  script:\n  'align'\n}\n",
+    );
     write(
       root,
       "modules/nf-core/minimap2/align/meta.yml",
@@ -273,7 +281,11 @@ test("align module") {
     write(root, "nextflow.config", "manifest { name = 'nf-core/subworkflow-tests' }\n");
     write(root, "modules/local/local.nf", "process LOCAL {\n  script:\n  'local'\n}\n");
     write(root, "modules/local/meta.yml", "description: Local metadata should not be promoted\n");
-    write(root, "modules/local/tests/local.nf.test", "test(\"local\") { then { assert workflow.success } }\n");
+    write(
+      root,
+      "modules/local/tests/local.nf.test",
+      'test("local") { then { assert workflow.success } }\n',
+    );
     write(root, "modules/local/other.nf", "process OTHER {\n  script:\n  'other'\n}\n");
     write(
       root,
@@ -285,7 +297,11 @@ test("align module") {
       "workflows/pipeline.nf",
       "workflow PIPELINE {\n  take:\n  reads\n  main:\n  LOCAL(reads)\n  OTHER(reads)\n}\n",
     );
-    write(root, "main.nf", "include { LOCAL } from './modules/local/local'\ninclude { OTHER } from './modules/local/other'\ninclude { TRIM } from './subworkflows/nf-core/trim'\ninclude { PIPELINE } from './workflows/pipeline'\nworkflow { PIPELINE(Channel.of('x')) }\n");
+    write(
+      root,
+      "main.nf",
+      "include { LOCAL } from './modules/local/local'\ninclude { OTHER } from './modules/local/other'\ninclude { TRIM } from './subworkflows/nf-core/trim'\ninclude { PIPELINE } from './workflows/pipeline'\nworkflow { PIPELINE(Channel.of('x')) }\n",
+    );
     write(
       root,
       "subworkflows/nf-core/trim/tests/main.nf.test",

--- a/packages/summarize-nextflow/test/resolver.test.ts
+++ b/packages/summarize-nextflow/test/resolver.test.ts
@@ -5,7 +5,22 @@ import { afterEach, describe, expect, test } from "vitest";
 import { buildSummary } from "../src/index.js";
 
 interface SummaryLike {
-  processes: { name: string; module_path: string; inputs: unknown[]; outputs: unknown[] }[];
+  processes: {
+    name: string;
+    module_path: string;
+    meta: {
+      description?: string;
+      keywords: string[];
+      authors: string[];
+      tools: { name: string; description?: string; homepage?: string; licence?: string[] }[];
+      input: { name: string; type?: string; description?: string; pattern?: string }[];
+      output: { name: string; type?: string; description?: string; pattern?: string }[];
+    } | null;
+    module_tests: { name: string; path: string; snapshot: { snap_path: string | null } | null }[];
+    inputs: unknown[];
+    outputs: unknown[];
+  }[];
+  subworkflows: { name: string; path: string; tests: { name: string; path: string }[] }[];
   warnings: string[];
 }
 
@@ -176,6 +191,120 @@ process SECOND {
       "auto-detected Nextflow pipeline root from workflow block: nf",
     );
     expect(summary.warnings).toContain("selected Nextflow entrypoint: ui.nf");
+  });
+
+  test("captures module meta.yml and module nf-tests on canonical process", async () => {
+    const root = tempPipelineRoot();
+    write(root, "nextflow.config", "manifest { name = 'nf-core/module-meta' }\n");
+    write(root, "main.nf", "include { ALIGN } from './modules/nf-core/minimap2/align'\nworkflow MODULE_META { ALIGN() }\n");
+    write(root, "modules/nf-core/minimap2/align/main.nf", "process ALIGN {\n  script:\n  'align'\n}\n");
+    write(
+      root,
+      "modules/nf-core/minimap2/align/meta.yml",
+      `description: Align reads against a reference
+keywords:
+  - align
+  - reference
+authors:
+  - "@author"
+maintainers:
+  - "@maintainer"
+tools:
+  - minimap2:
+      description: Fast sequence aligner
+      homepage: https://github.com/lh3/minimap2
+      licence:
+        - MIT
+input:
+  - reads:
+      type: file
+      description: Input reads
+      pattern: "*.fastq.gz"
+output:
+  - bam:
+      type: file
+      description: Aligned reads
+      pattern: "*.bam"
+`,
+    );
+    write(
+      root,
+      "modules/nf-core/minimap2/align/tests/main.nf.test",
+      `profile "test"
+test("align module") {
+  when { params { outdir = "results" } }
+  then { assert snapshot(workflow.trace.succeeded().size()).match() }
+}
+`,
+    );
+    write(root, "modules/nf-core/minimap2/align/tests/main.nf.test.snap", "snapshot\n");
+
+    const summary = await summarize(root);
+    const process = summary.processes[0]!;
+
+    expect(process.meta?.description).toBe("Align reads against a reference");
+    expect(process.meta?.keywords).toEqual(["align", "reference"]);
+    expect(process.meta?.authors).toEqual(["@author"]);
+    expect(process.meta?.tools[0]).toEqual(
+      expect.objectContaining({
+        name: "minimap2",
+        description: "Fast sequence aligner",
+        homepage: "https://github.com/lh3/minimap2",
+        licence: ["MIT"],
+      }),
+    );
+    expect(process.meta?.input[0]).toEqual(
+      expect.objectContaining({ name: "reads", type: "file", pattern: "*.fastq.gz" }),
+    );
+    expect(process.module_tests).toHaveLength(1);
+    expect(process.module_tests[0]).toEqual(
+      expect.objectContaining({
+        name: "align module",
+        path: "modules/nf-core/minimap2/align/tests/main.nf.test",
+        snapshot: expect.objectContaining({
+          snap_path: "modules/nf-core/minimap2/align/tests/main.nf.test.snap",
+        }),
+      }),
+    );
+  });
+
+  test("captures subworkflow tests and leaves local process module metadata empty", async () => {
+    const root = tempPipelineRoot();
+    write(root, "nextflow.config", "manifest { name = 'nf-core/subworkflow-tests' }\n");
+    write(root, "modules/local/local.nf", "process LOCAL {\n  script:\n  'local'\n}\n");
+    write(root, "modules/local/meta.yml", "description: Local metadata should not be promoted\n");
+    write(root, "modules/local/tests/local.nf.test", "test(\"local\") { then { assert workflow.success } }\n");
+    write(root, "modules/local/other.nf", "process OTHER {\n  script:\n  'other'\n}\n");
+    write(
+      root,
+      "subworkflows/nf-core/trim/main.nf",
+      "workflow TRIM {\n  take:\n  reads\n  main:\n  LOCAL(reads)\n}\n",
+    );
+    write(
+      root,
+      "workflows/pipeline.nf",
+      "workflow PIPELINE {\n  take:\n  reads\n  main:\n  LOCAL(reads)\n  OTHER(reads)\n}\n",
+    );
+    write(root, "main.nf", "include { LOCAL } from './modules/local/local'\ninclude { OTHER } from './modules/local/other'\ninclude { TRIM } from './subworkflows/nf-core/trim'\ninclude { PIPELINE } from './workflows/pipeline'\nworkflow { PIPELINE(Channel.of('x')) }\n");
+    write(
+      root,
+      "subworkflows/nf-core/trim/tests/main.nf.test",
+      `test("trim subworkflow") {
+  then { assert workflow.success }
+}
+`,
+    );
+
+    const summary = await summarize(root);
+
+    expect(summary.processes.every((process) => process.meta === null)).toBe(true);
+    expect(summary.processes.every((process) => process.module_tests.length === 0)).toBe(true);
+    expect(summary.subworkflows.find((workflow) => workflow.name === "TRIM")?.tests).toEqual([
+      expect.objectContaining({
+        name: "trim subworkflow",
+        path: "subworkflows/nf-core/trim/tests/main.nf.test",
+      }),
+    ]);
   });
 });
 

--- a/packages/summary-nextflow-schema/src/summary-nextflow.schema.generated.ts
+++ b/packages/summary-nextflow-schema/src/summary-nextflow.schema.generated.ts
@@ -253,6 +253,8 @@ export const summaryNextflowSchema = {
       "required": [
         "name",
         "module_path",
+        "meta",
+        "module_tests",
         "inputs",
         "outputs"
       ],
@@ -271,6 +273,24 @@ export const summaryNextflowSchema = {
         "module_path": {
           "type": "string",
           "description": "Relative path from the pipeline root to the file declaring the process."
+        },
+        "meta": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ModuleMeta"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Normalized `meta.yml` from the module directory when present. Null for local/ad-hoc processes without module metadata."
+        },
+        "module_tests": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/NfTest"
+          },
+          "description": "Module-scoped nf-test files under the module's `tests/` directory. Empty for local/ad-hoc modules without unit tests."
         },
         "tool": {
           "type": [
@@ -325,6 +345,105 @@ export const summaryNextflowSchema = {
         }
       }
     },
+    "ModuleMeta": {
+      "title": "ModuleMeta",
+      "description": "Normalized subset of nf-core module `meta.yml`, captured next to a process so module-scoped downstream Molds can consume `processes[i]` without reading the full pipeline summary.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "keywords",
+        "authors",
+        "maintainers",
+        "tools",
+        "input",
+        "output"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "keywords": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "authors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "maintainers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ModuleMetaEntry"
+          }
+        },
+        "input": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ModuleMetaEntry"
+          }
+        },
+        "output": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ModuleMetaEntry"
+          }
+        }
+      }
+    },
+    "ModuleMetaEntry": {
+      "title": "ModuleMetaEntry",
+      "description": "One named entry from a module `meta.yml` section, normalized from nf-core's single-key YAML maps into `{ name, ...fields }` objects.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "homepage": {
+          "type": "string"
+        },
+        "documentation": {
+          "type": "string"
+        },
+        "tool_dev_url": {
+          "type": "string"
+        },
+        "doi": {
+          "type": "string"
+        },
+        "licence": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "identifier": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "pattern": {
+          "type": "string"
+        }
+      }
+    },
     "Subworkflow": {
       "title": "Subworkflow",
       "description": "One named `workflow <NAME> { ... }` block other than the primary workflow. Includes nf-core utility wrappers (PIPELINE_INITIALISATION, PIPELINE_COMPLETION, UTILS_NFCORE_PIPELINE) which exist to compose helper-function calls rather than to invoke processes.",
@@ -334,7 +453,8 @@ export const summaryNextflowSchema = {
         "name",
         "path",
         "kind",
-        "calls"
+        "calls",
+        "tests"
       ],
       "properties": {
         "name": {
@@ -370,6 +490,13 @@ export const summaryNextflowSchema = {
           "items": {
             "$ref": "#/$defs/ChannelIO"
           }
+        },
+        "tests": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/NfTest"
+          },
+          "description": "Subworkflow-scoped nf-test files under the subworkflow's `tests/` directory. Empty when absent."
         }
       }
     },

--- a/packages/summary-nextflow-schema/src/summary-nextflow.schema.json
+++ b/packages/summary-nextflow-schema/src/summary-nextflow.schema.json
@@ -98,11 +98,13 @@
       "description": "One Nextflow `process { ... }` block.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "module_path", "inputs", "outputs"],
+      "required": ["name", "module_path", "meta", "module_tests", "inputs", "outputs"],
       "properties": {
         "name":            { "type": "string", "description": "Canonical process name (uppercase NF convention) as declared by the `process <NAME>` line in `module_path`." },
         "aliases":         { "type": "array", "items": { "type": "string" }, "description": "Alias names this process is imported as in workflow scopes via `include { <NAME> as <ALIAS> }`. Real nf-core pipelines re-import a single module multiple times under different aliases to invoke it with distinct runtime args (e.g. `MINIMAP2_ALIGN as MINIMAP2_CONSENSUS`, `MINIMAP2_ALIGN as MINIMAP2_POLISH`). Each alias appears in `workflow.edges[].from`/`.to` exactly as written; the canonical `name` does not appear in edges unless an unaliased import exists. Default `[]` when the process is only imported under its canonical name." },
         "module_path":     { "type": "string", "description": "Relative path from the pipeline root to the file declaring the process." },
+        "meta":            { "anyOf": [{ "$ref": "#/$defs/ModuleMeta" }, { "type": "null" }], "description": "Normalized `meta.yml` from the module directory when present. Null for local/ad-hoc processes without module metadata." },
+        "module_tests":    { "type": "array", "items": { "$ref": "#/$defs/NfTest" }, "description": "Module-scoped nf-test files under the module's `tests/` directory. Empty for local/ad-hoc modules without unit tests." },
         "tool":            { "type": ["string", "null"], "description": "Foreign key into `tools[].name` when the process runs a single recognizable tool; null for multi-tool or pure-Groovy processes." },
         "container":       { "type": ["string", "null"], "description": "Verbatim text of the process's `container` directive (or null). Modern nf-core modules use a ternary expression `\"${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ? '<singularity-uri>' : '<docker-uri>' }\"` — keep that text intact here. The two resolved branches are split out into `tools[].docker` / `tools[].singularity` (and `tools[].wave` / `tools[].biocontainer` as appropriate)." },
         "conda":           { "type": ["string", "null"], "description": "Verbatim text of the process's `conda` directive (or null). Two common shapes: a literal `bioconda::<name>=<version>` (legacy) or a file reference `${moduleDir}/environment.yml` (modern nf-core convention). Either way the resolved bioconda spec lands in `tools[].bioconda`." },
@@ -114,19 +116,57 @@
       }
     },
 
+    "ModuleMeta": {
+      "title": "ModuleMeta",
+      "description": "Normalized subset of nf-core module `meta.yml`, captured next to a process so module-scoped downstream Molds can consume `processes[i]` without reading the full pipeline summary.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["keywords", "authors", "maintainers", "tools", "input", "output"],
+      "properties": {
+        "description": { "type": "string" },
+        "keywords":    { "type": "array", "items": { "type": "string" } },
+        "authors":     { "type": "array", "items": { "type": "string" } },
+        "maintainers": { "type": "array", "items": { "type": "string" } },
+        "tools":       { "type": "array", "items": { "$ref": "#/$defs/ModuleMetaEntry" } },
+        "input":       { "type": "array", "items": { "$ref": "#/$defs/ModuleMetaEntry" } },
+        "output":      { "type": "array", "items": { "$ref": "#/$defs/ModuleMetaEntry" } }
+      }
+    },
+
+    "ModuleMetaEntry": {
+      "title": "ModuleMetaEntry",
+      "description": "One named entry from a module `meta.yml` section, normalized from nf-core's single-key YAML maps into `{ name, ...fields }` objects.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name":          { "type": "string" },
+        "description":   { "type": "string" },
+        "homepage":      { "type": "string" },
+        "documentation": { "type": "string" },
+        "tool_dev_url":  { "type": "string" },
+        "doi":           { "type": "string" },
+        "licence":       { "type": "array", "items": { "type": "string" } },
+        "identifier":    { "type": "string" },
+        "type":          { "type": "string" },
+        "pattern":       { "type": "string" }
+      }
+    },
+
     "Subworkflow": {
       "title": "Subworkflow",
       "description": "One named `workflow <NAME> { ... }` block other than the primary workflow. Includes nf-core utility wrappers (PIPELINE_INITIALISATION, PIPELINE_COMPLETION, UTILS_NFCORE_PIPELINE) which exist to compose helper-function calls rather than to invoke processes.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "path", "kind", "calls"],
+      "required": ["name", "path", "kind", "calls", "tests"],
       "properties": {
         "name":    { "type": "string" },
         "path":    { "type": "string", "description": "Relative path from the pipeline root." },
         "kind":    { "type": "string", "enum": ["pipeline", "utility"], "description": "`pipeline` when the subworkflow invokes pipeline processes (data-flow contributor). `utility` when it composes helper functions only — common nf-core template subworkflows like PIPELINE_INITIALISATION (which calls `paramsHelp`, `samplesheetToList`, `UTILS_NFSCHEMA_PLUGIN`) and PIPELINE_COMPLETION (`completionEmail`, `completionSummary`). Utility subworkflows have empty `calls[]` for processes but may still expose channel outputs the primary workflow consumes." },
         "calls":   { "type": "array", "items": { "type": "string" }, "description": "Names of processes and nested subworkflows this subworkflow invokes. Free-function calls (e.g. `paramsHelp`, `completionEmail`) are NOT recorded here; they're implied by `kind = utility`." },
         "inputs":  { "type": "array", "items": { "$ref": "#/$defs/ChannelIO" } },
-        "outputs": { "type": "array", "items": { "$ref": "#/$defs/ChannelIO" } }
+        "outputs": { "type": "array", "items": { "$ref": "#/$defs/ChannelIO" } },
+        "tests":   { "type": "array", "items": { "$ref": "#/$defs/NfTest" }, "description": "Subworkflow-scoped nf-test files under the subworkflow's `tests/` directory. Empty when absent." }
       }
     },
 


### PR DESCRIPTION
## Summary
- Add process-local module metadata and module nf-test enumeration to the Nextflow summary schema/resolver.
- Add subworkflow nf-test enumeration and resolver coverage for module/local behavior.
- Extend summarize-nextflow eval coverage for module-scoped wrapper inputs.

## Tests
- pnpm --filter @galaxy-foundry/summary-nextflow-schema build
- pnpm --filter @galaxy-foundry/summarize-nextflow build
- pnpm --filter @galaxy-foundry/summarize-nextflow test
- npm run validate

Closes #110