### PR TITLE
Add workflow testability research

### DIFF
--- a/content/Dashboard.md
+++ b/content/Dashboard.md
@@ -19,18 +19,18 @@ Generated from `dashboard_sections.json` and content frontmatter. Do not edit by
 | [[author-galaxy-tool-wrapper]] | Author a new Galaxy tool wrapper (XML) when discovery yields nothing acceptable. | draft | 2026-05-03 | 2 |
 | [[compare-against-iwc-exemplar]] | Find nearest IWC exemplar(s) and surface a structural diff against a draft. | draft | 2026-05-03 | 4 |
 | [[cwl-test-to-galaxy-test-plan]] | Translate CWL test fixtures into a Galaxy workflow test plan. | draft | 2026-05-03 | 2 |
+| [[implement-galaxy-tool-step]] | Convert an abstract step into a concrete gxformat2 step using a tool summary. | draft | 2026-05-03 | 4 |
+| [[implement-galaxy-workflow-test]] | Assemble Galaxy workflow test fixtures and assertions. | draft | 2026-05-03 | 4 |
 | [[nextflow-test-to-cwl-test-plan]] | Translate Nextflow test evidence into a CWL workflow test plan. | draft | 2026-05-03 | 1 |
 | [[nextflow-test-to-galaxy-test-plan]] | Translate Nextflow test evidence into a Galaxy workflow test plan. | draft | 2026-05-03 | 2 |
 | [[summarize-galaxy-tool]] | Pull JSON schema, container, source, inputs/outputs for a Galaxy tool. | draft | 2026-05-03 | 3 |
+| [[summary-to-galaxy-template]] | gxformat2 skeleton with per-step TODOs from a data-flow summary. | draft | 2026-05-03 | 3 |
+| [[validate-galaxy-workflow]] | Run terminal gxwf validation on an assembled Galaxy workflow and classify workflow-level failures. | draft | 2026-05-03 | 3 |
 | [[debug-galaxy-workflow-output]] | Triage failing Galaxy run outputs; classify failure modes; propose fixes. | draft | 2026-05-02 | 3 |
-| [[implement-galaxy-tool-step]] | Convert an abstract step into a concrete gxformat2 step using a tool summary. | draft | 2026-05-02 | 3 |
-| [[implement-galaxy-workflow-test]] | Assemble Galaxy workflow test fixtures and assertions. | draft | 2026-05-02 | 3 |
 | [[run-workflow-test]] | Execute a workflow's tests via Planemo; emit structured pass/fail and outputs. | draft | 2026-05-02 | 2 |
 | [[summarize-nextflow]] | Read a Nextflow pipeline source tree and emit a structured per-source summary downstream Molds bind to. | draft | 2026-05-02 | 7 |
 | [[summary-to-galaxy-data-flow]] | Abstract DAG with Galaxy collection / scatter / branching idioms surfaced. | draft | 2026-05-02 | 2 |
-| [[summary-to-galaxy-template]] | gxformat2 skeleton with per-step TODOs from a data-flow summary. | draft | 2026-05-02 | 2 |
 | [[validate-galaxy-step]] | Run gxwf validation on the just-implemented Galaxy step and route failures back to step implementation. | draft | 2026-05-02 | 2 |
-| [[validate-galaxy-workflow]] | Run terminal gxwf validation on an assembled Galaxy workflow and classify workflow-level failures. | draft | 2026-05-02 | 2 |
 | [[debug-cwl-workflow-output]] | Triage failing CWL run outputs; classify failure modes; propose fixes. | draft | 2026-04-30 | 1 |
 | [[discover-shed-tool]] | Search the Tool Shed for an existing wrapper, drill from hit to a pinnable changeset, classify candidates, and recommend or fall through. | draft | 2026-04-30 | 2 |
 | [[find-test-data]] | Search IWC fixtures and public sources for test data matching a data-flow shape. | draft | 2026-04-30 | 1 |
@@ -107,9 +107,14 @@ Generated from `dashboard_sections.json` and content frontmatter. Do not edit by
 | --- | --- | --- | --- | --- |
 | [[component-tool-shed-search]] | Tool Shed's Whoosh repo/tool search and partial GA4GH TRS v2, indexed from hg-walked metadata with no auto-refresh on upload | draft | 2026-05-03 | 2 |
 | [[galaxy-collection-semantics]] | Vendored formal spec of Galaxy dataset-collection mapping/reduction semantics, with labeled examples and pinned test references. | draft | 2026-05-03 | 3 |
+| [[galaxy-workflow-testability-design]] | Design guidance for Galaxy workflow inputs, outputs, and checkpoints that make IWC-style workflow tests possible. | draft | 2026-05-03 | 1 |
 | [[galaxy-xsd]] | Vendored Galaxy tool XML schema for wrapper structure, parameters, outputs, tests, and assertion syntax. | draft | 2026-05-03 | 1 |
 | [[iwc-nearest-exemplar-selection]] | Defines a feature hierarchy for selecting useful IWC exemplar workflows for structural comparison. | draft | 2026-05-03 | 2 |
-| [[planemo-asserts-idioms]] | Decision and idiom guide for picking planemo workflow-test assertions: which family per output type, how to size tolerances, when to validate. | draft | 2026-05-03 | 4 |
+| [[iwc-shortcuts-anti-patterns]] | What IWC test suites cut corners on (accepted) vs what's a code smell — existence-only probes, sim_size deltas, image dim checks, label coupling. | draft | 2026-05-03 | 2 |
+| [[iwc-test-data-conventions]] | How IWC workflows organize and reference test data — Zenodo-first, SHA-1 integrity, collection shapes, CVMFS gotchas. | draft | 2026-05-03 | 3 |
+| [[iwc-workflow-testability-survey]] | IWC evidence survey for Galaxy workflow structures that make workflow tests meaningful. | draft | 2026-05-03 | 2 |
+| [[planemo-asserts-idioms]] | Decision and idiom guide for picking planemo workflow-test assertions: which family per output type, how to size tolerances, when to validate. | draft | 2026-05-03 | 5 |
+| [[planemo-workflow-test-architecture]] | Reference for Planemo workflow test/run architecture, Galaxy modes, API polling, and noisy failure boundaries. | draft | 2026-05-03 | 2 |
 | [[galaxy-apply-rules-dsl]] | Reference for Galaxy's Apply Rules DSL: rule operations, mapping operations, composition patterns, pitfalls. | draft | 2026-05-02 | 2 |
 | [[galaxy-collection-tools]] | Catalog of Galaxy's collection-operation tools — purpose, IO, parameters, selection guide. Companion to galaxy-collection-semantics. | draft | 2026-05-02 | 2 |
 | [[galaxy-tool-job-failure-reference]] | Reference for Galaxy tool stdio rules, job failure detection, job states, and job API failure surfaces. | draft | 2026-05-02 | 1 |
