### PR TITLE
Add Nextflow source pattern pages

### DIFF
--- a/content/Dashboard.md
+++ b/content/Dashboard.md
@@ -92,6 +92,12 @@ Generated from `dashboard_sections.json` and content frontmatter. Do not edit by
 
 | Name | Summary | Status | Revised | Rev |
 | --- | --- | --- | --- | --- |
+| [[branch-filter-ifempty-to-galaxy-filters-gates]] | Route Nextflow branch, filter, and ifEmpty channel idioms to Galaxy collection cleanup, identifier filters, when gates, or review. | draft | 2026-05-04 | 1 |
+| [[grouped-channel-to-regrouped-collection]] | Route Nextflow groupTuple, transpose, and grouped tuple payloads to Galaxy collection reshape patterns when the key is a real axis. | draft | 2026-05-04 | 1 |
+| [[keyed-join-to-identifier-synchronized-mapover]] | Route Nextflow keyed joins and combine(by:) pairings to Galaxy collection identifier sync, ordering, relabeling, or table joins. | draft | 2026-05-04 | 1 |
+| [[mapped-output-cleanup-and-publishing]] | Route Nextflow mapped-output cleanup and publishDir-style intent to Galaxy filtering, relabeling, gating, bundling, and reports. | draft | 2026-05-04 | 1 |
+| [[mix-collect-to-report-aggregation]] | Route Nextflow mix, collect, toList, and collectFile report fan-in idioms to Galaxy aggregation and bundle patterns. | draft | 2026-05-04 | 1 |
+| [[samplesheet-rows-to-galaxy-collections]] | Route Nextflow samplesheet row streams and repeated tuple inputs to Galaxy list, paired, or list:paired collections. | draft | 2026-05-04 | 1 |
 | [[nextflow-patterns]] | Use this source-pattern map to route recurring Nextflow channel and operator idioms to Galaxy implementation patterns. | draft | 2026-05-03 | 1 |
 
 ## CLI Commands

--- a/content/Index.md
+++ b/content/Index.md
@@ -84,6 +84,12 @@ Generated from content frontmatter. Do not edit by hand.
 
 ## Source Patterns
 
+- [[branch-filter-ifempty-to-galaxy-filters-gates]] — Route Nextflow branch, filter, and ifEmpty channel idioms to Galaxy collection cleanup, identifier filters, when gates, or review.
+- [[grouped-channel-to-regrouped-collection]] — Route Nextflow groupTuple, transpose, and grouped tuple payloads to Galaxy collection reshape patterns when the key is a real axis.
+- [[keyed-join-to-identifier-synchronized-mapover]] — Route Nextflow keyed joins and combine(by:) pairings to Galaxy collection identifier sync, ordering, relabeling, or table joins.
+- [[mapped-output-cleanup-and-publishing]] — Route Nextflow mapped-output cleanup and publishDir-style intent to Galaxy filtering, relabeling, gating, bundling, and reports.
+- [[mix-collect-to-report-aggregation]] — Route Nextflow mix, collect, toList, and collectFile report fan-in idioms to Galaxy aggregation and bundle patterns.
+- [[samplesheet-rows-to-galaxy-collections]] — Route Nextflow samplesheet row streams and repeated tuple inputs to Galaxy list, paired, or list:paired collections.
 - [[nextflow-patterns]] — Use this source-pattern map to route recurring Nextflow channel and operator idioms to Galaxy implementation patterns.
 
 ## CLI Commands

