### PR TITLE
Add recipe pattern taxonomy

### DIFF
--- a/.claude/commands/iwc-survey-act.md
+++ b/.claude/commands/iwc-survey-act.md
@@ -42,7 +42,7 @@ Before asking the user anything, suppress questions covered by prior answers:
 Build a compact classification table before user questions:
 
 - `already-authored` — suppress unless the survey adds evidence.
-- `new leaf page` — candidate for issue or immediate `/iwc-survey-pattern` work.
+- `new operation page` — candidate for issue or immediate `/iwc-survey-pattern` work.
 - `refine existing` — existing page needs a section, citation, boundary change, or recommendation update.
 - `merge into existing` — no standalone page; harvest useful mechanics into an existing page.
 - `drop/gap/no page` — corpus-zero, too thin, or not a pattern by policy.

--- a/.claude/commands/iwc-survey-pattern.md
+++ b/.claude/commands/iwc-survey-pattern.md
@@ -56,7 +56,7 @@ Drop sections that do not earn their space. A thin “None surfaced” legacy se
 ## Frontmatter guidance
 
 - Required fields must conform to `meta_schema.yml`; do not add ad-hoc fields.
-- Set `pattern_kind: leaf` for concrete operation pages and `pattern_kind: moc` for map-of-content pages that route readers to leaf patterns.
+- Set `pattern_kind: operation` for concrete operation pages, `pattern_kind: recipe` for multi-step lifecycle pages, and `pattern_kind: moc` for map-of-content pages that route readers to operations and recipes.
 - `summary` is a compressed “what to do and when” line, not a mini abstract.
 - `related_notes` should name primary source notes only, usually the survey. Put secondary context notes in body or `See also` unless they are essential source material.
 - `related_patterns` should be focused: pages that decide against this one, close siblings, or immediate follow-ups. Do not list the whole neighborhood.

--- a/casts/claude/skills/summarize-nextflow/_provenance.json
+++ b/casts/claude/skills/summarize-nextflow/_provenance.json
@@ -5,12 +5,12 @@
     "name": "summarize-nextflow",
     "path": "content/molds/summarize-nextflow/index.md",
     "revision": 7,
-    "content_hash": "e35e59ed138365803fd6f70a5831bc199452b4c1dc271cd466fcda9ca5c3b0d3",
-    "commit": "4be9b4fbb5bc46ffbef6e3b3484f9482c6f8df73"
+    "content_hash": "7c6a3ddfeb36e8ed3f2bd8823450181f06608b8b8db500c32a8a963b1281488c",
+    "commit": "999310334d90346fb4b472a4f8e2b15e85aba147"
   },
   "cast_method": "hand-cast",
   "cast_agent": "claude (manual transcription, no LLM cast prompt)",
-  "cast_at": "2026-05-03T01:58:37.428Z",
+  "cast_at": "2026-05-03T20:02:14.126Z",
   "cast_date": "2026-05-01",
   "cast_revision": 3,
   "cast_history": [
@@ -89,8 +89,8 @@
       "load": "upfront",
       "evidence": "cast-validated",
       "purpose": "Validate the emitted Nextflow summary JSON and provide downstream consumers the output contract.",
-      "src_hash": "8c47e5ec11c0b3f166820e2a6b5a220c370fe82ac1ac3bdd1442ccf79ecc4fdc",
-      "dst_hash": "8c47e5ec11c0b3f166820e2a6b5a220c370fe82ac1ac3bdd1442ccf79ecc4fdc",
+      "src_hash": "6a94a2af1e035b6c17676b27928bdb9cd55d6a56df8c1b2d68a655ef2a76cbcc",
+      "dst_hash": "6a94a2af1e035b6c17676b27928bdb9cd55d6a56df8c1b2d68a655ef2a76cbcc",
       "source": "deterministic"
     }
   ],

--- a/casts/claude/skills/summarize-nextflow/references/schemas/summary-nextflow.schema.json
+++ b/casts/claude/skills/summarize-nextflow/references/schemas/summary-nextflow.schema.json
@@ -98,11 +98,13 @@
       "description": "One Nextflow `process { ... }` block.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "module_path", "inputs", "outputs"],
+      "required": ["name", "module_path", "meta", "module_tests", "inputs", "outputs"],
       "properties": {
         "name":            { "type": "string", "description": "Canonical process name (uppercase NF convention) as declared by the `process <NAME>` line in `module_path`." },
         "aliases":         { "type": "array", "items": { "type": "string" }, "description": "Alias names this process is imported as in workflow scopes via `include { <NAME> as <ALIAS> }`. Real nf-core pipelines re-import a single module multiple times under different aliases to invoke it with distinct runtime args (e.g. `MINIMAP2_ALIGN as MINIMAP2_CONSENSUS`, `MINIMAP2_ALIGN as MINIMAP2_POLISH`). Each alias appears in `workflow.edges[].from`/`.to` exactly as written; the canonical `name` does not appear in edges unless an unaliased import exists. Default `[]` when the process is only imported under its canonical name." },
         "module_path":     { "type": "string", "description": "Relative path from the pipeline root to the file declaring the process." },
+        "meta":            { "anyOf": [{ "$ref": "#/$defs/ModuleMeta" }, { "type": "null" }], "description": "Normalized `meta.yml` from the module directory when present. Null for local/ad-hoc processes without module metadata." },
+        "module_tests":    { "type": "array", "items": { "$ref": "#/$defs/NfTest" }, "description": "Module-scoped nf-test files under the module's `tests/` directory. Empty for local/ad-hoc modules without unit tests." },
         "tool":            { "type": ["string", "null"], "description": "Foreign key into `tools[].name` when the process runs a single recognizable tool; null for multi-tool or pure-Groovy processes." },
         "container":       { "type": ["string", "null"], "description": "Verbatim text of the process's `container` directive (or null). Modern nf-core modules use a ternary expression `\"${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ? '<singularity-uri>' : '<docker-uri>' }\"` — keep that text intact here. The two resolved branches are split out into `tools[].docker` / `tools[].singularity` (and `tools[].wave` / `tools[].biocontainer` as appropriate)." },
         "conda":           { "type": ["string", "null"], "description": "Verbatim text of the process's `conda` directive (or null). Two common shapes: a literal `bioconda::<name>=<version>` (legacy) or a file reference `${moduleDir}/environment.yml` (modern nf-core convention). Either way the resolved bioconda spec lands in `tools[].bioconda`." },
@@ -114,19 +116,57 @@
       }
     },
 
+    "ModuleMeta": {
+      "title": "ModuleMeta",
+      "description": "Normalized subset of nf-core module `meta.yml`, captured next to a process so module-scoped downstream Molds can consume `processes[i]` without reading the full pipeline summary.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["keywords", "authors", "maintainers", "tools", "input", "output"],
+      "properties": {
+        "description": { "type": "string" },
+        "keywords":    { "type": "array", "items": { "type": "string" } },
+        "authors":     { "type": "array", "items": { "type": "string" } },
+        "maintainers": { "type": "array", "items": { "type": "string" } },
+        "tools":       { "type": "array", "items": { "$ref": "#/$defs/ModuleMetaEntry" } },
+        "input":       { "type": "array", "items": { "$ref": "#/$defs/ModuleMetaEntry" } },
+        "output":      { "type": "array", "items": { "$ref": "#/$defs/ModuleMetaEntry" } }
+      }
+    },
+
+    "ModuleMetaEntry": {
+      "title": "ModuleMetaEntry",
+      "description": "One named entry from a module `meta.yml` section, normalized from nf-core's single-key YAML maps into `{ name, ...fields }` objects.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name":          { "type": "string" },
+        "description":   { "type": "string" },
+        "homepage":      { "type": "string" },
+        "documentation": { "type": "string" },
+        "tool_dev_url":  { "type": "string" },
+        "doi":           { "type": "string" },
+        "licence":       { "type": "array", "items": { "type": "string" } },
+        "identifier":    { "type": "string" },
+        "type":          { "type": "string" },
+        "pattern":       { "type": "string" }
+      }
+    },
+
     "Subworkflow": {
       "title": "Subworkflow",
       "description": "One named `workflow <NAME> { ... }` block other than the primary workflow. Includes nf-core utility wrappers (PIPELINE_INITIALISATION, PIPELINE_COMPLETION, UTILS_NFCORE_PIPELINE) which exist to compose helper-function calls rather than to invoke processes.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "path", "kind", "calls"],
+      "required": ["name", "path", "kind", "calls", "tests"],
       "properties": {
         "name":    { "type": "string" },
         "path":    { "type": "string", "description": "Relative path from the pipeline root." },
         "kind":    { "type": "string", "enum": ["pipeline", "utility"], "description": "`pipeline` when the subworkflow invokes pipeline processes (data-flow contributor). `utility` when it composes helper functions only — common nf-core template subworkflows like PIPELINE_INITIALISATION (which calls `paramsHelp`, `samplesheetToList`, `UTILS_NFSCHEMA_PLUGIN`) and PIPELINE_COMPLETION (`completionEmail`, `completionSummary`). Utility subworkflows have empty `calls[]` for processes but may still expose channel outputs the primary workflow consumes." },
         "calls":   { "type": "array", "items": { "type": "string" }, "description": "Names of processes and nested subworkflows this subworkflow invokes. Free-function calls (e.g. `paramsHelp`, `completionEmail`) are NOT recorded here; they're implied by `kind = utility`." },
         "inputs":  { "type": "array", "items": { "$ref": "#/$defs/ChannelIO" } },
-        "outputs": { "type": "array", "items": { "$ref": "#/$defs/ChannelIO" } }
+        "outputs": { "type": "array", "items": { "$ref": "#/$defs/ChannelIO" } },
+        "tests":   { "type": "array", "items": { "$ref": "#/$defs/NfTest" }, "description": "Subworkflow-scoped nf-test files under the subworkflow's `tests/` directory. Empty when absent." }
       }
     },
 