@@ -117,14 +122,11 @@ Generated from `dashboard_sections.json` and content frontmatter. Do not edit by
 | [[iwc-conditionals-survey]] | Corpus survey of Galaxy conditional step usage in IWC, covering when-gates, boolean shims, and routed output selection. | draft | 2026-05-02 | 2 |
 | [[iwc-parameter-derivation-survey]] | Corpus survey of Galaxy workflow recipes that turn upstream data, metadata, or small files into runtime parameters. | draft | 2026-05-02 | 1 |
 | [[iwc-tabular-operations-survey]] | Corpus survey of tabular tools and operations across IWC workflows; map for the leaf pattern hierarchy on row/column data manipulation. | draft | 2026-05-02 | 2 |
-| [[iwc-test-data-conventions]] | How IWC workflows organize and reference test data — Zenodo-first, SHA-1 integrity, collection shapes, CVMFS gotchas. | draft | 2026-05-02 | 2 |
 | [[iwc-transformations-survey]] | Corpus survey of collection-shape transformations across IWC: built-in collection ops, toolshed transformers, and the multi-step recipes that bracket map-over. | draft | 2026-05-02 | 2 |
 | [[nextflow-operators-to-galaxy-collection-recipes]] | Classifies common Nextflow operators as Galaxy wiring, collection semantics, explicit steps, or review triggers. | draft | 2026-05-02 | 1 |
 | [[nextflow-to-galaxy-channel-shape-mapping]] | Maps common Nextflow channel, tuple, and path shapes to Galaxy dataset and collection shapes. | draft | 2026-05-02 | 1 |
-| [[planemo-workflow-test-architecture]] | Reference for Planemo workflow test/run architecture, Galaxy modes, API polling, and noisy failure boundaries. | draft | 2026-05-02 | 1 |
 | [[component-nextflow-containers-and-envs]] | Stub. Biocontainers / bioconda equivalence, Docker/Singularity refs, container directive resolution. Grows from cast contact — see issue #17. | draft | 2026-05-01 | 1 |
 | [[component-nextflow-inspect]] | White paper on Nextflow's native introspection subcommands — `nextflow inspect`, `nextflow config`, and adjacent tooling. Survey, not decision. | draft | 2026-05-01 | 1 |
 | [[component-nextflow-pipeline-anatomy]] | Stub. DSL2 layout, channel idioms, operator-chain reading rules. Grows from cast contact with rnaseq/sarek/ad-hoc — see issue #17. | draft | 2026-05-01 | 1 |
 | [[component-nextflow-testing]] | Stub. conf/test.config, nf-core/test-datasets, nf-test idioms, samplesheet conventions. Grows from cast contact — see issue #17. | draft | 2026-05-01 | 1 |
 | [[component-nf-core-tools]] | White paper on nf-core/tools — conventions, CLI surface, schema universe, container resolution. Survey, not decision. | draft | 2026-05-01 | 1 |
-| [[iwc-shortcuts-anti-patterns]] | What IWC test suites cut corners on (accepted) vs what's a code smell — existence-only probes, sim_size deltas, image dim checks, label coupling. | draft | 2026-04-30 | 1 |

--- a/content/Index.md
+++ b/content/Index.md
@@ -105,6 +105,7 @@ Generated from content frontmatter. Do not edit by hand.
 - [[galaxy-tool-job-failure-reference]] — Reference for Galaxy tool stdio rules, job failure detection, job states, and job API failure surfaces.
 - [[galaxy-xsd]] — Vendored Galaxy tool XML schema for wrapper structure, parameters, outputs, tests, and assertion syntax.
 - [[galaxy-workflow-invocation-failure-reference]] — Reference for Galaxy workflow invocation states, messages, failure reasons, and invocation API surfaces.
+- [[galaxy-workflow-testability-design]] — Design guidance for Galaxy workflow inputs, outputs, and checkpoints that make IWC-style workflow tests possible.
 - [[iwc-conditionals-survey]] — Corpus survey of Galaxy conditional step usage in IWC, covering when-gates, boolean shims, and routed output selection.
 - [[iwc-nearest-exemplar-selection]] — Defines a feature hierarchy for selecting useful IWC exemplar workflows for structural comparison.
 - [[iwc-parameter-derivation-survey]] — Corpus survey of Galaxy workflow recipes that turn upstream data, metadata, or small files into runtime parameters.
@@ -112,6 +113,7 @@ Generated from content frontmatter. Do not edit by hand.
 - [[iwc-tabular-operations-survey]] — Corpus survey of tabular tools and operations across IWC workflows; map for the leaf pattern hierarchy on row/column data manipulation.
 - [[iwc-test-data-conventions]] — How IWC workflows organize and reference test data — Zenodo-first, SHA-1 integrity, collection shapes, CVMFS gotchas.
 - [[iwc-transformations-survey]] — Corpus survey of collection-shape transformations across IWC: built-in collection ops, toolshed transformers, and the multi-step recipes that bracket map-over.
+- [[iwc-workflow-testability-survey]] — IWC evidence survey for Galaxy workflow structures that make workflow tests meaningful.
 - [[nextflow-operators-to-galaxy-collection-recipes]] — Classifies common Nextflow operators as Galaxy wiring, collection semantics, explicit steps, or review triggers.
 - [[nextflow-to-galaxy-channel-shape-mapping]] — Maps common Nextflow channel, tuple, and path shapes to Galaxy dataset and collection shapes.
 - [[planemo-asserts-idioms]] — Decision and idiom guide for picking planemo workflow-test assertions: which family per output type, how to size tolerances, when to validate.

--- a/content/molds/implement-galaxy-tool-step/index.md
+++ b/content/molds/implement-galaxy-tool-step/index.md
@@ -8,11 +8,19 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-05-02
-revision: 3
+revised: 2026-05-03
+revision: 4
 ai_generated: true
 summary: "Convert an abstract step into a concrete gxformat2 step using a tool summary."
 references:
+  - kind: research
+    ref: "[[galaxy-workflow-testability-design]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Preserve testable output labels and collection element identifiers while replacing abstract steps with concrete gxformat2 steps."
+    trigger: "When a concrete step changes output labels, emits collection outputs, creates a diagnostic checkpoint, or makes a final output too weakly assertable."
   - kind: research
     ref: "[[galaxy-collection-semantics]]"
     used_at: runtime