--- a/content/source-patterns/nextflow/branch-filter-ifempty-to-galaxy-filters-gates.md
+++ b/content/source-patterns/nextflow/branch-filter-ifempty-to-galaxy-filters-gates.md
@@ -1,0 +1,70 @@
+---
+type: source-pattern
+title: "Nextflow: branch, filter, and ifEmpty to Galaxy filters and gates"
+source: nextflow
+target: galaxy
+source_pattern_kind: operator
+implemented_by_patterns:
+  - "[[galaxy-conditionals-patterns]]"
+  - "[[conditional-run-optional-step]]"
+  - "[[conditional-route-between-alternative-outputs]]"
+  - "[[conditional-transform-or-pass-through]]"
+  - "[[conditional-gate-on-nonempty-result]]"
+  - "[[collection-cleanup-after-mapover-failure]]"
+  - "[[sync-collections-by-identifier]]"
+  - "[[cleanup-sync-and-publish-nonempty-results]]"
+review_triggers:
+  - "Per-element branch routing uses non-trivial predicates."
+  - "Branch or filter closure inspects file contents or mutates tuple metadata."
+  - "Branch has default, unknown, or discarded data whose Galaxy fate is unclear."
+  - "filter drops channel items that must keep sibling collections aligned."
+  - "ifEmpty fallback changes required outputs, collection shape, or report semantics."
+  - "Translation would rely on FILTER_NULL as primary cleanup."
+tags:
+  - source-pattern
+  - source/nextflow
+  - target/galaxy
+status: draft
+created: 2026-05-04
+revised: 2026-05-04
+revision: 1
+ai_generated: true
+related_notes:
+  - "[[nextflow-patterns]]"
+summary: "Route Nextflow branch, filter, and ifEmpty channel idioms to Galaxy collection cleanup, identifier filters, when gates, or review."
+---
+
+# Nextflow: branch, filter, and ifEmpty to Galaxy filters and gates
+
+Use this when a Nextflow summary reports `.branch`, `.filter`, or `.ifEmpty`. Do not translate syntax directly; first classify the source intent.
+
+## Source idiom classification
+
+- Static workflow-level condition -> Galaxy `when` gate.
+- Mutually exclusive alternative route -> `when` alternatives plus `pick_value`.
+- Optional transform with original fallback -> optional branch plus `pick_value`.
+- Per-element cleanup after sparse map-over -> collection cleanup/filter recipes.
+- Whole-result empty/non-empty report admission -> data-derived boolean gate.
+- Arbitrary per-element branch/filter -> review trigger.
+
+## Translation table
+
+| Nextflow source shape | Galaxy target pattern | Notes |
+| --- | --- | --- |
+| `branch` separates workflow modes from a user parameter | `[[conditional-run-optional-step]]` or `[[conditional-route-between-alternative-outputs]]` | Gate whole steps; merge if downstream needs one value. |
+| `branch` selects among peer outputs | `[[conditional-route-between-alternative-outputs]]` | Require compatible branch outputs. |
+| `filter` removes empty or failed mapped outputs | `[[collection-cleanup-after-mapover-failure]]` | Prefer empty/failed filters, not `when`. |
+| Cleaned result membership subsets a sibling collection | `[[sync-collections-by-identifier]]` | Extract identifiers from the truth collection. |
+| `ifEmpty` controls final report/export | `[[conditional-gate-on-nonempty-result]]` | Derive a boolean, then gate report/export. |
+| cleanup + sibling sync + publish gate | `[[cleanup-sync-and-publish-nonempty-results]]` | Use the lifecycle recipe. |
+
+## Pitfalls
+
+- Galaxy `when` is step-level, not arbitrary per-channel-item routing.
+- Collection filters clean collection elements; they do not choose branches.
+- Identifier filtering filters by labels; it does not inspect dataset state.
+- If dropping elements, decide whether sibling collections need membership or order sync.
+
+## Evidence posture
+
+This page is grounded in existing Foundry conditional and transformation surveys. Direct `.filter` and `.ifEmpty` fixture evidence was not regenerated during authoring.

--- a/content/source-patterns/nextflow/grouped-channel-to-regrouped-collection.md
+++ b/content/source-patterns/nextflow/grouped-channel-to-regrouped-collection.md
@@ -1,0 +1,65 @@
+---
+type: source-pattern
+title: "Nextflow: grouped channel to regrouped Galaxy collection"
+source: nextflow
+target: galaxy
+source_pattern_kind: operator
+implemented_by_patterns:
+  - "[[reshape-relabel-remap-by-collection-axis]]"
+  - "[[collection-swap-nesting-with-apply-rules]]"
+  - "[[collection-split-identifier-via-rules]]"
+  - "[[collection-flatten-after-fanout]]"
+  - "[[collection-unbox-singleton]]"
+review_triggers:
+  - "groupTuple uses explicit size, sort, or groupKey behavior."
+  - "transpose changes payload arity or relies on arbitrary tuple-record structure."
+  - "Group key is not a real Galaxy collection axis."
+  - "Grouped payload contains heterogeneous files with no shared collection element type."
+  - "Downstream logic depends on tuple field order rather than named identifiers."
+  - "Flattening would discard a grouping axis needed downstream."
+tags:
+  - source-pattern
+  - source/nextflow
+  - target/galaxy
+status: draft
+created: 2026-05-04
+revised: 2026-05-04
+revision: 1
+ai_generated: true
+related_notes:
+  - "[[nextflow-patterns]]"
+summary: "Route Nextflow groupTuple, transpose, and grouped tuple payloads to Galaxy collection reshape patterns when the key is a real axis."
+---
+
+# Nextflow: grouped channel to regrouped Galaxy collection
+
+Use this when Nextflow groups records with `groupTuple()`, reshapes grouped records with `transpose()`, or passes grouped tuple payloads that must become Galaxy collection structure.
+
+## Source signal
+
+- `groupTuple()` gathers records by key.
+- `transpose()` can expand or rotate grouped tuple payloads.
+- Grouped payloads often look collection-like, but Galaxy collections are typed axes, not arbitrary tuple records.
+
+## Translation rule
+
+First decide whether the grouping key is a real Galaxy axis such as sample, region, segment, replicate, or method.
+
+- If yes, model it as `list`, `list:list`, `list:paired`, or another concrete collection shape.
+- If the axis order is wrong, use `[[collection-swap-nesting-with-apply-rules]]` or `[[reshape-relabel-remap-by-collection-axis]]`.
+- If one identifier encodes multiple axes, use `[[collection-split-identifier-via-rules]]`.
+- If the outer axis no longer matters, use `[[collection-flatten-after-fanout]]`.
+- If the grouped result is a known singleton, use `[[collection-unbox-singleton]]`.
+- If grouping only feeds a domain merge/reduce tool, implement the reducer rather than a synthetic reshape.
+
+## Decision checklist
+
+1. Name the group key.
+2. Name the grouped payload fields.
+3. Identify the Galaxy mapped axis needed by the next tool.
+4. Choose preserve, swap, split, flatten, unbox, or reduce.
+5. Add review if tuple shape is arbitrary or lossy.
+
+## Evidence posture
+
+This page is grounded in existing Foundry notes that map `groupTuple()` and `transpose()` to collection reshape decisions. Direct fixture evidence was not regenerated during authoring.

