### PR TITLE
Parse nf-test snapshot sidecars

### DIFF
--- a/packages/summarize-nextflow/src/resolver.ts
+++ b/packages/summarize-nextflow/src/resolver.ts
@@ -1183,7 +1183,12 @@ function parseParamsOverrides(text: string): Record<string, unknown> {
   return values;
 }
 
-function parseSnapshot(path: string, relPath: string, text: string, name: string): NfTest["snapshot"] {
+function parseSnapshot(
+  path: string,
+  relPath: string,
+  text: string,
+  name: string,
+): NfTest["snapshot"] {
   if (!text.includes("snapshot(")) return null;
   const snapPath = existsSync(`${path}.snap`) ? `${relPath}.snap` : null;
   return {

--- a/packages/summarize-nextflow/src/resolver.ts
+++ b/packages/summarize-nextflow/src/resolver.ts
@@ -135,9 +135,35 @@ interface NfTest {
     ignore_files: string[];
     ignore_globs: string[];
     snap_path: string | null;
+    parsed_content: SnapshotContent[];
   } | null;
   prose_assertions: string[];
 }
+
+interface SnapshotContent {
+  name: string;
+  channels: SnapshotChannel[];
+}
+
+interface SnapshotChannel {
+  key: string | null;
+  files: SnapshotFile[];
+  values: unknown[];
+}
+
+interface SnapshotFile {
+  path: string;
+  basename: string;
+  md5: string;
+  stub: boolean;
+}
+
+interface SnapshotParts {
+  files: SnapshotFile[];
+  values: unknown[];
+}
+
+const MAX_SNAPSHOT_SIDECAR_BYTES = 200_000;
 
 export interface ResolveOptions {
   profile: string;
@@ -1115,7 +1141,7 @@ function parseNfTestsInDir(pipelineRoot: string, testsRoot: string): NfTest[] {
         profiles: unique([...parseNfTestProfiles(block.body, block.name), ...fileProfiles]),
         params_overrides: parseParamsOverrides(block.body),
         assert_workflow_success: block.body.includes("workflow.success"),
-        snapshot: parseSnapshot(path, relPath, block.body),
+        snapshot: parseSnapshot(path, relPath, block.body, block.name),
         prose_assertions: parseProseAssertions(block.body),
       }));
     });
@@ -1157,8 +1183,9 @@ function parseParamsOverrides(text: string): Record<string, unknown> {
   return values;
 }
 