--- a/content/molds/implement-galaxy-workflow-test/index.md
+++ b/content/molds/implement-galaxy-workflow-test/index.md
@@ -8,10 +8,11 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-05-02
-revision: 3
+revised: 2026-05-03
+revision: 4
 ai_generated: true
 related_notes:
+  - "[[galaxy-workflow-testability-design]]"
   - "[[iwc-test-data-conventions]]"
   - "[[iwc-shortcuts-anti-patterns]]"
   - "[[planemo-asserts-idioms]]"
@@ -35,6 +36,14 @@ references:
     mode: verbatim
     evidence: corpus-observed
     purpose: "JSON Schema contract for the Galaxy workflow test format. Output of this Mold must validate against it."
+  - kind: research
+    ref: "[[galaxy-workflow-testability-design]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Revise workflow inputs, outputs, labels, checkpoints, and collection identifiers so meaningful tests can be authored."
+    trigger: "When test authoring reveals missing labels, omitted workflow-level outputs, unstable collection identifiers, weakly assertable final outputs, or fixture-shape pressure on workflow inputs."
   - kind: research
     ref: "[[iwc-test-data-conventions]]"
     used_at: runtime

--- a/content/molds/summary-to-galaxy-template/index.md
+++ b/content/molds/summary-to-galaxy-template/index.md
@@ -8,8 +8,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-05-02
-revision: 2
+revised: 2026-05-03
+revision: 3
 ai_generated: true
 summary: "gxformat2 skeleton with per-step TODOs from a data-flow summary."
 references:
@@ -20,6 +20,14 @@ references:
     mode: verbatim
     evidence: corpus-observed
     purpose: "Read source-level process, channel, tool, and test-fixture structure while drafting a Galaxy workflow skeleton."
+  - kind: research
+    ref: "[[galaxy-workflow-testability-design]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Choose stable workflow input/output labels, testable checkpoint outputs, and fixture-compatible workflow interfaces while drafting the skeleton."
+    trigger: "When the template decides workflow inputs, workflow outputs, promoted checkpoints, or collection output identifiers that future tests will need to address."
   - kind: research
     ref: "[[galaxy-collection-semantics]]"
     used_at: runtime

--- a/content/molds/validate-galaxy-workflow/index.md
+++ b/content/molds/validate-galaxy-workflow/index.md
@@ -8,8 +8,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-05-02
-revised: 2026-05-02
-revision: 2
+revised: 2026-05-03
+revision: 3
 ai_generated: true
 summary: "Run terminal gxwf validation on an assembled Galaxy workflow and classify workflow-level failures."
 references:
@@ -22,6 +22,14 @@ references:
     purpose: "Validate the assembled gxformat2 workflow before runtime testing."
     trigger: "After all Galaxy steps and workflow tests have been assembled."
     verification: "Run the cast skill on a complete IWC-derived workflow and confirm terminal validation findings are separated from runtime test failures."
+  - kind: research
+    ref: "[[galaxy-workflow-testability-design]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Classify validation or pre-test findings that indicate missing labels, omitted workflow outputs, or untestable checkpoint structure."
+    trigger: "When terminal validation passes but workflow-level outputs, labels, or collection shapes look likely to break future workflow tests."
   - kind: research
     ref: "[[galaxy-workflow-invocation-failure-reference]]"
     used_at: runtime

