### PR TITLE
fix astro build: add license/license_file to schema Zod mirror

### DIFF
--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -157,6 +157,8 @@ const schemaNoteSchema = z.object({
   package: z.string().optional(),
   upstream: z.string().optional(),
   package_export: z.string().optional(),
+  license: z.string().optional(),
+  license_file: z.string().optional(),
 }).strict();
 
 const noteSchema = z.discriminatedUnion('type', [


### PR DESCRIPTION
## Summary
- Deploy build was failing on `content/schemas/nextflow-parameters-meta.md` with `Unrecognized key(s) in object: 'license', 'license_file'`.
- `meta_schema.yml` already declares both fields; the Astro content collection schema in `site/src/content.config.ts` didn't mirror them.
- Adds `license` and `license_file` as optional strings on `schemaNoteSchema`.

## Test plan
- [x] `cd site && npm run build` succeeds (173 pages built).

🤖 Generated with [Claude Code](https://claude.com/claude-code)