### PR TITLE
Add /review-mold skill; drop runtime author-meta from two Molds

### DIFF
--- a/.claude/commands/review-mold.md
+++ b/.claude/commands/review-mold.md
@@ -1,0 +1,100 @@
+---
+description: Review a Foundry Mold and the research/pattern notes its manifest pulls in for runtime fitness.
+argument-hint: "<mold-slug>"
+---
+
+# Review a Foundry Mold
+
+Review the Mold at `content/molds/$1/` and return a structured report. Do **not** edit files — the orchestrator applies fixes.
+
+This skill complements `/review-pattern` (which reviews a single note in isolation). The Mold review centers on the *graph* the manifest pulls in: each on-demand reference is a runtime artifact whose body must earn its tokens.
+
+## Run the validator first
+
+Before reading anything, run `npm run validate` and capture its output. Do **not** halt on errors or warnings — surface them in the final report's Cross-check log so the orchestrator sees what the deterministic gate flagged. The validator at `packages/build-cli/src/commands/validate.ts` already enforces:
+
+- Frontmatter schema + tag registration.
+- Wiki-link resolution and target-type matching for `patterns`, `cli_commands`, `related_patterns`, `related_molds`.
+- `references[].kind` → target `type` matching (`pattern`, `cli-command`, `prompt`, `research`, `schema`, `example`).
+- `evidence: hypothesis` requires `verification`.
+- `load: on-demand` requires `trigger` (warning).
+- Schema refs require `package` + `package_export` on the target note.
+- Bidirectional `related_notes` backlinks.
+
+Run it once and trust it. Do **not** re-derive these checks by hand — spend tokens on judgment.
+
+## Load context first (in order)
+
+1. **`content/glossary.md`** — pinned vocabulary. Misreading "Mold," "Cast," "reference kind" breaks the review.
+2. **`CLAUDE.md`** / **`AGENTS.md`** — authoring rules.
+3. **`docs/MOLD_SPEC.md`** — Mold source layout and the eval/usage/refinement contract; reference-kind taxonomy; `load`/`mode`/`used_at` semantics.
+4. **`docs/COMPILATION_PIPELINE.md`** — what Cast does with each reference kind; `mode: verbatim` vs LLM-condensed.
+5. **`meta_schema.yml`** — only the Mold-specific shapes (`references[]` schema). Skim, don't memorize.
+6. **`common_paths.yml.sample`** — citation-prefix vocabulary for resolving inline `$NAME/...` corpus references.
+7. **The Mold itself** — `content/molds/$1/`:
+   - `index.md` (frontmatter + body)
+   - `eval.md`, `usage.md`, `casting.md`, `cast-skill-verification.md`, `refinement.md` if present
+   - prior entries under `refinements/`
+8. **The cast bundle if present** — `casts/claude/$1/_provenance.json` first; individual artifacts on demand.
+9. **Each referenced note** — open every `references[].ref` target. The whole point of this skill is auditing them in their loading context.
+
+## Judgment-required checks
+
+### Manifest semantics (not just structure)
+
+- **`mode` fits content.** `verbatim` on a long note that the consuming LLM doesn't need verbatim is waste. `condensed` on a JSON Schema is wrong.
+- **`load` fits trigger frequency.** `upfront` for a reference that fires in a narrow case is bloat. `on-demand` for something needed every run is friction.
+- **`evidence` is honest.** `corpus-observed` without citations in the referenced note is overclaiming. Demote to `corpus-inferred` or `hypothesis` (and require `verification`).
+- **`purpose` and `trigger` are distinct.** Purpose = what the reference contributes; trigger = when to load it. Triggers that restate purpose ("when this is needed") are dead.
+- **`evidence: hypothesis` + `load: upfront` + `mode: verbatim` is fix-before-merge.** Unverified content shipped as upfront context anchors the cast skill on potentially-wrong claims. Either demote to `on-demand` (loaded only under trigger) or verify the note and downgrade `evidence`.
+- **Trigger overlap across on-demand refs.** When two or more triggers fire on overlapping conditions ("When implementing concrete steps for…" appearing twice with different filters), the cast loads a clump of notes simultaneously and the body has to disambiguate. Flag for trigger-rewrite or reference consolidation.
+
+### Referenced-note runtime fitness
+
+For each on-demand reference, open the target note and check:
+
+- **Trigger / body duplication.** The note must not re-state the manifest's load condition in its own body (it's loaded *because* the trigger fired — the consumer doesn't need to re-read it). If a note has a "Mold loading guidance" or "When to use this" section that mirrors the manifest, flag for removal.
+- **Author-meta in runtime body.** Sections addressing the Foundry author ("Do not turn this into a pattern page," "Keep the Mold body thin") are noise at runtime. The note is loaded into the consuming LLM's context, not read by humans deciding how to organize the corpus. Flag for removal; if the author-meta encodes a real corpus-organization decision, push it to frontmatter (`subtype`, `type`) or a meta-note instead of the runtime body.
+- **Reverse-dependency naming.** Research / pattern notes that name the consuming Mold in their body create a cycle. The manifest is one-way: Mold → note. Flag.
+- **Body duplication across references.** Two referenced notes saying the same thing in the same load slice is token waste. Suggest consolidation.
+
+### Mold body thinness
+
+`index.md`'s body should not restate content that lives verbatim in an on-demand reference. If a section of `index.md` paraphrases what the cast will load anyway, flag for deletion in favor of relying on the load.
+
+### Author-meta sections in the runtime body
+
+The Mold body is loaded into the cast skill's context — it must address the runtime LLM, not the Foundry author. Heuristic section-title triggers (case-insensitive): `Reference dispatch`, `Tooling to wire in`, `Open questions`, `Pending`, `TODO`, `do not lose`, `Note to authors`, `Author note`. Sections matching these patterns, or sections whose first sentence explains what the manifest fields mean, are nearly always meta-commentary that belongs in `refinement.md` or a `refinements/` entry. Flag them and recommend the destination file.
+
+Same heuristic applies recursively to each on-demand referenced note's body.
+
+### Body-vs-`related_notes` drift
+
+Every wiki-link target in `index.md`'s body should generally appear in the frontmatter `related_notes` (or in `references[].ref`, `output_schemas`, `cli_commands`, etc.). Body wiki-links that resolve to no manifest entry are a sign the manifest is stale. Flag mismatches.
+
+### Eval coverage of triggers
+
+Every declared `trigger` should have at least one `eval.md` case that exercises it (otherwise the trigger is unverified). Flag triggers with no eval case. This is judgment, not grep — eval cases describe scenarios, not literal trigger strings.
+
+### Cast-bundle drift (if `casts/claude/$1/` exists)
+
+Compare `_provenance.json` against the current manifest:
+
+- References declared now but missing from the bundle → cast is stale.
+- References in the bundle but no longer in the manifest → bundle has dead weight.
+
+This is partly mechanical, but interpretation (does the drift matter? is it intentional pre-recast?) is judgment.
+
+### Inline citation verification
+
+For any `$NAME/path:line` citations in `index.md`, `eval.md`, `usage.md`, `casting.md`: resolve via `common_paths.yml.sample` and `Read` the cited range. Same standard as `/review-pattern`. Skip if there are no inline citations (Mold bodies often don't carry them — citations live in referenced research notes).
+
+## Reporting format
+
+1. **Verdict** — one short sentence.
+2. **Findings** — bulleted list, each with: severity (`blocker` / `fix-before-merge` / `nit`), location (file + section or quote), what's wrong, suggested correction. Group by Mold body / manifest / per-reference.
+3. **Manifest audit table** — one row per `references[]` entry: `ref | kind | load | mode | issues` (one-line summary; "ok" if clean).
+4. **Cross-check log** — one line per inline citation verified: `path:line — verified | mismatch (details)`. Plus the `npm run validate` summary line (`Files: N  Errors: E  Warnings: W`) and any errors/warnings that touch this Mold or its referenced notes.
+5. **What would have made this review more useful** — concrete asks (additional context, missing reference, sibling Mold that would calibrate house style).
+
+Keep the report under ~700 words; longer is welcome only when the Mold is genuinely rule-dense or many references need attention.

--- a/content/molds/implement-galaxy-workflow-test/index.md
+++ b/content/molds/implement-galaxy-workflow-test/index.md
@@ -80,12 +80,5 @@ references:
 # implement-galaxy-workflow-test
 
 Stub. Replace with real Mold content per MOLD_SPEC once first walks are done.
-
-## Tooling to wire in (do not lose)
-
-- **Test-format JSON Schema** — `@galaxy-tool-util/schema` exports `tests.schema.json` (auto-generated from `galaxy.tool_util_models.Tests`). Cast skill should ship the schema verbatim under `references/schemas/tests.schema.json` and validate every authored `-tests.yml` against it before any planemo invocation. See `docs/COMPILATION_PIPELINE.md` § *Schema artifacts in casts*.
-- **`validateTestsFile(yaml)`** — pure-JS schema validator from the same package. First gate in the inner authoring loop.
-- **`checkTestsAgainstWorkflow(workflow, tests)`** — pure-JS cross-checker that reports missing input/output labels and type mismatches between a `.ga` (or format2) workflow and its tests file. Catches the most common authoring failure (renamed output → broken test) without a full planemo run. Second gate in the inner loop. See [[planemo-asserts-idioms]] §6.
-- **`gxwf validate-tests <tests.yml> --workflow <workflow> --json`** — CLI form of the same static gates for cast skills that operate through subprocesses. See [[validate-tests]].
 - **`planemo workflow_test_init --from_invocation <id>`** — preferred bootstrap for new test files; reviewer convention. See [[planemo-asserts-idioms]] §7.
 - **`planemo workflow_test_on_invocation <tests.yml> <id>`** — fast assertion-iteration loop without re-running the workflow.

--- a/content/molds/implement-galaxy-workflow-test/refinement.md
+++ b/content/molds/implement-galaxy-workflow-test/refinement.md
@@ -1,0 +1,8 @@
+# refinement — implement-galaxy-workflow-test
+
+## Tooling to wire in when this Mold de-stubs
+
+- **Test-format JSON Schema** — `@galaxy-tool-util/schema` exports `tests.schema.json` (auto-generated from `galaxy.tool_util_models.Tests`). Cast skill should ship the schema verbatim under `references/schemas/tests.schema.json` and validate every authored `-tests.yml` against it before any planemo invocation. See `docs/COMPILATION_PIPELINE.md` § *Schema artifacts in casts*.
+- **`validateTestsFile(yaml)`** — pure-JS schema validator from the same package. First gate in the inner authoring loop.
+- **`checkTestsAgainstWorkflow(workflow, tests)`** — pure-JS cross-checker that reports missing input/output labels and type mismatches between a `.ga` (or format2) workflow and its tests file. Catches the most common authoring failure (renamed output → broken test) without a full planemo run. Second gate in the inner loop. See [[planemo-asserts-idioms]] §6.
+- **`gxwf validate-tests <tests.yml> --workflow <workflow> --json`** — CLI form of the same static gates for cast skills that operate through subprocesses. See [[validate-tests]].

--- a/content/molds/summarize-nextflow/index.md
+++ b/content/molds/summarize-nextflow/index.md
@@ -300,14 +300,4 @@ The procedure assumes — and the cast skill must surface in `warnings[]` when r
 - **Translation to a target idiom.** This Mold does not produce Galaxy collections, CWL scatter, or any target-shaped data flow. Those live in [[nextflow-summary-to-galaxy-interface]], [[nextflow-summary-to-galaxy-data-flow]], [[nextflow-summary-to-cwl-interface]], and [[nextflow-summary-to-cwl-data-flow]].
 - **Tool wrapping.** Container/conda info is captured for [[author-galaxy-tool-wrapper]] to consume; this Mold never authors a wrapper.
 - **Test execution.** Fixtures are described, not run. [[run-workflow-test]] owns execution.
-- **Schema evolution.** The schema at [[summary-nextflow]] is v1, draft. Adding fields requires evaluating against the §"Reference dispatch" exemplars (rnaseq, sarek, one ad-hoc) before merging.
-
-## Reference dispatch
-
-The `references:` manifest above is the source of truth for cast/runtime handling. `used_at` says whether a reference is consumed while building the cast, loaded by the generated skill at runtime, or both; `load` says whether the generated skill treats it as upfront context or an on-demand file.
-
-- `output_schemas` / `kind: schema` → [[summary-nextflow]] — resolved at cast time to `@galaxy-foundry/summary-nextflow-schema`'s `summaryNextflowSchema` export and written verbatim into the cast bundle's `references/schemas/summary-nextflow.schema.json`. The cast skill validates its emitted JSON with `validate-summary-nextflow` before returning. This reference is `used_at: both` because it shapes the generated skill and remains a runtime validation contract.
-- `cli_commands` — none today. Open question whether the Foundry seeds a `content/cli/nextflow/` family for `nextflow config`, `nf-core list`, `nf-test`. The cast skill calls these CLIs at runtime regardless; the question is whether the Foundry carries manpages for them.
-- `patterns` — none. Per-source summarization is correctly empty here; this is the first inventory case where a Mold legitimately declares no patterns. Relevant for MOLD_SPEC.
-- Research notes — [[component-nextflow-pipeline-anatomy]], [[component-nextflow-containers-and-envs]], and [[component-nextflow-testing]] are packaged into the cast bundle's `references/notes/` as runtime, on-demand grounding. They are not automatically dumped into the casting prompt; if one becomes necessary for cast-time synthesis, change that reference to `used_at: both` or `cast-time` and choose the appropriate `mode`.
-- `examples` — pending: `nf-core/rnaseq` (canonical, stresses every section), `nf-core/sarek` (heavy conditional subworkflows; stresses §6's reconciliation), and one ad-hoc DSL2 pipeline (no `meta.yml`, no `nextflow_schema.json`; stresses fallback paths). Bundling vs URL-referencing is open — `rnaseq` is too large to mirror; the corpus-first principle says cite by URL. See [[GXY_SKETCHES_ALIGNMENT]] for the analogous bundle-vs-URL discussion in gxy-sketches.
+- **Schema evolution.** The schema at [[summary-nextflow]] is v1, draft. Adding fields requires evaluating against the canonical exemplars (rnaseq, sarek, one ad-hoc DSL2 pipeline) before merging.

--- a/content/research/galaxy-workflow-testability-design.md
+++ b/content/research/galaxy-workflow-testability-design.md
@@ -108,24 +108,6 @@ Evidence:
 - 10x CellPlex job inputs include `fastq PE collection GEX`, `reference genome`, `gtf`, `cellranger_barcodes_3M-february-2018.txt`, `fastq PE collection CMO`, `sample name and CMO sequence collection`, and `Number of expected cells` (`$IWC/workflows/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:2-75`). The workflow declares matching collection, data, string, boolean, and int inputs (`$IWC_FORMAT2/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex.gxwf.yml:4-72`).
 - HyPhy accepts a `list` collection of unaligned sequences and preserves accession-like fixture identifiers through to output element assertions (`$IWC/workflows/comparative_genomics/hyphy/hyphy-core-tests.yml:7-30`; `$IWC_FORMAT2/comparative_genomics/hyphy/hyphy-core.gxwf.yml:14-25`).
 
-## 6. Mold loading guidance
-
-For [[implement-galaxy-workflow-test]], load this note when workflow structure may need revision before test YAML can be authored:
-
-- Missing or unstable input/output labels.
-- Need to assert an intermediate result that is not currently a workflow output.
-- Collection output tests need stable element identifiers.
-- Final outputs are too weakly assertable and a better checkpoint may need exposing.
-- Test fixture shape suggests the workflow input interface should be adjusted.
-
-This note should usually be loaded **before** [[planemo-asserts-idioms]] when the workflow itself is still editable. Once labels and outputs are fixed, assertion selection belongs to [[planemo-asserts-idioms]].
-
-## 7. What not to do
-
-- Do not turn these rules into `content/patterns/` pages unless a concrete operation-anchored Galaxy construction recipe emerges.
-- Do not stuff this guidance into a long Mold body. Keep the Mold body thin and auto-load this research note when the trigger applies.
-- Do not expose every intermediate output as boilerplate. The evidence supports promoted checkpoints, not indiscriminate output sprawl.
-
 ## Cross-references
 
 - [[iwc-workflow-testability-survey]] — corpus survey and distribution rationale.


### PR DESCRIPTION
## Summary

- New `.claude/commands/review-mold.md` — judgment-focused audit of a Mold and the research/pattern notes its manifest pulls in. Defers all deterministic checks (frontmatter, wiki-link resolution, type matching, schema/example refs, bidirectional backlinks) to `npm run validate`; spends LLM cycles on manifest semantics, runtime-body fitness of referenced notes, and inline citation verification.
- Drop §"Reference dispatch" from `summarize-nextflow` — explained `used_at` / `load` semantics and tracked open questions in the runtime body. Manifest meta belongs in frontmatter (parsed by Cast) or a refinement entry, not the cast LLM's context.
- Move "Tooling to wire in (do not lose)" from `implement-galaxy-workflow-test/index.md` into a new `refinement.md`. Same author-meta-in-runtime-body pattern; preserved verbatim where the next refinement run will see it.
- Drop §6 (Mold loading guidance) and §7 (What not to do) from `galaxy-workflow-testability-design`. §6 duplicated the manifest's trigger; §7 was author-meta about how to organize the corpus, not runtime guidance.

## Audit batch that produced this

Reviewed `summarize-nextflow`, `compare-against-iwc-exemplar`, `discover-shed-tool`, `implement-galaxy-tool-step`, `implement-galaxy-workflow-test`. Followups filed:

- #156 — `[[GXY_SKETCHES_ALIGNMENT]]` body wiki-links resolve outside `content/`; refactor approach to decide.
- #157 — Three deterministic checks worth promoting from `/review-mold` into `foundry-build validate` (body wiki-link resolution, schema-ref evidence floor, stub-body + populated-manifest detector).
- Stub Molds with full reference manifests is a real signal; will be addressed as those Molds de-stub.

## Test plan

- [x] `npm run validate` — 0 errors, 62 warnings (unchanged baseline; pre-existing missing-backlink + missing-eval warnings).
- [ ] First in-anger run of `/review-mold` against a real Mold to confirm the skill's reporting format is useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)