--- a/content/research/galaxy-workflow-testability-design.md
+++ b/content/research/galaxy-workflow-testability-design.md
@@ -1,0 +1,135 @@
+---
+type: research
+subtype: component
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-05-03
+revised: 2026-05-03
+revision: 1
+ai_generated: true
+related_notes:
+  - "[[iwc-workflow-testability-survey]]"
+  - "[[iwc-test-data-conventions]]"
+  - "[[planemo-asserts-idioms]]"
+  - "[[iwc-shortcuts-anti-patterns]]"
+  - "[[planemo-workflow-test-architecture]]"
+  - "[[implement-galaxy-workflow-test]]"
+summary: "Design guidance for Galaxy workflow inputs, outputs, and checkpoints that make IWC-style workflow tests possible."
+---
+
+# Galaxy workflow testability design
+
+Use this note when authoring or translating a Galaxy workflow **before** the `-tests.yml` file exists. It covers workflow structure choices that make later IWC-style tests meaningful: labels, promoted checkpoints, collection identifiers, and fixture-compatible inputs.
+
+This is not a `content/patterns/` page. It is cross-cutting design guidance for Molds that need testable Galaxy workflows. Assertion syntax lives in [[planemo-asserts-idioms]]. Test YAML fixture shapes live in [[iwc-test-data-conventions]]. Accepted shortcut vs smell calls live in [[iwc-shortcuts-anti-patterns]]. Corpus evidence trail lives in [[iwc-workflow-testability-survey]].
+
+## 1. Treat labels as API
+
+Workflow input and output labels are not cosmetic. Planemo and IWC tests address workflow inputs and outputs by label, and the survey found exact label matches for every asserted output across 114 matched workflow/test pairs. A generated workflow should therefore pick stable, descriptive labels before test authoring starts.
+
+Rules:
+
+- Label every output that may need a test assertion.
+- Treat input/output renames as breaking changes requiring sibling `-tests.yml` updates.
+- Prefer stable domain names over tool-step defaults or positional names.
+- Do not rely on unlabeled or positional outputs for tests.
+
+Evidence:
+
+- Scanpy exposes outputs such as `Initial Anndata General Info`, `UMAP of louvain`, `Ranked genes with Wilcoxon test`, and `Dotplot of top genes on clusters` (`$IWC_FORMAT2/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy.gxwf.yml:105-147`). The sibling test keys assertions by those exact labels (`$IWC/workflows/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml:27-205`).
+- VGP scaffolding uses punctuation-heavy labels such as `Hi-C duplication stats on scaffolds: Raw`, `Hi-C duplication stats on scaffolds: MultiQc`, and `Merged Alignment stats` (`$IWC_FORMAT2/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8.gxwf.yml:170-196`). The test asserts those exact labels (`$IWC/workflows/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8-tests.yml:218-245`).
+
+## 2. Promote assertable checkpoints
+
+IWC workflow tests assert workflow-level outputs. Intermediate step results are invisible unless promoted to top-level workflow outputs. When final reports are weakly assertable, expose intermediate checkpoints that carry deterministic content or structure.
+
+Rules:
+
+- Promote intermediate outputs when they are the best deterministic or structural checkpoint.
+- Prefer a checkpoint table/text/HDF5 object that can prove content over a final plot/report that can only prove existence.
+- Accept some output-list clutter when it buys meaningful tests.
+- Do not promote every intermediate by default; expose checkpoints that map to concrete assertion intent.
+
+Evidence:
+
+- Scanpy exposes 21 workflow outputs and the sibling test asserts all 21. These include initial AnnData summaries, intermediate plots, ranked-gene tables, final AnnData, cluster-count tables, and final plots (`$IWC_FORMAT2/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy.gxwf.yml:105-147`; `$IWC/workflows/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml:27-205`).
+- RNA-seq paired-end exposes mapped reads, stranded/unstranded coverage, abundance estimates, expression tables, counts tables, and MultiQC reports (`$IWC_FORMAT2/transcriptomics/rnaseq-pe/rnaseq-pe.gxwf.yml:90-112`). The sibling test asserts sizes for coverage/read outputs and stronger regex/line checks for expression/count outputs (`$IWC/workflows/transcriptomics/rnaseq-pe/rnaseq-pe-tests.yml:48-97`).
+- MGnify complete exposes 83 workflow outputs; 38 are asserted in the sibling test, including MultiQC reports, FASTA collections, taxonomic classifications, OTU tables, and HDF5/JSON outputs (`$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/mgnify-amplicon-pipeline-v5-complete.gxwf.yml:163-329`; `$IWC/workflows/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/mgnify-amplicon-pipeline-v5-complete-tests.yml:15-120`).
+
+## 3. Stabilize collection output identifiers
+
+Collection tests key assertions by element identifier. If a workflow emits collections with unstable or opaque identifiers, the test cannot target elements cleanly.
+
+Rules:
+
+- Preserve biologically or sample-meaningful identifiers through map-over and collection reshaping.
+- When generating or relabeling collections, make the identifier derivation deterministic and visible in workflow structure.
+- For nested collections, ensure each axis has predictable identifiers.
+- Quote special identifiers in tests when YAML requires it, but do not simplify identifiers merely for YAML convenience.
+
+Evidence:
+
+- 59 of 115 IWC test files use `element_tests:`, with 227 `element_tests:` blocks in the corpus survey.
+- 10x CellPlex tests nested collection outputs by `subsample`, then inner `matrix`, `barcodes`, and `genes` elements (`$IWC/workflows/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:82-128`). The workflow exposes the corresponding collection outputs (`$IWC_FORMAT2/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex.gxwf.yml:73-91`).
+- HyPhy collection outputs are tested by generated gene identifiers such as `NC_001477.1|capsid_protein_C|95-394_DENV1` (`$IWC/workflows/comparative_genomics/hyphy/hyphy-core-tests.yml:31-71`). The workflow exposes collection outputs for MEME, PRIME, BUSTED, and FEL (`$IWC_FORMAT2/comparative_genomics/hyphy/hyphy-core.gxwf.yml:26-38`).
+
+## 4. Choose checkpoints by assertion strength
+
+Assertion choice is not only a test-file decision. It should feed back into workflow output design. If the only exposed output is a stochastic plot or binary file, the best possible test may be a weak size check. Exposing a sibling table, report, HDF5 structure, or summary line can make the same workflow much more testable.
+
+Rules:
+
+- For image-heavy workflows, expose data or summary outputs behind the plot when possible.
+- For stochastic statistical outputs, expose structural checkpoints and stable summary tokens.
+- For binary outputs, expose a text/table report or stats file when the tool can produce one.
+- Use [[planemo-asserts-idioms]] to select the assertion family after choosing the checkpoint.
+
+Evidence:
+
+- Scanpy image outputs are mostly smoke-tested with `has_size`, `has_image_width`, and `has_image_height`, but the same workflow also exposes AnnData HDF5 keys and cluster-count table checks (`$IWC/workflows/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml:33-205`).
+- RNA-seq paired-end pairs coarse size checks for coverage/mapped-read outputs with stronger regex and exact-line checks for expression/count tables (`$IWC/workflows/transcriptomics/rnaseq-pe/rnaseq-pe-tests.yml:48-97`).
+- VGP scaffolding tests combine stable text checks for scaffold/report stats with size checks for map/alignment artifacts (`$IWC/workflows/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8-tests.yml:173-245`).
+
+## 5. Design inputs with fixtures in mind
+
+Workflow input labels and types constrain the eventual `job:` block. Fixture planning is not only a test-file activity: it should influence whether the workflow exposes a file input, a collection input, a string data-table input, or a typed parameter.
+
+Rules:
+
+- Choose input labels that will be readable as test `job:` keys.
+- Match workflow input collection types to realistic fixture shapes.
+- Decide early whether reference data should be a portable remote file or a CVMFS/data-table string.
+- Keep typed parameters explicit when tests need to set them (`int`, `boolean`, `string`) rather than burying them in step defaults.
+
+Evidence:
+
+- 10x CellPlex job inputs include `fastq PE collection GEX`, `reference genome`, `gtf`, `cellranger_barcodes_3M-february-2018.txt`, `fastq PE collection CMO`, `sample name and CMO sequence collection`, and `Number of expected cells` (`$IWC/workflows/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:2-75`). The workflow declares matching collection, data, string, boolean, and int inputs (`$IWC_FORMAT2/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex.gxwf.yml:4-72`).
+- HyPhy accepts a `list` collection of unaligned sequences and preserves accession-like fixture identifiers through to output element assertions (`$IWC/workflows/comparative_genomics/hyphy/hyphy-core-tests.yml:7-30`; `$IWC_FORMAT2/comparative_genomics/hyphy/hyphy-core.gxwf.yml:14-25`).
+
+## 6. Mold loading guidance
+
+For [[implement-galaxy-workflow-test]], load this note when workflow structure may need revision before test YAML can be authored:
+
+- Missing or unstable input/output labels.
+- Need to assert an intermediate result that is not currently a workflow output.
+- Collection output tests need stable element identifiers.
+- Final outputs are too weakly assertable and a better checkpoint may need exposing.
+- Test fixture shape suggests the workflow input interface should be adjusted.
+
+This note should usually be loaded **before** [[planemo-asserts-idioms]] when the workflow itself is still editable. Once labels and outputs are fixed, assertion selection belongs to [[planemo-asserts-idioms]].
+
+## 7. What not to do
+
+- Do not turn these rules into `content/patterns/` pages unless a concrete operation-anchored Galaxy construction recipe emerges.
+- Do not stuff this guidance into a long Mold body. Keep the Mold body thin and auto-load this research note when the trigger applies.
+- Do not expose every intermediate output as boilerplate. The evidence supports promoted checkpoints, not indiscriminate output sprawl.
+
+## Cross-references
+
+- [[iwc-workflow-testability-survey]] — corpus survey and distribution rationale.
+- [[iwc-test-data-conventions]] — job/input YAML shapes, remote fixtures, hashes, collection fixture syntax.
+- [[planemo-asserts-idioms]] — assertion-family choice after an output is exposed.
+- [[iwc-shortcuts-anti-patterns]] — accepted shortcut vs smell calls for weak assertions and label coupling.
+- [[planemo-workflow-test-architecture]] — Planemo execution, output-problem ambiguity, and structured artifacts.