--- a/content/Dashboard.md
+++ b/content/Dashboard.md
@@ -48,6 +48,10 @@ Generated from `dashboard_sections.json` and content frontmatter. Do not edit by
 
 | Name | Summary | Status | Revised | Rev |
 | --- | --- | --- | --- | --- |
+| [[cleanup-sync-and-publish-nonempty-results]] | Clean sparse mapped outputs, keep sibling collections aligned, then gate report publishing on non-empty results. | draft | 2026-05-04 | 1 |
+| [[fan-in-bundle-consume-and-flatten]] | Bundle parallel outputs into a collection consumer, then flatten nested results for pooled downstream processing. | draft | 2026-05-04 | 1 |
+| [[manifest-to-mapped-collection-lifecycle]] | Use a manifest or table to build a collection, map a tool per row, then relabel or reshape outputs. | draft | 2026-05-04 | 1 |
+| [[reshape-relabel-remap-by-collection-axis]] | Use Apply Rules and deterministic relabeling when domain fan-out creates the wrong map-over axis. | draft | 2026-05-04 | 1 |
 | [[collection-build-list-paired-with-apply-rules]] | Use Apply Rules to promote identifier columns into a list:paired collection, with optional cleanup first. | draft | 2026-05-03 | 2 |
 | [[collection-build-named-bundle]] | Use BUILD_LIST to assemble named outputs into a collection bundle for publishing or downstream fan-in. | draft | 2026-05-03 | 2 |
 | [[collection-cleanup-after-mapover-failure]] | Use FILTER_EMPTY or FILTER_FAILED after map-over when bad elements would break downstream collection steps. | draft | 2026-05-03 | 2 |
@@ -128,7 +132,7 @@ Generated from `dashboard_sections.json` and content frontmatter. Do not edit by
 | [[galaxy-workflow-invocation-failure-reference]] | Reference for Galaxy workflow invocation states, messages, failure reasons, and invocation API surfaces. | draft | 2026-05-02 | 1 |
 | [[iwc-conditionals-survey]] | Corpus survey of Galaxy conditional step usage in IWC, covering when-gates, boolean shims, and routed output selection. | draft | 2026-05-02 | 2 |
 | [[iwc-parameter-derivation-survey]] | Corpus survey of Galaxy workflow recipes that turn upstream data, metadata, or small files into runtime parameters. | draft | 2026-05-02 | 1 |
-| [[iwc-tabular-operations-survey]] | Corpus survey of tabular tools and operations across IWC workflows; map for the leaf pattern hierarchy on row/column data manipulation. | draft | 2026-05-02 | 2 |
+| [[iwc-tabular-operations-survey]] | Corpus survey of tabular tools and operations across IWC workflows; map for the operation pattern hierarchy on row/column data manipulation. | draft | 2026-05-02 | 2 |
 | [[iwc-transformations-survey]] | Corpus survey of collection-shape transformations across IWC: built-in collection ops, toolshed transformers, and the multi-step recipes that bracket map-over. | draft | 2026-05-02 | 2 |
 | [[nextflow-operators-to-galaxy-collection-recipes]] | Classifies common Nextflow operators as Galaxy wiring, collection semantics, explicit steps, or review triggers. | draft | 2026-05-02 | 1 |
 | [[nextflow-to-galaxy-channel-shape-mapping]] | Maps common Nextflow channel, tuple, and path shapes to Galaxy dataset and collection shapes. | draft | 2026-05-02 | 1 |

--- a/content/Index.md
+++ b/content/Index.md
@@ -42,6 +42,7 @@ Generated from content frontmatter. Do not edit by hand.
 
 ## Patterns
 
+- [[cleanup-sync-and-publish-nonempty-results]] — Clean sparse mapped outputs, keep sibling collections aligned, then gate report publishing on non-empty results.
 - [[collection-build-list-paired-with-apply-rules]] — Use Apply Rules to promote identifier columns into a list:paired collection, with optional cleanup first.
 - [[collection-build-named-bundle]] — Use BUILD_LIST to assemble named outputs into a collection bundle for publishing or downstream fan-in.
 - [[collection-cleanup-after-mapover-failure]] — Use FILTER_EMPTY or FILTER_FAILED after map-over when bad elements would break downstream collection steps.
@@ -57,12 +58,15 @@ Generated from content frontmatter. Do not edit by hand.
 - [[conditional-route-between-alternative-outputs]] — Use when-gated alternatives plus pick_value to merge binary or one-of-N routes into one downstream value.
 - [[conditional-run-optional-step]] — Use a workflow boolean connected as inputs.when to skip an optional Galaxy step or branch.
 - [[conditional-transform-or-pass-through]] — Gate an optional transform, then use pick_value to pass transformed data when present or original data otherwise.
+- [[fan-in-bundle-consume-and-flatten]] — Bundle parallel outputs into a collection consumer, then flatten nested results for pooled downstream processing.
 - [[galaxy-collection-patterns]] — Use this MOC to choose corpus-grounded Galaxy collection transformation patterns.
 - [[galaxy-conditionals-patterns]] — Use this MOC to choose corpus-grounded Galaxy when and pick_value conditional patterns.
 - [[galaxy-tabular-patterns]] — Use this MOC to choose corpus-grounded Galaxy tabular transformation patterns.
+- [[manifest-to-mapped-collection-lifecycle]] — Use a manifest or table to build a collection, map a tool per row, then relabel or reshape outputs.
 - [[compose-runtime-text-parameter]] — Use compose_text_param to build connected text expressions from constants plus runtime scalar values.
 - [[derive-parameter-from-file]] — Read a one-value dataset with param_value_from_file, including count recipes that feed typed parameters.
 - [[map-workflow-enum-to-tool-parameter]] — Use map_param_value to translate workflow enum values into downstream tool codes, flags, or snippets.
+- [[reshape-relabel-remap-by-collection-axis]] — Use Apply Rules and deterministic relabeling when domain fan-out creates the wrong map-over axis.
 - [[tabular-compute-new-column]] — Use column_maker (Add_a_column1) with strict error_handling to insert/replace a computed column. Per-expression-kind auto_col_types rule.
 - [[tabular-concatenate-collection-to-table]] — Use collapse_dataset to row-bind a collection of tabulars into one table, with optional element IDs and header dedupe.
 - [[tabular-cut-and-reorder-columns]] — Use Cut1 with a comma-separated cN list to project — and reorder — columns. Listing out of order is the canonical reorder idiom.
@@ -115,7 +119,7 @@ Generated from content frontmatter. Do not edit by hand.
 - [[iwc-nearest-exemplar-selection]] — Defines a feature hierarchy for selecting useful IWC exemplar workflows for structural comparison.
 - [[iwc-parameter-derivation-survey]] — Corpus survey of Galaxy workflow recipes that turn upstream data, metadata, or small files into runtime parameters.
 - [[iwc-shortcuts-anti-patterns]] — What IWC test suites cut corners on (accepted) vs what's a code smell — existence-only probes, sim_size deltas, image dim checks, label coupling.
-- [[iwc-tabular-operations-survey]] — Corpus survey of tabular tools and operations across IWC workflows; map for the leaf pattern hierarchy on row/column data manipulation.
+- [[iwc-tabular-operations-survey]] — Corpus survey of tabular tools and operations across IWC workflows; map for the operation pattern hierarchy on row/column data manipulation.
 - [[iwc-test-data-conventions]] — How IWC workflows organize and reference test data — Zenodo-first, SHA-1 integrity, collection shapes, CVMFS gotchas.
 - [[iwc-transformations-survey]] — Corpus survey of collection-shape transformations across IWC: built-in collection ops, toolshed transformers, and the multi-step recipes that bracket map-over.
 - [[iwc-workflow-testability-survey]] — IWC evidence survey for Galaxy workflow structures that make workflow tests meaningful.

--- a/content/molds/summary-to-galaxy-data-flow/index.md
+++ b/content/molds/summary-to-galaxy-data-flow/index.md
@@ -75,7 +75,7 @@ references:
     load: on-demand
     mode: verbatim
     evidence: corpus-observed
-    purpose: "Ground collection-shape choices in curated, corpus-observed leaf patterns."
+    purpose: "Ground collection-shape choices in curated, corpus-observed operation and recipe patterns."
     trigger: "When selecting between collection cleanup, reshape, identifier, or collection-tabular bridge patterns."
   - kind: pattern
     ref: "[[galaxy-tabular-patterns]]"
@@ -83,7 +83,7 @@ references:
     load: on-demand
     mode: verbatim
     evidence: corpus-observed
-    purpose: "Ground tabular bridge and table-operation choices in curated, corpus-observed leaf patterns."
+    purpose: "Ground tabular bridge and table-operation choices in curated, corpus-observed operation patterns."
     trigger: "When data-flow translation leaves collection-land for tabular projection, filtering, joining, aggregation, pivoting, or tabular-collection bridges."
 ---
 # summary-to-galaxy-data-flow