--- a/content/source-patterns/nextflow/keyed-join-to-identifier-synchronized-mapover.md
+++ b/content/source-patterns/nextflow/keyed-join-to-identifier-synchronized-mapover.md
@@ -1,0 +1,76 @@
+---
+type: source-pattern
+title: "Nextflow: keyed join/combine(by:) to identifier-synchronized map-over"
+source: nextflow
+target: galaxy
+source_pattern_kind: operator
+implemented_by_patterns:
+  - "[[sync-collections-by-identifier]]"
+  - "[[harmonize-by-sortlist-from-identifiers]]"
+  - "[[regex-relabel-via-tabular]]"
+  - "[[tabular-join-on-key]]"
+review_triggers:
+  - "join uses remainder, failOnMismatch, failOnDuplicate, or mismatch-tolerant behavior."
+  - "join or combine(by:) can emit duplicate keys."
+  - "Key is not a stable sample or file identifier."
+  - "Tuple payload structure cannot be modeled as aligned Galaxy collections."
+  - "Unmatched elements must be preserved rather than intersected."
+  - "Downstream semantics depend on key order as well as key membership."
+  - "combine lacks by: and implies Cartesian expansion."
+tags:
+  - source-pattern
+  - source/nextflow
+  - target/galaxy
+status: draft
+created: 2026-05-04
+revised: 2026-05-04
+revision: 1
+ai_generated: true
+related_notes:
+  - "[[nextflow-patterns]]"
+summary: "Route Nextflow keyed joins and combine(by:) pairings to Galaxy collection identifier sync, ordering, relabeling, or table joins."
+---
+
+# Nextflow: keyed join/combine(by:) to identifier-synchronized map-over
+
+Use this when the source uses `join(...)` or `combine(..., by: ...)` to pair records by a key that should become or match a Galaxy collection element identifier.
+
+Do not use this for unkeyed `combine()`. Treat unkeyed combine as Cartesian expansion and review by default.
+
+## Translation rule
+
+If both sides are already Galaxy collections with matching identifiers and compatible structure, ordinary multi-input mapped wiring may be enough.
+
+If membership, order, or labels may drift, add explicit identifier synchronization before downstream map-over:
+
+1. Extract identifiers from the reference collection.
+2. Filter sibling collections by identifiers when membership must match.
+3. Sort sibling collections by an identifier file when order must match.
+4. Relabel when order is correct but useful element names were lost.
+
+## Choose implementation pattern
+
+- `[[sync-collections-by-identifier]]` for membership intersection by identifier.
+- `[[harmonize-by-sortlist-from-identifiers]]` for order sync before zip-like mapped consumption.
+- `[[regex-relabel-via-tabular]]` to restore or clean labels before keyed pairing.
+- `[[tabular-join-on-key]]` when the source join is row/table data joining rather than file collection alignment.
+
+## Decision checklist
+
+- What is the key?
+- Is the key unique on both sides?
+- Is unmatched data dropped, fatal, or preserved?
+- Does downstream need membership sync only, order sync too, or relabeling?
+- Are payloads file-like collection elements or tabular rows?
+- Is one side global or broadcast rather than keyed?
+
+## Pitfalls
+
+- Identifier sync is not order sync.
+- File-driven sort can behave like reorder plus intersection; do not use it if unmatched elements must survive.
+- Relabeling does not filter or reorder.
+- Tabular key joins are different from collection identifier sync.
+
+## Evidence posture
+
+This page is grounded in existing Foundry research and Galaxy implementation patterns. Generated Nextflow fixtures were not present during authoring, so exact operator-flag behavior remains a review trigger.