--- a/content/research/iwc-shortcuts-anti-patterns.md
+++ b/content/research/iwc-shortcuts-anti-patterns.md
@@ -6,10 +6,11 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-04-30
-revision: 1
+revised: 2026-05-03
+revision: 2
 ai_generated: true
 related_notes:
+  - "[[galaxy-workflow-testability-design]]"
   - "[[iwc-test-data-conventions]]"
   - "[[planemo-asserts-idioms]]"
   - "[[implement-galaxy-workflow-test]]"
@@ -22,6 +23,8 @@ summary: "What IWC test suites cut corners on (accepted) vs what's a code smell 
 ## Purpose
 
 When an agent translates or authors a Galaxy workflow for IWC submission, the test suite it writes will be reviewed against IWC's *de facto* style — not against an idealized assertion ladder. That style routinely tolerates assertions that look weak in isolation. This note distinguishes the corner-cutting that is **normal and accepted** in the corpus from the patterns that an agent should treat as **smells** worth flagging.
+
+This note owns accepted-vs-smell calls. For positive workflow-structure guidance behind label stability, checkpoint promotion, and collection identifier design, use [[galaxy-workflow-testability-design]].
 
 Grounding: 115 `*-tests.yml` files under `workflow-fixtures/iwc-src/workflows/` (mirror of `galaxyproject/iwc`), prior synthesis in `galaxy-brain/vault/projects/workflow_state/skills/COMPONENT_GALAXY_WORKFLOW_TESTING.md`. Path citations below are relative to `iwc-src/workflows/` unless absolute.
 
@@ -189,6 +192,8 @@ Renaming an output label in the `.ga` without updating the sibling `-tests.yml` 
 
 **Smell:** a translated workflow with unlabeled outputs that later need test coverage. Agent should label every output it intends to assert on, before writing assertions.
 
+Positive design guidance now lives in [[galaxy-workflow-testability-design]]: pick stable labels before test authoring and treat renames as test-breaking API changes.
+
 ---
 
 ## 7. Intermediate-step output gap
@@ -205,6 +210,8 @@ Observed workaround across the corpus: **promote the intermediate to a workflow 
 **Accepted shortcut:** promoting an intermediate to a workflow output for test purposes. Not a smell.
 
 **Smell:** asserting on a step output via some side-channel (e.g., relying on Galaxy collection ordering, indexing into `tool_state`). The corpus does not do this and an agent should not invent it.
+
+Positive design guidance now lives in [[galaxy-workflow-testability-design]]: promote assertable checkpoints deliberately, especially when final reports or plots can only support weak smoke tests.
 
 ---
 
