### PR TITLE
Suppress Tailwind Typography backtick decorations on inline code

### DIFF
--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -239,6 +239,10 @@ a:hover .tag {
 .dark .prose :where(code):not(:where(pre *, [class~="not-prose"],[class~="not-prose"] *)) {
   background-color: var(--color-surface-raised);
 }
+.prose :where(code):not(:where([class~="not-prose"],[class~="not-prose"] *))::before,
+.prose :where(code):not(:where([class~="not-prose"],[class~="not-prose"] *))::after {
+  content: none;
+}
 .prose :where(pre):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
   background-color: var(--color-galaxy-dark);
   border-radius: 0.5rem;


### PR DESCRIPTION
## Summary
- Tailwind Typography's prose plugin adds literal backticks around inline `<code>` via `::before`/`::after` pseudo-elements.
- Result: `` `branch` `` rendered as `` `branch` `` (with literal quotes) instead of just `branch` in monospace, on every prose page.
- Override sets `content: none` on those pseudos.

## Test plan
- [ ] `npm run validate`
- [ ] Build site, confirm inline code on e.g. `/source-patterns/nextflow/branch-filter-ifempty-to-galaxy-filters-gates/` no longer shows literal backticks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)