--- a/content/patterns/cleanup-sync-and-publish-nonempty-results.md
+++ b/content/patterns/cleanup-sync-and-publish-nonempty-results.md
@@ -1,0 +1,74 @@
+---
+type: pattern
+pattern_kind: recipe
+evidence: corpus-observed
+title: "Cleanup, sync, and publish non-empty results"
+aliases:
+  - "cleanup sync publish nonempty"
+  - "mapped output cleanup and sibling sync"
+  - "non-empty mapped result publishing"
+tags:
+  - pattern
+  - target/galaxy
+  - topic/galaxy-transform
+  - topic/collection-transform
+status: draft
+created: 2026-05-04
+revised: 2026-05-04
+revision: 1
+ai_generated: true
+summary: "Clean sparse mapped outputs, keep sibling collections aligned, then gate report publishing on non-empty results."
+related_notes:
+  - "[[iwc-map-over-lifecycle-survey]]"
+related_patterns:
+  - "[[collection-cleanup-after-mapover-failure]]"
+  - "[[sync-collections-by-identifier]]"
+  - "[[harmonize-by-sortlist-from-identifiers]]"
+  - "[[conditional-gate-on-nonempty-result]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+  - "[[summary-to-galaxy-data-flow]]"
+iwc_exemplars:
+  - workflow: amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction
+    why: "Filters empty mapped BED outputs, syncs sibling collections from cleaned identifiers, then gates Krona and BIOM exports."
+    confidence: high
+---
+
+# Cleanup, sync, and publish non-empty results
+
+Use this recipe when a mapped search, extraction, or classification can produce empty per-element outputs and downstream reports should only run when useful results remain.
+
+The key decision is that cleanup is not enough. If sibling collections still represent the original sample set, they must be filtered, sorted, or relabeled to match the cleaned result collection before downstream map-over or report export.
+
+## Recipe
+
+1. Map the domain tool over the input collection.
+2. Drop empty/failed element outputs so the cleaned collection contains only usable results. Use replacement only when preserving shape is more important than defining a result-set truth mask.
+3. Extract identifiers from the cleaned collection that now represents the usable result set.
+4. Filter sibling collections to match those identifiers; add sorting or relabeling only when the downstream consumer needs order or label harmonization.
+5. Derive a whole-result non-empty boolean with the vetted collection-to-boolean chain when report/export tools should not run on empty collections.
+6. Gate report or export steps with Galaxy `when` conditions.
+
+## Reach For This When
+
+- "No hits" is valid for some samples but breaks downstream aggregation.
+- A cleaned result collection must stay aligned with sequence, metadata, or classification sibling collections.
+- Final reports should be omitted when there is no meaningful result to publish.
+
+## Operation Handoffs
+
+- Use [[collection-cleanup-after-mapover-failure]] immediately after sparse mapped outputs.
+- Use [[sync-collections-by-identifier]] when the cleaned collection defines sibling membership.
+- Use [[harmonize-by-sortlist-from-identifiers]] when downstream paired processing depends on order, not just membership.
+- Use [[conditional-gate-on-nonempty-result]] for the known-good `collection_element_identifiers -> wc_gnu -> column_maker -> param_value_from_file` gate.
+
+## Pitfalls
+
+- Do not filter sibling inputs from the original collection when the cleaned result collection is the truth set.
+- Do not assume identifier sync also guarantees order sync.
+- Do not gate per-element routing with Galaxy `when`; use filters/classifiers for per-element behavior and reserve `when` for step-level gates.
+
+## See Also
+
+- [[iwc-map-over-lifecycle-survey]] — Shape B evidence.
+- [[galaxy-conditionals-patterns]] — conditional operation map.

--- a/content/patterns/collection-build-list-paired-with-apply-rules.md
+++ b/content/patterns/collection-build-list-paired-with-apply-rules.md
@@ -1,6 +1,6 @@
 ---
 type: pattern
-pattern_kind: leaf
+pattern_kind: operation
 evidence: corpus-observed
 title: "Collection: build list paired with Apply Rules"
 aliases:

--- a/content/patterns/collection-build-named-bundle.md
+++ b/content/patterns/collection-build-named-bundle.md
@@ -1,6 +1,6 @@
 ---
 type: pattern
-pattern_kind: leaf
+pattern_kind: operation
 evidence: corpus-observed
 title: "Collection: build named bundle"
 aliases:

--- a/content/patterns/collection-cleanup-after-mapover-failure.md
+++ b/content/patterns/collection-cleanup-after-mapover-failure.md
@@ -1,6 +1,6 @@
 ---
 type: pattern
-pattern_kind: leaf
+pattern_kind: operation
 evidence: corpus-observed
 title: "Collection: cleanup after map-over failure"
 aliases:

--- a/content/patterns/collection-flatten-after-fanout.md
+++ b/content/patterns/collection-flatten-after-fanout.md
@@ -1,6 +1,6 @@
 ---
 type: pattern
-pattern_kind: leaf
+pattern_kind: operation
 evidence: corpus-observed
 title: "Collection: flatten after fan-out"
 aliases:

--- a/content/patterns/collection-split-identifier-via-rules.md
+++ b/content/patterns/collection-split-identifier-via-rules.md
@@ -1,6 +1,6 @@
 ---
 type: pattern
-pattern_kind: leaf
+pattern_kind: operation
 evidence: corpus-observed
 title: "Collection: split identifier via rules"
 aliases:

--- a/content/patterns/collection-swap-nesting-with-apply-rules.md
+++ b/content/patterns/collection-swap-nesting-with-apply-rules.md
@@ -1,6 +1,6 @@
 ---
 type: pattern
-pattern_kind: leaf
+pattern_kind: operation
 evidence: corpus-observed
 title: "Collection: swap nesting with Apply Rules"
 aliases:

--- a/content/patterns/collection-unbox-singleton.md
+++ b/content/patterns/collection-unbox-singleton.md
@@ -1,6 +1,6 @@
 ---
 type: pattern
-pattern_kind: leaf
+pattern_kind: operation
 evidence: corpus-observed
 title: "Collection: unbox singleton"
 aliases:

--- a/content/patterns/compose-runtime-text-parameter.md
+++ b/content/patterns/compose-runtime-text-parameter.md
@@ -1,6 +1,6 @@
 ---
 type: pattern
-pattern_kind: leaf
+pattern_kind: operation
 evidence: corpus-and-verified
 title: "Parameter: compose runtime text parameter"
 aliases:

--- a/content/patterns/conditional-gate-on-nonempty-result.md
+++ b/content/patterns/conditional-gate-on-nonempty-result.md
@@ -1,6 +1,6 @@
 ---
 type: pattern
-pattern_kind: leaf
+pattern_kind: recipe
 evidence: corpus-and-verified
 title: "Conditional: gate on non-empty result"
 aliases:
@@ -71,9 +71,9 @@ This is not map-over cleanup. If the need is to drop empty or failed elements in
 
 This is not `__FILTER_NULL__`. The conditionals survey found zero `__FILTER_NULL__` usage in the IWC corpus, but zero uptake alone is not an anti-pattern call.
 
-## Operation Boundary
+## Recipe Boundary
 
-This pattern covers data-derived branch admission:
+This recipe covers data-derived branch admission:
 
 - input fact: "this result is empty/non-empty";
 - output action: "run or skip downstream steps";
@@ -139,7 +139,7 @@ These snippets summarize observed and verified shapes. Do not simplify the MGnif
 
 ## Pitfalls
 
-- Do not lead with the MGnify four-step shim as "best" just because it is corpus-backed. It proves the operation; it may not be the ideal generated-workflow recipe.
+- Do not lead with the MGnify four-step shim as "best" just because it is corpus-backed. It proves the recipe; it may not be the ideal generated-workflow recipe.
 - Do not invent a shorter `when` expression without validation. Galaxy workflow syntax and tool-form roundtripping need a verified-pattern fixture first.
 - Do not use this when the choice is user-controlled. Direct boolean `when` gates are simpler.
 - Do not replace collection cleanup with a workflow gate. Cleanup changes collection members; this pattern skips whole downstream steps.

--- a/content/patterns/conditional-route-between-alternative-outputs.md
+++ b/content/patterns/conditional-route-between-alternative-outputs.md
@@ -1,6 +1,6 @@
 ---
 type: pattern
-pattern_kind: leaf
+pattern_kind: operation
 evidence: corpus-observed
 title: "Conditional: route between alternative outputs"
 aliases:

--- a/content/patterns/conditional-run-optional-step.md
+++ b/content/patterns/conditional-run-optional-step.md
@@ -1,6 +1,6 @@
 ---
 type: pattern
-pattern_kind: leaf
+pattern_kind: operation
 evidence: corpus-and-verified
 title: "Conditional: run optional step"
 aliases:

--- a/content/patterns/conditional-transform-or-pass-through.md
+++ b/content/patterns/conditional-transform-or-pass-through.md
@@ -1,6 +1,6 @@
 ---
 type: pattern
-pattern_kind: leaf
+pattern_kind: operation
 evidence: corpus-observed
 title: "Conditional: transform or pass through"
 aliases:

--- a/content/patterns/derive-parameter-from-file.md
+++ b/content/patterns/derive-parameter-from-file.md
@@ -1,6 +1,6 @@
 ---
 type: pattern