--- a/content/source-patterns/nextflow/mapped-output-cleanup-and-publishing.md
+++ b/content/source-patterns/nextflow/mapped-output-cleanup-and-publishing.md
@@ -1,0 +1,80 @@
+---
+type: source-pattern
+title: "Nextflow: mapped output cleanup and publishing"
+source: nextflow
+target: galaxy
+source_pattern_kind: lifecycle
+implemented_by_patterns:
+  - "[[cleanup-sync-and-publish-nonempty-results]]"
+  - "[[collection-cleanup-after-mapover-failure]]"
+  - "[[sync-collections-by-identifier]]"
+  - "[[regex-relabel-via-tabular]]"
+  - "[[relabel-via-rules-and-find-replace]]"
+  - "[[conditional-gate-on-nonempty-result]]"
+  - "[[collection-build-named-bundle]]"
+  - "[[tabular-concatenate-collection-to-table]]"
+  - "[[tabular-pivot-collection-to-wide]]"
+  - "[[collection-unbox-singleton]]"
+review_triggers:
+  - "publishDir encodes filesystem layout, subdirectories, or saveAs naming."
+  - "Mapped outputs are optional, sparse, empty, or failed per element."
+  - "Cleanup drops elements from one collection while siblings keep original membership."
+  - "Output labels are derived by regex, dynamic closures, task metadata, or filenames."
+  - "Final aggregation mixes channels with overlapping identifiers or unclear ordering."
+  - "Per-element branch or filter behavior controls what is published."
+  - "Publishing expects directory structure rather than labeled Galaxy outputs."
+tags:
+  - source-pattern
+  - source/nextflow
+  - target/galaxy
+status: draft
+created: 2026-05-04
+revised: 2026-05-04
+revision: 1
+ai_generated: true
+related_notes:
+  - "[[nextflow-patterns]]"
+summary: "Route Nextflow mapped-output cleanup and publishDir-style intent to Galaxy filtering, relabeling, gating, bundling, and reports."
+---
+
+# Nextflow: mapped output cleanup and publishing
+
+Use this when a Nextflow source has mapped process outputs, cleanup/filtering around sparse results, final output aggregation, or `publishDir`/output-layout intent.
+
+## Source signal
+
+- Repeated `tuple(meta, path(...))` outputs from mapped processes.
+- Operators like `map`, `filter`, `branch`, `collect`, `toList`, `collectFile`, and `mix` near outputs.
+- `publishDir` directives, output `emit:` names, report channels, or version channels.
+- Naming cleanup via metadata, regex, filenames, or task-derived labels.
+
+## Galaxy translation
+
+1. Treat mapped process output as a Galaxy collection map-over result.
+2. Drop unusable per-element outputs with empty/failed collection filters.
+3. If cleanup changes membership, sync sibling collections from cleaned identifiers.
+4. Relabel outputs when Nextflow metadata or filenames carried element identity.
+5. Aggregate report-ready collections into tables, wide matrices, bundles, or singleton outputs.
+6. Gate report/export steps when the whole result may be empty.
+7. Translate `publishDir` intent to Galaxy output labels, collections, bundles, or reports; do not preserve filesystem layout literally.
+
+## Pattern handoffs
+
+- Cleanup: `[[collection-cleanup-after-mapover-failure]]`.
+- Cleanup + sibling sync + publishing: `[[cleanup-sync-and-publish-nonempty-results]]`.
+- Sibling membership sync: `[[sync-collections-by-identifier]]`.
+- Label cleanup: `[[regex-relabel-via-tabular]]`, `[[relabel-via-rules-and-find-replace]]`.
+- Non-empty report gate: `[[conditional-gate-on-nonempty-result]]`.
+- Publishing bundles/reports: `[[collection-build-named-bundle]]`, `[[tabular-concatenate-collection-to-table]]`, `[[tabular-pivot-collection-to-wide]]`, `[[collection-unbox-singleton]]`.
+
+## Pitfalls
+
+- Cleanup is not publishing.
+- Dropping bad elements changes collection membership.
+- Identifier sync is not order sync.
+- `publishDir` paths are source-side filesystem presentation, not Galaxy workflow structure.
+- Do not translate arbitrary Groovy output-name logic from syntax alone.
+
+## Evidence posture
+
+This page is grounded in existing Foundry lifecycle and source-shape notes. `publishDir` specifics remain under-supported without direct fixture evidence.

--- a/content/source-patterns/nextflow/mix-collect-to-report-aggregation.md
+++ b/content/source-patterns/nextflow/mix-collect-to-report-aggregation.md
@@ -1,0 +1,70 @@
+---
+type: source-pattern
+title: "Nextflow: mix and collect to report aggregation"
+source: nextflow
+target: galaxy
+source_pattern_kind: operator
+implemented_by_patterns:
+  - "[[collection-flatten-after-fanout]]"
+  - "[[collection-build-named-bundle]]"
+  - "[[tabular-concatenate-collection-to-table]]"
+  - "[[tabular-pivot-collection-to-wide]]"
+  - "[[fan-in-bundle-consume-and-flatten]]"
+  - "[[conditional-gate-on-nonempty-result]]"
+review_triggers:
+  - "mix combines incompatible file or report types into one channel."
+  - "mix relies on ordering of emitted values."
+  - "collect or toList feeds a tool expecting tuple metadata not preserved as identifiers."
+  - "collectFile content concatenation has no existing Galaxy tool equivalent."
+  - "Aggregation should skip empty mapped outputs before report generation."
+  - "publishDir path or layout semantics are user-visible."
+tags:
+  - source-pattern
+  - source/nextflow
+  - target/galaxy
+status: draft
+created: 2026-05-04
+revised: 2026-05-04
+revision: 1
+ai_generated: true
+related_notes:
+  - "[[nextflow-patterns]]"
+summary: "Route Nextflow mix, collect, toList, and collectFile report fan-in idioms to Galaxy aggregation and bundle patterns."
+---
+
+# Nextflow: mix and collect to report aggregation
+
+Use this when Nextflow report, version, or QC channels converge before final reporting or publication.
+
+## Source idioms
+
+- `mix(...)` merges report, version, or QC channels.
+- `collect()` and `toList()` reduce many emitted values into one downstream invocation.
+- `collectFile(...)` materializes one file from channel values.
+
+## Galaxy translation
+
+- If source emits nested outputs for a report consumer, flatten first with `[[collection-flatten-after-fanout]]`.
+- If final artifacts should remain separate but published together, use `[[collection-build-named-bundle]]`.
+- If per-element tabular outputs should become one long table, use `[[tabular-concatenate-collection-to-table]]`.
+- If per-element id/value tables should become one wide matrix, use `[[tabular-pivot-collection-to-wide]]`.
+- If several parallel outputs feed a collection-aware consumer before flattening, use `[[fan-in-bundle-consume-and-flatten]]`.
+- If aggregation/reporting should only run when cleaned results remain, use `[[conditional-gate-on-nonempty-result]]`.
+
+## Operator-specific decisions
+
+### mix
+
+Usually this is Galaxy wiring or bundle construction. Review if order, duplicate identifiers, or mixed file types matter.
+
+### collect and toList
+
+Usually this becomes one downstream Galaxy tool invocation over a collection. Pick row-bind, wide-pivot, bundle, or flatten based on the downstream consumer shape.
+
+### collectFile
+
+Treat this as one materialized file. Prefer an explicit Galaxy tool or report output. Do not model it as collection assembly unless the downstream object remains a collection.
+
+## Evidence posture
+
+This page is grounded in existing Foundry source-shape and lifecycle notes. Direct Nextflow fixture evidence was not regenerated during authoring.