@@ -316,6 +323,7 @@ Synthesized from the COMPONENT_GALAXY_WORKFLOW_TESTING.md analysis (sections 9 a
 
 ## Sources
 
+- Positive workflow-structure guidance: [[galaxy-workflow-testability-design]].
 - Prior synthesis: `/Users/jxc755/projects/repositories/galaxy-brain/vault/projects/workflow_state/skills/COMPONENT_GALAXY_WORKFLOW_TESTING.md` (sections 2c, 2d, 2e, 9).
 - Corpus root: `/Users/jxc755/projects/repositories/workflow-fixtures/iwc-src/workflows/` (115 `*-tests.yml` files across 22 categories).
 - Specific files cited:

--- a/content/research/iwc-test-data-conventions.md
+++ b/content/research/iwc-test-data-conventions.md
@@ -6,10 +6,11 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-05-02
-revision: 2
+revised: 2026-05-03
+revision: 3
 ai_generated: true
 related_notes:
+  - "[[galaxy-workflow-testability-design]]"
   - "[[iwc-shortcuts-anti-patterns]]"
   - "[[planemo-asserts-idioms]]"
   - "[[implement-galaxy-workflow-test]]"
@@ -21,6 +22,8 @@ summary: "How IWC workflows organize and reference test data — Zenodo-first, S
 # IWC test data conventions
 
 Reference for an agent implementing or editing a `<workflow>-tests.yml` in IWC style. All evidence cited from `/Users/jxc755/projects/repositories/workflow-fixtures/iwc-src/workflows/` (raw IWC clone) and `workflows/README.md`. Authoritative spec: [planemo.readthedocs.io/en/latest/test_format.html](https://planemo.readthedocs.io/en/latest/test_format.html). The companion analysis at `/Users/jxc755/projects/repositories/galaxy-brain/vault/projects/workflow_state/skills/COMPONENT_GALAXY_WORKFLOW_TESTING.md` is the synthesized source for several normative claims here.
+
+This note owns **test YAML fixture shapes**. For workflow-structure choices that make those fixtures possible before the test file exists, use [[galaxy-workflow-testability-design]].
 
 ## 1. Where does test data live? Remote vs in-repo
 
@@ -237,6 +240,16 @@ Identifiers are arbitrary strings, used both as the YAML key (`element_tests:`) 
 - **Inline comments after identifier** are legal and used for provenance: `pox-virus-half-genome-tests.yml:23` — `identifier: 20L70   # SRR15145276`.
 - **Whitespace and special chars in workflow input *labels*** survive too — they are job-mapping keys, not collection identifiers, but the same YAML quoting rules apply. Example from the analysis doc: `Manually annotate celltypes?: true` as a job key in `Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml:23`.
 
+### 4a. Workflow-interface implications
+
+Fixture shape should feed back into workflow input design. Tests supply job inputs by workflow input label, and collection fixtures must match the workflow's declared collection type.
+
+- The 10x CellPlex test uses `fastq PE collection GEX`, `fastq PE collection CMO`, and `sample name and CMO sequence collection` as job keys with `list:paired` and `list` collection fixtures; the workflow declares matching collection inputs at `$IWC_FORMAT2/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex.gxwf.yml:4-72`.
+- CVMFS/data-table shortcuts like `reference genome: dm6` are workflow-interface choices as much as test YAML choices: they require the workflow input to be a string/data-table-backed parameter, not a file input.
+- If a fixture needs stable sample names, decide whether those names should enter through collection element identifiers, a mapping file, or a workflow parameter before writing assertions.
+
+Rule for an agent: when a new workflow input is being designed and the test fixture is already known, check [[galaxy-workflow-testability-design]] before locking the input label/type.
+
 ## 5. CVMFS / `.loc` / built-in-index references
 
 When a workflow input is a Galaxy data-table-backed reference (built-in genome index, dbsnp file, kraken DB, …), the input takes a **plain string** matching the `value` column of a `.loc` file. No `class: File`, no `location:`. Examples:
@@ -289,6 +302,7 @@ Gaps an agent should be aware of:
 
 ## Cross-references
 
+- [[galaxy-workflow-testability-design]] — workflow input/output structure choices that make these fixture shapes testable.
 - `/Users/jxc755/projects/repositories/galaxy-brain/vault/projects/workflow_state/skills/COMPONENT_GALAXY_WORKFLOW_TESTING.md` — full synthesis with assertion-vocabulary table, CI internals, and tooling rundown. Sections 2b, 3, 4, 5, 9 are the direct upstream of this note.
 - planemo test format spec: [planemo.readthedocs.io/en/latest/test_format.html](https://planemo.readthedocs.io/en/latest/test_format.html).
 - planemo best practices: [planemo.readthedocs.io/en/latest/best_practices_workflows.html](https://planemo.readthedocs.io/en/latest/best_practices_workflows.html).

--- a/content/research/iwc-workflow-testability-survey.md
+++ b/content/research/iwc-workflow-testability-survey.md
@@ -1,0 +1,131 @@
+---
+type: research
+subtype: component
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-05-03
+revised: 2026-05-03
+revision: 2
+ai_generated: true
+related_notes:
+  - "[[galaxy-workflow-testability-design]]"
+summary: "IWC evidence survey for Galaxy workflow structures that make workflow tests meaningful."
+---
+
+# IWC workflow testability survey
+
+Source corpus: 120 cleaned `gxformat2` workflows under `$IWC_FORMAT2/`, 120 skeletons under `$IWC_SKELETONS/`, and 115 sibling `*-tests.yml` files under `$IWC/workflows/` as materialized in `workflow-fixtures/iwc-src/workflows/`. This survey supports [[galaxy-workflow-testability-design]]; it is an evidence hub, not a pattern-page proposal.
+
+## 1. Scope
+
+Topic type: **workflow-shape concern**. The question is not "which assertion should a test use?" That is covered by [[planemo-asserts-idioms]]. The question is "how should a Galaxy workflow be structured so useful tests can be written later?"
+
+Evidence strategy, adapted from the `/iwc-survey` command:
+
+- **Skeleton scan first.** Use `$IWC_SKELETONS/` to catalog workflow outputs, labels, subworkflow boundaries, and collection-producing recipes without paying full parameter-read cost.
+- **Sibling-test scan second.** Use `*-tests.yml` files to identify which workflow outputs are actually asserted, which collection element identifiers matter, and which assertion families imply deterministic or stochastic behavior.
+- **Selective full workflow reads.** Read full `$IWC_FORMAT2` only for examples where output promotion, labels, or collection topology need line-level confirmation.
+- **Out of scope.** Do not re-survey the assertion vocabulary itself, fixture-hosting conventions, checksum/negative-test absences, or shortcut-vs-smell calls already pinned in [[iwc-test-data-conventions]], [[planemo-asserts-idioms]], and [[iwc-shortcuts-anti-patterns]].
+
+## 2. Corpus counts
+
+The first full pass matched top-level workflow `outputs:` against sibling test `outputs:` keys.
+
+| Measure | Count | Interpretation |
+|---|---:|---|
+| Cleaned format2 workflows | 120 | Survey denominator for workflow structure. |
+| Workflows with sibling tests found by path convention | 114 | Six workflows lacked a matching sibling test file in this materialized corpus. |
+| Total workflow-level outputs in those 114 workflows | 1,305 | IWC workflows expose many labeled outputs, including checkpoint/report outputs. |
+| Distinct asserted output labels across sibling tests | 617 | Tests assert a selective subset of exposed workflow outputs. |
+| Workflows where every asserted test output matched a workflow output label exactly | 114 / 114 | Output labels are the test API; no positional or unlabeled assertion route was observed. |
+| Test files with `element_tests:` | 59 / 115 | Collection-shaped output testing is common. |
+| `element_tests:` blocks | 227 | Stable collection element identifiers are central to testability. |
+| Test files with inline `attributes: {collection_type: ...}` | 2 / 115 | Explicit collection-type assertions exist but are much rarer than element-keyed assertions; four inline occurrences appear across those files. |
+
+Highest asserted-output examples:
+
+| Workflow | Workflow outputs | Asserted outputs | Why it matters |
+|---|---:|---:|---|
+| `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/mgnify-amplicon-pipeline-v5-complete.gxwf.yml` | 83 | 38 | Large workflow exposing many domain outputs; tests select report, table, FASTA, HDF5/JSON, and collection checkpoints. |
+| `$IWC_FORMAT2/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy.gxwf.yml` | 21 | 21 | Every exposed output is asserted, including many mid-pipeline plots and AnnData checkpoints. |
+| `$IWC_FORMAT2/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8.gxwf.yml` | 48 | 16 | Workflow exposes many report/checkpoint outputs, while tests assert a diagnostic subset. |
+| `$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction.gxwf.yml` | 13 | 13 | Smaller report-heavy workflow where all outputs are test-facing. |
+
+Assertion-family counts from sibling tests:
+
+| Assertion family | Files | Line hits | Workflow-design implication |
+|---|---:|---:|---|
+| `has_text` | 78 | 597 | Text/report checkpoints are broadly assertable with stable tokens. |
+| `has_size` | 57 | 201 | Binary/report/plot checkpoints often use size bands. |
+| `has_n_lines` | 40 | 146 | Line-count checkpoints are common for tabular/text outputs. |
+| `has_line` | 23 | 69 | Deterministic table rows make stronger checkpoints than final reports. |
+| `has_text_matching` | 17 | 56 | Regex checkpoints cover numeric drift while preserving content checks. |
+| `compare: sim_size` | 9 | 26 | Stochastic or binary outputs may only support magnitude checks. |
+| `compare: diff` | 5 | 10 | Strict exact comparison is rare and format-specific. |
+| `has_image_width` / `has_image_height` | 1 | 15 each | Image checkpoints are mostly smoke-tested by size/dimensions in this corpus. |
+
+## 3. Findings
+
+### 3a. Workflow labels are the test API
+
+Every asserted output key in the 114 matched workflow/test pairs resolved to a top-level workflow output label. The direct coupling is visible in Scanpy: the workflow exposes outputs like `Initial Anndata General Info`, `UMAP of louvain`, `Ranked genes with Wilcoxon test`, and `Dotplot of top genes on clusters` at `$IWC_FORMAT2/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy.gxwf.yml:105-147`; the test file keys assertions by those labels at `$IWC/workflows/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml:27-205`.
+
+VGP scaffolding shows the same with punctuation-heavy labels: workflow outputs include `Hi-C duplication stats on scaffolds: Raw`, `Hi-C duplication stats on scaffolds: MultiQc`, and `Merged Alignment stats` at `$IWC_FORMAT2/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8.gxwf.yml:170-196`; tests assert those exact labels at `$IWC/workflows/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8-tests.yml:218-245`.
+
+Design implication: input/output labels are stable interface names. Renaming is a test-breaking API change.
+
+### 3b. IWC promotes checkpoint outputs so tests can see them
+
+Workflow tests can assert only workflow-level outputs, so IWC workflows expose intermediate summaries, plots, and diagnostics as top-level outputs.
+
+Scanpy exposes a dense ladder of checkpoints: initial AnnData summaries, intermediate plots, ranked-gene tables, final AnnData, cluster-count tables, and final plots (`$IWC_FORMAT2/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy.gxwf.yml:105-147`). The sibling test asserts every one of the 21 workflow outputs, mixing HDF5 key probes, text probes, image dimensions, and line checks (`$IWC/workflows/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml:27-205`).
+
+RNA-seq paired-end exposes mapped reads, stranded/unstranded coverage, abundance estimates, expression tables, counts tables, and MultiQC reports (`$IWC_FORMAT2/transcriptomics/rnaseq-pe/rnaseq-pe.gxwf.yml:90-112`). The sibling test asserts coverage sizes, mapped-read sizes, expression regexes, and a deterministic counts row (`$IWC/workflows/transcriptomics/rnaseq-pe/rnaseq-pe-tests.yml:48-97`).
+
+Design implication: promote the strongest useful checkpoint, not only the final human-facing report. The cost is output-list clutter; IWC tolerates that when it buys testability.
+
+### 3c. Collection-shaped outputs need stable element identifiers
+
+The 10x CellPlex workflow exposes collection-shaped outputs such as `Seurat input for gene expression (filtered)`, `CITE-seq-Count report`, and `Seurat input for CMO (UMI)` (`$IWC_FORMAT2/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex.gxwf.yml:73-91`). The test asserts collection shape with `attributes: {collection_type: ...}` and drills into element identifiers such as `subsample`, `matrix`, `barcodes`, and `genes` (`$IWC/workflows/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:82-128`).
+
+HyPhy shows identifier stability in a different form: the workflow emits `meme_output`, `prime_output`, `busted_output`, and `fel_output` collection outputs (`$IWC_FORMAT2/comparative_genomics/hyphy/hyphy-core.gxwf.yml:26-38`), and tests key element checks by generated gene identifiers such as `NC_001477.1|capsid_protein_C|95-394_DENV1` (`$IWC/workflows/comparative_genomics/hyphy/hyphy-core-tests.yml:31-71`).
+
+Design implication: generated workflows need deterministic collection element identifiers before test authoring begins. Otherwise `element_tests:` cannot target outputs cleanly.
+
+### 3d. Assertion strength feeds back into checkpoint choice
+
+Scanpy plot outputs are mostly smoke-tested with `has_size`, `has_image_width`, and `has_image_height` tolerances (`$IWC/workflows/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml:33-205`). The same workflow also exposes stronger non-image checkpoints such as AnnData HDF5 keys and `Number of cells per cluster` line checks (`$IWC/workflows/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml:159-195`).
+
+RNA-seq paired-end pairs coarse size checks for BAM/bigWig-like outputs with stronger regex/line checks for expression/count tables (`$IWC/workflows/transcriptomics/rnaseq-pe/rnaseq-pe-tests.yml:48-97`). MGnify complete uses MultiQC token checks, exact file/location comparisons, collection element checks, and table-shape assertions in the same test file (`$IWC/workflows/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/mgnify-amplicon-pipeline-v5-complete-tests.yml:15-120`).
+
+Design implication: if final outputs are stochastic, binary, image-only, or report-heavy, expose an adjacent table/text/HDF5 checkpoint that can carry a stronger assertion.
+
+### 3e. Fixture shape constrains workflow inputs
+
+Tests supply job inputs by workflow input label. The 10x CellPlex test uses labels like `fastq PE collection GEX`, `reference genome`, `gtf`, `cellranger_barcodes_3M-february-2018.txt`, `fastq PE collection CMO`, `sample name and CMO sequence collection`, and `Number of expected cells` (`$IWC/workflows/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:2-75`); the workflow declares matching inputs and types, including data, string, boolean, int, and collection inputs (`$IWC_FORMAT2/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex.gxwf.yml:4-72`).
+
+HyPhy's input collection identifiers contain pipes and accession-like labels (`$IWC/workflows/comparative_genomics/hyphy/hyphy-core-tests.yml:7-30`), while the workflow only declares the collection type (`$IWC_FORMAT2/comparative_genomics/hyphy/hyphy-core.gxwf.yml:14-25`). The test contract therefore lives partly in workflow input shape and partly in fixture element identifiers.
+
+Design implication: workflow input labels and collection types should be designed with fixture authoring in mind, not treated as a test-file afterthought.
+
+## 4. Distribution plan
+
+No formal `content/patterns/*.md` pages are recommended from this issue right now. These findings are cross-cutting workflow-testability guidance, not operation-anchored Galaxy construction patterns as defined in `docs/PATTERNS.md`.
+
+| Finding | Permanent home | Integration action |
+|---|---|---|
+| Labels as test API | [[galaxy-workflow-testability-design]], with shortcut warning retained in [[iwc-shortcuts-anti-patterns]] | New durable note owns design guidance; anti-pattern note keeps accepted/smell wording. |
+| Promote checkpoint outputs | [[galaxy-workflow-testability-design]] | New durable note owns the workflow-authoring rule and evidence. |
+| Stable collection output identifiers | [[galaxy-workflow-testability-design]], cross-linked from [[iwc-test-data-conventions]] | Design note owns output-side stability; test-data note keeps YAML shapes. |
+| Assertion strength affects checkpoint choice | [[galaxy-workflow-testability-design]], cross-linked from [[planemo-asserts-idioms]] | Assertion note keeps assertion families; design note explains upstream checkpoint selection. |
+| Fixture shape constrains workflow inputs | [[iwc-test-data-conventions]] plus [[galaxy-workflow-testability-design]] | Test-data note owns input fixture YAML; design note owns workflow interface implications. |
+| Planemo missing-output ambiguity | [[planemo-workflow-test-architecture]] | Architecture note should mention label drift and omitted workflow outputs as likely causes. |
+| Mold auto-load behavior | [[implement-galaxy-workflow-test]] frontmatter `references` | Add design note as on-demand research reference; avoid expanding Mold body. |
+
+## 5. Open questions
+
+1. Should [[galaxy-workflow-testability-design]] be loaded only by [[implement-galaxy-workflow-test]], or also by upstream workflow-construction Molds that choose outputs before tests exist?
+2. Should the survey stay as a draft evidence hub, or become `stale` after the durable note absorbs the guidance?
+3. Should we add a separate workflow-authoring research note later for user-facing output curation, or is testability-specific output clutter enough for this note?

--- a/content/research/planemo-asserts-idioms.md
+++ b/content/research/planemo-asserts-idioms.md
@@ -7,9 +7,10 @@ tags:
 status: draft
 created: 2026-04-30
 revised: 2026-05-03
-revision: 4
+revision: 5
 ai_generated: true
 related_notes:
+  - "[[galaxy-workflow-testability-design]]"
   - "[[iwc-test-data-conventions]]"
   - "[[iwc-shortcuts-anti-patterns]]"
   - "[[implement-galaxy-workflow-test]]"
@@ -21,7 +22,7 @@ summary: "Decision and idiom guide for picking planemo workflow-test assertions:
 
 # Planemo asserts: idiom and decision guide
 
-Companion to [[iwc-test-data-conventions]] (input shapes) and [[iwc-shortcuts-anti-patterns]] (what's accepted vs smell). This note is forward-looking: when authoring a new `<workflow>-tests.yml`, which assertion family fits which output, and what the recommended tolerances and operators are.
+Companion to [[iwc-test-data-conventions]] (input shapes), [[galaxy-workflow-testability-design]] (workflow structure before test YAML exists), and [[iwc-shortcuts-anti-patterns]] (what's accepted vs smell). This note is forward-looking: when authoring a new `<workflow>-tests.yml`, which assertion family fits which output, and what the recommended tolerances and operators are.
 
 The **vocabulary itself is not restated here** — every assertion's parameter list, types, defaults, required fields, and Python docstring is rendered from the test-format JSON Schema at [[tests-format]]. Assertion names below deep-link into that page (e.g. `[[tests-format#has_text_model|has_text]]` jumps straight to that `$def`).
 
@@ -50,6 +51,15 @@ The single most useful decision table. Pick the row that matches the file format
 | **Cool / HiC matrices** | `compare: sim_size` with multi-MB `delta:` | Binary, run-to-run variance | [[tests-format#has_archive_member_model|has_archive_member]] for HDF5 component |
 
 When in doubt: start with [[tests-format#has_size_model|has_size]] + `delta_frac: 0.1`. It catches the catastrophic failure mode (empty / 10x bigger output). Then add a content probe.
+
+### 1a. If the assertion is too weak, revisit the workflow output
+
+Assertion choice sometimes reveals a workflow-design problem. If the only available output can support only a size check or image-dimension smoke test, check whether the workflow should expose a stronger checkpoint before settling for the weak assertion.
+
+- Scanpy's plot outputs use size and image-dimension assertions, but the same workflow also exposes AnnData HDF5 checkpoints and a cluster-count table (`$IWC/workflows/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml:33-205`).
+- RNA-seq paired-end uses coarse size bands for coverage/mapped-read outputs, but expression/count tables get stronger regex and exact-line checks (`$IWC/workflows/transcriptomics/rnaseq-pe/rnaseq-pe-tests.yml:48-97`).
+
+Rule: if a translated workflow exposes only weakly assertable final reports, consult [[galaxy-workflow-testability-design]] and consider promoting a table/text/HDF5 checkpoint before writing the final assertions.
 
 ## 2. The `compare:` operators
 
@@ -227,6 +237,7 @@ clustered_anndata:
 
 ## 10. Cross-references
 
+- [[galaxy-workflow-testability-design]] — decide which workflow outputs and checkpoints to expose before choosing assertions.
 - [[iwc-test-data-conventions]] — input-side conventions (job inputs, collection shapes, `hashes:`, CVMFS).
 - [[iwc-shortcuts-anti-patterns]] — accepted-vs-smell catalog and corpus prevalence; this note's mirror image.
 - Test-format schema (`@galaxy-tool-util/schema` npm package) — authoritative vocabulary; will be vendored into a Foundry-rendered schema note. See `docs/COMPILATION_PIPELINE.md` for the casting story.

--- a/content/research/planemo-workflow-test-architecture.md
+++ b/content/research/planemo-workflow-test-architecture.md
@@ -8,10 +8,11 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-05-02
-revised: 2026-05-02
-revision: 1
+revised: 2026-05-03
+revision: 2
 ai_generated: true
 related_notes:
+  - "[[galaxy-workflow-testability-design]]"
   - "[[galaxy-tool-job-failure-reference]]"
   - "[[galaxy-workflow-invocation-failure-reference]]"
   - "[[planemo-asserts-idioms]]"
@@ -95,6 +96,8 @@ Important operations:
 
 For workflows, Planemo invokes Galaxy using input labels/names. Stable generated labels are therefore important for both test execution and debugging.
 
+Workflow testability design guidance lives in [[galaxy-workflow-testability-design]]. This architecture note only records why Planemo makes labels and workflow-level outputs operationally important.
+
 ## Structured Artifacts
 
 Useful Planemo artifacts and fields:
@@ -135,6 +138,7 @@ For [[run-workflow-test]]:
 For [[debug-galaxy-workflow-output]]:
 
 - Start from structured Planemo output.
+- For missing-output failures, check label drift and omitted workflow-level outputs before assuming tool failure.
 - If the failure is job-level, inspect Galaxy job APIs described in [[galaxy-tool-job-failure-reference]].
 - If the failure is invocation-level, inspect Galaxy invocation APIs described in [[galaxy-workflow-invocation-failure-reference]].
 - If only assertions failed, use [[planemo-asserts-idioms]] before deciding to rerun.


### PR DESCRIPTION
## Summary
- add durable workflow testability design guidance for labels, checkpoints, collection identifiers, and fixture-aware inputs
- keep the IWC workflow testability survey as an evidence hub instead of formal pattern-page guidance
- wire the guidance into relevant Galaxy workflow/test Molds and sharpen adjacent research notes

## Validation
- npm run validate passes with existing advisory warnings only