-pattern_kind: leaf
+pattern_kind: operation
 evidence: corpus-and-verified
 title: "Parameter: derive from file"
 aliases:

--- a/content/patterns/fan-in-bundle-consume-and-flatten.md
+++ b/content/patterns/fan-in-bundle-consume-and-flatten.md
@@ -1,0 +1,74 @@
+---
+type: pattern
+pattern_kind: recipe
+evidence: corpus-observed
+title: "Fan-in bundle, consume, and flatten"
+aliases:
+  - "fan-in bundle then flatten"
+  - "build list for collection consumer"
+  - "mid-workflow collection fan-in lifecycle"
+tags:
+  - pattern
+  - target/galaxy
+  - topic/galaxy-transform
+  - topic/collection-transform
+status: draft
+created: 2026-05-04
+revised: 2026-05-04
+revision: 1
+ai_generated: true
+summary: "Bundle parallel outputs into a collection consumer, then flatten nested results for pooled downstream processing."
+related_notes:
+  - "[[iwc-map-over-lifecycle-survey]]"
+related_patterns:
+  - "[[collection-build-named-bundle]]"
+  - "[[collection-flatten-after-fanout]]"
+  - "[[tabular-concatenate-collection-to-table]]"
+  - "[[tabular-pivot-collection-to-wide]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+  - "[[summary-to-galaxy-data-flow]]"
+iwc_exemplars:
+  - workflow: microbiome/mags-building/MAGs-generation
+    why: "Builds a collection from multiple binner outputs for binette, then flattens nested bins for pooled downstream processing."
+    confidence: high
+---
+
+# Fan-in bundle, consume, and flatten
+
+Use this recipe when several parallel outputs should become one named collection for a downstream collection-aware tool, then nested results must be flattened before optional pooled aggregation.
+
+This contrasts with [[manifest-to-mapped-collection-lifecycle]]: collection construction happens mid-workflow as fan-in, not just at the workflow boundary.
+
+## Recipe
+
+1. Identify parallel outputs that represent comparable alternatives, bins, reports, or method results.
+2. Build a named collection bundle from those individual outputs.
+3. Feed the bundle into the downstream tool that expects a collection input.
+4. Flatten nested collection output if the downstream tool emits one subcollection per input element.
+5. Aggregate tabular/report outputs when the final consumer needs one file rather than a collection.
+
+## Reach For This When
+
+- Multiple tools produce equivalent artifacts and a later tool compares, refines, or pools them.
+- A workflow bundles related outputs because a later collection-aware tool consumes them, not merely for publication.
+- A downstream collection consumer emits nested outputs that need pooled processing.
+
+## Operation Handoffs
+
+- Use [[collection-build-named-bundle]] to assemble individual datasets or outputs into a `list`.
+- Use [[collection-flatten-after-fanout]] when the consumer returns nested collections and the outer axis no longer matters.
+- Use [[tabular-concatenate-collection-to-table]] or [[tabular-pivot-collection-to-wide]] when flattened tabular outputs should become one report table.
+
+Bundle-only publication is related but narrower; use [[collection-build-named-bundle]] when there is no downstream collection consumer.
+
+## Pitfalls
+
+- Do not use collection bundling when the real operation is file-content concatenation.
+- Do not use positional identifiers for bundles that will become test-facing outputs.
+- Do not flatten away an axis that still encodes method, sample, or replicate identity needed downstream.
+
+## See Also
+
+- [[iwc-map-over-lifecycle-survey]] — Shape E evidence.
+- [[manifest-to-mapped-collection-lifecycle]] — boundary collection construction in the opposite direction.

--- a/content/patterns/galaxy-collection-patterns.md
+++ b/content/patterns/galaxy-collection-patterns.md
@@ -21,6 +21,10 @@ summary: "Use this MOC to choose corpus-grounded Galaxy collection transformatio
 related_notes:
   - "[[iwc-transformations-survey]]"
 related_patterns:
+  - "[[manifest-to-mapped-collection-lifecycle]]"
+  - "[[cleanup-sync-and-publish-nonempty-results]]"
+  - "[[reshape-relabel-remap-by-collection-axis]]"
+  - "[[fan-in-bundle-consume-and-flatten]]"
   - "[[collection-cleanup-after-mapover-failure]]"
   - "[[sync-collections-by-identifier]]"
   - "[[harmonize-by-sortlist-from-identifiers]]"
@@ -41,12 +45,19 @@ related_molds:
 
 # Galaxy: collection patterns
 
-This is the runtime-facing map for Galaxy collection transformation choices. Use it before loading raw survey notes. The survey remains evidence backing; the leaf pages are the actionable references.
+This is the runtime-facing map for Galaxy collection transformation choices. Use it before loading raw survey notes. The survey remains evidence backing; the operation and recipe pages are the actionable references.
 
 ## Cleanup
 
 - [[collection-cleanup-after-mapover-failure]] — use `__FILTER_EMPTY_DATASETS__` or `__FILTER_FAILED_DATASETS__` after map-over when empty or errored elements would break downstream steps.
 - [[collection-unbox-singleton]] — use `__EXTRACT_DATASET__` with `which: first` when a known one-element collection must become a dataset.
+
+## Map-over Lifecycle Recipes
+
+- [[manifest-to-mapped-collection-lifecycle]] — build collection elements from manifest/table rows, map a tool over them, then relabel or reshape outputs.
+- [[cleanup-sync-and-publish-nonempty-results]] — clean sparse mapped outputs, sync siblings from surviving identifiers, then gate final reports.
+- [[reshape-relabel-remap-by-collection-axis]] — correct the mapped axis after domain fan-out using Apply Rules and deterministic relabeling.
+- [[fan-in-bundle-consume-and-flatten]] — bundle parallel outputs for a collection consumer, then flatten or aggregate results.
 
 ## Identifiers
 

--- a/content/patterns/galaxy-conditionals-patterns.md
+++ b/content/patterns/galaxy-conditionals-patterns.md
@@ -34,7 +34,7 @@ related_molds:
 
 # Galaxy: conditionals patterns
 
-This is the runtime-facing map for Galaxy conditional workflow choices. Use it before loading raw survey notes. The survey remains evidence backing; the leaf pages are the actionable references.
+This is the runtime-facing map for Galaxy conditional workflow choices. Use it before loading raw survey notes. The survey remains evidence backing; the operation and recipe pages are the actionable references.
 
 ## Direct Gates
 

--- a/content/patterns/galaxy-tabular-patterns.md
+++ b/content/patterns/galaxy-tabular-patterns.md
@@ -44,7 +44,7 @@ related_molds:
 
 # Galaxy: tabular patterns
 
-This is the runtime-facing map for Galaxy tabular transformation choices. Use it before loading raw survey notes. The survey remains evidence backing; the leaf pages are the actionable references.
+This is the runtime-facing map for Galaxy tabular transformation choices. Use it before loading raw survey notes. The survey remains evidence backing; the operation pages are the actionable references.
 
 ## Row And Column Operations
 

--- a/content/patterns/harmonize-by-sortlist-from-identifiers.md
+++ b/content/patterns/harmonize-by-sortlist-from-identifiers.md
@@ -1,6 +1,6 @@
 ---
 type: pattern
-pattern_kind: leaf
+pattern_kind: operation
 evidence: corpus-observed
 title: "Collection: harmonize by sortlist from identifiers"
 aliases:

--- a/content/patterns/manifest-to-mapped-collection-lifecycle.md
+++ b/content/patterns/manifest-to-mapped-collection-lifecycle.md
@@ -1,0 +1,82 @@
+---
+type: pattern
+pattern_kind: recipe
+evidence: corpus-observed
+title: "Manifest to mapped collection lifecycle"
+aliases:
+  - "manifest table to mapped collection"
+  - "samplesheet to Galaxy map-over"
+  - "table rows to mapped collection outputs"
+tags:
+  - pattern
+  - target/galaxy
+  - topic/galaxy-transform
+  - topic/collection-transform
+status: draft
+created: 2026-05-04
+revised: 2026-05-04
+revision: 1
+ai_generated: true
+summary: "Use a manifest or table to build a collection, map a tool per row, then relabel or reshape outputs."
+related_notes:
+  - "[[iwc-map-over-lifecycle-survey]]"
+  - "[[nextflow-to-galaxy-channel-shape-mapping]]"
+related_patterns:
+  - "[[tabular-to-collection-by-row]]"
+  - "[[collection-build-list-paired-with-apply-rules]]"
+  - "[[regex-relabel-via-tabular]]"
+  - "[[harmonize-by-sortlist-from-identifiers]]"
+  - "[[collection-swap-nesting-with-apply-rules]]"
+  - "[[collection-flatten-after-fanout]]"
+  - "[[collection-unbox-singleton]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+  - "[[summary-to-galaxy-data-flow]]"
+iwc_exemplars:
+  - workflow: data-fetching/sra-manifest-to-concatenated-fastqs/sra-manifest-to-concatenated-fastqs
+    why: "Splits a manifest to accessions, maps fasterq_dump, then relabels and reshapes paired/single outputs."
+    confidence: high
+  - workflow: virology/pox-virus-amplicon/pox-virus-half-genome
+    why: "Derives sibling collections from table structure before mapped paired processing."
+    confidence: medium
+---
+
+# Manifest to mapped collection lifecycle
+
+Use this recipe when a source manifest, samplesheet, or tabular list describes repeated work and Galaxy should run one domain tool invocation per row or key.
+
+The reusable value is the handoff from tabular structure into collection map-over, then from mapped outputs back into stable labels or downstream collection shapes.
+
+## Recipe
+
+1. Normalize the manifest to the columns that define one unit of work.
+2. Build a Galaxy collection from those rows or from Apply Rules-derived identifiers.
+3. Connect the collection to the domain tool input so Galaxy maps the tool over elements.
+4. Relabel mapped outputs when the tool emits generic or source-derived names, or harmonize sibling collections when paired map-over depends on shared identifiers/order.
+5. Reshape, flatten, or unbox paired, nested, or singleton outputs before publication or downstream map-over.
+
+## Reach For This When
+
+- A Nextflow samplesheet or `tuple(meta, path)` stream is being translated into repeated Galaxy collection elements.
+- A paper protocol says "run this step for each accession/sample/amplicon/region" and the repeated unit is represented in a table.
+- The output collection needs stable sample labels rather than tool-generated names.
+
+## Operation Handoffs
+
+- Use [[tabular-to-collection-by-row]] when one manifest row becomes one collection element.
+- Use [[collection-build-list-paired-with-apply-rules]] when manifest columns encode paired inputs.
+- Use [[regex-relabel-via-tabular]] when mapped outputs need deterministic label cleanup.
+- Use [[harmonize-by-sortlist-from-identifiers]] when sibling collections from the manifest must align before paired map-over.
+- Use [[collection-flatten-after-fanout]] when later nested outputs need pooled downstream processing.
+- Use [[collection-swap-nesting-with-apply-rules]] or [[collection-unbox-singleton]] when the mapped output shape is not the shape the next step expects.
+
+## Pitfalls
+
+- Do not preserve manifest columns blindly. Keep the columns that define collection identity, pairing, or downstream parameters.
+- Do not let tool defaults choose output element identifiers when tests or sibling sync will need stable names.
+- Do not use this recipe for simple file-content concatenation or report reduction; use the relevant aggregation operation after map-over.
+
+## See Also
+
+- [[iwc-map-over-lifecycle-survey]] — Shape A and Nextflow samplesheet mapping evidence.
+- [[galaxy-collection-patterns]] — collection operation map.

--- a/content/patterns/map-workflow-enum-to-tool-parameter.md
+++ b/content/patterns/map-workflow-enum-to-tool-parameter.md
@@ -1,6 +1,6 @@
 ---
 type: pattern
-pattern_kind: leaf
+pattern_kind: operation
 evidence: corpus-and-verified
 title: "Parameter: map workflow enum to tool parameter"
 aliases:

--- a/content/patterns/regex-relabel-via-tabular.md
+++ b/content/patterns/regex-relabel-via-tabular.md
@@ -1,6 +1,6 @@
 ---
 type: pattern
-pattern_kind: leaf
+pattern_kind: operation
 evidence: corpus-observed
 title: "Collection: regex relabel via tabular"
 aliases:

--- a/content/patterns/relabel-via-rules-and-find-replace.md
+++ b/content/patterns/relabel-via-rules-and-find-replace.md
@@ -1,6 +1,6 @@
 ---
 type: pattern
-pattern_kind: leaf
+pattern_kind: recipe
 evidence: corpus-observed
 title: "Collection: relabel via rules and find/replace"
 aliases:

--- a/content/patterns/reshape-relabel-remap-by-collection-axis.md
+++ b/content/patterns/reshape-relabel-remap-by-collection-axis.md
@@ -1,0 +1,79 @@
+---
+type: pattern
+pattern_kind: recipe
+evidence: corpus-observed
+title: "Reshape, relabel, and remap by collection axis"
+aliases:
+  - "reshape relabel remap by axis"
+  - "collection axis remap lifecycle"
+  - "fan-out axis correction before map-over"
+tags:
+  - pattern
+  - target/galaxy
+  - topic/galaxy-transform
+  - topic/collection-transform
+status: draft
+created: 2026-05-04
+revised: 2026-05-04
+revision: 1
+ai_generated: true
+summary: "Use Apply Rules and deterministic relabeling when domain fan-out creates the wrong map-over axis."
+related_notes:
+  - "[[iwc-map-over-lifecycle-survey]]"
+related_patterns:
+  - "[[collection-swap-nesting-with-apply-rules]]"
+  - "[[collection-split-identifier-via-rules]]"
+  - "[[relabel-via-rules-and-find-replace]]"
+  - "[[regex-relabel-via-tabular]]"
+  - "[[collection-flatten-after-fanout]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+  - "[[summary-to-galaxy-data-flow]]"
+iwc_exemplars:
+  - workflow: virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping
+    why: "Uses Apply Rules, identifier extraction, find-and-replace, relabeling, and another Apply Rules pass before mapped consensus."
+    confidence: high
+---
+
+# Reshape, relabel, and remap by collection axis
+
+Use this recipe when an upstream domain fan-out produces the right datasets but nests or labels them along the wrong axis for the next mapped tool.
+
+This is a high-density recipe with narrow corpus evidence. Keep it grounded in explicit identifier transformations and review it carefully before applying it to unrelated tuple/grouping structures.
+
+The reusable move is not relabeling alone; it is correcting which collection level Galaxy will map over after domain fan-out, while preserving a visible identifier derivation path.
+
+## Recipe
+
+1. Identify the downstream tool input that will be mapped and the collection level it should iterate over.
+2. Compare that expected axis with the current nested collection shape and labels.
+3. Use Apply Rules to expose, swap, or restore the axis that should become the mapped collection level.
+4. Extract identifiers from the collection level whose labels must drive downstream mapping.
+5. Rewrite labels deterministically when domain names contain extra suffixes, prefixes, or compound keys.
+6. Relabel the collection from the derived label file.
+7. Reshape again if relabeling fixed names but left the wrong collection type or nesting order.
+8. Connect the corrected collection to the downstream mapped tool and verify element labels/order.
+
+## Reach For This When
+
+- A tool fans out by region, segment, sample, replicate, or other domain axis, but the next tool needs a different axis.
+- Collection element identifiers encode multiple fields that must become separate nested axes or cleaner labels.
+- A Nextflow `groupTuple()` or `transpose()` idiom has been reviewed as a real domain grouping axis, not arbitrary tuple reshaping, and Galaxy needs concrete collection axes for the equivalent map-over.
+
+## Operation Handoffs
+
+- Use [[collection-swap-nesting-with-apply-rules]] when the main problem is `list:list` axis order.
+- Use [[collection-split-identifier-via-rules]] when one identifier string contains multiple axis labels.
+- Use [[relabel-via-rules-and-find-replace]] or [[regex-relabel-via-tabular]] when labels need deterministic cleanup.
+- Use [[collection-flatten-after-fanout]] when the outer fan-out axis no longer matters.
+
+## Pitfalls
+
+- Do not treat arbitrary Nextflow tuple grouping as automatically representable in Galaxy collections.
+- Do not relabel without preserving a visible derivation path; hidden label magic breaks review and tests.
+- Do not generalize from a single dense workflow to all domain fan-out cases without a second exemplar or manual review.
+
+## See Also
+
+- [[iwc-map-over-lifecycle-survey]] — Shape C evidence and review caveat.
+- [[nextflow-operators-to-galaxy-collection-recipes]] — source-operator pressure points.

--- a/content/patterns/sync-collections-by-identifier.md
+++ b/content/patterns/sync-collections-by-identifier.md
@@ -1,6 +1,6 @@
 ---
 type: pattern
-pattern_kind: leaf
+pattern_kind: operation
 evidence: corpus-observed
 title: "Collection: sync collections by identifier"
 aliases:

--- a/content/patterns/tabular-compute-new-column.md
+++ b/content/patterns/tabular-compute-new-column.md
@@ -1,6 +1,6 @@
 ---
 type: pattern
-pattern_kind: leaf
+pattern_kind: operation
 evidence: corpus-observed
 title: "Tabular: compute a new column"
 tags:

--- a/content/patterns/tabular-concatenate-collection-to-table.md
+++ b/content/patterns/tabular-concatenate-collection-to-table.md
@@ -1,6 +1,6 @@
 ---
 type: pattern
-pattern_kind: leaf
+pattern_kind: operation
 evidence: corpus-observed
 title: "Tabular: concatenate collection to table"
 aliases:

--- a/content/patterns/tabular-cut-and-reorder-columns.md
+++ b/content/patterns/tabular-cut-and-reorder-columns.md
@@ -1,6 +1,6 @@
 ---
 type: pattern
-pattern_kind: leaf
+pattern_kind: operation
 evidence: corpus-observed
 title: "Tabular: cut and reorder columns"
 tags:

--- a/content/patterns/tabular-filter-by-column-value.md
+++ b/content/patterns/tabular-filter-by-column-value.md
@@ -1,6 +1,6 @@
 ---
 type: pattern
-pattern_kind: leaf
+pattern_kind: operation
 evidence: corpus-observed
 title: "Tabular: filter rows by column value"
 tags:

--- a/content/patterns/tabular-filter-by-regex.md
+++ b/content/patterns/tabular-filter-by-regex.md
@@ -1,6 +1,6 @@
 ---
 type: pattern
-pattern_kind: leaf
+pattern_kind: operation
 evidence: corpus-observed
 title: "Tabular: filter rows by regex"
 tags:

--- a/content/patterns/tabular-group-and-aggregate-with-datamash.md
+++ b/content/patterns/tabular-group-and-aggregate-with-datamash.md
@@ -1,6 +1,6 @@
 ---
 type: pattern
-pattern_kind: leaf
+pattern_kind: operation
 evidence: corpus-observed
 title: "Tabular: group and aggregate"
 tags:

--- a/content/patterns/tabular-join-on-key.md
+++ b/content/patterns/tabular-join-on-key.md
@@ -1,6 +1,6 @@
 ---
 type: pattern
-pattern_kind: leaf
+pattern_kind: operation
 evidence: corpus-observed
 title: "Tabular: join on key"
 tags:

--- a/content/patterns/tabular-pivot-collection-to-wide.md
+++ b/content/patterns/tabular-pivot-collection-to-wide.md
@@ -1,6 +1,6 @@
 ---
 type: pattern
-pattern_kind: leaf
+pattern_kind: operation
 evidence: corpus-observed
 title: "Tabular: pivot collection to wide"
 aliases:

--- a/content/patterns/tabular-prepend-header.md
+++ b/content/patterns/tabular-prepend-header.md
@@ -1,6 +1,6 @@
 ---
 type: pattern
-pattern_kind: leaf
+pattern_kind: operation
 evidence: corpus-observed
 title: "Tabular: prepend header"
 tags:

--- a/content/patterns/tabular-relabel-by-row-counter.md
+++ b/content/patterns/tabular-relabel-by-row-counter.md
@@ -1,6 +1,6 @@
 ---
 type: pattern
-pattern_kind: leaf
+pattern_kind: operation
 evidence: corpus-observed
 title: "Tabular: relabel by row counter"
 aliases:

--- a/content/patterns/tabular-split-taxonomy-string.md
+++ b/content/patterns/tabular-split-taxonomy-string.md
@@ -1,6 +1,6 @@
 ---
 type: pattern
-pattern_kind: leaf
+pattern_kind: operation
 evidence: corpus-observed
 title: "Tabular: split taxonomy string"
 tags:

--- a/content/patterns/tabular-sql-query.md
+++ b/content/patterns/tabular-sql-query.md
@@ -1,6 +1,6 @@
 ---
 type: pattern
-pattern_kind: leaf
+pattern_kind: operation
 evidence: corpus-observed
 title: "Tabular: SQL query"
 tags:
@@ -41,7 +41,7 @@ iwc_exemplars:
 
 ## Tool
 
-`toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/query_tabular/3.3.2` ("Query Tabular"). 16 step occurrences in the surveyed IWC corpus. This is the SQL leaf in the tabular hierarchy: powerful, but deliberately narrow.
+`toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/query_tabular/3.3.2` ("Query Tabular"). 16 step occurrences in the surveyed IWC corpus. This is the SQL operation in the tabular hierarchy: powerful, but deliberately narrow.
 
 ## When to reach for it
 
@@ -134,7 +134,7 @@ Anchored by the clinical metaproteomics verification IWC exemplar.
 
 ## Pitfalls
 
-- **Do not use SQL for simple filters or cuts.** The survey decision keeps this page narrow; simple row predicates and projections have clearer leaf pages.
+- **Do not use SQL for simple filters or cuts.** The survey decision keeps this page narrow; simple row predicates and projections have clearer operation pages.
 - **Header handling is split across fields.** `query_result.header`, `tables[].tbl_opts.column_names_from_first_line`, and load filters like `skip` are independent.
 - **Line filters run before SQL.** `prepend_dataset_name`, `prepend_line_num`, and `normalize` change column positions before the query sees the table.
 - **Blank `table_name` is meaningful.** Blank means default `t1`; named joins need explicit table names.
@@ -144,7 +144,7 @@ Anchored by the clinical metaproteomics verification IWC exemplar.
 
 ## See also
 
-- [[iwc-tabular-operations-survey]] — corpus survey and §7 decision record for SQL as a narrow tabular leaf.
+- [[iwc-tabular-operations-survey]] — corpus survey and §7 decision record for SQL as a narrow tabular operation.
 - [[tabular-filter-by-column-value]] — one-table row predicates.
 - [[tabular-cut-and-reorder-columns]] — pure projection.
 - [[tabular-compute-new-column]] — simple computed columns.

--- a/content/patterns/tabular-synthesize-bed-from-3col.md
+++ b/content/patterns/tabular-synthesize-bed-from-3col.md
@@ -1,6 +1,6 @@
 ---
 type: pattern
-pattern_kind: leaf
+pattern_kind: operation
 evidence: corpus-observed
 title: "Tabular: synthesize BED from 3-column input"
 tags:

--- a/content/patterns/tabular-to-collection-by-row.md
+++ b/content/patterns/tabular-to-collection-by-row.md
@@ -1,6 +1,6 @@
 ---
 type: pattern
-pattern_kind: leaf
+pattern_kind: operation
 evidence: corpus-observed
 title: "Tabular: to collection by row"
 aliases:

--- a/content/research/iwc-conditionals-survey.md
+++ b/content/research/iwc-conditionals-survey.md
@@ -129,7 +129,7 @@ Evidence:
 - Optional StringTie/Cufflinks branches in RNA-seq: `$IWC_FORMAT2/transcriptomics/rnaseq-pe/rnaseq-pe.gxwf.yml:1082-1140`, `$IWC_FORMAT2/transcriptomics/rnaseq-pe/rnaseq-pe.gxwf.yml:1141-1214`.
 - Optional suffixing branch in VGP Hi-C: `$IWC_FORMAT2/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation.gxwf.yml:338-459`.
 
-Call: **keep**. This is the leaf-level primitive all other conditional recipes build on.
+Call: **keep**. This is the operation-level primitive all other conditional recipes build on.
 
 ### Candidate B: `conditional-route-between-alternative-outputs`
 
@@ -188,7 +188,7 @@ Call: **merge** into the collection-cleanup pattern family; do not create a cond
 
 ## 6. Open questions
 
-1. Should conditionals get a MOC page (`galaxy-conditionals-patterns.md`) now, or wait until at least two leaf pages are authored?
+1. Should conditionals get a MOC page (`galaxy-conditionals-patterns.md`) now, or wait until at least two operation pages are authored?
 
 2. Answered for now: keep `conditional-transform-or-pass-through` separate from `conditional-route-between-alternative-outputs`. The boundary is "same value optionally modified" vs "peer alternatives routed to one output". Revisit only if the separate page proves too thin.
 
@@ -196,4 +196,4 @@ Call: **merge** into the collection-cleanup pattern family; do not create a cond
 
 4. No. Do not add `__FILTER_NULL__` to the anti-pattern note from zero uptake alone. Lack of uptake does not make a Galaxy feature an anti-pattern; users can be slow to adopt newer or esoteric features. Keep the survey call as "catalog capability, no IWC-backed pattern candidate" unless separate evidence shows a concrete reason not to endorse it.
 
-5. Does the Foundry need a background reference note for Galaxy `when:` syntax and nullable downstream behavior before leaf pattern pages are useful?
+5. Does the Foundry need a background reference note for Galaxy `when:` syntax and nullable downstream behavior before operation pattern pages are useful?

--- a/content/research/iwc-map-over-lifecycle-survey.md
+++ b/content/research/iwc-map-over-lifecycle-survey.md
@@ -36,7 +36,7 @@ summary: "Survey of IWC map-over lifecycle recipes, with a Nextflow-to-Galaxy cr
 
 # IWC map-over lifecycle survey
 
-Source corpus: 120 cleaned `gxformat2` workflows under `$IWC_FORMAT2/`, with structural scans over `$IWC_SKELETONS/`. Nextflow comparison uses local fixtures under `workflow-fixtures/pipelines/` plus existing Foundry notes. This survey is intentionally lifecycle-shaped: it composes existing leaf pattern pages rather than rediscovering each collection tool.
+Source corpus: 120 cleaned `gxformat2` workflows under `$IWC_FORMAT2/`, with structural scans over `$IWC_SKELETONS/`. Nextflow comparison uses local fixtures under `workflow-fixtures/pipelines/` plus existing Foundry notes. This survey is intentionally lifecycle-shaped: it composes existing operation pattern pages rather than rediscovering each collection tool.
 
 Scope is the end-to-end shape around Galaxy collection map-over:
 
@@ -50,7 +50,7 @@ Scope is the end-to-end shape around Galaxy collection map-over:
 Out of scope:
 
 - Re-surveying individual collection operations already covered by [[iwc-transformations-survey]].
-- Rewriting leaf pattern decisions already captured in [[galaxy-collection-patterns]], [[galaxy-conditionals-patterns]], or [[galaxy-tabular-patterns]].
+- Rewriting operation pattern decisions already captured in [[galaxy-collection-patterns]], [[galaxy-conditionals-patterns]], or [[galaxy-tabular-patterns]].
 - Treating domain tools as collection patterns unless their collection lifecycle role is the reusable part.
 - Proposing pages for corpus-zero Galaxy collection capabilities.
 
@@ -102,7 +102,7 @@ Evidence:
 
 Lifecycle recipe: `domain fan-out -> reshape axes -> derive labels -> relabel -> reshape again -> mapped consensus`.
 
