### PR TITLE
Polish mold body chips, related links, reference contract

### DIFF
--- a/site/src/components/MoldBody.astro
+++ b/site/src/components/MoldBody.astro
@@ -25,11 +25,80 @@ const prompts = resolveAll(data.prompts);
 const axisChip = data.axis;
 const specifier = data.source ?? data.target ?? data.tool ?? null;
 ---
-<div class="mb-6 flex flex-wrap gap-2 items-center">
-  <span class="text-xs px-2 py-1 rounded bg-(--color-galaxy-primary) text-white font-mono">{axisChip}</span>
-  {specifier && <span class="text-xs px-2 py-1 rounded border border-(--color-border) font-mono">{specifier}</span>}
-  <span class="text-xs text-(--color-text-secondary) font-mono">{data.name}</span>
-</div>
+<dl class="mold-strip">
+  <div class="mold-strip-cell mold-strip-cell-axis">
+    <dt>axis</dt>
+    <dd>{axisChip}</dd>
+  </div>
+  {specifier && (
+    <div class="mold-strip-cell">
+      <dt>{data.source ? 'source' : data.target ? 'target' : 'tool'}</dt>
+      <dd>{specifier}</dd>
+    </div>
+  )}
+  <div class="mold-strip-cell mold-strip-cell-name">
+    <dt>name</dt>
+    <dd>{data.name}</dd>
+  </div>
+</dl>
+
+<style>
+  .mold-strip {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: stretch;
+    gap: 0;
+    margin: 0 0 1.5rem;
+    padding: 0;
+    border: 1px solid var(--color-border-subtle);
+    border-radius: 0.6rem;
+    background: var(--color-surface-raised);
+    overflow: hidden;
+  }
+  .mold-strip-cell {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    padding: 0.55rem 0.95rem;
+    border-right: 1px solid var(--color-border-subtle);
+    min-width: 0;
+  }
+  .mold-strip-cell:last-child { border-right: 0; }
+  .mold-strip-cell dt {
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+    margin: 0;
+  }
+  .mold-strip-cell dd {
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+    color: var(--color-text-primary);
+    overflow-wrap: anywhere;
+  }
+  .mold-strip-cell-axis {
+    background: color-mix(in srgb, var(--color-galaxy-primary) 8%, transparent);
+    box-shadow: inset 3px 0 0 var(--color-galaxy-primary);
+  }
+  .mold-strip-cell-axis dd {
+    color: var(--color-link);
+    font-weight: 600;
+  }
+  .mold-strip-cell-name dd {
+    color: var(--color-text-secondary);
+  }
+  @media (max-width: 480px) {
+    .mold-strip-cell {
+      flex-basis: 100%;
+      border-right: 0;
+      border-bottom: 1px solid var(--color-border-subtle);
+    }
+    .mold-strip-cell:last-child { border-bottom: 0; }
+  }
+</style>
 
 <ReferenceContract references={data.references} linkMap={linkMap} />
 

--- a/site/src/components/NoteMeta.astro
+++ b/site/src/components/NoteMeta.astro
@@ -85,14 +85,15 @@ const hasAnything =
     <div class="meta-pair">
       <dt>Patterns</dt>
       <dd>
-        {relatedPatterns.map((l, i) => (
-          <>
-            {l.href
-              ? <a href={l.href} title={l.summary || undefined}>{l.label}</a>
-              : <span class="dangling">{l.label}</span>}
-            {i < relatedPatterns.length - 1 ? ', ' : ''}
-          </>
-        ))}
+        <ul class="link-chips">
+          {relatedPatterns.map(l => (
+            <li>
+              {l.href
+                ? <a class="link-chip" href={l.href} title={l.summary || undefined}>{l.label}</a>
+                : <span class="link-chip link-chip-dangling">{l.label}</span>}
+            </li>
+          ))}
+        </ul>
       </dd>
     </div>
   )}
@@ -101,14 +102,15 @@ const hasAnything =
     <div class="meta-pair">
       <dt>Implemented By</dt>
       <dd>
-        {implementedByPatterns.map((l, i) => (
-          <>
-            {l.href
-              ? <a href={l.href} title={l.summary || undefined}>{l.label}</a>
-              : <span class="dangling">{l.label}</span>}
-            {i < implementedByPatterns.length - 1 ? ', ' : ''}
-          </>
-        ))}
+        <ul class="link-chips">
+          {implementedByPatterns.map(l => (
+            <li>
+              {l.href
+                ? <a class="link-chip" href={l.href} title={l.summary || undefined}>{l.label}</a>
+                : <span class="link-chip link-chip-dangling">{l.label}</span>}
+            </li>
+          ))}
+        </ul>
       </dd>
     </div>
   )}