--- a/content/source-patterns/nextflow/nextflow-patterns.md
+++ b/content/source-patterns/nextflow/nextflow-patterns.md
@@ -18,6 +18,12 @@ revised: 2026-05-03
 revision: 1
 ai_generated: true
 related_notes:
+  - "[[samplesheet-rows-to-galaxy-collections]]"
+  - "[[keyed-join-to-identifier-synchronized-mapover]]"
+  - "[[grouped-channel-to-regrouped-collection]]"
+  - "[[branch-filter-ifempty-to-galaxy-filters-gates]]"
+  - "[[mix-collect-to-report-aggregation]]"
+  - "[[mapped-output-cleanup-and-publishing]]"
   - "[[iwc-map-over-lifecycle-survey]]"
   - "[[nextflow-to-galaxy-channel-shape-mapping]]"
   - "[[nextflow-operators-to-galaxy-collection-recipes]]"
@@ -32,11 +38,12 @@ The Galaxy pattern library remains the implementation layer. Source-pattern page
 
 ## Intended operation or recipe pages
 
-- **Samplesheet rows to Galaxy collections** — route `fromSamplesheet`, `splitCsv`, and repeated `tuple(meta, path)` inputs toward Galaxy `list`, `paired`, and `list:paired` collection construction.
-- **Keyed joins to identifier synchronization** — route `join` and `combine(by:)` toward identifier extraction, filtering, sorting, and relabeling patterns.
-- **Grouped channels to collection reshaping** — route `groupTuple`, `transpose`, and grouped tuple payloads toward nested collections, Apply Rules reshaping, flattening, or domain reduction.
-- **Branches to filters or gates** — route `branch`, `.filter`, and `.ifEmpty` toward Galaxy filters, conditional gates, or review triggers.
-- **Mix and collect to report aggregation** — route `mix`, `collect`, `toList`, and `collectFile` toward report aggregation, tabular collapse/pivot, and output bundles.
+- [[samplesheet-rows-to-galaxy-collections]] — route `fromSamplesheet`, `splitCsv`, and repeated `tuple(meta, path)` inputs toward Galaxy `list`, `paired`, and `list:paired` collection construction.
+- [[keyed-join-to-identifier-synchronized-mapover]] — route `join` and `combine(by:)` toward identifier extraction, filtering, sorting, and relabeling patterns.
+- [[grouped-channel-to-regrouped-collection]] — route `groupTuple`, `transpose`, and grouped tuple payloads toward nested collections, Apply Rules reshaping, flattening, or domain reduction.
+- [[branch-filter-ifempty-to-galaxy-filters-gates]] — route `branch`, `.filter`, and `.ifEmpty` toward Galaxy filters, conditional gates, or review triggers.
+- [[mix-collect-to-report-aggregation]] — route `mix`, `collect`, `toList`, and `collectFile` toward report aggregation, tabular collapse/pivot, and output bundles.
+- [[mapped-output-cleanup-and-publishing]] — route mapped output cleanup and `publishDir` intent toward filtering, relabeling, gating, bundles, and report outputs.
 
 ## Metadata contract
 