-This is high-density but narrow evidence. It probably belongs as a recipe section in a lifecycle MOC before it becomes a standalone leaf page.
+This is high-density but narrow evidence. It probably belongs as a recipe pattern or section in a lifecycle MOC before being treated as a broad operation.
 
 ### Shape D — sibling collection order harmonization before mapped paired processing
 
@@ -173,7 +173,7 @@ The broad Nextflow anatomy note, [[component-nextflow-pipeline-anatomy]], is sti
 
 ### Nextflow-first recipe boundaries
 
-The Nextflow-first layer probably should not replace Galaxy leaf patterns. It should route from source idioms to the Galaxy pages that implement them:
+The Nextflow-first layer probably should not replace Galaxy operation patterns. It should route from source idioms to the Galaxy pages that implement them:
 
 - `samplesheet-to-collection-input` -> [[tabular-to-collection-by-row]], [[collection-build-list-paired-with-apply-rules]], [[galaxy-collection-patterns]].
 - `keyed-join-to-identifier-synchronized-mapover` -> [[sync-collections-by-identifier]], [[harmonize-by-sortlist-from-identifiers]], [[regex-relabel-via-tabular]].
@@ -187,13 +187,13 @@ This is a strong argument for a source-pattern layer above the Galaxy pattern la
 
 ### Keep
 
-1. **`galaxy-map-over-lifecycle-patterns` MOC.** Existing pages are phase-specific. A MOC can route authors through prepare -> map -> cleanup -> sync -> reshape -> aggregate -> publish without duplicating leaf details. Evidence spans MGnify, SRA manifest, influenza, pox-virus, and MAGs.
+1. **`galaxy-map-over-lifecycle-patterns` MOC.** Existing pages are phase-specific. A MOC can route authors through prepare -> map -> cleanup -> sync -> reshape -> aggregate -> publish without duplicating operation details. Evidence spans MGnify, SRA manifest, influenza, pox-virus, and MAGs.
 
 2. **`manifest-to-mapped-collection-lifecycle` recipe.** Scope: a tabular manifest/list becomes a collection, a mapped tool runs once per row/key, and outputs are relabeled or reshaped. Strongest evidence: SRA manifest and pox-virus.
 
 3. **`cleanup-sync-and-publish-nonempty-results` recipe.** Scope: mapped outputs may be empty; clean them, use identifiers to keep siblings aligned, and gate reports on non-empty results. Strongest evidence: MGnify rRNA prediction.
 
-4. **`reshape-relabel-remap-by-collection-axis` recipe.** Scope: domain fan-out creates the wrong axis; use Apply Rules and relabeling to expose the downstream map-over axis. Evidence is dense but mostly influenza; keep as a MOC section or tentative recipe, not a broad leaf yet.
+4. **`reshape-relabel-remap-by-collection-axis` recipe.** Scope: domain fan-out creates the wrong axis; use Apply Rules and relabeling to expose the downstream map-over axis. Evidence is dense but mostly influenza; keep as a recipe page with confidence caveats, not a broad operation.
 
 5. **Nextflow-source-pattern MOC.** Scope: source-facing pages that explain Nextflow channel/operator idioms and list Galaxy pattern pages that implement each idiom. This is not an IWC pattern page in the same sense as collection leaves; it is a translation index over them.
 
@@ -207,13 +207,13 @@ This is a strong argument for a source-pattern layer above the Galaxy pattern la
 ### Drop
 
 10. Tool-anchored lifecycle pages such as `FILTER_EMPTY lifecycle` or `Apply Rules lifecycle`.
-11. Generic `map-over-in-galaxy` as a leaf page. Map-over itself is semantics; corpus-backed reusable value is in the lifecycle recipes around it.
+11. Generic `map-over-in-galaxy` as an operation page. Map-over itself is semantics; corpus-backed reusable value is in the lifecycle recipes around it.
 12. Unkeyed Nextflow `combine` / Cartesian product as a corpus-backed pattern. Treat it as review-trigger until stronger IWC evidence appears.
 
 ## 5. Open questions
 
 1. Should `galaxy-map-over-lifecycle-patterns` be a `pattern_kind: moc` page under `content/patterns/`, or remain a research survey until one conversion workflow uses it?
-2. Should lifecycle recipes be standalone leaf pages, or sections inside the lifecycle MOC that link to existing leaves?
+2. Should lifecycle recipes be standalone recipe pages, or sections inside the lifecycle MOC that link to existing operations?
 3. Is dense single-workflow evidence enough for `reshape-relabel-remap-by-collection-axis`, or should it stay survey-only until a second workflow attests the full sequence?
 4. Should source-pattern pages be a new note type, a `research/component` subtype convention, or ordinary `pattern` pages with source-specific metadata?
 5. If source-pattern pages list `implemented_by` Galaxy pattern pages, should that field be schema-validated as wiki links?

--- a/content/research/iwc-tabular-operations-survey.md
+++ b/content/research/iwc-tabular-operations-survey.md
@@ -15,7 +15,7 @@ related_notes:
   - "[[planemo-asserts-idioms]]"
   - "[[nextflow-operators-to-galaxy-collection-recipes]]"
   - "[[iwc-nearest-exemplar-selection]]"
-summary: "Corpus survey of tabular tools and operations across IWC workflows; map for the leaf pattern hierarchy on row/column data manipulation."
+summary: "Corpus survey of tabular tools and operations across IWC workflows; map for the operation pattern hierarchy on row/column data manipulation."
 ---
 
 # IWC tabular operations survey
@@ -264,9 +264,9 @@ Not visible at the tabular layer in any sampled file; sampling happens upstream 
 - **query_tabular** (16 steps) — niche but powerful (SQL window functions, multi-table JOINs). Worth a page so users don't reach for awk when SQL is genuinely cleaner.
 - **collection_column_join** (32 steps) — *the* wide-pivot idiom, and unobvious unless you already know about it. Worth a page.
 
-## 4. Candidate leaf-pattern boundaries
+## 4. Candidate operation-pattern boundaries
 
-Proposed leaf pages, each scoped tightly. Where a candidate is weak, I say so.
+Proposed operation pages, each scoped tightly. Where a candidate is weak, I say so.
 
 1. **`tabular-filter-by-column-value`** — `Filter1` with `cond: cN == 'X' or cN > Y`. Cite `sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.gxwf.yml:545`, `epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun.gxwf.yml:320`, `sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation.gxwf.yml:276`. Tools: `Filter1`. *Why:* highest-frequency single operation; the `header_lines:` parameter is an easy-to-miss correctness lever; the `cond:` mini-language is non-obvious (Python with `cN` columns). **Keep.**
 
@@ -317,7 +317,7 @@ Proposed leaf pages, each scoped tightly. Where a candidate is weak, I say so.
 - **Q1.** `Grep1` (47) vs `tp_grep_tool` (43) — semantic difference real? Both take `pattern`, `invert`, `keep_header`. Suggest the regex page recommend one and demote the other; need your call which.
 - **Q2.** `awk-in-galaxy` page depth: one page covering all 195 invocations, or split into 4 sub-pages (`awk-header-injection`, `awk-bed-synthesis`, `awk-taxonomy-split`, `awk-relabel`)? Lean: one page with idiom sections; split only if frontmatter cross-linking gets noisy.
 - **Q3.** Should `Add_a_column1` page warn against `auto_col_types: false`? Many corpus uses set it true, some false (`variation-reporting.gxwf.yml:454`); silent string-vs-numeric coercion is a real bug source. Need your call on prescriptiveness.
-- **Q4.** Is `query_tabular` deep-dive in scope for this hierarchy or its own thing? It overlaps Galaxy's broader "compute over tabular" story (R, Python, csvtk-shaped). Lean: keep it in this hierarchy as the SQL leaf.
+- **Q4.** Is `query_tabular` deep-dive in scope for this hierarchy or its own thing? It overlaps Galaxy's broader "compute over tabular" story (R, Python, csvtk-shaped). Lean: keep it in this hierarchy as the SQL operation.
 - **Q5.** Tabular format conversion is genuinely sparse (no `tab_to_csv`, no `csv_to_tab` ops; `biom_convert` is the only thing close). Write a one-paragraph "gap note" page or skip entirely?
 - **Q6.** Older tool IDs (`Grouping1`, `cat1`, `addValue/1.0.1`, `Remove beginning1`, `Paste1`, `sort1`) — do pages mention them as legacy or only the modern equivalent? Lean: mention with a "newer alternative" pointer; corpus still uses them so doc-blindness is wrong.
 - **Q7.** Out-of-scope in this survey but adjacent: `multiqc` and `tooldistillator_summarize` produce tabular outputs that downstream tabular tools then chew on. Worth a "tabular sources" cross-reference page or skip?
@@ -327,7 +327,7 @@ Proposed leaf pages, each scoped tightly. Where a candidate is weak, I say so.
 
 Resolved via `AskUserQuestion` after this survey landed. Pinned here so the next subagent inherits them without re-litigation.
 