@@ -128,14 +130,15 @@ const hasAnything =
     <div class="meta-pair">
       <dt>Molds</dt>
       <dd>
-        {relatedMolds.map((l, i) => (
-          <>
-            {l.href
-              ? <a href={l.href} title={l.summary || undefined}>{l.label}</a>
-              : <span class="dangling">{l.label}</span>}
-            {i < relatedMolds.length - 1 ? ', ' : ''}
-          </>
-        ))}
+        <ul class="link-chips">
+          {relatedMolds.map(l => (
+            <li>
+              {l.href
+                ? <a class="link-chip" href={l.href} title={l.summary || undefined}>{l.label}</a>
+                : <span class="link-chip link-chip-dangling">{l.label}</span>}
+            </li>
+          ))}
+        </ul>
       </dd>
     </div>
   )}
@@ -144,14 +147,15 @@ const hasAnything =
     <div class="meta-pair">
       <dt>Related</dt>
       <dd>
-        {relatedNotes.map((l, i) => (
-          <>
-            {l.href
-              ? <a href={l.href} title={l.summary || undefined}>{l.label}</a>
-              : <span class="dangling">{l.label}</span>}
-            {i < relatedNotes.length - 1 ? ', ' : ''}
-          </>
-        ))}
+        <ul class="link-chips">
+          {relatedNotes.map(l => (
+            <li>
+              {l.href
+                ? <a class="link-chip" href={l.href} title={l.summary || undefined}>{l.label}</a>
+                : <span class="link-chip link-chip-dangling">{l.label}</span>}
+            </li>
+          ))}
+        </ul>
       </dd>
     </div>
   )}
@@ -215,5 +219,40 @@ const hasAnything =
   .meta-pair a:hover {
     color: var(--color-link-hover);
     border-color: var(--color-accent);
+  }
+  .link-chips {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    vertical-align: middle;
+  }
+  .link-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.22rem 0.6rem;
+    border: 1px solid var(--color-border-subtle);
+    border-radius: 0.45rem;
+    background: var(--color-surface-raised);
+    color: var(--color-link);
+    font-size: 0.82rem;
+    line-height: 1.25;
+    text-decoration: none;
+    transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease, transform 0.15s ease;
+  }
+  .meta-pair a.link-chip {
+    border-bottom: 1px solid var(--color-border-subtle);
+  }
+  .meta-pair a.link-chip:hover {
+    background: var(--color-surface-hover);
+    border-color: var(--color-accent);
+    color: var(--color-link-hover);
+    transform: translateY(-1px);
+  }
+  .link-chip-dangling {
+    color: var(--color-text-muted);
+    font-style: italic;
   }
 </style>