--- a/content/source-patterns/nextflow/samplesheet-rows-to-galaxy-collections.md
+++ b/content/source-patterns/nextflow/samplesheet-rows-to-galaxy-collections.md
@@ -1,0 +1,65 @@
+---
+type: source-pattern
+title: "Nextflow: samplesheet rows to Galaxy collections"
+source: nextflow
+target: galaxy
+source_pattern_kind: channel-shape
+implemented_by_patterns:
+  - "[[manifest-to-mapped-collection-lifecycle]]"
+  - "[[tabular-to-collection-by-row]]"
+  - "[[collection-build-list-paired-with-apply-rules]]"
+  - "[[galaxy-collection-patterns]]"
+review_triggers:
+  - "Samplesheet row identity is not unique or stable."
+  - "Rows encode both single-end and paired-end reads."
+  - "Paired roles need regex normalization before Galaxy construction."
+  - "Metadata fields drive downstream parameters, grouping, or branching."
+  - "Rows encode multiple files that are not paired reads."
+  - "fromSamplesheet or splitCsv logic mutates the row shape."
+tags:
+  - source-pattern
+  - source/nextflow
+  - target/galaxy
+status: draft
+created: 2026-05-04
+revised: 2026-05-04
+revision: 1
+ai_generated: true
+related_notes:
+  - "[[nextflow-patterns]]"
+summary: "Route Nextflow samplesheet row streams and repeated tuple inputs to Galaxy list, paired, or list:paired collections."
+---
+
+# Nextflow: samplesheet rows to Galaxy collections
+
+Use this when the source evidence is a samplesheet or manifest reader that emits repeated channel records such as `tuple(meta, path(reads))`.
+
+## Source idiom
+
+- `val(meta)` carries identity and attributes; it is not itself a Galaxy dataset.
+- Repeated `tuple(meta, path(file))` usually maps to a Galaxy `list` collection.
+- Repeated `tuple(meta, [R1, R2])` usually maps to `list:paired`.
+- One standalone pair may be `paired`, but repeated samples should stay `list:paired`.
+
+## Galaxy target choice
+
+| Source row payload | Galaxy shape | Implementation route |
+| --- | --- | --- |
+| One file per row | `list` | `[[tabular-to-collection-by-row]]` or direct collection input |
+| Forward/reverse reads per row | `list:paired` | `[[collection-build-list-paired-with-apply-rules]]` |
+| One pair total | `paired` | Direct paired input or paired collection construction |
+| Mixed single/paired rows | split collections or review | source review trigger |
+| Extra non-read files | parallel collections or review | source review trigger |
+
+## Implementation route
+
+1. Preserve stable sample identity from the row metadata.
+2. Decide collection type from file payload shape, not from metadata object shape alone.
+3. If the source starts as a tabular manifest, use `[[tabular-to-collection-by-row]]`.
+4. If pairedness is encoded in columns or identifiers, use `[[collection-build-list-paired-with-apply-rules]]`.
+5. If the workflow maps domain tools per row, use `[[manifest-to-mapped-collection-lifecycle]]`.
+6. After mapped steps, relabel, reshape, or sync only as needed through `[[galaxy-collection-patterns]]`.
+
+## Evidence posture
+
+This page is grounded in existing Foundry research notes, especially `[[nextflow-to-galaxy-channel-shape-mapping]]` and `[[iwc-map-over-lifecycle-survey]]`. Generated Nextflow fixtures were not present during authoring, so do not treat this page as direct fixture evidence.

--- a/site/src/components/NoteMeta.astro
+++ b/site/src/components/NoteMeta.astro
@@ -27,6 +27,7 @@ const relatedNotes = resolveAll(data.related_notes);
 const relatedPatterns = resolveAll(data.related_patterns);
 const implementedByPatterns = resolveAll(data.implemented_by_patterns);
 const relatedMolds = resolveAll(data.related_molds);
+const reviewTriggers = Array.isArray(data.review_triggers) ? data.review_triggers : [];
 const hasSources = data.sources && data.sources.length > 0;
 const hasAnything =
   showRevision ||
@@ -34,6 +35,7 @@ const hasAnything =
   (showRevision && hasSources) ||
   relatedPatterns.length > 0 ||
   implementedByPatterns.length > 0 ||
+  reviewTriggers.length > 0 ||
   relatedMolds.length > 0 ||
   relatedNotes.length > 0;
 ---
@@ -111,6 +113,17 @@ const hasAnything =
     </div>
   )}
 