-function parseSnapshot(path: string, relPath: string, text: string): NfTest["snapshot"] {
+function parseSnapshot(path: string, relPath: string, text: string, name: string): NfTest["snapshot"] {
   if (!text.includes("snapshot(")) return null;
+  const snapPath = existsSync(`${path}.snap`) ? `${relPath}.snap` : null;
   return {
     captures: parseSnapshotCaptures(text),
     helpers: unique(
@@ -1170,8 +1197,83 @@ function parseSnapshot(path: string, relPath: string, text: string): NfTest["sna
     ignore_globs: [...text.matchAll(/ignore:\s*\[([^\]]+)\]/gu)].flatMap((match) =>
       [...match[1]!.matchAll(/['"]([^'"]+)['"]/gu)].map((inner) => inner[1]!),
     ),
-    snap_path: existsSync(`${path}.snap`) ? `${relPath}.snap` : null,
+    snap_path: snapPath,
+    parsed_content: snapPath === null ? [] : parseSnapshotSidecar(`${path}.snap`, name),
   };
+}
+
+function parseSnapshotSidecar(path: string, name: string): SnapshotContent[] {
+  try {
+    if (statSync(path).size > MAX_SNAPSHOT_SIDECAR_BYTES) return [];
+    const parsed: unknown = JSON.parse(readText(path));
+    if (!isRecord(parsed)) return [];
+    const entries = Object.entries(parsed);
+    const matching = entries.filter(([entryName]) => entryName === name);
+    return (matching.length > 0 ? matching : entries).flatMap(([entryName, entry]) =>
+      parseSnapshotContent(entryName, entry),
+    );
+  } catch {
+    return [];
+  }
+}
+
+function parseSnapshotContent(name: string, entry: unknown): SnapshotContent[] {
+  if (!isRecord(entry)) return [];
+  const content = entry["content"];
+  if (!Array.isArray(content)) return [];
+  return [{ name, channels: content.flatMap(parseSnapshotContentItem) }];
+}
+
+function parseSnapshotContentItem(item: unknown): SnapshotChannel[] {
+  if (Array.isArray(item)) return [snapshotChannel(null, item)];
+  if (typeof item === "string") return [snapshotChannel(null, [item])];
+  if (!isRecord(item)) return [snapshotChannel(null, [item])];
+  return Object.entries(item).map(([key, value]) =>
+    snapshotChannel(key, Array.isArray(value) ? value : [value]),
+  );
+}
+
+function snapshotChannel(key: string | null, values: unknown[]): SnapshotChannel {
+  const parts = values.map(parseSnapshotParts);
+  return {
+    key,
+    files: parts.flatMap((part) => part.files),
+    values: parts.flatMap((part) => part.values),
+  };
+}
+
+function parseSnapshotParts(value: unknown): SnapshotParts {
+  if (typeof value === "string") {
+    const match = /^(.*):md5,([a-fA-F0-9]{32})$/u.exec(value);
+    if (match === null) return { files: [], values: [value] };
+    const path = match[1]!;
+    const md5 = match[2]!;
+    return {
+      files: [
+        {
+          path,
+          basename: path.split(/[\\/]/u).pop() ?? path,
+          md5,
+          stub: md5 === "d41d8cd98f00b204e9800998ecf8427e",
+        },
+      ],
+      values: [],
+    };
+  }
+  if (Array.isArray(value)) {
+    const parts = value.map(parseSnapshotParts);
+    const files = parts.flatMap((part) => part.files);
+    if (files.length === 0) return { files: [], values: [value] };
+    return {
+      files,
+      values: parts.flatMap((part) => part.values),
+    };
+  }
+  return { files: [], values: [value] };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function parseSnapshotCaptures(text: string): string[] {

--- a/packages/summarize-nextflow/test/resolver.test.ts
+++ b/packages/summarize-nextflow/test/resolver.test.ts
@@ -16,7 +16,21 @@ interface SummaryLike {
       input: { name: string; type?: string; description?: string; pattern?: string }[];
       output: { name: string; type?: string; description?: string; pattern?: string }[];
     } | null;
-    module_tests: { name: string; path: string; snapshot: { snap_path: string | null } | null }[];
+    module_tests: {
+      name: string;
+      path: string;
+      snapshot: {
+        snap_path: string | null;
+        parsed_content?: {
+          name: string;
+          channels: {
+            key: string | null;
+            files: { path: string; basename: string; md5: string; stub: boolean }[];
+            values: unknown[];
+          }[];
+        }[];
+      } | null;
+    }[];
     inputs: unknown[];
     outputs: unknown[];
   }[];
@@ -245,7 +259,25 @@ test("align module") {
 }
 `,
     );
-    write(root, "modules/nf-core/minimap2/align/tests/main.nf.test.snap", "snapshot\n");
+    write(
+      root,
+      "modules/nf-core/minimap2/align/tests/main.nf.test.snap",
+      JSON.stringify({
+        "align module": {
+          content: [
+            {
+              "0": ["aligned.bam:md5,aa8b2aa1e0b5fbbba3b04d471e1b0535"],
+              versions: [["MINIMAP2", "minimap2", "2.28"]],
+              bam: [["sample1", "results/aligned.bam:md5,d41d8cd98f00b204e9800998ecf8427e"]],
+            },
+          ],
+          meta: { "nf-test": "0.9.3" },
+        },
+        "sibling module": {
+          content: [{ bam: ["sibling.bam:md5,ffffffffffffffffffffffffffffffff"] }],
+        },
+      }),
+    );
 
     const summary = await summarize(root);
     const process = summary.processes[0]!;
@@ -271,6 +303,42 @@ test("align module") {
         path: "modules/nf-core/minimap2/align/tests/main.nf.test",
         snapshot: expect.objectContaining({
           snap_path: "modules/nf-core/minimap2/align/tests/main.nf.test.snap",
+          parsed_content: [
+            {
+              name: "align module",
+              channels: [
+                {
+                  key: "0",
+                  files: [
+                    {
+                      path: "aligned.bam",
+                      basename: "aligned.bam",
+                      md5: "aa8b2aa1e0b5fbbba3b04d471e1b0535",
+                      stub: false,
+                    },
+                  ],
+                  values: [],
+                },
+                {
+                  key: "versions",
+                  files: [],
+                  values: [["MINIMAP2", "minimap2", "2.28"]],
+                },
+                {
+                  key: "bam",
+                  files: [
+                    {
+                      path: "results/aligned.bam",
+                      basename: "aligned.bam",
+                      md5: "d41d8cd98f00b204e9800998ecf8427e",
+                      stub: true,
+                    },
+                  ],
+                  values: ["sample1"],
+                },
+              ],
+            },
+          ],
         }),
       }),
     );

--- a/packages/summary-nextflow-schema/src/summary-nextflow.schema.generated.ts
+++ b/packages/summary-nextflow-schema/src/summary-nextflow.schema.generated.ts
@@ -879,6 +879,99 @@ export const summaryNextflowSchema = {
             "null"
           ],
           "description": "Repo-relative path of the corresponding `.nf.test.snap` file when present."
+        },
+        "parsed_content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SnapshotContent"
+          },
+          "description": "Parsed entries from the `.nf.test.snap` JSON sidecar. Empty when the sidecar is absent, too large for compact summary output, or not valid JSON. Each entry preserves the snapshot name plus channel-keyed file md5 assertions and non-file scalar values."
+        }
+      }
+    },
+    "SnapshotContent": {
+      "title": "SnapshotContent",
+      "description": "One top-level snapshot entry from an nf-test `.snap` JSON sidecar.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "channels"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Top-level key in the `.snap` file, usually the `test(\"...\")` name."
+        },
+        "channels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SnapshotChannel"
+          },
+          "description": "Channel-keyed snapshot values. Pipeline-template flat file lists use `key: null`."
+        }
+      }
+    },
+    "SnapshotChannel": {
+      "title": "SnapshotChannel",
+      "description": "One output channel or flat snapshot list inside a `.snap` entry.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "key",
+        "files",
+        "values"
+      ],
+      "properties": {
+        "key": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Channel key from the snapshot object, e.g. `0`, `1`, or `genome_gtf`; null for flat file-list snapshots."
+        },
+        "files": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SnapshotFile"
+          },
+          "description": "File md5 assertions parsed from `<path>:md5,<hex>` strings."
+        },
+        "values": {
+          "type": "array",
+          "items": {},
+          "description": "Non-file snapshot values preserved verbatim for consumers that need versions, counts, or scalar tuple emissions."
+        }
+      }
+    },
+    "SnapshotFile": {
+      "title": "SnapshotFile",
+      "description": "One file digest assertion from a `.snap` sidecar.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "basename",
+        "md5",
+        "stub"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Path portion before `:md5,` exactly as stored in the sidecar."
+        },
+        "basename": {
+          "type": "string",
+          "description": "Final path segment, suitable for Galaxy test `file:` assertions when the snapshot stores only basenames."
+        },
+        "md5": {
+          "type": "string",
+          "pattern": "^[a-fA-F0-9]{32}$",
+          "description": "MD5 digest from the sidecar."
+        },
+        "stub": {
+          "type": "boolean",
+          "description": "True when the digest is the empty-file md5 emitted by many `-stub` tests."
         }
       }
     }