--- a/site/src/components/ReferenceContract.astro
+++ b/site/src/components/ReferenceContract.astro
@@ -40,7 +40,11 @@ function pillInfo(group: keyof typeof contract, key: string, extraClass = '') {
 {references.length > 0 && (
   <section class="reference-contract mb-6">
     <div class="reference-contract-head">
-      <h2>Reference Loading Contract</h2>
+      <span class="reference-contract-eyebrow">
+        <span class="reference-contract-rule" aria-hidden="true"></span>
+        <span>contract</span>
+      </span>
+      <h2>Reference Loading</h2>
       <p>Typed Mold references describe what casting consumes and when the generated skill should load each artifact.</p>
     </div>
     <div class="reference-grid">
@@ -52,8 +56,8 @@ function pillInfo(group: keyof typeof contract, key: string, extraClass = '') {
         const mode = pillInfo('modes', ref.mode);
         const evidence = pillInfo('evidence', ref.evidence, `evidence evidence-${ref.evidence}`);
         return (
-          <article class="reference-card">
-            <div class="reference-card-top">
+          <article class={`reference-card reference-kind-${ref.kind}`}>
+            <header class="reference-card-top">
               <a class={kind.className} href={kind.href} title={kind.description}>{kind.label}</a>
               <span class="ref">
                 {link
@@ -62,7 +66,7 @@ function pillInfo(group: keyof typeof contract, key: string, extraClass = '') {
                     : <span class="dangling">{link.label}</span>
                   : ref.ref}
               </span>
-            </div>
+            </header>
             <p class="kind-help">{term('kinds', ref.kind).description}</p>
             <div class="chips" aria-label="loading metadata">
               <a class={usedAt.className} href={usedAt.href} title={usedAt.description}>{usedAt.label}</a>
@@ -70,9 +74,13 @@ function pillInfo(group: keyof typeof contract, key: string, extraClass = '') {
               <a class={mode.className} href={mode.href} title={mode.description}>{mode.label}</a>
               <a class={evidence.className} href={evidence.href} title={evidence.description}>{evidence.label}</a>
             </div>
-            {ref.purpose && <p class="detail"><strong>Purpose:</strong> {ref.purpose}</p>}
-            {ref.trigger && <p class="detail"><strong>Trigger:</strong> {ref.trigger}</p>}
-            {ref.verification && <p class="detail verification"><strong>Verification:</strong> {ref.verification}</p>}
+            {(ref.purpose || ref.trigger || ref.verification) && (
+              <dl class="reference-card-detail">
+                {ref.purpose && (<><dt>Purpose</dt><dd>{ref.purpose}</dd></>)}
+                {ref.trigger && (<><dt>Trigger</dt><dd>{ref.trigger}</dd></>)}
+                {ref.verification && (<><dt class="verification-dt">Verify</dt><dd class="verification">{ref.verification}</dd></>)}
+              </dl>
+            )}
           </article>
         );
       })}
@@ -82,99 +90,187 @@ function pillInfo(group: keyof typeof contract, key: string, extraClass = '') {
 
 <style>
   .reference-contract {
-    border: 1px solid var(--color-border);
+    position: relative;
+    border: 1px solid var(--color-border-subtle);
     border-radius: 1rem;
-    background: var(--color-surface-raised);
-    padding: 1rem;
+    background:
+      linear-gradient(180deg,
+        color-mix(in srgb, var(--color-galaxy-primary) 4%, transparent),
+        transparent 40%),
+      var(--color-surface-raised);
+    padding: 1.25rem 1.25rem 1.1rem;
+    box-shadow: 0 1px 0 color-mix(in srgb, var(--color-galaxy-primary) 6%, transparent);
   }
   .reference-contract-head {
-    margin-bottom: 0.9rem;
+    margin-bottom: 1.1rem;
+  }
+  .reference-contract-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-family: var(--font-mono);
+    font-size: 0.66rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+  }
+  .reference-contract-rule {
+    width: 1.25rem;
+    height: 2px;
+    background: var(--color-accent);
   }
   .reference-contract h2 {
-    margin: 0 0 0.25rem;
-    font-size: 0.95rem;
+    margin: 0.35rem 0 0.3rem;
+    font-size: 1.05rem;
     font-weight: 700;
+    letter-spacing: -0.01em;
+    color: var(--color-text-primary);
   }
   .reference-contract p {
     margin: 0;
   }
-  .reference-contract-head p,
-  .kind-help,
-  .detail {
+  .reference-contract-head p {
     color: var(--color-text-secondary);
-    font-size: 0.82rem;
+    font-size: 0.86rem;
+    max-width: 60ch;
+    line-height: 1.5;
+  }
+  .kind-help {
+    color: var(--color-text-secondary);
+    font-size: 0.8rem;
+    line-height: 1.45;
+    margin: 0;
   }
   .reference-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
-    gap: 0.75rem;
+    grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr));
+    gap: 0.85rem;
   }
   .reference-card {
-    border: 1px solid var(--color-border);
-    border-radius: 0.75rem;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+    border: 1px solid var(--color-border-subtle);
+    border-radius: 0.7rem;
     background: var(--color-surface);
-    padding: 0.85rem;
+    padding: 0.95rem 1rem 0.95rem 1.15rem;
+    transition: border-color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
+  }
+  .reference-card::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 0.7rem;
+    bottom: 0.7rem;
+    width: 3px;
+    border-radius: 0 2px 2px 0;
+    background: var(--color-galaxy-primary);
+    opacity: 0.55;
+  }
+  .reference-kind-research::before { background: var(--color-galaxy-primary); }
+  .reference-kind-schema::before   { background: var(--color-accent); }
+  .reference-kind-pattern::before  { background: var(--color-link); }
+  .reference-kind-mold::before     { background: var(--color-galaxy-gold-dark); }
+  .reference-card:hover {
+    border-color: color-mix(in srgb, var(--color-accent) 50%, var(--color-border));
+    transform: translateY(-1px);
+    box-shadow:
+      0 1px 2px color-mix(in srgb, var(--color-galaxy-dark) 6%, transparent),
+      0 6px 14px color-mix(in srgb, var(--color-galaxy-dark) 7%, transparent);
   }
   .reference-card-top {
     display: flex;
     align-items: baseline;
     justify-content: space-between;
     gap: 0.75rem;
-    margin-bottom: 0.4rem;
   }
   .pill {
     font-family: var(--font-mono);
-    font-size: 0.68rem;
-    letter-spacing: 0.08em;
+    font-size: 0.66rem;
+    letter-spacing: 0.12em;
     text-transform: uppercase;
     text-decoration: none;
+    transition: color 0.15s ease, background 0.15s ease, border-color 0.15s ease;
   }
   .kind {
     color: var(--color-text-muted);
+    font-weight: 600;
   }
   .ref {
-    font-size: 0.86rem;
+    font-size: 0.92rem;
+    font-weight: 600;
     text-align: right;
     overflow-wrap: anywhere;
+    letter-spacing: -0.005em;
   }
   .ref a {
     color: var(--color-link);
     text-decoration: none;
+    border-bottom: 1px solid color-mix(in srgb, var(--color-link) 25%, transparent);
+    transition: color 0.15s ease, border-color 0.15s ease;
   }
   .ref a:hover {
-    text-decoration: underline;
+    color: var(--color-link-hover);
+    border-color: var(--color-accent);
   }
   .chips {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.35rem;
-    margin: 0.65rem 0;
+    gap: 0.3rem;
   }
   .chips .pill {
-    border: 1px solid var(--color-border);
-    border-radius: 999px;
-    padding: 0.14rem 0.45rem;
+    border: 1px solid var(--color-border-subtle);
+    border-radius: 0.35rem;
+    padding: 0.16rem 0.5rem;
     color: var(--color-text-secondary);
     background: var(--color-surface-raised);
   }