+  {reviewTriggers.length > 0 && (
+    <div class="meta-pair meta-pair-block">
+      <dt>Review Triggers</dt>
+      <dd>
+        <ul class="review-trigger-list">
+          {reviewTriggers.map((trigger: string) => <li>{trigger}</li>)}
+        </ul>
+      </dd>
+    </div>
+  )}
+
   {relatedMolds.length > 0 && (
     <div class="meta-pair">
       <dt>Molds</dt>
@@ -177,6 +190,21 @@ const hasAnything =
   }
   .meta-pair dd {
     margin: 0;
+  }
+  .review-trigger-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+  .review-trigger-list li {
+    padding: 0.16rem 0.45rem;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--color-accent) 9%, transparent);
+    color: var(--color-text-secondary);
+    font-size: 0.78rem;
   }
   .meta-pair a {
     color: var(--color-link);

--- a/site/src/components/PatternBody.astro
+++ b/site/src/components/PatternBody.astro
@@ -12,7 +12,7 @@ const { entry, linkMap, placement = 'before' } = Astro.props;
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const data = entry.data as any;
 const isMap = data.pattern_kind === 'moc';
-const isLeaf = data.pattern_kind === 'leaf';
+const isImplementationPattern = ['operation', 'recipe'].includes(data.pattern_kind);
 const exemplars = Array.isArray(data.iwc_exemplars) ? data.iwc_exemplars : [];
 const relatedPatterns = (data.related_patterns ?? [])
   .map((link: string) => resolveWikiLink(link, linkMap, base))
@@ -28,7 +28,7 @@ const relatedPatterns = (data.related_patterns ?? [])
     <h2 id="pattern-map-heading">Start Here</h2>
     <p>
       This page is a map of content, not a leaf recipe. Use it to choose the right operation page,
-      then follow the linked leaf pattern for concrete Galaxy authoring guidance.
+      then follow the linked implementation pattern for concrete Galaxy authoring guidance.
     </p>
     {relatedPatterns.length > 0 && (
       <div class="pattern-map-links">
@@ -43,7 +43,7 @@ const relatedPatterns = (data.related_patterns ?? [])
   </aside>
 )}
 
-{placement === 'after' && isLeaf && exemplars.length > 0 && (
+{placement === 'after' && isImplementationPattern && exemplars.length > 0 && (
   <section class="iwc-exemplars" aria-labelledby="iwc-exemplars-heading">
     <div class="iwc-exemplars-top">
       <span class="badge badge-draft">IWC exemplars</span>

--- a/site/src/components/PatternSpotlight.astro
+++ b/site/src/components/PatternSpotlight.astro
@@ -14,8 +14,8 @@ const patterns = all
 const maps = patterns
   .filter(p => (p.data as any).pattern_kind === 'moc')
   .sort((a, b) => (a.data as any).title.localeCompare((b.data as any).title));
-const recentLeaves = patterns
-  .filter(p => (p.data as any).pattern_kind === 'leaf')
+const recentImplementationPatterns = patterns
+  .filter(p => ['operation', 'recipe'].includes((p.data as any).pattern_kind))
   .slice(0, 4);
 
 function shortTitle(title: string): string {
@@ -50,7 +50,7 @@ function shortTitle(title: string): string {
     )}
 
     <div class="spotlight-grid">
-      {recentLeaves.map((pattern, index) => {
+      {recentImplementationPatterns.map((pattern, index) => {
         const data = pattern.data as any;
         return (
           <a href={`${base}/${pattern.id}/`} class="spotlight-card no-underline tinted-shadow tinted-shadow-hover">
@@ -59,7 +59,7 @@ function shortTitle(title: string): string {
             <span class="spotlight-summary">{data.summary}</span>
             <span class="spotlight-foot">
               <span class={`badge badge-${data.status}`}>{data.status}</span>
-              <span class="font-mono">leaf</span>
+              <span class="font-mono">{data.pattern_kind}</span>
             </span>
           </a>
         );

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -109,7 +109,7 @@ const moldSchema = z.object({
 const patternSchema = z.object({
   ...baseFields,
   type: z.literal('pattern'),
-  pattern_kind: z.enum(['leaf', 'moc']),
+  pattern_kind: z.enum(['operation', 'recipe', 'moc']),
   evidence: z.enum(['corpus-observed', 'structurally-verified', 'corpus-and-verified', 'hypothesis']),
   title: z.string(),
   parent_pattern: wikiLink.optional(),

--- a/site/src/pages/[...slug].astro
+++ b/site/src/pages/[...slug].astro
@@ -77,7 +77,7 @@ const metaMode: 'full' | 'related-only' = data.type === 'mold' ? 'related-only' 
     {showMeta && <NoteMeta entry={entry} linkMap={linkMap} mode={metaMode} />}
 
     {data.type === 'mold' && <MoldHealth entry={entry} linkMap={linkMap} entryById={entryMap} />}
-    {data.type === 'pattern' && data.pattern_kind === 'leaf' && <PatternHealth entry={entry} linkMap={linkMap} entryById={entryMap} />}
+    {data.type === 'pattern' && data.pattern_kind !== 'moc' && <PatternHealth entry={entry} linkMap={linkMap} entryById={entryMap} />}
     {data.type === 'mold' && <MoldBody entry={entry} linkMap={linkMap} />}
     {data.type === 'pipeline' && <PipelineBody entry={entry} linkMap={linkMap} />}
     {data.type === 'pattern' && <PatternBody entry={entry} linkMap={linkMap} placement="before" />}

--- a/site/src/pages/patterns/index.astro
+++ b/site/src/pages/patterns/index.astro
@@ -9,12 +9,12 @@ const patterns = all
   .sort((a, b) => (a.data as any).title.localeCompare((b.data as any).title));
 
 const maps = patterns.filter(p => (p.data as any).pattern_kind === 'moc');
-const leafPatterns = patterns.filter(p => (p.data as any).pattern_kind === 'leaf');
+const implementationPatterns = patterns.filter(p => ['operation', 'recipe'].includes((p.data as any).pattern_kind));
 const topicTags = [...new Set(patterns.flatMap(p => (p.data.tags as string[]).filter(t => t.startsWith('topic/'))))]
   .sort((a, b) => a.localeCompare(b));
 
-const groups = new Map<string, typeof leafPatterns>();
-for (const pattern of leafPatterns) {
+const groups = new Map<string, typeof implementationPatterns>();
+for (const pattern of implementationPatterns) {
   const title = (pattern.data as any).title as string;
   const group = title.includes(':') ? title.split(':')[0] : 'General';
   const list = groups.get(group) ?? [];
@@ -37,7 +37,7 @@ function formatDate(d: Date): string {
           IWC-grounded workflow construction recipes.
         </h1>
         <p class="patterns-lede text-pretty">
-          Pattern maps are the entry points; leaf pages are the concrete Galaxy authoring moves that Molds can reference and casts can condense.
+          Pattern maps are the entry points; operation and recipe pages are the concrete Galaxy authoring moves that Molds can reference and casts can condense.
         </p>
       </div>
       <dl class="patterns-stats" aria-label="Pattern library stats">
@@ -98,7 +98,7 @@ function formatDate(d: Date): string {
     <section class="pattern-group" aria-labelledby={`patterns-${group.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`}>
       <div class="section-rule">
         <h2 id={`patterns-${group.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`}>{group}</h2>
-        <span class="section-tail">/ {list.length} leaf {list.length === 1 ? 'pattern' : 'patterns'}</span>
+        <span class="section-tail">/ {list.length} implementation {list.length === 1 ? 'pattern' : 'patterns'}</span>
       </div>
       <div class="pattern-grid">
         {list.map(pattern => {
@@ -108,7 +108,7 @@ function formatDate(d: Date): string {
             <article class="pattern-card tinted-shadow tinted-shadow-hover">
               <div class="pattern-card-top">
                 <span class={`badge badge-${data.status}`}>{data.status}</span>
-                <span class="pattern-date font-mono">leaf · rev {data.revision} · {formatDate(data.revised)}</span>
+                <span class="pattern-date font-mono">{data.pattern_kind} · rev {data.revision} · {formatDate(data.revised)}</span>
               </div>
               <h3 class="pattern-card-title">
                 <a href={`${base}/${pattern.id}/`}>{data.title}</a>

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -33,6 +33,17 @@ const patternRequired = (overrides: Record<string, unknown> = {}) => baseRequire
   ...overrides,
 });
 
+const sourcePatternRequired = (overrides: Record<string, unknown> = {}) => baseRequired({
+  type: "source-pattern",
+  tags: ["source-pattern", "source/nextflow", "target/galaxy"],
+  source: "nextflow",
+  target: "galaxy",
+  source_pattern_kind: "operator",
+  implemented_by_patterns: ["[[pattern-x]]"],
+  title: "Nextflow Source Pattern",
+  ...overrides,
+});
+
 describe("validateData (per-file)", () => {
   const schema = loadRealSchema();
 
@@ -173,6 +184,18 @@ describe("validateData (per-file)", () => {
   it("warns on tag coherence drift", () => {
     const r = validateData(patternRequired({ tags: ["mold"] }), schema);
     expect(r.warnings.some((w) => /expected 'pattern'/.test(w))).toBe(true);
+  });
+
+  it("accepts source-pattern metadata", () => {
+    const r = validateData(sourcePatternRequired({
+      review_triggers: ["unmatched keys need review"],
+    }), schema);
+    expect(r.errors).toEqual([]);
+  });
+
+  it("requires source-pattern implementation links", () => {
+    const r = validateData(sourcePatternRequired({ implemented_by_patterns: undefined }), schema);
+    expect(r.errors.some((e) => /implemented_by_patterns/.test(e))).toBe(true);
   });
 
   it("accepts iwc_exemplars metadata", () => {
@@ -485,6 +508,49 @@ describe("validateDirectory (cross-file)", () => {
     });
     writeFm(path.join(dir, "patterns/not-research.md"), {
       ...patternRequired({ type: "pattern", tags: ["pattern"], title: "Not Research" }),
+    });
+
+    const r = validateDirectory({
+      directory: dir,
+      schemaPath: SCHEMA_PATH,
+      tagsPath: TAGS_PATH,
+    });
+    expect(r.errors).toBeGreaterThanOrEqual(1);
+  });
+
+  it("validates source-pattern implementation links", () => {
+    writeFm(path.join(dir, "source-patterns/nextflow/source-x.md"), sourcePatternRequired({
+      implemented_by_patterns: ["[[pattern-x]]"],
+    }));
+    writeFm(path.join(dir, "patterns/pattern-x.md"), patternRequired({ title: "Pattern X" }));
+
+    const r = validateDirectory({
+      directory: dir,
+      schemaPath: SCHEMA_PATH,
+      tagsPath: TAGS_PATH,
+    });
+    expect(r.errors).toBe(0);
+  });
+
+  it("rejects source-pattern links that do not resolve", () => {
+    writeFm(path.join(dir, "source-patterns/nextflow/source-x.md"), sourcePatternRequired({
+      implemented_by_patterns: ["[[missing-pattern]]"],
+    }));
+
+    const r = validateDirectory({
+      directory: dir,
+      schemaPath: SCHEMA_PATH,
+      tagsPath: TAGS_PATH,
+    });
+    expect(r.errors).toBeGreaterThanOrEqual(1);
+  });
+
+  it("rejects source-pattern links that resolve to non-patterns", () => {
+    writeFm(path.join(dir, "source-patterns/nextflow/source-x.md"), sourcePatternRequired({
+      implemented_by_patterns: ["[[not-a-pattern]]"],
+    }));
+    writeFm(path.join(dir, "research/not-a-pattern.md"), {
+      ...baseRequired({ type: "research", tags: ["research/component"], subtype: "component" }),
     });
 
     const r = validateDirectory({


### PR DESCRIPTION
## Summary
- Add six Nextflow source-pattern pages mapping source idioms to Galaxy implementation patterns.
- Render `review_triggers` in note metadata and align site pattern-kind handling with `operation | recipe | moc`.
- Add validator coverage for source-pattern metadata and implementation links.

## Validation
- `npm run validate`
- `npm run test`
- `npm run check:index`
- `npm run check:dashboard`
- `npm run site:build`

## Known Issue
- `npm run typecheck` still fails on broader root/Astro TypeScript setup issues, including unresolved `astro:content` from root `tsc` and strict null checks in `site/src/lib/remark-wiki-links.ts`.