### PR TITLE
Vendor Nextflow schemas, add structured research digests, license infra

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+MIT License
+
+Copyright (c) 2026 John Chilton
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+Third-party content vendored into this repository (see content/schemas/ and
+content/research/) is redistributed under its own license. Vendored licenses
+live under LICENSES/. Each schema or research note that vendors upstream
+content declares its `license_file` in frontmatter; the validator (npm run
+validate) ensures every declared license_file exists.

--- a/LICENSES/README.md
+++ b/LICENSES/README.md
@@ -1,0 +1,25 @@
+# Vendored upstream licenses
+
+This directory holds verbatim copies of LICENSE files from upstream projects
+whose content the Foundry redistributes (vendored JSON Schemas, structured
+specs, etc.).
+
+The Foundry's own license is the root `LICENSE` (MIT). Files under this
+directory cover **only** the third-party content vendored alongside Foundry
+notes — they don't license the Foundry itself.
+
+Each schema or research note that redistributes upstream content declares
+`license` and `license_file: LICENSES/<file>` in its frontmatter. The
+validator (`npm run validate`) errors on:
+
+- A `license_file` that points at a missing or empty file under `LICENSES/`.
+- A `type: schema` note whose `upstream` URL is not under the Foundry repo
+  but lacks a `license_file`.
+
+## Current entries
+
+| File | License | Vendored content |
+|---|---|---|
+| `nf-core-modules.LICENSE` | MIT (Philip Ewels) | nf-core module `meta-schema.json` and subworkflow `yaml-schema.json` from [`nf-core/modules`](https://github.com/nf-core/modules). |
+| `nf-schema.LICENSE` | Apache-2.0 | `parameters_meta_schema.json` from [`nextflow-io/nf-schema`](https://github.com/nextflow-io/nf-schema). |
+| `galaxy-tool-util-ts.LICENSE` | MIT (John Chilton) | Test-format schema from [`@galaxy-tool-util/schema`](https://github.com/jmchilton/galaxy-tool-util-ts). |

--- a/LICENSES/galaxy-tool-util-ts.LICENSE
+++ b/LICENSES/galaxy-tool-util-ts.LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 John Chilton
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSES/nf-core-modules.LICENSE
+++ b/LICENSES/nf-core-modules.LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Philip Ewels
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSES/nf-schema.LICENSE
+++ b/LICENSES/nf-schema.LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/content/molds/summarize-nextflow/index.md
+++ b/content/molds/summarize-nextflow/index.md
@@ -21,6 +21,27 @@ references:
     mode: verbatim
     evidence: cast-validated
     purpose: "Validate the emitted Nextflow summary JSON and provide downstream consumers the output contract."
+  - kind: schema
+    ref: "[[nf-core-module-meta]]"
+    used_at: both
+    load: upfront
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Validate per-module meta.yml when walking nf-core modules; pins the channel IO `type` enum and tools/containers shape."
+  - kind: schema
+    ref: "[[nf-core-subworkflow-meta]]"
+    used_at: both
+    load: upfront
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Validate subworkflow meta.yml; backs Subworkflow.calls extraction via the components: declaration."
+  - kind: schema
+    ref: "[[nextflow-parameters-meta]]"
+    used_at: both
+    load: upfront
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Validate per-pipeline nextflow_schema.json (Draft 2020-12) when extracting params[]."
   - kind: research
     ref: "[[component-nextflow-pipeline-anatomy]]"
     used_at: runtime
@@ -34,11 +55,10 @@ references:
     ref: "[[component-nextflow-containers-and-envs]]"
     used_at: runtime
     load: on-demand
-    mode: verbatim
-    evidence: hypothesis
+    mode: condense
+    evidence: corpus-observed
     purpose: "Resolve container, conda, Wave, and Bioconda/Biocontainers environment evidence."
     trigger: "When extracting tools, versions, containers, conda directives, or environment equivalences."
-    verification: "Run the generated summarize-nextflow skill against nf-core/rnaseq and confirm this reference improves tool/container/environment extraction."
   - kind: research
     ref: "[[component-nextflow-testing]]"
     used_at: runtime

--- a/content/research/component-nextflow-channel-operators.md
+++ b/content/research/component-nextflow-channel-operators.md
@@ -1,0 +1,77 @@
+---
+type: research
+subtype: component
+tags:
+  - research/component
+  - source/nextflow
+component: "Nextflow Channel Operators"
+status: draft
+created: 2026-05-05
+revised: 2026-05-05
+revision: 1
+ai_generated: true
+summary: "Structured digest of Nextflow channel operators (47 entries) with cardinality and shape semantics; backs summarize-nextflow §6 edge reconciliation."
+sources:
+  - "https://docs.seqera.io/nextflow/reference/operator"
+  - "https://www.nextflow.io/docs/latest/reference/operator.html"
+  - "https://training.nextflow.io/2.1/basic_training/operators/"
+related_molds:
+  - "[[summarize-nextflow]]"
+related_notes:
+  - "[[component-nextflow-pipeline-anatomy]]"
+---
+
+# Nextflow Channel Operators
+
+Operational grounding for `[[summarize-nextflow]]` §6 ("Reconcile the workflow DAG"). The Mold's deterministic parser records the *literal* operator chain a workflow uses (`["map", "join", "groupTuple"]` in `Edge.via`); a second LLM pass reconciles the chain into a coherent `from → to` edge with resolved shape.
+
+That reconciliation badly needs operator-level cardinality semantics: which operators preserve cardinality, which fan out, which fan in, which fork. Without a structured operator catalog, the LLM is guessing.
+
+Companion structured form: `component-nextflow-channel-operators.yml`. The cast skill consumes the YAML at runtime; this prose note explains the categories and the cardinality model.
+
+## Categories
+
+Six categories, ordered by how they affect downstream channel cardinality:
+
+1. **`transform`** — emits one output per input. Cardinality preserved. (`map`, `view`, `set`, `tap`, `dump`, `ifEmpty`, `randomSample`.)
+2. **`filter`** — emits ≤ one output per input. Cardinality reduced. (`filter`, `distinct`, `unique`, `first`, `last`, `take`, `until`.)
+3. **`fan-in`** — collects N inputs into 1 (or fewer) outputs. (`collect`, `collectFile`, `groupTuple`, `reduce`, `sum`, `count*`, `max`, `min`, `toList`, `toSortedList`, `buffer`, `collate`.)
+4. **`fan-out`** — emits >1 outputs per input. (`flatten`, `flatMap`, `transpose`, `splitCsv`, `splitFasta`, `splitFastq`, `splitJson`, `splitText`.)
+5. **`combine`** — joins or concatenates two source channels. (`combine`, `concat`, `cross`, `join`, `merge`, `mix`.)
+6. **`fork`** — splits one source channel into multiple downstream channels. (`branch`, `multiMap`.) Returns a multi-channel object, not a single channel.
+7. **`terminal`** — consumes a channel without producing one. (`subscribe`.) Rare in workflow definitions; usually only in `view`-adjacent debug paths.
+
+The category determines what the resolver records as the chain's effect on shape. A chain that ends in `groupTuple` produces a list-shaped output even if every preceding operator was `transform`-category. A chain containing `branch` produces multiple downstream channels and the cast skill must record the branch keys.
+
+## Reading the YAML
+
+Each entry has:
+
+- `name` — exact operator identifier as it appears in DSL2 source.
+- `category` — one of the seven above.
+- `arity_in` — how many channels the operator consumes (`1` or `2`).
+- `cardinality` — `preserved` | `reduced` | `expanded` | `aggregated` | `forked`.
+- `output_shape_rule` — terse description of what the output channel's shape is, given the input.
+- `key_args` — the parameters that materially change the shape effect (e.g., `groupTuple(by: [0, 1])`'s grouping key).
+- `notes` — anything that surprises an inattentive reader (e.g., `merge` is deprecated in DSL2, `cross` joins on first element).
+
+The cast skill's reconciliation pass walks the chain left-to-right, applying each entry's `output_shape_rule` to the running shape estimate. When the LLM is uncertain, `Edge.notes` records the reasoning chain for review.
+
+## Anti-patterns to recognize, not resolve
+
+The Mold §6 says operator chains with deeply nested closures may produce edges flagged with low confidence. Specifically:
+
+- **`map { ... }` with substantial Groovy logic.** The closure can reshape arbitrarily; the YAML's `output_shape_rule: same shape unless closure restructures` is honest about the limit. The LLM falls back to surface inspection of the closure body.
+- **`branch { ... }` with non-obvious keys.** The branch keys are determined by the closure; static parsing recovers the keys from `branch.<name>` references in the workflow body.
+- **`multiMap { ... }` returning records.** Same as branch — the keys come from the closure's emit list.
+- **`cross` / `combine` with complex keys.** `cross` joins on the first tuple element by default; `combine(by: [0, 1])` joins on multiple elements. The reconciliation needs to know which.
+
+## Cross-references
+
+- `summarize-nextflow.md` §6 — the consumer of this digest.
+- `[[component-nextflow-pipeline-anatomy]]` — DSL2 layout context.
+- The `Edge.via` field in `[[summary-nextflow]]` — where the operator chain is recorded.
+
+## Open gaps
+
+_Updated when contact with real pipelines reveals an operator pattern the bucketing rules do not handle cleanly. Each entry names the motivating target._

--- a/content/research/component-nextflow-channel-operators.yml
+++ b/content/research/component-nextflow-channel-operators.yml
@@ -1,0 +1,370 @@
+# Nextflow channel operators — structured digest for summarize-nextflow §6.
+# Companion to component-nextflow-channel-operators.md.
+#
+# Source: https://docs.seqera.io/nextflow/reference/operator (47 operators).
+# Categories: transform | filter | fan-in | fan-out | combine | fork | terminal.
+
+operators:
+
+  # ---- transform: 1-in 1-out, cardinality preserved ----
+
+  - name: map
+    category: transform
+    arity_in: 1
+    cardinality: preserved
+    output_shape_rule: "Same shape unless closure restructures the value."
+    key_args: ["closure"]
+    notes: "Most flexible operator; closure body determines shape effect. Surface closure literal in Edge.notes when shape is non-obvious."
+
+  - name: view
+    category: transform
+    arity_in: 1
+    cardinality: preserved
+    output_shape_rule: "Pass-through; emits unchanged."
+    key_args: ["closure?"]
+    notes: "Side-effecting print; transparent for shape reasoning."
+
+  - name: set
+    category: transform
+    arity_in: 1
+    cardinality: preserved
+    output_shape_rule: "Binds channel to a name; pass-through."
+    key_args: ["name"]
+
+  - name: tap
+    category: transform
+    arity_in: 1
+    cardinality: preserved
+    output_shape_rule: "Side-channel copy; main pass-through."
+    key_args: ["name"]
+    notes: "Creates a named channel that mirrors the source; downstream sees source unchanged."
+
+  - name: dump
+    category: transform
+    arity_in: 1
+    cardinality: preserved
+    output_shape_rule: "Pass-through; debug print under -dump-channels."
+    key_args: ["tag?"]
+
+  - name: ifEmpty
+    category: transform
+    arity_in: 1
+    cardinality: preserved
+    output_shape_rule: "If source is empty, emits the supplied default; else pass-through."
+    key_args: ["default_value"]
+    notes: "Used to short-circuit empty-channel deadlocks; default may change shape."
+
+  - name: randomSample
+    category: transform
+    arity_in: 1
+    cardinality: reduced
+    output_shape_rule: "Emits N random items (or fewer); same per-item shape."
+    key_args: ["n", "seed?"]
+
+  # ---- filter: 1-in 0..1-out per input ----
+
+  - name: filter
+    category: filter
+    arity_in: 1
+    cardinality: reduced
+    output_shape_rule: "Same per-item shape; total count reduced by predicate."
+    key_args: ["predicate"]
+
+  - name: distinct
+    category: filter
+    arity_in: 1
+    cardinality: reduced
+    output_shape_rule: "Drops consecutive duplicates."
+    key_args: []
+
+  - name: unique
+    category: filter
+    arity_in: 1
+    cardinality: reduced
+    output_shape_rule: "Drops all duplicates; emits each value once."
+    key_args: []
+    notes: "Distinct from `distinct`: drops *all* dupes, not just consecutive."
+
+  - name: first
+    category: filter
+    arity_in: 1
+    cardinality: reduced
+    output_shape_rule: "Emits exactly the first value (or first matching predicate)."
+    key_args: ["predicate?"]
+
+  - name: last
+    category: filter
+    arity_in: 1
+    cardinality: reduced
+    output_shape_rule: "Emits exactly the last value."
+    key_args: []
+
+  - name: take
+    category: filter
+    arity_in: 1
+    cardinality: reduced
+    output_shape_rule: "Emits first N values."
+    key_args: ["n"]
+
+  - name: until
+    category: filter
+    arity_in: 1
+    cardinality: reduced
+    output_shape_rule: "Emits values until predicate becomes true."
+    key_args: ["predicate"]
+
+  # ---- fan-in: N-in 1-out (or aggregated) ----
+
+  - name: collect
+    category: fan-in
+    arity_in: 1
+    cardinality: aggregated
+    output_shape_rule: "Emits a single list containing all source values."
+    key_args: ["flat?"]
+    notes: "Use before processes that need all-at-once batched input. Output is one item: a list."
+
+  - name: collectFile
+    category: fan-in
+    arity_in: 1
+    cardinality: aggregated
+    output_shape_rule: "Emits one file per group; default is one file overall."
+    key_args: ["name?", "storeDir?", "by?", "sort?"]
+
+  - name: groupTuple
+    category: fan-in
+    arity_in: 1
+    cardinality: aggregated
+    output_shape_rule: "Groups tuples by key (default: first element); emits one tuple per key with grouped fields as lists."
+    key_args: ["by", "size?", "remainder?"]
+    notes: "Crucial for sample-grouped fan-in. `by: [0, 1]` groups by first two tuple elements. Without `size`, blocks until source closes — common deadlock cause."
+
+  - name: reduce
+    category: fan-in
+    arity_in: 1
+    cardinality: aggregated
+    output_shape_rule: "Emits a single accumulator value."
+    key_args: ["seed?", "closure"]
+
+  - name: sum
+    category: fan-in
+    arity_in: 1
+    cardinality: aggregated
+    output_shape_rule: "Emits a single numeric sum."
+    key_args: ["closure?"]
+
+  - name: count
+    category: fan-in
+    arity_in: 1
+    cardinality: aggregated
+    output_shape_rule: "Emits a single integer count."
+    key_args: ["predicate?"]
+
+  - name: countFasta
+    category: fan-in
+    arity_in: 1
+    cardinality: aggregated
+    output_shape_rule: "Emits a single integer (FASTA records across all source files)."
+    key_args: []
+
+  - name: countFastq
+    category: fan-in
+    arity_in: 1
+    cardinality: aggregated
+    output_shape_rule: "Emits a single integer (FASTQ records across all source files)."
+    key_args: []
+
+  - name: countJson
+    category: fan-in
+    arity_in: 1
+    cardinality: aggregated
+    output_shape_rule: "Emits a single integer (JSON records across all source files)."
+    key_args: []
+
+  - name: countLines
+    category: fan-in
+    arity_in: 1
+    cardinality: aggregated
+    output_shape_rule: "Emits a single integer (lines across all source files)."
+    key_args: []
+
+  - name: max
+    category: fan-in
+    arity_in: 1
+    cardinality: aggregated
+    output_shape_rule: "Emits the maximum value."
+    key_args: ["closure?"]
+
+  - name: min
+    category: fan-in
+    arity_in: 1
+    cardinality: aggregated
+    output_shape_rule: "Emits the minimum value."
+    key_args: ["closure?"]
+
+  - name: toList
+    category: fan-in
+    arity_in: 1
+    cardinality: aggregated
+    output_shape_rule: "Emits a single list of all values."
+    key_args: []
+    notes: "Like collect but always preserves nested structure (no flatten)."
+
+  - name: toSortedList
+    category: fan-in
+    arity_in: 1
+    cardinality: aggregated
+    output_shape_rule: "Emits a single sorted list of all values."
+    key_args: ["closure?"]
+
+  - name: buffer
+    category: fan-in
+    arity_in: 1
+    cardinality: aggregated
+    output_shape_rule: "Emits lists of N values; partial last list possible."
+    key_args: ["size", "skip?", "remainder?"]
+
+  - name: collate
+    category: fan-in
+    arity_in: 1
+    cardinality: aggregated
+    output_shape_rule: "Emits lists of N values (alias-like for buffer with stricter semantics)."
+    key_args: ["size", "step?", "remainder?"]
+
+  # ---- fan-out: 1-in N-out per input ----
+
+  - name: flatten
+    category: fan-out
+    arity_in: 1
+    cardinality: expanded
+    output_shape_rule: "Emits each element of each list-typed value separately."
+    key_args: []
+
+  - name: flatMap
+    category: fan-out
+    arity_in: 1
+    cardinality: expanded
+    output_shape_rule: "Like map then flatten; closure may emit a list per input."
+    key_args: ["closure"]
+
+  - name: transpose
+    category: fan-out
+    arity_in: 1
+    cardinality: expanded
+    output_shape_rule: "For tuples whose elements are lists, emits the cross-product; e.g. tuple(meta, [a,b,c]) → 3 tuples."
+    key_args: ["by?", "remainder?"]
+    notes: "Inverse of groupTuple in many idioms. Used to fan a sample-grouped channel back out per-replicate."
+
+  - name: splitCsv
+    category: fan-out
+    arity_in: 1
+    cardinality: expanded
+    output_shape_rule: "Emits one item per CSV row; row shape is a list (or map if header)."
+    key_args: ["header?", "sep?", "quote?", "skip?", "limit?", "decompress?"]
+    notes: "Schema-aware sample-sheet parsing today goes via nf-schema's samplesheetToList; splitCsv is the lower-level split."
+
+  - name: splitFasta
+    category: fan-out
+    arity_in: 1
+    cardinality: expanded
+    output_shape_rule: "Emits one item per FASTA record (or per chunk of size N records)."
+    key_args: ["by?", "size?", "record?"]
+
+  - name: splitFastq
+    category: fan-out
+    arity_in: 1
+    cardinality: expanded
+    output_shape_rule: "Emits one item per FASTQ record (or per chunk)."
+    key_args: ["by?", "pe?", "record?"]
+    notes: "`pe: true` splits paired-end reads with paired chunks."
+
+  - name: splitJson
+    category: fan-out
+    arity_in: 1
+    cardinality: expanded
+    output_shape_rule: "Emits one item per top-level JSON value."
+    key_args: ["path?"]
+
+  - name: splitText
+    category: fan-out
+    arity_in: 1
+    cardinality: expanded
+    output_shape_rule: "Emits one item per line (or per chunk of N lines)."
+    key_args: ["by?", "limit?", "decompress?"]
+
+  # ---- combine: 2-in (or N-in) 1-out ----
+
+  - name: combine
+    category: combine
+    arity_in: 2
+    cardinality: aggregated
+    output_shape_rule: "Cross-product of two sources, joined as concatenated tuples."
+    key_args: ["by?", "flat?"]
+    notes: "Without `by`, full cross-product. With `by: [0]`, joins on first tuple element."
+
+  - name: concat
+    category: combine
+    arity_in: 2
+    cardinality: preserved
+    output_shape_rule: "Emits all items from first source, then all items from second."
+    key_args: []
+    notes: "Order is preserved across sources."
+
+  - name: cross
+    category: combine
+    arity_in: 2
+    cardinality: aggregated
+    output_shape_rule: "Joins two sources where first tuple element matches; emits concatenated tuples."
+    key_args: []
+    notes: "Default join key is the first tuple element. Inner-join semantics."
+
+  - name: join
+    category: combine
+    arity_in: 2
+    cardinality: aggregated
+    output_shape_rule: "Inner-joins two sources by key; emits one tuple per matched key."
+    key_args: ["by?", "remainder?", "failOnDuplicate?", "failOnMismatch?"]
+    notes: "`by: 0` (default) joins on first tuple element. `remainder: true` switches to outer-join. Most common nf-core fan-in idiom for sample metadata + data join."
+
+  - name: merge
+    category: combine
+    arity_in: 2
+    cardinality: preserved
+    output_shape_rule: "Emits paired items in source order; deprecated in DSL2."
+    key_args: []
+    notes: "DEPRECATED — use join or combine instead. Surface as a warning if encountered in modern DSL2."
+
+  - name: mix
+    category: combine
+    arity_in: 2
+    cardinality: preserved
+    output_shape_rule: "Interleaves items from N sources; arrival order, no key matching."
+    key_args: []
+    notes: "Common for assembling versions/multiqc inputs from heterogeneous processes."
+
+  # ---- fork: 1-in N-out (multiple channels) ----
+
+  - name: branch
+    category: fork
+    arity_in: 1
+    cardinality: forked
+    output_shape_rule: "Returns a multi-channel object; each branch is a separate downstream channel."
+    key_args: ["closure with branch labels"]
+    notes: "Branch keys come from the closure body (`branch.foo`, `branch.bar`). Cast skill must record the keys for downstream wiring."
+
+  - name: multiMap
+    category: fork
+    arity_in: 1
+    cardinality: forked
+    output_shape_rule: "Returns a multi-channel object; closure emits per-channel values."
+    key_args: ["closure with emit list"]
+    notes: "Closure's emit names define the downstream channels."
+
+  # ---- terminal: 1-in 0-out ----
+
+  - name: subscribe
+    category: terminal
+    arity_in: 1
+    cardinality: aggregated
+    output_shape_rule: "Side-effecting; no downstream channel."
+    key_args: ["closure", "onNext?", "onComplete?", "onError?"]
+    notes: "Rarely seen in workflow definitions; mostly debug paths."

--- a/content/research/component-nextflow-containers-and-envs.md
+++ b/content/research/component-nextflow-containers-and-envs.md
@@ -5,34 +5,253 @@ tags:
   - research/component
   - source/nextflow
   - target/galaxy
-component: "Nextflow containers and environments"
+component: "Nextflow Containers and Environments"
 status: draft
 created: 2026-05-01
-revised: 2026-05-04
-revision: 2
+revised: 2026-05-05
+revision: 3
 ai_generated: true
-summary: "Maps Nextflow container and conda evidence to Galaxy package and container requirements."
+summary: "Container URL grammar (depot, BioContainers, mulled-v2, Wave, ORAS) and conda directive resolution rules backing summarize-nextflow §5."
+sources:
+  - "https://docs.seqera.io/nextflow/process"
+  - "https://docs.seqera.io/nextflow/reference/process"
+  - "https://github.com/nf-core/modules/blob/master/modules/nf-core/fastqc/main.nf"
+  - "https://github.com/nf-core/modules/blob/master/modules/nf-core/multiqc/main.nf"
+  - "https://github.com/nf-core/modules/blob/master/modules/nf-core/dragmap/align/main.nf"
+  - "https://github.com/nf-core/modules/blob/master/modules/nf-core/seqkit/sample/main.nf"
+  - "https://github.com/nf-core/modules/blob/master/modules/meta-schema.json"
+  - "https://github.com/nf-core/modules/blob/master/modules/environment-schema.json"
+  - "https://github.com/nf-core/tools/blob/master/nf_core/module-template/main.nf"
+  - "https://github.com/BioContainers/multi-package-containers"
+  - "https://github.com/BioContainers/singularity-build-bot"
+  - "https://depot.galaxyproject.org/singularity/"
+  - "https://biocontainers.pro/registry"
+  - "https://bioconda.github.io/"
+  - "https://docs.seqera.io/wave"
+  - "https://nf-co.re/events/2024/bytesize_pipeline_container_urls"
 related_molds:
   - "[[summarize-nextflow]]"
   - "[[author-galaxy-tool-wrapper]]"
   - "[[summarize-galaxy-tool]]"
-sources:
-  - "https://www.nextflow.io/docs/latest/container.html"
-  - "https://www.nextflow.io/docs/latest/conda.html"
-  - "https://docs.galaxyproject.org/en/latest/dev/schema.html#tool-requirements"
-  - "https://docs.galaxyproject.org/en/latest/admin/container_resolvers.html"
-  - "https://docs.galaxyproject.org/en/latest/admin/conda_faq.html"
-  - "https://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html"
-  - "https://biocontainers.pro/registry"
+related_notes:
+  - "[[component-nextflow-pipeline-anatomy]]"
+  - "[[component-nf-core-tools]]"
+  - "[[component-nextflow-inspect]]"
 ---
 
 # Nextflow Containers and Environments
 
-This note maps Nextflow process-level runtime evidence into Galaxy tool XML `<requirements>` evidence. It is for `[[summarize-nextflow]]`, `[[author-galaxy-tool-wrapper]]`, and `[[summarize-galaxy-tool]]` when a source process has container or conda evidence that could explain executable dependencies.
+Operational grounding for `[[summarize-nextflow]]` §5 ("Build the tool registry"). Resolves the regex-pinned URL grammar a static walker needs to bucket each NF process's `container` and `conda` directives into the right `tools[]` field, and surfaces the cases the cast skill must recognize but cannot resolve without runtime help.
 
-## Decision
+Companion structured form: `component-nextflow-containers-and-envs.yml` (regex + example + derivation rule per form). Agents and resolver code consume the YAML; this prose note explains the *why* and pins the canonical examples.
 
-Prefer Galaxy package requirements when the Nextflow evidence names Bioconda or conda packages with versions. Add explicit Galaxy container requirements only when the source gives a stable container URI or when package requirements cannot adequately describe the runtime.
+Cross-link rather than restate: ternary directive mechanics, `nextflow inspect` runtime resolution, and the `nf-core download` flow are documented in `[[component-nextflow-inspect]]` and `[[component-nf-core-tools]]`. This note is grammar + bucketing rules.
+
+## Sources of truth
+
+- `nextflow-io/nextflow` — `container` and `conda` directive semantics: [docs.seqera.io/nextflow/process](https://docs.seqera.io/nextflow/process), source at `modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy`.
+- `nf-core/modules` — module library + the **module template `main.nf`** (the canonical ternary form): [`modules/nf-core/`](https://github.com/nf-core/modules/tree/master/modules/nf-core), [`modules/meta-schema.json`](https://github.com/nf-core/modules/blob/master/modules/meta-schema.json), [`modules/environment-schema.json`](https://github.com/nf-core/modules/blob/master/modules/environment-schema.json).
+- `nf-core/tools` — module scaffolding template at [`nf_core/module-template/main.nf`](https://github.com/nf-core/tools/blob/master/nf_core/module-template/main.nf).
+- `BioContainers/multi-package-containers` — mulled-v2 README + `mulled-hash` CLI documentation: [README.md](https://github.com/BioContainers/multi-package-containers/blob/master/README.md).
+- `BioContainers/singularity-build-bot` — quay.io → depot.galaxyproject.org Singularity mirroring service.
+- `depot.galaxyproject.org/singularity/` — public BioContainers Singularity mirror; CVMFS-distributed.
+- Seqera Wave — [docs.seqera.io/wave](https://docs.seqera.io/wave). Live URL-pattern docs were sparse at the time of this note; Wave URL grammar below is grounded in real nf-core modules (multiqc, seqkit/sample) plus the meta-schema's `^oras://.*$` constraint.
+
+## The canonical ternary directive
+
+The current nf-core module template shipped by `nf-core/tools` produces a `container` directive of the form:
+
+```groovy
+conda "${moduleDir}/environment.yml"
+container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+    '<singularity-branch-url>':
+    '<docker-branch-url>' }"
+```
+
+— from [`nf_core/module-template/main.nf`](https://github.com/nf-core/tools/blob/master/nf_core/module-template/main.nf) lines 27-30.
+
+The Mold body §5 currently encodes the **older** form `workflow.containerEngine == 'singularity'`. Both forms appear in the field today because modules have been generated across multiple template eras. **The cast skill's tokenizer must accept both.** Concretely, a reasonable predicate-detection pattern is:
+
+```
+workflow\.containerEngine\s*(?:==\s*'singularity'|in\s*\[\s*'singularity'(?:\s*,\s*'apptainer')?\s*\])
+```
+
+Beyond the predicate, every nf-core module the validator has seen in 2025+ shares the `&& !task.ext.singularity_pull_docker_container` clause. The semantics of that clause are documented inline with the resolution rules below.
+
+### What `task.ext.singularity_pull_docker_container` does
+
+It is a per-process escape hatch. When `true`, the ternary collapses to the docker-branch URL even under a Singularity engine, forcing Singularity/Apptainer to pull and convert the Docker BioContainer in place of the Galaxy depot Singularity image. The toggle exists for processes whose Singularity image is missing or broken on `depot.galaxyproject.org`.
+
+A GitHub code search across the `nf-core` org for `singularity_pull_docker_container = true` in committed configs returns zero hits. The flag is reserved for ad-hoc per-task overrides, not normal configuration. **Operational consequence for the resolver:** the singularity branch is the URL that actually runs under a Singularity engine; the docker branch is what runs under Docker/Podman. Bucket both, but treat the singularity branch as authoritative for its host registry.
+
+## Container URL forms
+
+Five forms account for essentially every container URL in current nf-core modules. Each form's regex, example (verbatim), bucket field (matches `summary-nextflow.schema.json`'s `tools[]`), and derivation rule for `(name, version)`:
+
+### 1. Galaxy depot Singularity (BioContainers mirror)
+
+- **Regex:** `^https://depot\.galaxyproject\.org/singularity/(?P<name>[^:/]+):(?P<version>[^-][^-]*)--(?P<build>[^/]+)$`
+- **Verbatim example:** `https://depot.galaxyproject.org/singularity/fastqc:0.12.1--hdfd78af_0` — [`modules/nf-core/fastqc/main.nf`](https://github.com/nf-core/modules/blob/master/modules/nf-core/fastqc/main.nf) line 7.
+- **Bucket:** `tools[].singularity`.
+- **Derivation:** path basename's `<name>:<version>--<build>` triple. `name` and `version` extracted directly. `--<build>` is the Bioconda build string.
+- **Provenance:** every Bioconda recipe that builds successfully produces a corresponding BioContainer Docker image on `quay.io/biocontainers`; [`BioContainers/singularity-build-bot`](https://github.com/BioContainers/singularity-build-bot) monitors quay.io and uploads each image's Singularity conversion to `depot.galaxyproject.org/singularity`. The depot is further CVMFS-mirrored. **The depot URL is dual to the quay biocontainer URL — same image, different registry/format.** This is the fact that makes round-trip to Galaxy `<requirement type="package">` clean for these forms.
+
+### 2. Quay BioContainers Docker
+
+- **Regex:** `^quay\.io/biocontainers/(?P<name>[^:/]+):(?P<version>[^-][^-]*)--(?P<build>[^/]+)$`
+- **Verbatim example:** `quay.io/biocontainers/fastqc:0.12.1--hdfd78af_0` — fastqc module, line 8.
+- **Bucket:** `tools[].biocontainer`.
+- **Derivation:** identical triple to the depot URL; the `<name>:<version>--<build>` for any given (name,version,build) is identical between depot Singularity and quay Docker. The cast skill can populate `tools[].biocontainer` and `tools[].singularity` together when both URLs share the suffix.
+
+### 3. Mulled-v2 multi-package containers
+
+- **Regex (depot Singularity):** `^https://depot\.galaxyproject\.org/singularity/mulled-v2-(?P<hash>[0-9a-f]+):(?P<verhash>[0-9a-f]+)-\d+$`
+- **Regex (quay Docker):** `^quay\.io/biocontainers/mulled-v2-(?P<hash>[0-9a-f]+):(?P<verhash>[0-9a-f]+)-\d+$`
+- **Verbatim example:** `https://depot.galaxyproject.org/singularity/mulled-v2-580d344d9d4a496cd403932da8765f9e0187774d:df80ed8d23d0a2c43181a2b3dd1b39f2d00fab5c-0` paired with `quay.io/biocontainers/mulled-v2-580d344d9d4a496cd403932da8765f9e0187774d:df80ed8d23d0a2c43181a2b3dd1b39f2d00fab5c-0` — [`modules/nf-core/dragmap/align/main.nf`](https://github.com/nf-core/modules/blob/master/modules/nf-core/dragmap/align/main.nf) lines 7-9. The corresponding `environment.yml` packs three deps: `bioconda::dragmap=1.2.1`, `bioconda::samtools=1.19.2`, `conda-forge::pigz=2.3.4`.
+- **Bucket:** same as the underlying registry — depot URL → `tools[].singularity`; quay URL → `tools[].biocontainer`. The cast skill records the `mulled-v2` form by setting `tools[].name` to a synthetic identifier (e.g. `<primary>_mulled` or the hash itself) and surfacing the contributing package list from the sibling `environment.yml`.
+- **Hash derivation:** the `<hash>` is a content-addressed digest of the **sorted package name list**; the `<verhash>` is a digest including pinned versions/builds; the `-0` suffix is a build counter. The function is implemented in `galaxy-tool-util` and exposed via the `mulled-hash` CLI:
+  ```
+  $ mulled-hash r-shiny=1.8.1.1,bioconductor-phyloseq=1.46.0,r-curl=5.1.0,r-biocmanager=1.30.23
+  mulled-v2-3f22c1adbbead1a8888120ab6f59758c0a05e86b:e77384d3aca3277e7caf46a60e0eb848aec72912
+  ```
+  ([BioContainers/multi-package-containers README](https://github.com/BioContainers/multi-package-containers#finding-mulled-hash-names-for-containers)).
+- **Reverse lookup (hash → packages):** there is **no first-class registry mapping the hash back to its package list**. The README is explicit: "you usually don't search for containers, you construct the hash and pull them down." The cast skill's path forward is: read the sibling `environment.yml`, treat its `dependencies:` list as the authoritative tool inventory, and record the mulled-v2 URL as the container reference for the combined set. The BioContainers `mulled-search` CLI exists but is for forward (package → existing container) lookup.
+
+### 4. Wave / Seqera community registry
+
+Two URL hosts; both are Wave-built, both encode a content digest in the URL.
+
+- **Wave Docker (Wave-as-Docker-image):**
+  - **Regex:** `^community\.wave\.seqera\.io/library/(?P<name>[^:/]+):(?P<version>[^-]+)--(?P<digest>[0-9a-f]+)$`
+  - **Verbatim:** `community.wave.seqera.io/library/multiqc:1.34--db7c73dae76bc9e6` — [`modules/nf-core/multiqc/main.nf`](https://github.com/nf-core/modules/blob/master/modules/nf-core/multiqc/main.nf) line 9.
+- **Wave Singularity via OCI registry blob:**
+  - **Regex:** `^https://community-cr-prod\.seqera\.io/docker/registry/v2/blobs/sha256/[0-9a-f]{2}/(?P<digest>[0-9a-f]{64})/data$`
+  - **Verbatim:** `https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/1b/1bef8af6be88c5733461959c46ac8ef73d18f65277f62a1695d0e1633054f9c2/data` — multiqc module, line 8.
+- **Wave Singularity via ORAS (newer, preferred):**
+  - **Regex:** `^oras://community\.wave\.seqera\.io/library/(?P<name>[^:/]+):(?P<version>[^-]+)--(?P<digest>[0-9a-f]+)$`
+  - **Verbatim:** `oras://community.wave.seqera.io/library/seqkit:2.13.0--205358a3675c7775` — [`modules/nf-core/seqkit/sample/main.nf`](https://github.com/nf-core/modules/blob/master/modules/nf-core/seqkit/sample/main.nf) lines 7-8. The ORAS protocol pulls Singularity images directly from an OCI-conformant registry without HTTP-blob intermediation. The nf-core module meta-schema explicitly declares `^oras://.*$` as a legal Singularity-container `name` value.
+- **Bucket:** `tools[].wave` for **all three** Wave forms.
+- **Derivation:** `name` and `version` are recoverable from the `community.wave.seqera.io/library/<name>:<version>--<digest>` Docker and ORAS forms. The bare `community-cr-prod.seqera.io/...sha256/.../data` Singularity form encodes only a digest; **name + version are not recoverable from this URL alone** — read them from the sibling Docker branch URL or the `environment.yml`. The pattern multiqc uses (Wave Docker on the docker branch + Wave-CR Singularity on the singularity branch) is by design.
+- **Provenance differs from BioContainers.** Wave images are Seqera-built on demand from Conda specs (and other recipes); they are **not** the BioContainers ecosystem and they are **not** mirrored to `depot.galaxyproject.org`. For Galaxy translation purposes, a Wave reference cannot be converted to a Galaxy `<requirement type="package">` line by direct mapping — the `environment.yml` is the round-trippable source.
+
+### Bucketing rule (resolver hypothesis)
+
+The Mold's §5 prose buckets by *ternary branch* ("singularity branch → `tools[].singularity`; fallthrough → `tools[].biocontainer | wave | docker`"). Every example in current nf-core modules can also be bucketed by *URL prefix*. **The two rules disagree** on multiqc (singularity branch is `community-cr-prod.seqera.io/...` — under the branch rule, `tools[].singularity`; under the URL-prefix rule, `tools[].wave`) and seqkit/sample (singularity branch is `oras://community.wave.seqera.io/...` — same disagreement).
+
+**Foundry hypothesis to confirm with the Mold author:** bucket by URL prefix.
+
+- `tools[].singularity` reserved for `https://depot.galaxyproject.org/singularity/...` and any non-Wave `oras://` URL.
+- `tools[].biocontainer` for `quay.io/biocontainers/...` and `docker.io/biocontainers/...` (rare; see below).
+- `tools[].wave` for the three Wave forms above, regardless of which ternary branch produced them.
+- `tools[].docker` for any other registry (`docker.io/<org>/<name>`, `<registry>/<org>/<name>`, etc.).
+
+URL-prefix bucketing keeps the `tools[]` fields semantically uniform — `tools[].wave` always means "Seqera-built, no Bioconda dual" — at the cost of `tools[].singularity` no longer being "what runs under Singularity for this process." If the latter framing is preferred, it should be a separate field on `processes[]` (e.g. `process.container_singularity` / `process.container_docker`), not a reuse of `tools[]`.
+
+### 5. Generic Docker (escape hatch)
+
+Anything not matching the four canonical forms — `docker.io/<org>/<name>:<tag>`, `<registry>/<org>/<name>@sha256:<digest>`, no-namespace fallback, etc.
+
+- **Regex (loose):** `^(?:(?P<registry>[^/]+)/)?(?P<path>[^:@]+)(?:[:](?P<tag>[^@]+))?(?:@(?P<digest>sha256:[0-9a-f]+))?$`
+- **Bucket:** `tools[].docker`.
+- **Derivation:** best-effort; the cast skill records the URL as a string and leaves `(name, version)` to the LLM-driven prose pass when no other signal exists.
+
+### Aside: legacy `biocontainers/<name>...` (docker.io alias)
+
+The Mold body lists `biocontainers/<name>:<version>--<build>` (no registry prefix; resolves to docker.io's `biocontainers` org) as a docker-branch form. In current nf-core, this is rare. A GitHub code search for explicit `docker.io/biocontainers/` across the `nf-core` org returns 22 hits; bare `biocontainers/...` (no `quay.io/`) appears in a handful of legacy modules. The **same image** is published to both registries by the BioContainers production pipeline, so the round-trip semantics are identical to the quay form. Bucket as `tools[].biocontainer` either way.
+
+## Conda directive resolution
+
+Two legal forms today; one dominates.
+
+### Modern: file reference
+
+```groovy
+conda "${moduleDir}/environment.yml"
+```
+
+— virtually every current nf-core module (fastqc, multiqc, dragmap/align, seqkit/sample, …). The cast skill must:
+
+1. Resolve `${moduleDir}` to the directory holding `main.nf` (not the pipeline root).
+2. Read the sibling `environment.yml`.
+3. Parse `dependencies:` for the package list.
+
+The file's structure is fixed by [`modules/environment-schema.json`](https://github.com/nf-core/modules/blob/master/modules/environment-schema.json):
+
+```yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::fastqc=0.12.1
+```
+
+— [`modules/nf-core/fastqc/environment.yml`](https://github.com/nf-core/modules/blob/master/modules/nf-core/fastqc/environment.yml).
+
+The schema enforces:
+- `channels` must not include `default`.
+- `dependencies` items must match `^.*[^><]=[^><].*$` — **i.e. a `=` (not `>=` or `<=`) version pin is required**, ensuring reproducibility.
+- `name:` must be **absent** (`"not": { "required": ["name"] }`).
+- `pip:` sub-dependencies must use `==` pinning.
+
+### Channel ordering
+
+The `nf-core/modules` lint check requires `conda-forge` first, then `bioconda`. Conda resolves channels in declaration order and `conda-forge` carries general dependencies that bioconda recipes typically build against, so the order matters at install time. The schema does not enforce ordering; the lint does.
+
+### Single-dep vs multi-dep
+
+| Pattern | Container directive | `tools[].bioconda` |
+|---|---|---|
+| Single `bioconda::<name>=<version>` | Pairs with simple `<name>:<version>--<build>` (Galaxy depot / quay) | `bioconda::<name>=<version>` (verbatim) |
+| Multiple `<channel>::<name>=<version>` deps | Pairs with `mulled-v2-<hash>:<verhash>-0` | List of all dep strings; `tools[].name` becomes a synthetic combined name |
+| Mixed bioconda + conda-forge (e.g. dragmap, samtools, pigz) | mulled-v2 (bioconda+conda-forge can be combined) | All deps listed |
+
+Only `bioconda::` deps round-trip cleanly to a Galaxy `<requirement type="package">` line. `conda-forge::` deps are typically system-level (pigz, openjdk) and have to be matched against the Galaxy `requirement` namespace separately — they exist in Bioconda's mulled multi-package output but are not Bioconda recipes themselves.
+
+### Legacy: literal string
+
+```groovy
+conda "bioconda::fastqc=0.12.1"
+```
+
+— still parses; the cast skill should accept it as identical to a single-dep `environment.yml` and populate `tools[].bioconda` from the literal string.
+
+## Tool name and version derivation
+
+In rough order of reliability:
+
+1. **`environment.yml` `dependencies[]`** — most reliable. `bioconda::<name>=<version>` directly yields `(name, version)`. Pair with `<name>:<version>` grep against the container URL to confirm.
+2. **Galaxy depot / quay URL path basename** — `<name>:<version>--<build>`. Reliable for non-mulled forms.
+3. **Wave Docker / Wave ORAS URL path basename** — `library/<name>:<version>--<digest>`. Reliable.
+4. **Wave-CR Singularity URL** — only a content digest; **name + version not recoverable from this URL**. Resolve from sibling docker branch or `environment.yml`.
+5. **Mulled-v2** — hash-only; resolve from sibling `environment.yml`.
+6. **Generic Docker** — best-effort path-basename split.
+
+For the `tools[]` deduplication step in the Mold's §5: dedupe by `(name, version)` after the resolution pass. Mulled-v2 entries dedupe under their synthetic name and the underlying Bioconda deps are *not* split into separate `tools[]` entries (they belong to one container). This is the field-name parity gxy-sketches `ToolSpec` was designed for: one `tools[]` entry per container/env, not per binary.
+
+## Edge cases the resolver must recognize
+
+These are not warnings to log; they are forms the bucketing rules above must continue to handle correctly. Listed in order of how often the cast skill is likely to hit them.
+
+- **Modern ternary predicate variant.** `workflow.containerEngine in ['singularity', 'apptainer']` (current nf-core template) and `workflow.containerEngine == 'singularity'` (older form, still in the Mold's prose) must both parse.
+- **`task.ext.singularity_pull_docker_container` toggle.** Per-task override that flips the ternary to the docker branch even under Singularity. Effectively unused in committed nf-core configs (0 hits), but the directive expression must still parse cleanly.
+- **`conf/modules.config` `withName:` overrides.** Pipeline-level `process { withName: 'PROC' { container = '...' } }` blocks override the module-level directive. The pipeline template ships these by convention — see `nf_core/pipeline-template/conf/modules.config`. The cast skill cannot resolve these statically with regex over `.nf` files; either run `nextflow inspect` (which honors them) or surface the override as an unresolved directive.
+- **`params.*` interpolation in directives.** `container = "registry/${params.image_tag}"` resolves at config-build time. Without a `-params-file` or CLI override, interpolation produces `null`. See `[[component-nextflow-inspect]]` for the runtime behavior; the static walker should report the raw string.
+- **Closure-form directives.** `container = { task.ext.foo ? 'A' : 'B' }`. Nextflow allows the directive itself to be a closure rather than a GString. Less common than the GString ternary, but legal.
+- **Multi-tool processes.** A single process running multiple binaries (e.g. `dragmap | samtools`) backed by a mulled-v2 container. The Mold notes `Process.tool` is nullable for these — populate by linking to the `tools[]` mulled entry, not by splitting one process across multiple `tools[]` entries.
+- **Mixed BioContainer + Wave in one pipeline.** Common in 2025 nf-core: fastqc still ships a quay BioContainer, multiqc has migrated to Wave. Both forms appear in the same pipeline's `tools[]`. No special handling required if URL-prefix bucketing is used.
+
+## Galaxy translation (handoff to `[[author-galaxy-tool-wrapper]]`)
+
+The `tools[]` block this Mold produces is the input contract for Galaxy `<requirements>` translation. The mapping is:
+
+- `tools[].bioconda` (`bioconda::<name>=<version>`) → `<requirement type="package" version="<version>">name</requirement>`. Galaxy resolves this through the same Bioconda → BioContainers chain documented above.
+- `tools[].biocontainer` / `tools[].singularity` → cross-validation that the Bioconda requirement resolves to a real BioContainer image. If `tools[].bioconda` is absent (Wave-only modules), the cast skill cannot emit a clean `<requirement>` and must fall back to the `environment.yml` deps.
+- `tools[].wave` alone → no Galaxy round-trip. The wrapper authoring Mold must surface this as an unresolved tool.
+- `tools[].docker` alone → no Galaxy round-trip; emit as a tool that requires a Galaxy `<container>` directive rather than `<requirement>`.
+
+The `[[author-galaxy-tool-wrapper]]` Mold owns this translation; this note documents the contract on the producer side.
 
 The safest default for newly authored Galaxy wrappers is:
 

--- a/content/research/component-nextflow-containers-and-envs.yml
+++ b/content/research/component-nextflow-containers-and-envs.yml
@@ -1,0 +1,125 @@
+# Container & conda directive cheatsheet for summarize-nextflow §5.
+# Companion to component-nextflow-containers-and-envs.md.
+#
+# Matching contract: regexes match URL/string token *content* after the cast skill
+# has unwrapped the directive's outer "${ ... ? '<url>' : '<url>' }" GString.
+# The walker is responsible for extracting both ternary-branch strings before
+# applying these patterns.
+#
+# Bucketing rule: by URL prefix (NOT by ternary branch). See note §"Bucketing rule".
+
+ternary_predicate:
+  description: "Detect either form of the canonical nf-core ternary predicate."
+  patterns:
+    - "workflow\\.containerEngine\\s*==\\s*'singularity'"
+    - "workflow\\.containerEngine\\s+in\\s*\\[\\s*'singularity'(?:\\s*,\\s*'apptainer')?\\s*\\]"
+  also_typical: "&& !task.ext.singularity_pull_docker_container"
+
+container_forms:
+
+  - id: galaxy_singularity_simple
+    regex: "^https://depot\\.galaxyproject\\.org/singularity/(?P<name>[^:/]+):(?P<version>[^-][^-]*)--(?P<build>[^/]+)$"
+    example: "https://depot.galaxyproject.org/singularity/fastqc:0.12.1--hdfd78af_0"
+    source: "modules/nf-core/fastqc/main.nf"
+    resolves_to_field: "singularity"
+    derivation_rule: "name+version+build from path basename; Bioconda dual exists at quay.io/biocontainers/<name>:<version>--<build>."
+    notes: "BioContainers Singularity mirror; CVMFS-distributed; produced by singularity-build-bot from quay.io."
+
+  - id: galaxy_singularity_mulled
+    regex: "^https://depot\\.galaxyproject\\.org/singularity/mulled-v2-(?P<hash>[0-9a-f]+):(?P<verhash>[0-9a-f]+)-(?P<rev>\\d+)$"
+    example: "https://depot.galaxyproject.org/singularity/mulled-v2-580d344d9d4a496cd403932da8765f9e0187774d:df80ed8d23d0a2c43181a2b3dd1b39f2d00fab5c-0"
+    source: "modules/nf-core/dragmap/align/main.nf"
+    resolves_to_field: "singularity"
+    derivation_rule: "Hash and verhash are not reversible to package list; read sibling environment.yml dependencies[] for the canonical inventory. Use galaxy-tool-util mulled-hash to verify."
+    notes: "Multi-package container; one tools[] entry, dependencies[] is the source of truth."
+
+  - id: quay_biocontainer_simple
+    regex: "^quay\\.io/biocontainers/(?P<name>[^:/]+):(?P<version>[^-][^-]*)--(?P<build>[^/]+)$"
+    example: "quay.io/biocontainers/fastqc:0.12.1--hdfd78af_0"
+    source: "modules/nf-core/fastqc/main.nf"
+    resolves_to_field: "biocontainer"
+    derivation_rule: "Same triple as galaxy_singularity_simple; pair when both URLs share <name>:<version>--<build>."
+
+  - id: quay_biocontainer_mulled
+    regex: "^quay\\.io/biocontainers/mulled-v2-(?P<hash>[0-9a-f]+):(?P<verhash>[0-9a-f]+)-(?P<rev>\\d+)$"
+    example: "quay.io/biocontainers/mulled-v2-580d344d9d4a496cd403932da8765f9e0187774d:df80ed8d23d0a2c43181a2b3dd1b39f2d00fab5c-0"
+    source: "modules/nf-core/dragmap/align/main.nf"
+    resolves_to_field: "biocontainer"
+    derivation_rule: "Same as galaxy_singularity_mulled; read sibling environment.yml."
+
+  - id: docker_io_biocontainer_alias
+    regex: "^(?:docker\\.io/)?biocontainers/(?P<name>[^:/]+):(?P<version>[^-][^-]*)--(?P<build>[^/]+)$"
+    example: "biocontainers/fastqc:0.12.1--hdfd78af_0"
+    source: "legacy modules; rare in current nf-core"
+    resolves_to_field: "biocontainer"
+    derivation_rule: "Same image as quay_biocontainer_simple; same derivation."
+    notes: "docker.io alias for the BioContainers org; identical content to quay form."
+
+  - id: wave_docker
+    regex: "^community\\.wave\\.seqera\\.io/library/(?P<name>[^:/]+):(?P<version>[^-]+)--(?P<digest>[0-9a-f]+)$"
+    example: "community.wave.seqera.io/library/multiqc:1.34--db7c73dae76bc9e6"
+    source: "modules/nf-core/multiqc/main.nf"
+    resolves_to_field: "wave"
+    derivation_rule: "name+version directly from URL path. Digest is content-addressed, not Bioconda build."
+    notes: "Seqera-built; no Bioconda/BioContainer dual. environment.yml remains the round-trippable source."
+
+  - id: wave_singularity_cr
+    regex: "^https://community-cr-prod\\.seqera\\.io/docker/registry/v2/blobs/sha256/[0-9a-f]{2}/(?P<digest>[0-9a-f]{64})/data$"
+    example: "https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/1b/1bef8af6be88c5733461959c46ac8ef73d18f65277f62a1695d0e1633054f9c2/data"
+    source: "modules/nf-core/multiqc/main.nf"
+    resolves_to_field: "wave"
+    derivation_rule: "name+version NOT recoverable from URL; resolve from sibling docker branch or environment.yml."
+
+  - id: wave_oras
+    regex: "^oras://community\\.wave\\.seqera\\.io/library/(?P<name>[^:/]+):(?P<version>[^-]+)--(?P<digest>[0-9a-f]+)$"
+    example: "oras://community.wave.seqera.io/library/seqkit:2.13.0--205358a3675c7775"
+    source: "modules/nf-core/seqkit/sample/main.nf"
+    resolves_to_field: "wave"
+    derivation_rule: "name+version directly from URL path."
+    notes: "Newer ORAS-based Singularity pull form; meta-schema declares ^oras://.*$ legal for the Singularity branch."
+
+  - id: generic_docker
+    regex: "^(?:(?P<registry>[^/]+)/)?(?P<path>[^:@]+)(?::(?P<tag>[^@]+))?(?:@(?P<digest>sha256:[0-9a-f]+))?$"
+    example: "docker.io/myorg/mytool:1.0"
+    source: "ad-hoc DSL2 pipelines; nf-core escape hatch"
+    resolves_to_field: "docker"
+    derivation_rule: "Best-effort path-basename split; surface to LLM prose pass for tool naming when other signal absent."
+    notes: "Apply only after the four canonical forms have been ruled out — this regex matches almost anything."
+
+conda_forms:
+
+  - id: file_reference_modern
+    regex: "^\\$\\{moduleDir\\}/environment\\.yml$"
+    example: "${moduleDir}/environment.yml"
+    source: "modules/nf-core/fastqc/main.nf"
+    resolution: "Read sibling environment.yml; parse dependencies[] for tools[].bioconda."
+    notes: "Dominant form in current nf-core. environment.yml schema requires channels, dependencies; forbids name; pins via '=' (not '>=')."
+
+  - id: literal_string_legacy
+    regex: "^bioconda::(?P<name>[^=]+)=(?P<version>.+)$"
+    example: 'conda "bioconda::fastqc=0.12.1"'
+    source: "legacy modules"
+    resolution: "Use match groups directly as tools[].bioconda."
+
+environment_yml:
+  schema_url: "https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json"
+  channel_order_convention: ["conda-forge", "bioconda"]  # lint-enforced, not schema-enforced
+  dependency_pin_pattern: "^.*[^><]=[^><].*$"            # schema-enforced: '=' required
+  forbidden: ["name", "default channel"]
+  dep_buckets:
+    - prefix: "bioconda::"
+      target_field: "bioconda"
+      galaxy_translation: "<requirement type=\"package\" version=\"<v>\"><n></requirement>"
+    - prefix: "conda-forge::"
+      target_field: null
+      galaxy_translation: "system-level dep; resolve case-by-case (pigz, openjdk, etc.)"
+
+bucketing_rule:
+  approach: "url_prefix"  # not "ternary_branch" — see note §"Bucketing rule"
+  fields:
+    singularity: ["galaxy_singularity_simple", "galaxy_singularity_mulled"]
+    biocontainer: ["quay_biocontainer_simple", "quay_biocontainer_mulled", "docker_io_biocontainer_alias"]
+    wave: ["wave_docker", "wave_singularity_cr", "wave_oras"]
+    docker: ["generic_docker"]
+    bioconda: ["file_reference_modern → dependencies[bioconda::]", "literal_string_legacy"]
+  hypothesis_status: "Foundry hypothesis; confirm with summarize-nextflow Mold author before encoding in the cast skill."

--- a/content/research/component-nextflow-testing.md
+++ b/content/research/component-nextflow-testing.md
@@ -3,28 +3,90 @@ type: research
 subtype: component
 tags:
   - research/component
+  - source/nextflow
 component: "Nextflow Testing and Test Fixtures"
 status: draft
 created: 2026-05-01
-revised: 2026-05-01
-revision: 1
+revised: 2026-05-05
+revision: 2
 ai_generated: true
-summary: "Stub. conf/test.config, nf-core/test-datasets, nf-test idioms, samplesheet conventions. Grows from cast contact — see issue #17."
+summary: "nf-test patterns mapped to Galaxy planemo asserts and CWL test equivalents — backs nextflow-test-to-target-tests Mold and summarize-nextflow §7."
+sources:
+  - "https://www.nf-test.com/"
+  - "https://www.nf-test.com/docs/assertions/"
+  - "https://www.nf-test.com/docs/assertions/snapshots/"
+  - "https://www.nf-test.com/docs/configuration/"
+  - "https://nf-co.re/docs/contributing/nf-test/assertions"
+  - "https://nf-co.re/docs/developing/testing/overview"
+  - "https://github.com/nf-core/test-datasets"
+  - "https://www.nextflow.io/docs/latest/config.html#config-profiles"
+  - "https://nf-co.re/docs/contributing/pipelines#test-data"
 related_molds:
   - "[[summarize-nextflow]]"
+  - "[[nextflow-test-to-target-tests]]"
+  - "[[implement-galaxy-workflow-test]]"
+related_notes:
+  - "[[planemo-asserts-idioms]]"
+  - "[[tests-format]]"
+  - "[[iwc-test-data-conventions]]"
+  - "[[component-nf-core-tools]]"
 ---
 
 # Nextflow Testing and Test Fixtures
 
-Stub. Grown from cast contact, not pre-emptively (see issue #17).
+Operational grounding for two Molds:
 
-## Primary sources
+- `[[summarize-nextflow]]` §7 — extract `nf_tests[]` and `test_fixtures` from a real nf-core or DSL2 pipeline.
+- `[[nextflow-test-to-target-tests]]` — translate nf-test fixtures + assertions into Galaxy / CWL equivalents.
 
-- nf-core test data repo: https://github.com/nf-core/test-datasets
-- nf-test framework: https://www.nf-test.com/
-- Nextflow profiles and `conf/`: https://www.nextflow.io/docs/latest/config.html#config-profiles
-- nf-core test config conventions: https://nf-co.re/docs/contributing/pipelines#test-data
+The summarize side is mostly *enumeration*: walk `tests/*.nf.test`, extract structured fields per the Mold §7 spec. The translation side is *mapping*: each nf-test assertion pattern has a (sometimes lossy) Galaxy or CWL equivalent.
+
+Companion structured form: `component-nextflow-testing.yml`. Per-pattern entries with `nf_test_pattern`, `description`, `galaxy_equivalent`, `cwl_equivalent`, `notes`, plus `assertion` (the precise nf-test syntax) and `target_link` (deep-links into [[tests-format]] or planemo idioms when applicable).
+
+## What `summarize-nextflow` §7 already encodes
+
+The Mold body's §7 lists the structural fields per nf-test file: `name`, `path`, `profiles[]`, `params_overrides`, `assert_workflow_success`, `snapshot` (with `captures`, `helpers`, `ignore_files`, `ignore_globs`, `snap_path`), `prose_assertions[]`. The schema is `summary-nextflow.schema.json`'s `NfTest` and `SnapshotFixture`.
+
+This note's contribution: the *interpretation* layer that turns those structured fields into target-shaped tests.
+
+## The nf-core snapshot idiom
+
+Templated nf-core modules and pipelines use a near-uniform snapshot pattern:
+
+```groovy
+assert snapshot(
+    workflow.trace.succeeded().size(),
+    versions_yml,
+    getAllFilesFromDir(...).list().sort(),    // stable names
+    getAllFilesFromDir(...)*.path.collect{ ... }  // stable paths or md5
+).match()
+```
+
+Four logical captures: succeeded-task count, version YAML, stable file-name list, stable file-path / md5 list. The pruning happens through `ignoreFile: 'tests/.nftignore'` arguments to `getAllFilesFromDir(...)` plus `ignore: [glob1, glob2]` lists.
+
+The translation table in the YAML maps each capture to a Galaxy or CWL assertion. Some are direct (succeeded count → workflow execution success); some are lossy (stable_paths → has_text per output, no md5 chain).
+
+## Source-of-truth chain
+
+1. **nf-test framework** (askimed/nf-test, MIT) — the assertion DSL and snapshot semantics: [www.nf-test.com/docs/assertions/](https://www.nf-test.com/docs/assertions/).
+2. **nf-core conventions** — how nf-core pipelines use nf-test: [nf-co.re/docs/contributing/nf-test/assertions](https://nf-co.re/docs/contributing/nf-test/assertions).
+3. **planemo / tests-format** — the Galaxy target side. Vocabulary in [[tests-format]]; idiom guide in [[planemo-asserts-idioms]].
+4. **cwltest** — the CWL target side. JSON-schema validated YAML test job + expected outputs; cited inline per pattern in the YAML.
+
+## Test-data fixtures
+
+Separate from assertions: where the input data lives.
+
+- `conf/<profile>.config` (default `conf/test.config`) — declares `params.input` (samplesheet URL) and other URL-shaped params per profile. nf-core templates resolve runtime URLs via `params.pipelines_testdata_base_path + 'foo.csv'`.
+- [`nf-core/test-datasets`](https://github.com/nf-core/test-datasets) — branch-per-pipeline; the canonical location for samplesheet content. The cast skill follows samplesheet URLs into the appropriate branch when a single fetch enumerates the referenced files.
+- The `Mold §7` rule: emit the resolved samplesheet URL plus referenced data files as `TestDataRef` entries; do *not* download for content validation.
+
+## Cross-references
+
+- `[[planemo-asserts-idioms]]` — Galaxy-side idiom guide; the YAML's `target_link` fields deep-link into this.
+- `[[tests-format]]` — vendored JSON Schema for `<workflow>-tests.yml`; deep-link target for the Galaxy assertion column.
+- `[[component-nf-core-tools]]` — wider tool ecosystem (nf-core's `test_datasets_utils`, branch listings).
 
 ## Open gaps
 
-_Paragraphs land here when the runtime cast hits a test fixture or assertion shape the procedure does not surface cleanly. Each entry names the motivating target._
+_Updated when a real pipeline exposes an nf-test pattern not mapped here. Each entry names the motivating pipeline._

--- a/content/research/component-nextflow-testing.yml
+++ b/content/research/component-nextflow-testing.yml
@@ -1,0 +1,197 @@
+# nf-test patterns → Galaxy / CWL test equivalents.
+# Companion to component-nextflow-testing.md.
+#
+# Rows ordered by frequency in real nf-core pipelines (snapshot block first).
+
+mappings:
+
+  # ---- Snapshot block (nf-core canonical idiom) ----
+
+  - id: snapshot.match
+    nf_test_pattern: "assert snapshot(...).match()"
+    description: "Top-level snapshot assertion comparing serialized form of N captured values to a stored .nf.test.snap file."
+    galaxy_equivalent: "Per-output assertion block in <workflow>-tests.yml; no single-line analog. Decompose into per-capture assertions (rows below)."
+    cwl_equivalent: "cwltest expected_outputs entries per output; no single-line analog. Decompose."
+    target_link: "[[tests-format]]"
+    notes: "The whole-snapshot idiom is lossy on translation; explode into N per-capture assertions and accept the surface-area increase."
+
+  - id: snapshot.succeeded_task_count
+    nf_test_pattern: "workflow.trace.succeeded().size()"
+    description: "Count of successfully completed tasks. nf-core canonical first capture; brittle across pipeline versions but stable per release."
+    galaxy_equivalent: "Implicit in workflow execution success. Galaxy workflow tests pass iff the workflow completes; per-step success surfaces via has_text on log outputs."
+    cwl_equivalent: "Implicit in cwltest's `should_succeed` / `should_fail` boolean. No per-task count."
+    target_link: "[[planemo-asserts-idioms]] §1 (Plain text reports / logs)"
+    notes: "Drop on translation; targets verify success implicitly."
+
+  - id: snapshot.versions_yml
+    nf_test_pattern: "ch_versions or path('versions.yml')"
+    description: "The `versions` topic channel collected per process and dumped to versions.yml at workflow end. nf-core canonical second capture."
+    galaxy_equivalent: "has_text on the workflow's versions output (or the multiqc report's software-versions section). Galaxy versions surface via tool-shed metadata, not a unified versions.yml."
+    cwl_equivalent: "has_text or contains_string on the versions.yml output if produced; CWL doesn't enforce a versions topic."
+    target_link: "[[tests-format#has_text_model]]"
+    notes: "Galaxy assertion targets stable tool-name strings rather than version numbers (versions drift across Bioconda releases)."
+
+  - id: snapshot.stable_names
+    nf_test_pattern: "getAllFilesFromDir(params.outdir).list().sort()"
+    description: "Sorted list of file names produced under outdir; ignores content. nf-core canonical third capture."
+    galaxy_equivalent: "Tabular has_n_lines + has_text per known canonical filename; or a directory-listing collection with element_identifiers asserted."
+    cwl_equivalent: "expected_outputs with explicit listing on the output directory (Directory type)."
+    target_link: "[[tests-format#has_text_model]]"
+    notes: "nf-test's stable_names is a list comparison; Galaxy/CWL comparable via per-name has_text."
+
+  - id: snapshot.stable_paths
+    nf_test_pattern: "getAllFilesFromDir(...) with md5 hashing or path tuples"
+    description: "Per-file fingerprint (md5 or path tuple) of files under outdir. nf-core canonical fourth capture."
+    galaxy_equivalent: "Per-output `compare: diff` for byte-stable outputs; `compare: sim_size` for non-deterministic; has_text or has_archive_member for binary archives. See planemo-asserts-idioms by output type."
+    cwl_equivalent: "expected_outputs with `checksum` field (sha1 or sha256) per file."
+    target_link: "[[planemo-asserts-idioms]] §1 (decision table by output type)"
+    notes: "The richest translation surface; per-file decisions required. Cast skill should consult planemo-asserts-idioms for the right Galaxy assertion per file format."
+
+  - id: snapshot.helpers.getAllFilesFromDir
+    nf_test_pattern: "getAllFilesFromDir(<dir>, ignoreFile: <path>, ignore: [<globs>])"
+    description: "nf-test helper that recursively lists files, applying .nftignore / inline glob filters."
+    galaxy_equivalent: "No single-helper analog. Galaxy tests assert on individual outputs; the ignore pattern is implicit (tests don't reference filtered files)."
+    cwl_equivalent: "expected_outputs by file path; CWL has no `ignore` analog."
+    notes: "On translation, the cast skill records ignore_files/ignore_globs in summary-nextflow's SnapshotFixture but doesn't propagate them to the target test (the target is per-file, not per-tree)."
+
+  - id: snapshot.helpers.removeNextflowVersion
+    nf_test_pattern: "removeNextflowVersion(<file>)"
+    description: "nf-test helper that strips the Nextflow version line from a file before snapshotting."
+    galaxy_equivalent: "compare: diff with lines_diff: 1-2 (header tolerance); or has_text on stable rows only."
+    cwl_equivalent: "checksum on a sed-postprocessed copy."
+    target_link: "[[planemo-asserts-idioms]] §2 (compare operators)"
+
+  # ---- Workflow / process success assertions ----
+
+  - id: assert.workflow_success
+    nf_test_pattern: "assert workflow.success"
+    description: "Workflow completed without error."
+    galaxy_equivalent: "Implicit. planemo workflow test fails if any step errors."
+    cwl_equivalent: "should_succeed: true (default)."
+    notes: "Drop on translation."
+
+  - id: assert.workflow_failed
+    nf_test_pattern: "assert workflow.failed"
+    description: "Workflow expected to fail (negative test)."
+    galaxy_equivalent: "Galaxy workflow tests don't directly support expected-failure; encode as a separate negative test or skip."
+    cwl_equivalent: "should_fail: true."
+    notes: "Galaxy translation requires either skipping or reframing as a non-test (unusual)."
+
+  - id: assert.process_succeeded
+    nf_test_pattern: "assert process.success"
+    description: "Module-level test: the wrapped process succeeded."
+    galaxy_equivalent: "Implicit (process is a tool; tool failure → test failure)."
+    cwl_equivalent: "Implicit (CommandLineTool zero-exit)."
+    notes: "Module tests translate to Galaxy <tests> blocks (single-tool tests), not workflow tests."
+
+  - id: assert.process_failed
+    nf_test_pattern: "assert process.failed"
+    description: "Module-level test: process expected to fail."
+    galaxy_equivalent: "Galaxy <test expect_failure='true'>."
+    cwl_equivalent: "should_fail at job level."
+
+  # ---- Output assertions (file/channel) ----
+
+  - id: assert.output_path_equals
+    nf_test_pattern: "assert path(process.out.<name>[0]).equals(...)"
+    description: "Byte-exact file equality."
+    galaxy_equivalent: "compare: diff with file: fixture path."
+    cwl_equivalent: "expected_outputs with checksum (sha1 of fixture)."
+    target_link: "[[tests-format]]"
+
+  - id: assert.output_path_md5
+    nf_test_pattern: "assert path(process.out.<name>[0]).md5 == '<hash>'"
+    description: "MD5-pinned file equality."
+    galaxy_equivalent: "compare: diff with sim_size fallback if upstream tool is non-deterministic."
+    cwl_equivalent: "expected_outputs checksum: 'sha1$<hash>' (CWL prefers sha1; conversion needed)."
+    notes: "CWL conversion lossy: nf-test md5 must be re-derived as sha1 over the same fixture."
+
+  - id: assert.output_text_contains
+    nf_test_pattern: "assert path(out).text.contains('substring')"
+    description: "Substring match on file content."
+    galaxy_equivalent: "has_text: text: 'substring'."
+    cwl_equivalent: "expected_outputs partial-content match (cwltest doesn't support substring directly; checksum a normalized form or use a wrapper)."
+    target_link: "[[tests-format#has_text_model]]"
+
+  - id: assert.output_text_matches_regex
+    nf_test_pattern: "assert path(out).text =~ /<regex>/"
+    description: "Regex match on file content."
+    galaxy_equivalent: "has_text_matching: expression: '<regex>'."
+    cwl_equivalent: "Not supported natively; checksum a normalized form."
+    target_link: "[[tests-format#has_text_matching_model]]"
+
+  - id: assert.output_lines_count
+    nf_test_pattern: "assert path(out).readLines().size() == N"
+    description: "Line count equality."
+    galaxy_equivalent: "has_n_lines: n: N (with optional delta:)."
+    cwl_equivalent: "Not supported natively."
+    target_link: "[[tests-format#has_n_lines_model]]"
+
+  - id: assert.output_size
+    nf_test_pattern: "assert path(out).size() in <range>"
+    description: "File size assertion."
+    galaxy_equivalent: "has_size: value: <bytes> with delta: or delta_frac:."
+    cwl_equivalent: "Not supported natively; check via wrapper."
+    target_link: "[[tests-format#has_size_model]]"
+
+  - id: assert.output_channel_size
+    nf_test_pattern: "assert process.out.<name>.size() == N"
+    description: "Number of items in an output channel (e.g., scatter results)."
+    galaxy_equivalent: "Galaxy collection element count via element_count or has_collection_element."
+    cwl_equivalent: "expected_outputs array length on a Directory listing or output array."
+    notes: "Cardinality assertion translates to collection-shape tests in Galaxy; CWL needs an explicit listing."
+
+  # ---- File comparison via cmp/diff ----
+
+  - id: assert.cmp_files
+    nf_test_pattern: "assert path(out).bytes == path(fixture).bytes"
+    description: "Byte-exact comparison via Path API."
+    galaxy_equivalent: "compare: diff."
+    cwl_equivalent: "checksum match."
+
+  - id: assert.snapshot_file_md5
+    nf_test_pattern: "assert snapshot(path(out)).match() (single-file snapshot, md5 fingerprint)"
+    description: "Single-file snapshot. nf-test fingerprints by md5; the .snap file stores the hash."
+    galaxy_equivalent: "compare: diff or has_text per output type (per planemo-asserts-idioms decision table)."
+    cwl_equivalent: "expected_outputs checksum."
+    target_link: "[[planemo-asserts-idioms]] §1"
+
+  # ---- Workflow-level assertions ----
+
+  - id: workflow.trace_outputs
+    nf_test_pattern: "workflow.out.<name>"
+    description: "Reference a published-via-emit channel from a workflow."
+    galaxy_equivalent: "Galaxy workflow output dataset (named by output_name in <output>)."
+    cwl_equivalent: "Workflow output port with explicit type."
+    notes: "Map nf-test output names to Galaxy output_name 1:1; CWL output ports get the same names."
+
+  - id: workflow.publishDir_outputs
+    nf_test_pattern: "Files under params.outdir checked via getAllFilesFromDir"
+    description: "Files written by publishDir directives, asserted via tree walk."
+    galaxy_equivalent: "Galaxy History / collection assertions per output dataset."
+    cwl_equivalent: "Directory output with explicit listing."
+    notes: "publishDir is pipeline-level; module tests typically don't use this idiom."
+
+  # ---- Setup / teardown ----
+
+  - id: setup.test_data_path
+    nf_test_pattern: "setup { ... } block with file fetch from nf-core/test-datasets"
+    description: "Test fixture preparation; pulls files from a versioned test-datasets branch."
+    galaxy_equivalent: "Test fixtures under test_data/ in the workflow repo, or referenced by URL."
+    cwl_equivalent: "Job file referencing fixtures with location: URLs or relative paths."
+    target_link: "[[iwc-test-data-conventions]]"
+    notes: "Translation requires resolving the runtime URL (params.pipelines_testdata_base_path + ...) into a static fixture reference."
+
+  # ---- Configuration ----
+
+  - id: config.profile_test
+    nf_test_pattern: "-profile test (or test_full, test_dfast, ...)"
+    description: "Activates a conf/<profile>.config selecting test-sized inputs."
+    galaxy_equivalent: "Galaxy workflow tests have a single fixture set per test; multi-profile equivalent is multiple test entries."
+    cwl_equivalent: "Multiple cwltest test entries with different job files."
+
+  - id: config.params_file
+    nf_test_pattern: "-params-file <yaml>"
+    description: "Override params.* from a YAML file."
+    galaxy_equivalent: "<test><param name='X' value='Y'/></test> entries."
+    cwl_equivalent: "Job file in YAML; same as default."

--- a/content/research/component-nf-core-module-conventions.md
+++ b/content/research/component-nf-core-module-conventions.md
@@ -1,0 +1,69 @@
+---
+type: research
+subtype: component
+tags:
+  - research/component
+  - source/nextflow
+component: "nf-core Module Conventions"
+status: draft
+created: 2026-05-05
+revised: 2026-05-05
+revision: 1
+ai_generated: true
+summary: "RFC 2119 conventions enforced by nf-core/tools module lint, with lint-check pointers. Backs summarize-nextflow + author-galaxy-tool-wrapper."
+sources:
+  - "https://nf-co.re/docs/guidelines/components/modules"
+  - "https://github.com/nf-core/tools/tree/main/nf_core/modules/lint"
+  - "https://github.com/nf-core/modules/blob/master/modules/meta-schema.json"
+  - "https://github.com/nf-core/modules/blob/master/modules/environment-schema.json"
+  - "https://github.com/nf-core/tools/blob/main/nf_core/module-template/main.nf"
+related_molds:
+  - "[[summarize-nextflow]]"
+  - "[[author-galaxy-tool-wrapper]]"
+related_notes:
+  - "[[component-nf-core-tools]]"
+  - "[[component-nextflow-containers-and-envs]]"
+  - "[[nf-core-module-meta]]"
+---
+
+# nf-core Module Conventions
+
+Structured digest of the nf-core module specification — the conventions a module **MUST** or **SHOULD** follow to pass `nf-core modules lint`. Operational grounding for two Molds:
+
+- `[[summarize-nextflow]]` — when extracting tools/containers/IO from a real nf-core module, the conventions tell the cast skill what to *expect* and what to *flag as drift*.
+- `[[author-galaxy-tool-wrapper]]` — when translating an nf-core module into a Galaxy `<tool>` wrapper, the conventions are the contract the source-side has already enforced (versions are emitted, args go through `task.ext.args`, containers carry both branches, etc.).
+
+Companion structured form: `component-nf-core-module-conventions.yml`. Per-rule entries with `id`, `level`, `description`, `lint_check`, `evidence`, `affects`. Cast skill consumes the YAML for confidence-checking and warning suppression.
+
+## Rule levels
+
+- **MUST** — module fails lint if violated. The cast skill can assume these hold for a lint-clean module; surface a warning if not.
+- **SHOULD** — lint warns but does not fail. The cast skill should *not* assume these; treat as a hint, not a contract.
+
+## Categories
+
+The YAML groups rules into:
+
+1. **Layout** — directory structure, file inventory.
+2. **Containers and conda** — directive form, environment.yml shape (also covered structurally in `[[component-nextflow-containers-and-envs]]`).
+3. **Process and IO** — input/output channel declarations, meta map keys, args via `task.ext.args`.
+4. **Versions** — how each tool emits its version, the `topic: versions` convention.
+5. **Stubs and tests** — mandatory stub block, nf-test presence.
+6. **Documentation** — meta.yml fields, descriptions, keywords.
+7. **Code hygiene** — no `System.exit`, no leftover Jinja, no merge markers, no TODOs in committed code.
+
+## Source provenance
+
+Each rule's `lint_check` field names the lint test inside `nf-core/tools` that enforces it (e.g., `main_nf`, `meta_yml`, `environment_yml`, `module_changes`, `module_tests`). The rule fires when the lint test reports a fail or a warn. The lint suite registry is `nf_core/modules/lint/__init__.py`'s `lint_tests` list; individual tests live in `nf_core/modules/lint/<name>.py`.
+
+The `evidence` field cites either a specific lint-test source path or the documented spec page. When neither is precise (e.g., "convention emerges from the module template"), `evidence` cites the template file.
+
+## Cross-references
+
+- `[[component-nf-core-tools]]` — wider tool ecosystem (modules.json, the install/update flow).
+- `[[component-nextflow-containers-and-envs]]` — container and conda directive deep-dive (the "containers and conda" category here is the policy layer; the other note is the URL grammar).
+- `[[nf-core-module-meta]]` — the JSON Schema this convention list operationalizes.
+
+## Open gaps
+
+_Updated when a real module exposes a convention not captured here. Each entry names the motivating module._

--- a/content/research/component-nf-core-module-conventions.yml
+++ b/content/research/component-nf-core-module-conventions.yml
@@ -1,0 +1,206 @@
+# nf-core module conventions — structured digest.
+# Companion to component-nf-core-module-conventions.md.
+#
+# Levels: MUST (lint fails) | SHOULD (lint warns).
+# `lint_check` names the lint test in nf_core/modules/lint/.
+# `affects` lists Mold steps that consume this rule.
+
+rules:
+
+  # ---- Layout ----
+
+  - id: layout.directory_structure
+    level: MUST
+    category: layout
+    description: "Module lives at modules/nf-core/<tool>/<subtool>/ with files: main.nf, meta.yml, environment.yml, tests/main.nf.test (and tests/main.nf.test.snap when applicable)."
+    lint_check: "modules_structure"
+    evidence: "nf_core/modules/lint/modules_structure.py"
+    affects: ["summarize-nextflow §1 (detect pipeline shape)", "summarize-nextflow §4 (enumerate processes)"]
+
+  - id: layout.module_path_naming
+    level: MUST
+    category: layout
+    description: "Process name in main.nf is the upper-snake-case form of <tool>_<subtool> (e.g. modules/nf-core/samtools/index/ → SAMTOOLS_INDEX)."
+    lint_check: "main_nf"
+    evidence: "nf_core/modules/lint/main_nf.py"
+    affects: ["summarize-nextflow §4 (process aliases via include { X as Y })"]
+
+  # ---- Containers and conda ----
+
+  - id: containers.ternary_directive
+    level: MUST
+    category: containers
+    description: "Container directive uses the canonical ternary: 'workflow.containerEngine in [singularity, apptainer] && !task.ext.singularity_pull_docker_container ? <sing> : <docker>'. Older modules use '== singularity'; both accepted."
+    lint_check: "main_nf"
+    evidence: "nf_core/module-template/main.nf, lines 27-30; nf_core/modules/lint/main_nf.py"
+    affects: ["summarize-nextflow §5 (extract both ternary branches)"]
+
+  - id: containers.environment_yml_present
+    level: MUST
+    category: containers
+    description: "environment.yml is a sibling of main.nf and validates against environment-schema.json: requires channels (no `default`), dependencies (= pinned, not >=); forbids name."
+    lint_check: "environment_yml"
+    evidence: "modules/environment-schema.json"
+    affects: ["summarize-nextflow §5 (resolve conda directive); author-galaxy-tool-wrapper (Galaxy <requirement> translation)"]
+
+  - id: containers.channel_order
+    level: SHOULD
+    category: containers
+    description: "environment.yml declares channels in order: conda-forge, bioconda. Schema does not enforce; lint does."
+    lint_check: "environment_yml"
+    evidence: "nf_core/modules/lint/environment_yml.py"
+    affects: ["author-galaxy-tool-wrapper (channel-order-aware translation)"]
+
+  - id: containers.bioconda_pin
+    level: MUST
+    category: containers
+    description: "Bioconda dependencies use `=` version pin (e.g. `bioconda::fastqc=0.12.1`); `>=`, `<=`, `*` are forbidden by environment-schema.json."
+    lint_check: "environment_yml"
+    evidence: "modules/environment-schema.json"
+    affects: ["summarize-nextflow §5; author-galaxy-tool-wrapper"]
+
+  # ---- Process and IO ----
+
+  - id: process.input_channels_declared
+    level: MUST
+    category: process_io
+    description: "All mandatory and optional file inputs are declared in input channels (not embedded in script via interpolation)."
+    lint_check: "main_nf"
+    evidence: "nf-co.re/docs/guidelines/components/modules"
+    affects: ["summarize-nextflow §4 (input channel extraction)"]
+
+  - id: process.args_via_task_ext_args
+    level: MUST
+    category: process_io
+    description: "Non-mandatory CLI arguments are provided via `$task.ext.args` (and `args2`, `args3` for piped-stage args). Hardcoded options in script are forbidden."
+    lint_check: "main_nf"
+    evidence: "nf-co.re/docs/guidelines/components/modules"
+    affects: ["summarize-nextflow §4 (script_summary); author-galaxy-tool-wrapper (Galaxy <param> generation)"]
+
+  - id: process.meta_map_keys_standard_only
+    level: SHOULD
+    category: process_io
+    description: "Modules SHOULD support meta maps in any file input channel. Only `meta.id` and `meta.single_end` are accepted standard keys; custom hardcoded metadata fields are prohibited."
+    lint_check: "main_nf"
+    evidence: "nf-co.re/docs/guidelines/components/modules"
+    affects: ["summarize-nextflow §4 (channel shape extraction); author-galaxy-tool-wrapper (collection-element-identifier mapping)"]
+
+  - id: process.publishdir_in_pipeline_config
+    level: MUST
+    category: process_io
+    description: "Modules do not declare publishDir. Output publishing is configured at the pipeline level via conf/modules.config withName: blocks."
+    lint_check: "main_nf"
+    evidence: "nf_core/modules/lint/main_nf.py"
+    affects: ["summarize-nextflow §6 (workflow-level conditionals); module vs pipeline override resolution"]
+
+  # ---- Versions ----
+
+  - id: versions.topic_versions_emission
+    level: MUST
+    category: versions
+    description: "Each tool emits its version into the `versions` topic via `tuple(val(\"${task.process}\"), val('toolname'), eval(<cmd-that-prints-version>)) topic: versions`."
+    lint_check: "main_nf"
+    evidence: "nf_core/module-template/main.nf"
+    affects: ["summarize-nextflow §4 (detect topic: versions); summarize-nextflow §5 (cross-check tool name with environment.yml)"]
+
+  - id: versions.no_leading_v
+    level: SHOULD
+    category: versions
+    description: "Version strings start with numeric characters (no leading 'v'). softwareVersionsToYAML normalizes downstream."
+    lint_check: "main_nf"
+    evidence: "nf-co.re/docs/guidelines/components/modules"
+    affects: ["summarize-nextflow §5 (tool version derivation)"]
+
+  - id: versions.per_tool_emission
+    level: MUST
+    category: versions
+    description: "Each binary the process invokes gets its own version emission row. Multi-tool processes emit multiple rows under the same `task.process` value."
+    lint_check: "main_nf"
+    evidence: "nf-co.re/docs/guidelines/components/modules"
+    affects: ["summarize-nextflow §5 (multi-tool process detection)"]
+
+  # ---- Stubs and tests ----
+
+  - id: stubs.mandatory_stub_block
+    level: MUST
+    category: stubs_tests
+    description: "Every module includes a stub block that produces minimal versions of each declared output. Gzipped stub files use `echo | gzip > \"${prefix}.txt.gz\"` (not `touch` then gzip)."
+    lint_check: "main_nf"
+    evidence: "nf-co.re/docs/guidelines/components/modules"
+    affects: ["summarize-nextflow (stub vs script body distinction); nextflow-test-to-target-tests (stub-only test execution path)"]
+
+  - id: tests.nf_test_present
+    level: MUST
+    category: stubs_tests
+    description: "Module ships at least one tests/main.nf.test file with required tags. Snapshot file (tests/main.nf.test.snap) is mandatory when assertions use snapshot(...).match()."
+    lint_check: "module_tests"
+    evidence: "nf_core/modules/lint/module_tests.py"
+    affects: ["summarize-nextflow §7 (nf_tests[] enumeration); nextflow-test-to-target-tests"]
+
+  - id: tests.required_tags
+    level: MUST
+    category: stubs_tests
+    description: "nf-test files declare `tag` entries naming the module path (e.g., 'modules_nfcore', 'samtools', 'samtools/index'). The lint check enforces tag conventions."
+    lint_check: "module_tests"
+    evidence: "nf_core/modules/lint/module_tests.py"
+    affects: ["summarize-nextflow §7 (test profile attribution)"]
+
+  # ---- Documentation (meta.yml) ----
+
+  - id: docs.meta_yml_validates
+    level: MUST
+    category: documentation
+    description: "meta.yml validates against modules/meta-schema.json (Draft-07): name, description, keywords (≥3, no 'example'), authors, output, tools required."
+    lint_check: "meta_yml"
+    evidence: "modules/meta-schema.json"
+    affects: ["summarize-nextflow §4 (use meta.yml as IO ground truth)"]
+
+  - id: docs.tool_attribution
+    level: MUST
+    category: documentation
+    description: "Each tool in meta.yml's tools[] declares description plus at least one of homepage / documentation / tool_dev_url / doi. licence is an SPDX identifier list. identifier is a bio.tools ID (^biotools:.*)."
+    lint_check: "meta_yml"
+    evidence: "modules/meta-schema.json"
+    affects: ["author-galaxy-tool-wrapper (Galaxy <citations> generation)"]
+
+  - id: docs.io_descriptions
+    level: SHOULD
+    category: documentation
+    description: "Every input and output channel element has type + description. Pattern (Java glob) and ontologies (URL-keyed) are optional but recommended."
+    lint_check: "meta_yml"
+    evidence: "modules/meta-schema.json"
+    affects: ["summarize-nextflow §4 (description fields); author-galaxy-tool-wrapper (Galaxy <param help>)"]
+
+  # ---- Code hygiene ----
+
+  - id: hygiene.no_system_exit
+    level: MUST
+    category: hygiene
+    description: "Groovy `System.exit` is forbidden; modules use `error()` instead so Nextflow can capture the failure cleanly."
+    lint_check: "system_exit"
+    evidence: "nf_core/modules/lint/main_nf.py (system_exit check); also enforced at pipeline level"
+    affects: ["summarize-nextflow (script_summary unaffected; flagged as a smell if encountered)"]
+
+  - id: hygiene.no_template_strings
+    level: MUST
+    category: hygiene
+    description: "No leftover Jinja/template strings ({{ ... }}) committed."
+    lint_check: "template_strings"
+    evidence: "nf_core/pipelines/lint/template_strings.py (parallels module-side check)"
+    affects: ["summarize-nextflow (would invalidate parsing)"]
+
+  - id: hygiene.no_merge_markers
+    level: MUST
+    category: hygiene
+    description: "No git merge conflict markers (<<<<<<<, =======, >>>>>>>) in committed source."
+    lint_check: "merge_markers"
+    evidence: "nf_core/pipelines/lint/merge_markers.py"
+    affects: ["summarize-nextflow (would crash parser)"]
+
+  - id: hygiene.no_todos_in_committed
+    level: SHOULD
+    category: hygiene
+    description: "TODO comments are flagged in committed code; allowed during PR review but should be resolved or tracked elsewhere before merge."
+    lint_check: "pipeline_todos"
+    evidence: "nf_core/pipelines/lint/pipeline_todos.py"
+    affects: ["summarize-nextflow (informational only)"]

--- a/content/schemas/nextflow-parameters-meta.md
+++ b/content/schemas/nextflow-parameters-meta.md
@@ -1,0 +1,56 @@
+---
+type: schema
+name: nextflow-parameters-meta
+title: Nextflow parameter schema (nf-schema meta-schema)
+package: "@galaxy-foundry/summary-nextflow-schema"
+package_export: "nextflowParametersMetaSchema"
+upstream: "https://github.com/nextflow-io/nf-schema/blob/bde406e81a4ac614650d73df6df6dcf793182929/parameters_meta_schema.json"
+license: Apache-2.0
+license_file: LICENSES/nf-schema.LICENSE
+tags:
+  - schema
+  - source/nextflow
+status: draft
+created: 2026-05-05
+revised: 2026-05-05
+revision: 1
+ai_generated: true
+related_notes:
+  - "[[summarize-nextflow]]"
+  - "[[component-nextflow-pipeline-anatomy]]"
+  - "[[component-nf-core-tools]]"
+related_molds:
+  - "[[summarize-nextflow]]"
+summary: "JSON Schema (Draft 2020-12) meta-schema validating per-pipeline nextflow_schema.json files. Upstream from nextflow-io/nf-schema."
+---
+
+JSON Schema (**Draft 2020-12**) vendored verbatim from `nextflow-io/nf-schema` at SHA `bde406e`. Validates every pipeline's `nextflow_schema.json` — the parameter-surface contract consumed by the runtime `nf-schema` plugin, the nf-co.re schema builder, `nf-core launch`, and Seqera Platform.
+
+**Operational role.** This is the meta-schema referenced by `summarize-nextflow` §3: "When `nextflow_schema.json` exists (nf-core), prefer it as the source of truth for `type`, `description`, and `required` — it is real JSON Schema, copy verbatim." This schema pins exactly which JSON Schema subset and which nf-core extensions are legal, so the cast skill emitting `summary-nextflow.schema.json`'s `params[]` block can validate its source rather than guess.
+
+**Draft-version note.** This is the only Foundry-vendored schema currently authored against JSON Schema Draft 2020-12 (others are Draft-07). Validators consuming this schema must be Draft-2020-12-capable; AJV needs `import Ajv from "ajv/dist/2020.js"` rather than the default Draft-07 import. The Foundry's own validator (`scripts/validate.ts`) only validates Foundry frontmatter (Draft-07) and does not load this schema as a meta — there's no impedance.
+
+**Source-of-truth chain:**
+
+1. `parameters_meta_schema.json` in [`nextflow-io/nf-schema`](https://github.com/nextflow-io/nf-schema).
+2. Vendored verbatim into `content/schemas/nextflow-parameters-meta.schema.json`, pinned at `upstream`'s SHA.
+3. **Re-sync:** `curl -sL https://raw.githubusercontent.com/nextflow-io/nf-schema/<sha>/parameters_meta_schema.json -o content/schemas/nextflow-parameters-meta.schema.json` and bump the SHA.
+
+## Top-level shape
+
+A valid `nextflow_schema.json` is an object with required keys `$schema`, `$id`, `title`, `description`, `type` (constrained to `object`). Optional: `$defs` (parameter groups, the canonical nf-core idiom), `allOf` (composes the groups).
+
+Each parameter property must declare `type` ∈ `[string, boolean, integer, number]` — **narrower than vanilla JSON Schema**; arrays and objects are deliberately disallowed at the top level (the `samplesheetToList` plugin handles tabular data outside the parameter schema). Optional keywords:
+
+- `format` ∈ `[file-path, directory-path, path, file-path-pattern]` — semantic enrichment for path-shaped params.
+- `exists` (boolean) — runtime existence check.
+- `mimetype` (`.+/.+`) — sniffed at validation time.
+- `pattern`, `schema` — string constraints; `schema` references a sample-sheet sub-schema.
+- `description`, `help_text`, `errorMessage`, `fa_icon` (`^fa…`), `hidden`.
+- `minLength`, `maxLength`, `minimum`, `maximum` — integers.
+
+Parameter groups under `$defs` themselves require `title`, `type` (`object`), `properties`. Optional `description`, `fa_icon`, `required` — the same enrichment vocabulary.
+
+## Upstream license
+
+Apache-2.0. See `LICENSES/nf-schema.LICENSE`.

--- a/content/schemas/nextflow-parameters-meta.schema.json
+++ b/content/schemas/nextflow-parameters-meta.schema.json
@@ -1,0 +1,155 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://nextflow.io",
+  "title": "Nextflow Schema Meta-schema",
+  "description": "Meta-schema to validate Nextflow parameter schema files",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "title": "schema",
+      "type": "string",
+      "minLength": 1
+    },
+    "$id": {
+      "title": "ID URI",
+      "type": "string",
+      "minLength": 1
+    },
+    "title": {
+      "title": "Title",
+      "type": "string",
+      "minLength": 1
+    },
+    "description": {
+      "title": "Description",
+      "type": "string",
+      "minLength": 1
+    },
+    "type": {
+      "title": "Top level type",
+      "type": "string",
+      "const": "object"
+    },
+    "$defs": {
+      "title": "Parameter groups",
+      "type": "object",
+      "patternProperties": {
+        "^.*$": {
+          "type": "object",
+          "required": [
+            "title",
+            "type",
+            "properties"
+          ],
+          "properties": {
+            "title": {
+              "type": "string",
+              "minLength": 1
+            },
+            "type": {
+              "const": "object"
+            },
+            "fa_icon": {
+              "type": "string",
+              "pattern": "^fa"
+            },
+            "description": {
+              "type": "string"
+            },
+            "required": {
+              "type": "array"
+            },
+            "properties": {
+              "type": "object",
+              "patternProperties": {
+                "^.*$": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": ["string", "boolean", "integer", "number"]
+                      },
+                      "format": {
+                        "type": "string",
+                        "enum": ["file-path", "directory-path", "path", "file-path-pattern"]
+                      },
+                      "exists": {
+                        "type": "boolean"
+                      },
+                      "mimetype": {
+                        "type": "string",
+                        "pattern": ".+/.+"
+                      },
+                      "pattern": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "schema": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "help_text": {
+                        "type": "string"
+                      },
+                      "fa_icon": {
+                        "type": "string",
+                        "pattern": "^fa"
+                      },
+                      "errorMessage": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "hidden": {
+                        "type": "boolean"
+                      },
+                      "minLength": {
+                        "type": "integer"
+                      },
+                      "maxLength": {
+                        "type": "integer"
+                      },
+                      "minimum": {
+                        "type": "integer"
+                      },
+                      "maximum": {
+                        "type": "integer"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+    },
+    "allOf": {
+      "title": "Combine definition groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ],
+        "properties": {
+          "$ref": {
+            "type": "string",
+            "pattern": "^#/$defs/"
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "$schema",
+    "$id",
+    "title",
+    "description",
+    "type"
+  ]
+}

--- a/content/schemas/nf-core-module-meta.md
+++ b/content/schemas/nf-core-module-meta.md
@@ -1,0 +1,55 @@
+---
+type: schema
+name: nf-core-module-meta
+title: nf-core module meta.yml schema
+package: "@galaxy-foundry/summary-nextflow-schema"
+package_export: "nfCoreModuleMetaSchema"
+upstream: "https://github.com/nf-core/modules/blob/d8529909206a06d9ec73703ea07a533a511bb786/modules/meta-schema.json"
+license: MIT
+license_file: LICENSES/nf-core-modules.LICENSE
+tags:
+  - schema
+  - source/nextflow
+status: draft
+created: 2026-05-05
+revised: 2026-05-05
+revision: 1
+ai_generated: true
+related_notes:
+  - "[[summarize-nextflow]]"
+  - "[[nf-core-subworkflow-meta]]"
+  - "[[component-nextflow-pipeline-anatomy]]"
+  - "[[component-nf-core-tools]]"
+  - "[[component-nextflow-containers-and-envs]]"
+related_molds:
+  - "[[summarize-nextflow]]"
+  - "[[author-galaxy-tool-wrapper]]"
+summary: "JSON Schema (Draft-07) validating nf-core module meta.yml — channel IO, tools, containers, conda lockfiles. Upstream from nf-core/modules."
+---
+
+JSON Schema vendored verbatim from `nf-core/modules` at SHA `d852990`. Validates every `meta.yml` under `modules/nf-core/<tool>/<subtool>/`.
+
+**Operational role.** This is the IO ground truth for `summarize-nextflow` §4. The Mold body says "Where `meta.yml` exists, **use it** for `description` and IO documentation rather than parsing the `script:` block" — this schema is the contract that says what fields are mandatory, what shapes they take, and what `type` enum the LLM extracting `processes[].inputs[].shape` is allowed to emit.
+
+**Source-of-truth chain:**
+
+1. `modules/meta-schema.json` in [`nf-core/modules`](https://github.com/nf-core/modules) — authored alongside the module library and cited by every `meta.yml` via `# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json`.
+2. Vendored verbatim into `content/schemas/nf-core-module-meta.schema.json` here, pinned at the SHA in `upstream`.
+3. **Re-sync:** re-run `curl -sL https://raw.githubusercontent.com/nf-core/modules/<sha>/modules/meta-schema.json -o content/schemas/nf-core-module-meta.schema.json` and bump the SHA in this note's `upstream` field.
+
+**At cast time** (per `docs/COMPILATION_PIPELINE.md`): copied verbatim into the cast bundle's `references/schemas/`. Cast skills resolving an nf-core module's `meta.yml` validate against this contract before consuming the IO descriptions.
+
+## Top-level shape
+
+The schema's required keys are `name`, `description`, `keywords` (≥3, no `example`), `authors`, `output`, `tools`. Optional but commonly present: `input`, `extra_args`, `topics`, `maintainers`, `containers`.
+
+The most important sub-shapes for downstream Molds:
+
+- **`elementProperties.type`** — enum `[map, file, directory, string, integer, float, boolean, list, eval]`. This is the canonical set the cast skill must coerce into `summary-nextflow.schema.json`'s `ChannelIO.shape` strings.
+- **`channelArray`** — list of `channelElement` or list-of-list (the recent flat-vs-nested change the [2025-meta.yml blog post](https://nf-co.re/blog/2025/modules-meta-yml) introduced: tuple channels are nested arrays, single-element channels are flat).
+- **`tools[]`** — each tool block requires `description` and at least one of `homepage` / `documentation` / `tool_dev_url` / `doi`. `licence` is an array of SPDX identifiers. `identifier` is a `bio.tools` ID (pattern `^(biotools:.*)?$`).
+- **`containers.docker` / `.singularity` / `.conda`** — the schema explicitly allows `^oras://.*$` for the singularity branch (legal ORAS pull form documented in `[[component-nextflow-containers-and-envs]]`).
+
+## Upstream license
+
+This schema is redistributed under `nf-core/modules`'s MIT license. See `LICENSES/nf-core-modules.LICENSE`.

--- a/content/schemas/nf-core-module-meta.schema.json
+++ b/content/schemas/nf-core-module-meta.schema.json
@@ -1,0 +1,309 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "title": "Meta yaml",
+    "description": "Validate the meta yaml file for an nf-core module",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "Name of the module"
+        },
+        "description": {
+            "type": "string",
+            "description": "Description of the module"
+        },
+        "keywords": {
+            "type": "array",
+            "description": "Keywords for the module",
+            "items": {
+                "type": "string",
+                "not": {
+                    "const": "example"
+                }
+            },
+            "uniqueItems": true,
+            "minItems": 3
+        },
+        "tools": {
+            "type": "array",
+            "description": "Tools used by the module",
+            "items": {
+                "type": "object",
+                "patternProperties": {
+                    ".*": {
+                        "type": "object",
+                        "properties": {
+                            "description": {
+                                "type": "string",
+                                "description": "Description of the output channel"
+                            },
+                            "homepage": {
+                                "type": "string",
+                                "description": "Homepage of the tool",
+                                "pattern": "^https?://.*$"
+                            },
+                            "documentation": {
+                                "type": "string",
+                                "description": "Documentation of the tool",
+                                "pattern": "^(https?|ftp)://.*$"
+                            },
+                            "tool_dev_url": {
+                                "type": "string",
+                                "description": "URL of the development version of the tool's documentation",
+                                "pattern": "^https?://.*$"
+                            },
+                            "doi": {
+                                "description": "DOI of the tool",
+                                "anyOf": [
+                                    {
+                                        "type": "string",
+                                        "pattern": "^10\\.\\d{4,9}\\/[^,]+$"
+                                    },
+                                    {
+                                        "type": "string",
+                                        "enum": ["no DOI available"]
+                                    }
+                                ]
+                            },
+                            "licence": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "description": "Licence of the tool",
+                                "minItems": 1,
+                                "uniqueItems": true,
+                                "message": "Licence must be an array of one or more entries, e.g. [\"MIT\"]"
+                            },
+                            "identifier": {
+                                "type": "string",
+                                "description": "bio.tools identifier of the tool",
+                                "pattern": "^(biotools:.*)?$"
+                            }
+                        },
+                        "required": ["description"],
+                        "anyOf": [
+                            {
+                                "required": ["homepage"]
+                            },
+                            {
+                                "required": ["documentation"]
+                            },
+                            {
+                                "required": ["tool_dev_url"]
+                            },
+                            {
+                                "required": ["doi"]
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        "extra_args": {
+            "type": "array",
+            "description": "Extra arguments for the module",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "description": {
+                        "type": "string",
+                        "description": "Description of the argument"
+                    }
+                }
+            }
+        },
+        "input": {
+            "type": "array",
+            "description": "Input channels for the module",
+            "items": {
+                "oneOf": [
+                    {
+                        "$ref": "#/definitions/channelElement"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/channelElement"
+                        }
+                    }
+                ]
+            }
+        },
+        "output": {
+            "type": "object",
+            "description": "Output channels for the module",
+            "patternProperties": {
+                ".*": {
+                    "$ref": "#/definitions/channelArray"
+                }
+            }
+        },
+        "topics": {
+            "type": "object",
+            "description": "Topics of the module",
+            "patternProperties": {
+                ".*": {
+                    "$ref": "#/definitions/channelArray"
+                }
+            }
+        },
+        "authors": {
+            "type": "array",
+            "description": "Authors of the module",
+            "items": {
+                "type": "string"
+            }
+        },
+        "maintainers": {
+            "type": "array",
+            "description": "Maintainers of the module",
+            "items": {
+                "type": "string"
+            }
+        },
+        "containers": {
+            "type": "object",
+            "description": "Container images for the module",
+            "properties": {
+                "docker": {
+                    "type": "object",
+                    "description": "Docker containers for different architectures",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/container"
+                    }
+                },
+                "singularity": {
+                    "type": "object",
+                    "description": "Singularity containers for different architectures",
+                    "additionalProperties": {
+                        "allOf": [
+                            {
+                                "$ref": "#/definitions/container"
+                            },
+                            {
+                                "properties": {
+                                    "name": {
+                                        "pattern": "^oras://.*$"
+                                    }
+                                },
+                                "required": ["https"]
+                            }
+                        ]
+                    }
+                },
+                "conda": {
+                    "type": "object",
+                    "description": "Conda lock files for different architectures",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/condaLockFile"
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "channelElement": {
+            "type": "object",
+            "patternProperties": {
+                ".*": {
+                    "$ref": "#/definitions/elementProperties"
+                }
+            }
+        },
+        "channelArray": {
+            "type": "array",
+            "items": {
+                "oneOf": [
+                    {
+                        "$ref": "#/definitions/channelElement"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/channelElement"
+                        }
+                    }
+                ]
+            }
+        },
+        "elementProperties": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Type of the channel element",
+                    "enum": ["map", "file", "directory", "string", "integer", "float", "boolean", "list", "eval"]
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Description of the channel"
+                },
+                "pattern": {
+                    "type": "string",
+                    "description": "Pattern of the channel, given in Java glob syntax"
+                },
+                "enum": {
+                    "type": "array",
+                    "description": "List of allowed values for the channel",
+                    "items": {
+                        "type": ["string", "number", "boolean", "array", "object"]
+                    },
+                    "uniqueItems": true
+                },
+                "ontologies": {
+                    "type": "array",
+                    "description": "List of ontologies for the channel",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "object",
+                        "patternProperties": {
+                            ".*": {
+                                "type": "string",
+                                "pattern": "^https?://.*"
+                            }
+                        }
+                    }
+                }
+            },
+            "required": ["type", "description"]
+        },
+        "container": {
+            "type": "object",
+            "description": "Container information for Docker or Singularity",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Container name/URI"
+                },
+                "https": {
+                    "type": "string",
+                    "description": "HTTPS URL to download the container (only for Singularity)",
+                    "pattern": "^https://.*$"
+                },
+                "build_id": {
+                    "type": "string",
+                    "description": "Build ID of the container"
+                },
+                "scan_id": {
+                    "type": "string",
+                    "description": "Security scan ID of the container (only for Docker)"
+                }
+            },
+            "required": ["name", "build_id"]
+        },
+        "condaLockFile": {
+            "type": "object",
+            "description": "Conda lock file information",
+            "properties": {
+                "lock_file": {
+                    "type": "string",
+                    "description": "Path to the conda lock file, relative to the repository root",
+                    "pattern": "^.*\\.conda-lock/.*\\.txt$"
+                }
+            },
+            "required": ["lock_file"]
+        }
+    },
+    "required": ["name", "description", "keywords", "authors", "output", "tools"]
+}

--- a/content/schemas/nf-core-subworkflow-meta.md
+++ b/content/schemas/nf-core-subworkflow-meta.md
@@ -1,0 +1,51 @@
+---
+type: schema
+name: nf-core-subworkflow-meta
+title: nf-core subworkflow meta.yml schema
+package: "@galaxy-foundry/summary-nextflow-schema"
+package_export: "nfCoreSubworkflowMetaSchema"
+upstream: "https://github.com/nf-core/modules/blob/d8529909206a06d9ec73703ea07a533a511bb786/subworkflows/yaml-schema.json"
+license: MIT
+license_file: LICENSES/nf-core-modules.LICENSE
+tags:
+  - schema
+  - source/nextflow
+status: draft
+created: 2026-05-05
+revised: 2026-05-05
+revision: 1
+ai_generated: true
+related_notes:
+  - "[[nf-core-module-meta]]"
+  - "[[summarize-nextflow]]"
+  - "[[component-nextflow-pipeline-anatomy]]"
+  - "[[component-nf-core-tools]]"
+related_molds:
+  - "[[summarize-nextflow]]"
+summary: "JSON Schema (Draft-07) validating nf-core subworkflow meta.yml — channel IO, components dependencies, authors. Upstream from nf-core/modules."
+---
+
+JSON Schema vendored verbatim from `nf-core/modules` at SHA `d852990`. Validates every subworkflow `meta.yml` under `subworkflows/nf-core/<name>/`.
+
+**Operational role.** Companion to `[[nf-core-module-meta]]` for the subworkflow tier. `summarize-nextflow` §6 distinguishes `kind: pipeline` vs `kind: utility` subworkflows; this schema's `components` field — the declared transitive module/subworkflow dependencies — is the structured signal that backs the call-graph extraction.
+
+**Source-of-truth chain:**
+
+1. `subworkflows/yaml-schema.json` in [`nf-core/modules`](https://github.com/nf-core/modules), cited by every subworkflow `meta.yml` via `# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json`.
+2. Vendored verbatim into `content/schemas/nf-core-subworkflow-meta.schema.json`, pinned at `upstream`'s SHA.
+3. **Re-sync:** identical recipe to [[nf-core-module-meta]].
+
+## Top-level shape
+
+Required: `name`, `description`, `keywords` (≥3), `authors`, `output`, `components`. Optional: `input`, `maintainers`.
+
+Differences from the module schema:
+
+- `components` (required, array of strings) — declares modules and subworkflows the subworkflow depends on. Resolves transitively at install time per `nf-core/tools` modules.json. The cast skill walks this to fill `Subworkflow.calls[]`.
+- No `tools[]` block (tools are declared at the leaf module level).
+- No `containers` block.
+- `input` and `output` shapes use the same `channelElement` / `channelArray` grammar as the module schema, so the `summarize-nextflow` channel IO extractor handles both with the same code path.
+
+## Upstream license
+
+Same MIT redistribution as [[nf-core-module-meta]]. See `LICENSES/nf-core-modules.LICENSE`.

--- a/content/schemas/nf-core-subworkflow-meta.schema.json
+++ b/content/schemas/nf-core-subworkflow-meta.schema.json
@@ -1,0 +1,121 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "title": "Meta yaml",
+    "description": "Validate the meta yaml file for an nf-core subworkflow",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "Name of the subworkflow"
+        },
+        "description": {
+            "type": "string",
+            "description": "Description of the subworkflow"
+        },
+        "authors": {
+            "type": "array",
+            "description": "Authors of the subworkflow",
+            "items": {
+                "type": "string"
+            }
+        },
+        "maintainers": {
+            "type": "array",
+            "description": "Maintainers of the subworkflow",
+            "items": {
+                "type": "string"
+            }
+        },
+        "components": {
+            "type": "array",
+            "description": "Modules and subworkflows used in the subworkflow",
+            "items": {
+                "type": "string"
+            },
+            "minItems": 0
+        },
+        "keywords": {
+            "type": "array",
+            "description": "Keywords for the module",
+            "items": {
+                "type": "string"
+            },
+            "minItems": 3
+        },
+        "input": {
+            "type": "array",
+            "description": "Input channels for the subworkflow",
+            "items": {
+                "type": "object",
+                "patternProperties": {
+                    ".*": {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "description": "Type of the input channel"
+                            },
+                            "description": {
+                                "type": "string",
+                                "description": "Description of the input channel"
+                            },
+                            "pattern": {
+                                "type": "string",
+                                "description": "Pattern of the input channel, given in Java glob syntax"
+                            },
+                            "default": {
+                                "type": ["string", "number", "boolean", "array", "object"],
+                                "description": "Default value for the input channel"
+                            },
+                            "enum": {
+                                "type": "array",
+                                "description": "List of allowed values for the input channel",
+                                "items": {
+                                    "type": ["string", "number", "boolean", "array", "object"]
+                                },
+                                "uniqueItems": true
+                            }
+                        },
+                        "required": ["description"]
+                    }
+                }
+            }
+        },
+        "output": {
+            "type": "array",
+            "description": "Output channels for the subworkflow",
+            "items": {
+                "type": "object",
+                "patternProperties": {
+                    ".*": {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "description": "Type of the output channel"
+                            },
+                            "description": {
+                                "type": "string",
+                                "description": "Description of the output channel"
+                            },
+                            "pattern": {
+                                "type": "string",
+                                "description": "Pattern of the input channel, given in Java glob syntax"
+                            },
+                            "enum": {
+                                "type": "array",
+                                "description": "List of allowed values for the output channel",
+                                "items": {
+                                    "type": ["string", "number", "boolean", "array", "object"]
+                                },
+                                "uniqueItems": true
+                            }
+                        },
+                        "required": ["description"]
+                    }
+                }
+            }
+        }
+    },
+    "required": ["name", "description", "keywords", "authors", "output", "components"]
+}

--- a/content/schemas/summary-nextflow.md
+++ b/content/schemas/summary-nextflow.md
@@ -5,6 +5,7 @@ title: Nextflow pipeline summary
 package: "@galaxy-foundry/summary-nextflow-schema"
 package_export: "summaryNextflowSchema"
 upstream: "https://github.com/jmchilton/foundry/blob/main/packages/summary-nextflow-schema/src/summary-nextflow.schema.json"
+license: MIT
 tags:
   - schema
   - source/nextflow

--- a/content/schemas/tests-format.md
+++ b/content/schemas/tests-format.md
@@ -5,13 +5,15 @@ title: Galaxy workflow test format
 package: "@galaxy-tool-util/schema"
 package_export: "testsSchema"
 upstream: "https://github.com/jmchilton/galaxy-tool-util-ts/blob/main/packages/schema/src/test-format/tests.schema.json"
+license: MIT
+license_file: LICENSES/galaxy-tool-util-ts.LICENSE
 tags:
   - schema
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-05-04
-revision: 3
+revised: 2026-05-05
+revision: 4
 ai_generated: true
 related_notes:
   - "[[implement-galaxy-workflow-test]]"

--- a/meta_schema.yml
+++ b/meta_schema.yml
@@ -240,6 +240,21 @@ properties:
     type: string
     description: "For package-vendored schemas: the named runtime export from `package` that returns the JSON Schema object (e.g. `testsSchema`). cast-mold imports and stringifies this when resolving a typed `kind: schema` reference."
 
+  # --- Vendoring fields (any note redistributing upstream content) ---
+  # SPDX identifier of the content's license. Set on schema notes whose
+  # `upstream` lives outside this repo, and on research notes that vendor a
+  # structured upstream artifact alongside their prose.
+  license:
+    type: string
+    enum: [MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, AFL-3.0, GPL-2.0-only, GPL-3.0-only]
+    description: "SPDX license identifier for the note's vendored content. The Foundry's own content is covered by the root LICENSE; this field annotates third-party redistributions."
+  # Repo-relative path to the upstream LICENSE under LICENSES/. The validator
+  # confirms the file exists and is non-empty.
+  license_file:
+    type: string
+    pattern: "^LICENSES/[A-Za-z0-9._-]+(\\.LICENSE|\\.txt)?$"
+    description: "Repo-relative path under LICENSES/ to the verbatim upstream LICENSE this note redistributes content under."
+
 allOf:
   # mold requires name + axis
   - if:

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -569,6 +569,101 @@ describe("validateDirectory (cross-file)", () => {
     expect(r.errors).toBeGreaterThanOrEqual(1);
   });
 
+  it("rejects a vendored schema missing license_file", () => {
+    mkdirSync(path.join(dir, "schemas"), { recursive: true });
+    writeFileSync(path.join(dir, "schemas/x.schema.json"), "{}");
+    writeFm(path.join(dir, "schemas/x.md"), {
+      ...baseRequired({
+        type: "schema",
+        tags: ["schema"],
+        name: "x",
+        title: "X",
+        package: "@some-org/x",
+        upstream: "https://github.com/some-org/x/blob/main/x.schema.json",
+      }),
+    });
+
+    const r = validateDirectory({
+      directory: dir,
+      schemaPath: SCHEMA_PATH,
+      tagsPath: TAGS_PATH,
+    });
+    expect(r.errors).toBeGreaterThanOrEqual(1);
+  });
+
+  it("accepts a vendored schema with license_file resolving inside the vault", () => {
+    mkdirSync(path.join(dir, "LICENSES"), { recursive: true });
+    writeFileSync(path.join(dir, "LICENSES/some-org.LICENSE"), "MIT License\n\nCopyright …\n");
+    mkdirSync(path.join(dir, "schemas"), { recursive: true });
+    writeFileSync(path.join(dir, "schemas/x.schema.json"), "{}");
+    writeFm(path.join(dir, "schemas/x.md"), {
+      ...baseRequired({
+        type: "schema",
+        tags: ["schema"],
+        name: "x",
+        title: "X",
+        package: "@some-org/x",
+        upstream: "https://github.com/some-org/x/blob/main/x.schema.json",
+        license: "MIT",
+        license_file: "LICENSES/some-org.LICENSE",
+      }),
+    });
+
+    const r = validateDirectory({
+      directory: dir,
+      schemaPath: SCHEMA_PATH,
+      tagsPath: TAGS_PATH,
+    });
+    expect(r.errors).toBe(0);
+  });
+
+  it("rejects a license_file pointing at a missing file", () => {
+    mkdirSync(path.join(dir, "schemas"), { recursive: true });
+    writeFileSync(path.join(dir, "schemas/x.schema.json"), "{}");
+    writeFm(path.join(dir, "schemas/x.md"), {
+      ...baseRequired({
+        type: "schema",
+        tags: ["schema"],
+        name: "x",
+        title: "X",
+        package: "@some-org/x",
+        upstream: "https://github.com/some-org/x/blob/main/x.schema.json",
+        license: "MIT",
+        license_file: "LICENSES/does-not-exist.LICENSE",
+      }),
+    });
+
+    const r = validateDirectory({
+      directory: dir,
+      schemaPath: SCHEMA_PATH,
+      tagsPath: TAGS_PATH,
+    });
+    expect(r.errors).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does not require license_file for Foundry-authored schemas", () => {
+    mkdirSync(path.join(dir, "schemas"), { recursive: true });
+    writeFileSync(path.join(dir, "schemas/x.schema.json"), "{}");
+    writeFm(path.join(dir, "schemas/x.md"), {
+      ...baseRequired({
+        type: "schema",
+        tags: ["schema"],
+        name: "x",
+        title: "X",
+        package: "@galaxy-foundry/x-schema",
+        upstream: "https://github.com/jmchilton/foundry/blob/main/packages/x-schema/src/x.schema.json",
+        license: "MIT",
+      }),
+    });
+
+    const r = validateDirectory({
+      directory: dir,
+      schemaPath: SCHEMA_PATH,
+      tagsPath: TAGS_PATH,
+    });
+    expect(r.errors).toBe(0);
+  });
+
   it("requires verification for hypothesis references", () => {
     writeFm(path.join(dir, "molds/m/index.md"), {
       ...baseRequired({


### PR DESCRIPTION
## Summary

Lands the Tier-A vendoring + Tier-B structured digests from the Nextflow coverage research, plus the license infrastructure to make vendoring enforceable.

**License infrastructure**
- root MIT `LICENSE`; `LICENSES/` directory for upstream-redistributed content (with README index)
- `meta_schema.yml` gains `license` (SPDX enum) + `license_file` (`^LICENSES/...$`) optional properties
- `scripts/validate.ts` adds `validateLicenseFiles`: declared `license_file` must resolve to a non-empty file; `type: schema` notes whose `upstream` is not under `github.com/jmchilton/foundry` must declare both `license` and `license_file`
- 4 new validator unit tests; 34/34 total passing

**Tier A — vendored schemas (pinned by upstream SHA, verbatim, MIT/Apache-2.0)**
- `content/schemas/nf-core-module-meta.{md,schema.json}` — backs `meta.yml` extraction in `summarize-nextflow` §4 ("use it" as IO ground truth)
- `content/schemas/nf-core-subworkflow-meta.{md,schema.json}` — backs `Subworkflow.calls[]` via `components:` declaration
- `content/schemas/nextflow-parameters-meta.{md,schema.json}` — Draft 2020-12 meta-schema for per-pipeline `nextflow_schema.json`; backs §3 params extraction
- `summarize-nextflow` Mold wires all three as `kind: schema`, `used_at: both`, `load: upfront`, `evidence: corpus-observed`

**Tier B — Foundry-authored structured digests (md + yml pairs)**
- `component-nextflow-containers-and-envs.{md,yml}` — fills the previous stub. URL-prefix bucketing rules for container directives (Galaxy depot, BioContainers, mulled-v2, Wave, ORAS, generic Docker) with regex + verbatim examples + derivation rules per form. Surfaces a Foundry hypothesis on URL-prefix vs ternary-branch bucketing for the Mold author to confirm. Drafted by a background subagent against canonical nf-core modules (fastqc, multiqc, dragmap, seqkit/sample) + the nf-core meta-schema.
- `component-nextflow-channel-operators.{md,yml}` — 47 operators across 7 categories with cardinality + shape semantics; backs `summarize-nextflow` §6 edge reconciliation.
- `component-nf-core-module-conventions.{md,yml}` — ~24 RFC 2119 rules from the nf-core/tools lint registry, each tagged with the lint check that enforces it and which Mold step consumes it.
- `component-nextflow-testing.{md,yml}` — replaces the previous stub; ~28 `nf_test_pattern` → Galaxy / CWL mapping rows with deep-links into `[[tests-format]]` and `[[planemo-asserts-idioms]]`. Backs the (still-stub) `nextflow-test-to-target-tests` Mold.

**Backfill**
- `tests-format.md` (existing vendored schema) declares `license: MIT`, `license_file: LICENSES/galaxy-tool-util-ts.LICENSE` to satisfy the new rule.
- `summary-nextflow.md` (Foundry-authored) declares `license: MIT` (no `license_file`; covered by root LICENSE).

## Test plan
- [x] `npm run validate` — 60 content files, 0 errors (37 pre-existing backlink-asymmetry warnings)
- [x] `npm run test` — 34/34 pass (4 new license-validation tests added)
- [ ] Reviewer sanity-check: open `content/research/component-nextflow-containers-and-envs.md` — confirm the URL-prefix vs ternary-branch bucketing recommendation matches the Mold author's intent for `summarize-nextflow` §5
- [ ] Confirm Draft 2020-12 schema (`nextflow-parameters-meta.schema.json`) is acceptable as a sidecar payload (Foundry's own validator only loads Draft-07 frontmatter; this schema is content the cast skill loads, not something the validator parses as a meta)

🤖 Generated with [Claude Code](https://claude.com/claude-code)