-  .pill:hover {
-    color: var(--color-link-hover);
+  .chips .pill:hover {
+    color: var(--color-link);
     border-color: var(--color-accent);
+    background: var(--color-surface-hover);
   }
   .evidence-hypothesis {
     color: var(--color-badge-draft-text) !important;
     background: var(--color-badge-draft-bg) !important;
+    border-color: color-mix(in srgb, var(--color-badge-draft-text) 30%, transparent) !important;
   }
   .evidence-corpus-observed,
   .evidence-cast-validated {
     color: var(--color-badge-reviewed-text) !important;
     background: var(--color-badge-reviewed-bg) !important;
+    border-color: color-mix(in srgb, var(--color-badge-reviewed-text) 30%, transparent) !important;
   }
-  .verification {
-    border-left: 3px solid var(--color-badge-draft-text);
+  .reference-card-detail {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    column-gap: 0.7rem;
+    row-gap: 0.3rem;
+    margin: 0.1rem 0 0;
+    padding-top: 0.55rem;
+    border-top: 1px dashed var(--color-border-subtle);
+    font-size: 0.82rem;
+    line-height: 1.45;
+  }
+  .reference-card-detail dt {
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+    padding-top: 0.18rem;
+  }
+  .reference-card-detail dd {
+    margin: 0;
+    color: var(--color-text-secondary);
+  }
+  .verification-dt {
+    color: var(--color-badge-draft-text) !important;
+  }
+  dd.verification {
+    color: var(--color-text-primary);
     padding-left: 0.55rem;
-  }
-  .detail + .detail {
-    margin-top: 0.35rem;
+    border-left: 2px solid var(--color-badge-draft-text);
   }
 </style>


### PR DESCRIPTION
## Summary

Three small visual upgrades on Mold note pages (e.g. `molds/nextflow-summary-to-galaxy-interface/`):

- **MoldBody header strip** — replace the three loose Tailwind chips (axis / specifier / name) with a unified bordered metadata strip. Mono micro-caps labels per cell, inset accent rail on the axis cell, stacks vertically below 480px.
- **NoteMeta related lists** — `Patterns`, `Implemented By`, `Molds`, `Related` now render as `link-chip` tiles in a wrap-grid with hover lift, instead of comma-joined inline links.
- **ReferenceContract** — added contract eyebrow + accent rule, kind-keyed left ribbon per card (research / schema / pattern / mold), tighter mono pill typography, reformatted Purpose / Trigger / Verify into a definition-list grid separated by a dashed divider with an accent-bordered verification block. Section gets a faint Galaxy-blue gradient; cards lift with tinted shadow on hover.

All changes use existing CSS variables (no new tokens), preserve every prop and data path, and 173 pages build clean.

## Test plan

- [ ] `npm run validate`
- [ ] `npx astro build` from `site/` succeeds
- [ ] Visit a Mold page (e.g. `molds/nextflow-summary-to-galaxy-interface/`) — header strip, Reference Loading section, and Related row read as polished
- [ ] Visit a Pattern page — `Patterns` / `Molds` / `Related` chip rows render correctly and align with their dt labels
- [ ] Dark mode parity check on the same pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)