--- a/packages/summary-nextflow-schema/src/summary-nextflow.schema.json
+++ b/packages/summary-nextflow-schema/src/summary-nextflow.schema.json
@@ -306,7 +306,47 @@
         "helpers":       { "type": "array", "items": { "type": "string" }, "description": "nf-test helper functions invoked in the snapshot expression (e.g. `getAllFilesFromDir`, `removeNextflowVersion`). Used to detect whether a target framework can replicate the comparison." },
         "ignore_files":  { "type": "array", "items": { "type": "string" }, "description": "Repo-relative paths passed as `ignoreFile:` to helpers (e.g. `tests/.nftignore`, `tests/.nftignore_files_entirely`). The files themselves are line-delimited globs." },
         "ignore_globs":  { "type": "array", "items": { "type": "string" }, "description": "Inline `ignore: [...]` glob list passed to helpers (e.g. `['Prokka/**', '**/multiqc_busco.yaml']`). Distinct from ignore_files which references on-disk lists." },
-        "snap_path":     { "type": ["string", "null"], "description": "Repo-relative path of the corresponding `.nf.test.snap` file when present." }
+        "snap_path":     { "type": ["string", "null"], "description": "Repo-relative path of the corresponding `.nf.test.snap` file when present." },
+        "parsed_content": { "type": "array", "items": { "$ref": "#/$defs/SnapshotContent" }, "description": "Parsed entries from the `.nf.test.snap` JSON sidecar. Empty when the sidecar is absent, too large for compact summary output, or not valid JSON. Each entry preserves the snapshot name plus channel-keyed file md5 assertions and non-file scalar values." }
+      }
+    },
+
+    "SnapshotContent": {
+      "title": "SnapshotContent",
+      "description": "One top-level snapshot entry from an nf-test `.snap` JSON sidecar.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "channels"],
+      "properties": {
+        "name":     { "type": "string", "description": "Top-level key in the `.snap` file, usually the `test(\"...\")` name." },
+        "channels": { "type": "array", "items": { "$ref": "#/$defs/SnapshotChannel" }, "description": "Channel-keyed snapshot values. Pipeline-template flat file lists use `key: null`." }
+      }
+    },
+
+    "SnapshotChannel": {
+      "title": "SnapshotChannel",
+      "description": "One output channel or flat snapshot list inside a `.snap` entry.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key", "files", "values"],
+      "properties": {
+        "key":    { "type": ["string", "null"], "description": "Channel key from the snapshot object, e.g. `0`, `1`, or `genome_gtf`; null for flat file-list snapshots." },
+        "files":  { "type": "array", "items": { "$ref": "#/$defs/SnapshotFile" }, "description": "File md5 assertions parsed from `<path>:md5,<hex>` strings." },
+        "values": { "type": "array", "items": {}, "description": "Non-file snapshot values preserved verbatim for consumers that need versions, counts, or scalar tuple emissions." }
+      }
+    },
+
+    "SnapshotFile": {
+      "title": "SnapshotFile",
+      "description": "One file digest assertion from a `.snap` sidecar.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "basename", "md5", "stub"],
+      "properties": {
+        "path":     { "type": "string", "description": "Path portion before `:md5,` exactly as stored in the sidecar." },
+        "basename": { "type": "string", "description": "Final path segment, suitable for Galaxy test `file:` assertions when the snapshot stores only basenames." },
+        "md5":      { "type": "string", "pattern": "^[a-fA-F0-9]{32}$", "description": "MD5 digest from the sidecar." },
+        "stub":     { "type": "boolean", "description": "True when the digest is the empty-file md5 emitted by many `-stub` tests." }
       }
     }
   }


### PR DESCRIPTION
## Summary
- Extend `SnapshotFixture` with parsed `.nf.test.snap` content for channel-keyed file md5 assertions and scalar values.
- Parse compact valid sidecars in `summarize-nextflow`, filtering multi-test sidecars to the current test block and flagging empty-file stub md5s.
- Add resolver coverage for parsed file md5s, tuple metadata preservation, stub detection, and sibling snapshot filtering.

Closes #142.

## Tests
- `pnpm --filter @galaxy-foundry/summarize-nextflow typecheck`
- `pnpm --filter @galaxy-foundry/summarize-nextflow exec vitest run test/resolver.test.ts`
- `pnpm --filter @galaxy-foundry/summary-nextflow-schema test`
- `npm run validate` (passes with existing warnings)

## Notes
- Full `pnpm --filter @galaxy-foundry/summarize-nextflow test` still fails in existing bacass integration cases where `spawnSync` returns `status: null`; focused resolver/schema validation passes.