-- **Naming axis (Q8 + general).** Operation-anchored leaf page names. Tool-anchored content is fine inside an operation-named page. Even the awk-split sub-pages get operation names (`tabular-prepend-header`, `tabular-synthesize-bed-from-3col`, `tabular-split-taxonomy-string`, `tabular-relabel-by-row-counter`); awk is the recipe, not the title.
+- **Naming axis (Q8 + general).** Operation-anchored page names. Tool-anchored content is fine inside an operation-named page. Even the awk-split sub-pages get operation names (`tabular-prepend-header`, `tabular-synthesize-bed-from-3col`, `tabular-split-taxonomy-string`, `tabular-relabel-by-row-counter`); awk is the implementation, not the title.
 - **awk page depth (Q2).** Split into 4-5 operation-named sub-pages per the bullet above. No single `awk-in-galaxy` umbrella page; cross-link the awk-as-recipe sub-pages from a §Recipes line in any operation page that uses awk.
 - **Grep1 vs tp_grep_tool (Q1).** Recommend `tp_grep_tool`. Demote `Grep1` to a "legacy alternative" footnote. Consistency with the rest of the `tp_*` family wins over slight corpus-frequency edge of `Grep1`.
 - **Format-conversion gap (Q5).** Skip. Corpus-first principle: no exemplar = no page. The §2m gap note in this survey stands as the only record.

--- a/content/research/iwc-transformations-survey.md
+++ b/content/research/iwc-transformations-survey.md
@@ -206,7 +206,7 @@ Citations:
 - `$IWC_FORMAT2/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation.gxwf.yml:553` — same shape, with `collection_column_join` downstream.
 - `$IWC_FORMAT2/virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping.gxwf.yml` steps 21, 22, 28, 44, 45 — five distinct `collapse_dataset` steps in one workflow, each immediately followed by a tabular tool (`Grep1`, `tp_find_and_replace`, `Filter1`).
 
-**Cross-reference, do not write again.** [[iwc-tabular-operations-survey]] §candidate 9 already proposes `collection-to-single-tabular-with-collapse_dataset` as a leaf pattern. Do not duplicate; cross-link from this hierarchy to the tabular page once it lands. (The collection-side page may want a one-paragraph "you're entering tabular-land" pointer.)
+**Cross-reference, do not write again.** [[iwc-tabular-operations-survey]] §candidate 9 already proposes `collection-to-single-tabular-with-collapse_dataset` as an operation pattern. Do not duplicate; cross-link from this hierarchy to the tabular page once it lands. (The collection-side page may want a one-paragraph "you're entering tabular-land" pointer.)
 
 ### Recipe E — `__EXTRACT_DATASET__` as "unbox a singleton"
 
@@ -319,7 +319,7 @@ Where a single tool has a *recurring parameter shape* the corpus uses, beyond th
 
 ## 7. Candidate pattern boundaries
 
-Operation-anchored leaf-pattern proposals. Each carries scope sketch, primary corpus citations (file:line), and an explicit keep / drop / merge call. Recipes (multi-step) are first-class candidates per `docs/PATTERNS.md`. Numbering parallels [[iwc-tabular-operations-survey]] §4 and continues from a fresh start since the hierarchies are independent.
+Operation-anchored pattern proposals. Each carries scope sketch, primary corpus citations (file:line), and an explicit keep / drop / merge call. Recipes (multi-step) are first-class candidates per `docs/PATTERNS.md`. Numbering parallels [[iwc-tabular-operations-survey]] §4 and continues from a fresh start since the hierarchies are independent.
 
 ### Keep
 

--- a/content/source-patterns/nextflow/nextflow-patterns.md
+++ b/content/source-patterns/nextflow/nextflow-patterns.md
@@ -30,7 +30,7 @@ This is the source-facing map for Nextflow-to-Galaxy conversion patterns. Use it
 
 The Galaxy pattern library remains the implementation layer. Source-pattern pages should explain what the converter saw in Nextflow, then link to the Galaxy patterns that implement or approximate that source idiom.
 
-## Intended leaf pages
+## Intended operation or recipe pages
 
 - **Samplesheet rows to Galaxy collections** — route `fromSamplesheet`, `splitCsv`, and repeated `tuple(meta, path)` inputs toward Galaxy `list`, `paired`, and `list:paired` collection construction.
 - **Keyed joins to identifier synchronization** — route `join` and `combine(by:)` toward identifier extraction, filtering, sorting, and relabeling patterns.
@@ -40,7 +40,7 @@ The Galaxy pattern library remains the implementation layer. Source-pattern page
 
 ## Metadata contract
 
-Each leaf page should list the Galaxy implementation pages in `implemented_by_patterns`. That field is machine-validated to resolve only to `type: pattern` notes.
+Each source-pattern page should list the Galaxy implementation pages in `implemented_by_patterns`. That field is machine-validated to resolve only to `type: pattern` notes.
 
 Use `review_triggers` when the Nextflow idiom has semantics Galaxy cannot preserve automatically: unmatched join keys, duplicate keys, `remainder`, arbitrary tuple records, per-element dynamic branching, or filesystem-specific `publishDir` layout.
 

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -4,16 +4,25 @@ Project-infrastructure policy for `content/patterns/` notes. Read this before ha
 pattern pages or running survey commands that propose new ones. Pattern-specific rules (for example,
 when to set `auto_col_types: true`) belong on the pattern page itself, not here.
 
-## Naming: operation-anchored
+## Pattern kinds
 
-Leaf pattern pages are named after the **operation** they describe, not the tool that implements it. Tool-anchored content is fine *inside* an operation-named page.
+Use `pattern_kind` to describe the level of organization:
+
+- `operation` — an actionable pattern centered on one workflow-construction operation. It may link to related operations but should not require a multi-step lifecycle to explain its core move.
+- `recipe` — an actionable pattern centered on an ordered composition of operations. Use this when the reusable value is sequencing, handoff, and decision points across multiple lower-level operations.
+- `moc` — a map-of-content page that routes readers to operations and recipes. It should not own a primary construction recipe.
+
+## Naming: operation- and recipe-anchored
+
+Operation pattern pages are named after the **operation** they describe, not the tool that implements it. Recipe pattern pages are named after the lifecycle or composition they describe. Tool-anchored content is fine *inside* an operation- or recipe-named page.
 
 - ✅ `tabular-filter-by-regex.md` — operation; lists `tp_grep_tool` as the recommended tool, `Grep1` as a legacy footnote.
-- ✅ `tabular-prepend-header.md` — operation; recipe is awk, but awk isn't in the title.
+- ✅ `tabular-prepend-header.md` — operation; implementation uses awk, but awk isn't in the title.
+- ✅ `cleanup-sync-and-publish-nonempty-results.md` — recipe; the value is the ordered cleanup, sibling sync, and publish gate.
 - ❌ `tp_grep_tool.md` — tool name in title.
 - ❌ `awk-in-galaxy.md` — tool name in title; split into operation-named sub-pages instead.
 
-Decided 2026-04-30 in the tabular survey (`content/research/iwc-tabular-operations-survey.md` §7). Applies to every pattern hierarchy going forward.
+Operation-anchored naming was decided 2026-04-30 in the tabular survey (`content/research/iwc-tabular-operations-survey.md` §7). Recipe pages extend the same rule to multi-step lifecycle patterns.
 
 ## Corpus-first
 

--- a/meta_schema.yml
+++ b/meta_schema.yml
@@ -45,7 +45,7 @@ properties:
       type: string
   pattern_kind:
     type: string
-    enum: [leaf, moc]
+    enum: [operation, recipe, moc]
   evidence:
     type: string
     enum: [corpus-observed, structurally-verified, corpus-and-verified, hypothesis]

--- a/packages/build-cli/src/commands/validate.ts
+++ b/packages/build-cli/src/commands/validate.ts
@@ -679,11 +679,11 @@ const LINE_REF_RE = /:\d+(?:-\d+)?$/;
 
 function validatePatternIwcExemplars(file: FileMeta, findings: CrossFileFinding[]): void {
   const exemplars = Array.isArray(file.meta.iwc_exemplars) ? file.meta.iwc_exemplars : [];
-  if (file.meta.pattern_kind === "leaf" && exemplars.length === 0) {
+  if (["operation", "recipe"].includes(String(file.meta.pattern_kind)) && exemplars.length === 0) {
     findings.push({
       path: file.path,
       severity: "warning",
-      message: "leaf pattern should declare iwc_exemplars metadata",
+      message: "operation or recipe pattern should declare iwc_exemplars metadata",
     });
   }
 

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -28,7 +28,7 @@ const baseRequired = (overrides: Record<string, unknown> = {}) => ({
 });
 
 const patternRequired = (overrides: Record<string, unknown> = {}) => baseRequired({
-  pattern_kind: "leaf",
+  pattern_kind: "operation",
   evidence: "corpus-observed",
   ...overrides,
 });
@@ -341,7 +341,7 @@ describe("validateDirectory (cross-file)", () => {
     expect(r.errors).toBeGreaterThanOrEqual(1);
   });
 
-  it("warns when leaf patterns omit iwc_exemplars during migration", () => {
+  it("warns when operation patterns omit iwc_exemplars during migration", () => {
     writeFm(path.join(dir, "patterns/pattern-x.md"), patternRequired({ title: "Pattern X" }));
 
     const r = validateDirectory({


### PR DESCRIPTION
## Summary
- replace the pattern `leaf` kind with `operation` and add first-class `recipe` pattern taxonomy
- add map-over lifecycle recipe pages for manifest map-over, cleanup/sync/publish, axis remap, and fan-in/flatten flows
- update validator wording/tests and sync the summarize-nextflow cast schema so cast checks stay clean

## Validation
- `npm run validate` passes with advisory warnings only
- `npm run test` passes, 55 tests
- `pnpm --filter @galaxy-foundry/build-cli typecheck` passes