### PR TITLE
Artifact contracts

### DIFF
--- a/casts/claude/skills/summarize-nextflow/_provenance.json
+++ b/casts/claude/skills/summarize-nextflow/_provenance.json
@@ -5,12 +5,12 @@
     "name": "summarize-nextflow",
     "path": "content/molds/summarize-nextflow/index.md",
     "revision": 9,
-    "content_hash": "7ab309b54802acbcf4a27c7fc3f7df455613446f75f675a6f2667a2b4f124aa8",
-    "commit": "23b63d508c4f9062ad01515130997a969c710f83"
+    "content_hash": "7c64dabadfdf98c5ee3fde3c0977a2297ccc3d81bd83db5c0762556ddf88bb56",
+    "commit": "a3c1e82d0cef7f53a28d10dd790141dce3c53c48"
   },
   "cast_method": "hand-cast",
   "cast_agent": "claude (manual transcription, no LLM cast prompt)",
-  "cast_at": "2026-05-05T18:57:03.949Z",
+  "cast_at": "2026-05-05T19:33:24.620Z",
   "cast_date": "2026-05-05",
   "cast_revision": 5,
   "cast_history": [
@@ -145,6 +145,18 @@
       "source": "deterministic"
     }
   ],
+  "artifacts": {
+    "produces": [
+      {
+        "id": "summary-nextflow",
+        "kind": "json",
+        "default_filename": "summary-nextflow.json",
+        "schema": "[[summary-nextflow]]",
+        "description": "Structured summary of a Nextflow pipeline: processes, channels, params, containers, tools, test fixtures, nf-tests."
+      }
+    ],
+    "consumes": []
+  },
   "open_questions": [
     "The three notes are stubs; first-paragraph contents will come from running this cast against nf-core/rnaseq — see issue #17."
   ]

--- a/casts/claude/skills/summarize-nextflow/_provenance.json
+++ b/casts/claude/skills/summarize-nextflow/_provenance.json
@@ -5,12 +5,12 @@
     "name": "summarize-nextflow",
     "path": "content/molds/summarize-nextflow/index.md",
     "revision": 9,
-    "content_hash": "5987e7ad339a112e402aac3a711961e5479645d95f0b8a3ae581e29b20fc58cd",
-    "commit": "872ebf6fe05d4d7573ec4425ec2d13b6a827f446"
+    "content_hash": "7ab309b54802acbcf4a27c7fc3f7df455613446f75f675a6f2667a2b4f124aa8",
+    "commit": "23b63d508c4f9062ad01515130997a969c710f83"
   },
   "cast_method": "hand-cast",
   "cast_agent": "claude (manual transcription, no LLM cast prompt)",
-  "cast_at": "2026-05-05T18:02:10.857Z",
+  "cast_at": "2026-05-05T18:57:03.949Z",
   "cast_date": "2026-05-05",
   "cast_revision": 5,
   "cast_history": [
@@ -43,7 +43,7 @@
   "refs": [
     {
       "kind": "research",
-      "mode": "condense",
+      "mode": "verbatim",
       "ref": "[[component-nextflow-containers-and-envs]]",
       "src": "content/research/component-nextflow-containers-and-envs.md",
       "dst": "references/notes/component-nextflow-containers-and-envs.md",
@@ -53,8 +53,8 @@
       "purpose": "Resolve container, conda, Wave, and Bioconda/Biocontainers environment evidence.",
       "trigger": "When extracting tools, versions, containers, conda directives, or environment equivalences.",
       "src_hash": "0db9a019da6ea6f05937c4bacf9da3bd43ec0bf8d909b874f3f789106098887a",
-      "dst_hash": "94cf6897cec62d2f06be19d48c42864fc1df66d4e2d29f44dbf16e573c6c5a53",
-      "source": "llm"
+      "dst_hash": "0db9a019da6ea6f05937c4bacf9da3bd43ec0bf8d909b874f3f789106098887a",
+      "source": "deterministic"
     },
     {
       "kind": "research",

--- a/casts/claude/skills/summarize-nextflow/references/notes/component-nextflow-containers-and-envs.md
+++ b/casts/claude/skills/summarize-nextflow/references/notes/component-nextflow-containers-and-envs.md
@@ -5,34 +5,253 @@ tags:
   - research/component
   - source/nextflow
   - target/galaxy
-component: "Nextflow containers and environments"
+component: "Nextflow Containers and Environments"
 status: draft
 created: 2026-05-01
-revised: 2026-05-04
-revision: 2
+revised: 2026-05-05
+revision: 3
 ai_generated: true
-summary: "Maps Nextflow container and conda evidence to Galaxy package and container requirements."
+summary: "Container URL grammar (depot, BioContainers, mulled-v2, Wave, ORAS) and conda directive resolution rules backing summarize-nextflow §5."
+sources:
+  - "https://docs.seqera.io/nextflow/process"
+  - "https://docs.seqera.io/nextflow/reference/process"
+  - "https://github.com/nf-core/modules/blob/master/modules/nf-core/fastqc/main.nf"
+  - "https://github.com/nf-core/modules/blob/master/modules/nf-core/multiqc/main.nf"
+  - "https://github.com/nf-core/modules/blob/master/modules/nf-core/dragmap/align/main.nf"
+  - "https://github.com/nf-core/modules/blob/master/modules/nf-core/seqkit/sample/main.nf"
+  - "https://github.com/nf-core/modules/blob/master/modules/meta-schema.json"
+  - "https://github.com/nf-core/modules/blob/master/modules/environment-schema.json"
+  - "https://github.com/nf-core/tools/blob/master/nf_core/module-template/main.nf"
+  - "https://github.com/BioContainers/multi-package-containers"
+  - "https://github.com/BioContainers/singularity-build-bot"
+  - "https://depot.galaxyproject.org/singularity/"
+  - "https://biocontainers.pro/registry"
+  - "https://bioconda.github.io/"
+  - "https://docs.seqera.io/wave"
+  - "https://nf-co.re/events/2024/bytesize_pipeline_container_urls"
 related_molds:
   - "[[summarize-nextflow]]"
   - "[[author-galaxy-tool-wrapper]]"
   - "[[summarize-galaxy-tool]]"
-sources:
-  - "https://www.nextflow.io/docs/latest/container.html"
-  - "https://www.nextflow.io/docs/latest/conda.html"
-  - "https://docs.galaxyproject.org/en/latest/dev/schema.html#tool-requirements"
-  - "https://docs.galaxyproject.org/en/latest/admin/container_resolvers.html"
-  - "https://docs.galaxyproject.org/en/latest/admin/conda_faq.html"
-  - "https://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html"
-  - "https://biocontainers.pro/registry"
+related_notes:
+  - "[[component-nextflow-pipeline-anatomy]]"
+  - "[[component-nf-core-tools]]"
+  - "[[component-nextflow-inspect]]"
 ---
 
 # Nextflow Containers and Environments
 
-This note maps Nextflow process-level runtime evidence into Galaxy tool XML `<requirements>` evidence. It is for `[[summarize-nextflow]]`, `[[author-galaxy-tool-wrapper]]`, and `[[summarize-galaxy-tool]]` when a source process has container or conda evidence that could explain executable dependencies.
+Operational grounding for `[[summarize-nextflow]]` §5 ("Build the tool registry"). Resolves the regex-pinned URL grammar a static walker needs to bucket each NF process's `container` and `conda` directives into the right `tools[]` field, and surfaces the cases the cast skill must recognize but cannot resolve without runtime help.
 
-## Decision
+Companion structured form: `component-nextflow-containers-and-envs.yml` (regex + example + derivation rule per form). Agents and resolver code consume the YAML; this prose note explains the *why* and pins the canonical examples.
 
-Prefer Galaxy package requirements when the Nextflow evidence names Bioconda or conda packages with versions. Add explicit Galaxy container requirements only when the source gives a stable container URI or when package requirements cannot adequately describe the runtime.
+Cross-link rather than restate: ternary directive mechanics, `nextflow inspect` runtime resolution, and the `nf-core download` flow are documented in `[[component-nextflow-inspect]]` and `[[component-nf-core-tools]]`. This note is grammar + bucketing rules.
+
+## Sources of truth
+
+- `nextflow-io/nextflow` — `container` and `conda` directive semantics: [docs.seqera.io/nextflow/process](https://docs.seqera.io/nextflow/process), source at `modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy`.
+- `nf-core/modules` — module library + the **module template `main.nf`** (the canonical ternary form): [`modules/nf-core/`](https://github.com/nf-core/modules/tree/master/modules/nf-core), [`modules/meta-schema.json`](https://github.com/nf-core/modules/blob/master/modules/meta-schema.json), [`modules/environment-schema.json`](https://github.com/nf-core/modules/blob/master/modules/environment-schema.json).
+- `nf-core/tools` — module scaffolding template at [`nf_core/module-template/main.nf`](https://github.com/nf-core/tools/blob/master/nf_core/module-template/main.nf).
+- `BioContainers/multi-package-containers` — mulled-v2 README + `mulled-hash` CLI documentation: [README.md](https://github.com/BioContainers/multi-package-containers/blob/master/README.md).
+- `BioContainers/singularity-build-bot` — quay.io → depot.galaxyproject.org Singularity mirroring service.
+- `depot.galaxyproject.org/singularity/` — public BioContainers Singularity mirror; CVMFS-distributed.
+- Seqera Wave — [docs.seqera.io/wave](https://docs.seqera.io/wave). Live URL-pattern docs were sparse at the time of this note; Wave URL grammar below is grounded in real nf-core modules (multiqc, seqkit/sample) plus the meta-schema's `^oras://.*$` constraint.
+
+## The canonical ternary directive
+
+The current nf-core module template shipped by `nf-core/tools` produces a `container` directive of the form:
+
+```groovy
+conda "${moduleDir}/environment.yml"
+container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+    '<singularity-branch-url>':
+    '<docker-branch-url>' }"
+```
+
+— from [`nf_core/module-template/main.nf`](https://github.com/nf-core/tools/blob/master/nf_core/module-template/main.nf) lines 27-30.
+
+The Mold body §5 currently encodes the **older** form `workflow.containerEngine == 'singularity'`. Both forms appear in the field today because modules have been generated across multiple template eras. **The cast skill's tokenizer must accept both.** Concretely, a reasonable predicate-detection pattern is:
+
+```
+workflow\.containerEngine\s*(?:==\s*'singularity'|in\s*\[\s*'singularity'(?:\s*,\s*'apptainer')?\s*\])
+```
+
+Beyond the predicate, every nf-core module the validator has seen in 2025+ shares the `&& !task.ext.singularity_pull_docker_container` clause. The semantics of that clause are documented inline with the resolution rules below.
+
+### What `task.ext.singularity_pull_docker_container` does
+
+It is a per-process escape hatch. When `true`, the ternary collapses to the docker-branch URL even under a Singularity engine, forcing Singularity/Apptainer to pull and convert the Docker BioContainer in place of the Galaxy depot Singularity image. The toggle exists for processes whose Singularity image is missing or broken on `depot.galaxyproject.org`.
+
+A GitHub code search across the `nf-core` org for `singularity_pull_docker_container = true` in committed configs returns zero hits. The flag is reserved for ad-hoc per-task overrides, not normal configuration. **Operational consequence for the resolver:** the singularity branch is the URL that actually runs under a Singularity engine; the docker branch is what runs under Docker/Podman. Bucket both, but treat the singularity branch as authoritative for its host registry.
+
+## Container URL forms
+
+Five forms account for essentially every container URL in current nf-core modules. Each form's regex, example (verbatim), bucket field (matches `summary-nextflow.schema.json`'s `tools[]`), and derivation rule for `(name, version)`:
+
+### 1. Galaxy depot Singularity (BioContainers mirror)
+
+- **Regex:** `^https://depot\.galaxyproject\.org/singularity/(?P<name>[^:/]+):(?P<version>[^-][^-]*)--(?P<build>[^/]+)$`
+- **Verbatim example:** `https://depot.galaxyproject.org/singularity/fastqc:0.12.1--hdfd78af_0` — [`modules/nf-core/fastqc/main.nf`](https://github.com/nf-core/modules/blob/master/modules/nf-core/fastqc/main.nf) line 7.
+- **Bucket:** `tools[].singularity`.
+- **Derivation:** path basename's `<name>:<version>--<build>` triple. `name` and `version` extracted directly. `--<build>` is the Bioconda build string.
+- **Provenance:** every Bioconda recipe that builds successfully produces a corresponding BioContainer Docker image on `quay.io/biocontainers`; [`BioContainers/singularity-build-bot`](https://github.com/BioContainers/singularity-build-bot) monitors quay.io and uploads each image's Singularity conversion to `depot.galaxyproject.org/singularity`. The depot is further CVMFS-mirrored. **The depot URL is dual to the quay biocontainer URL — same image, different registry/format.** This is the fact that makes round-trip to Galaxy `<requirement type="package">` clean for these forms.
+
+### 2. Quay BioContainers Docker
+
+- **Regex:** `^quay\.io/biocontainers/(?P<name>[^:/]+):(?P<version>[^-][^-]*)--(?P<build>[^/]+)$`
+- **Verbatim example:** `quay.io/biocontainers/fastqc:0.12.1--hdfd78af_0` — fastqc module, line 8.
+- **Bucket:** `tools[].biocontainer`.
+- **Derivation:** identical triple to the depot URL; the `<name>:<version>--<build>` for any given (name,version,build) is identical between depot Singularity and quay Docker. The cast skill can populate `tools[].biocontainer` and `tools[].singularity` together when both URLs share the suffix.
+
+### 3. Mulled-v2 multi-package containers
+
+- **Regex (depot Singularity):** `^https://depot\.galaxyproject\.org/singularity/mulled-v2-(?P<hash>[0-9a-f]+):(?P<verhash>[0-9a-f]+)-\d+$`
+- **Regex (quay Docker):** `^quay\.io/biocontainers/mulled-v2-(?P<hash>[0-9a-f]+):(?P<verhash>[0-9a-f]+)-\d+$`
+- **Verbatim example:** `https://depot.galaxyproject.org/singularity/mulled-v2-580d344d9d4a496cd403932da8765f9e0187774d:df80ed8d23d0a2c43181a2b3dd1b39f2d00fab5c-0` paired with `quay.io/biocontainers/mulled-v2-580d344d9d4a496cd403932da8765f9e0187774d:df80ed8d23d0a2c43181a2b3dd1b39f2d00fab5c-0` — [`modules/nf-core/dragmap/align/main.nf`](https://github.com/nf-core/modules/blob/master/modules/nf-core/dragmap/align/main.nf) lines 7-9. The corresponding `environment.yml` packs three deps: `bioconda::dragmap=1.2.1`, `bioconda::samtools=1.19.2`, `conda-forge::pigz=2.3.4`.
+- **Bucket:** same as the underlying registry — depot URL → `tools[].singularity`; quay URL → `tools[].biocontainer`. The cast skill records the `mulled-v2` form by setting `tools[].name` to a synthetic identifier (e.g. `<primary>_mulled` or the hash itself) and surfacing the contributing package list from the sibling `environment.yml`.
+- **Hash derivation:** the `<hash>` is a content-addressed digest of the **sorted package name list**; the `<verhash>` is a digest including pinned versions/builds; the `-0` suffix is a build counter. The function is implemented in `galaxy-tool-util` and exposed via the `mulled-hash` CLI:
+  ```
+  $ mulled-hash r-shiny=1.8.1.1,bioconductor-phyloseq=1.46.0,r-curl=5.1.0,r-biocmanager=1.30.23
+  mulled-v2-3f22c1adbbead1a8888120ab6f59758c0a05e86b:e77384d3aca3277e7caf46a60e0eb848aec72912
+  ```
+  ([BioContainers/multi-package-containers README](https://github.com/BioContainers/multi-package-containers#finding-mulled-hash-names-for-containers)).
+- **Reverse lookup (hash → packages):** there is **no first-class registry mapping the hash back to its package list**. The README is explicit: "you usually don't search for containers, you construct the hash and pull them down." The cast skill's path forward is: read the sibling `environment.yml`, treat its `dependencies:` list as the authoritative tool inventory, and record the mulled-v2 URL as the container reference for the combined set. The BioContainers `mulled-search` CLI exists but is for forward (package → existing container) lookup.
+
+### 4. Wave / Seqera community registry
+
+Two URL hosts; both are Wave-built, both encode a content digest in the URL.
+
+- **Wave Docker (Wave-as-Docker-image):**
+  - **Regex:** `^community\.wave\.seqera\.io/library/(?P<name>[^:/]+):(?P<version>[^-]+)--(?P<digest>[0-9a-f]+)$`
+  - **Verbatim:** `community.wave.seqera.io/library/multiqc:1.34--db7c73dae76bc9e6` — [`modules/nf-core/multiqc/main.nf`](https://github.com/nf-core/modules/blob/master/modules/nf-core/multiqc/main.nf) line 9.
+- **Wave Singularity via OCI registry blob:**
+  - **Regex:** `^https://community-cr-prod\.seqera\.io/docker/registry/v2/blobs/sha256/[0-9a-f]{2}/(?P<digest>[0-9a-f]{64})/data$`
+  - **Verbatim:** `https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/1b/1bef8af6be88c5733461959c46ac8ef73d18f65277f62a1695d0e1633054f9c2/data` — multiqc module, line 8.
+- **Wave Singularity via ORAS (newer, preferred):**
+  - **Regex:** `^oras://community\.wave\.seqera\.io/library/(?P<name>[^:/]+):(?P<version>[^-]+)--(?P<digest>[0-9a-f]+)$`
+  - **Verbatim:** `oras://community.wave.seqera.io/library/seqkit:2.13.0--205358a3675c7775` — [`modules/nf-core/seqkit/sample/main.nf`](https://github.com/nf-core/modules/blob/master/modules/nf-core/seqkit/sample/main.nf) lines 7-8. The ORAS protocol pulls Singularity images directly from an OCI-conformant registry without HTTP-blob intermediation. The nf-core module meta-schema explicitly declares `^oras://.*$` as a legal Singularity-container `name` value.
+- **Bucket:** `tools[].wave` for **all three** Wave forms.
+- **Derivation:** `name` and `version` are recoverable from the `community.wave.seqera.io/library/<name>:<version>--<digest>` Docker and ORAS forms. The bare `community-cr-prod.seqera.io/...sha256/.../data` Singularity form encodes only a digest; **name + version are not recoverable from this URL alone** — read them from the sibling Docker branch URL or the `environment.yml`. The pattern multiqc uses (Wave Docker on the docker branch + Wave-CR Singularity on the singularity branch) is by design.
+- **Provenance differs from BioContainers.** Wave images are Seqera-built on demand from Conda specs (and other recipes); they are **not** the BioContainers ecosystem and they are **not** mirrored to `depot.galaxyproject.org`. For Galaxy translation purposes, a Wave reference cannot be converted to a Galaxy `<requirement type="package">` line by direct mapping — the `environment.yml` is the round-trippable source.
+
+### Bucketing rule (resolver hypothesis)
+
+The Mold's §5 prose buckets by *ternary branch* ("singularity branch → `tools[].singularity`; fallthrough → `tools[].biocontainer | wave | docker`"). Every example in current nf-core modules can also be bucketed by *URL prefix*. **The two rules disagree** on multiqc (singularity branch is `community-cr-prod.seqera.io/...` — under the branch rule, `tools[].singularity`; under the URL-prefix rule, `tools[].wave`) and seqkit/sample (singularity branch is `oras://community.wave.seqera.io/...` — same disagreement).
+
+**Foundry hypothesis to confirm with the Mold author:** bucket by URL prefix.
+
+- `tools[].singularity` reserved for `https://depot.galaxyproject.org/singularity/...` and any non-Wave `oras://` URL.
+- `tools[].biocontainer` for `quay.io/biocontainers/...` and `docker.io/biocontainers/...` (rare; see below).
+- `tools[].wave` for the three Wave forms above, regardless of which ternary branch produced them.
+- `tools[].docker` for any other registry (`docker.io/<org>/<name>`, `<registry>/<org>/<name>`, etc.).
+
+URL-prefix bucketing keeps the `tools[]` fields semantically uniform — `tools[].wave` always means "Seqera-built, no Bioconda dual" — at the cost of `tools[].singularity` no longer being "what runs under Singularity for this process." If the latter framing is preferred, it should be a separate field on `processes[]` (e.g. `process.container_singularity` / `process.container_docker`), not a reuse of `tools[]`.
+
+### 5. Generic Docker (escape hatch)
+
+Anything not matching the four canonical forms — `docker.io/<org>/<name>:<tag>`, `<registry>/<org>/<name>@sha256:<digest>`, no-namespace fallback, etc.
+
+- **Regex (loose):** `^(?:(?P<registry>[^/]+)/)?(?P<path>[^:@]+)(?:[:](?P<tag>[^@]+))?(?:@(?P<digest>sha256:[0-9a-f]+))?$`
+- **Bucket:** `tools[].docker`.
+- **Derivation:** best-effort; the cast skill records the URL as a string and leaves `(name, version)` to the LLM-driven prose pass when no other signal exists.
+
+### Aside: legacy `biocontainers/<name>...` (docker.io alias)
+
+The Mold body lists `biocontainers/<name>:<version>--<build>` (no registry prefix; resolves to docker.io's `biocontainers` org) as a docker-branch form. In current nf-core, this is rare. A GitHub code search for explicit `docker.io/biocontainers/` across the `nf-core` org returns 22 hits; bare `biocontainers/...` (no `quay.io/`) appears in a handful of legacy modules. The **same image** is published to both registries by the BioContainers production pipeline, so the round-trip semantics are identical to the quay form. Bucket as `tools[].biocontainer` either way.
+
+## Conda directive resolution
+
+Two legal forms today; one dominates.
+
+### Modern: file reference
+
+```groovy
+conda "${moduleDir}/environment.yml"
+```
+
+— virtually every current nf-core module (fastqc, multiqc, dragmap/align, seqkit/sample, …). The cast skill must:
+
+1. Resolve `${moduleDir}` to the directory holding `main.nf` (not the pipeline root).
+2. Read the sibling `environment.yml`.
+3. Parse `dependencies:` for the package list.
+
+The file's structure is fixed by [`modules/environment-schema.json`](https://github.com/nf-core/modules/blob/master/modules/environment-schema.json):
+
+```yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::fastqc=0.12.1
+```
+
+— [`modules/nf-core/fastqc/environment.yml`](https://github.com/nf-core/modules/blob/master/modules/nf-core/fastqc/environment.yml).
+
+The schema enforces:
+- `channels` must not include `default`.
+- `dependencies` items must match `^.*[^><]=[^><].*$` — **i.e. a `=` (not `>=` or `<=`) version pin is required**, ensuring reproducibility.
+- `name:` must be **absent** (`"not": { "required": ["name"] }`).
+- `pip:` sub-dependencies must use `==` pinning.
+
+### Channel ordering
+
+The `nf-core/modules` lint check requires `conda-forge` first, then `bioconda`. Conda resolves channels in declaration order and `conda-forge` carries general dependencies that bioconda recipes typically build against, so the order matters at install time. The schema does not enforce ordering; the lint does.
+
+### Single-dep vs multi-dep
+
+| Pattern | Container directive | `tools[].bioconda` |
+|---|---|---|
+| Single `bioconda::<name>=<version>` | Pairs with simple `<name>:<version>--<build>` (Galaxy depot / quay) | `bioconda::<name>=<version>` (verbatim) |
+| Multiple `<channel>::<name>=<version>` deps | Pairs with `mulled-v2-<hash>:<verhash>-0` | List of all dep strings; `tools[].name` becomes a synthetic combined name |
+| Mixed bioconda + conda-forge (e.g. dragmap, samtools, pigz) | mulled-v2 (bioconda+conda-forge can be combined) | All deps listed |
+
+Only `bioconda::` deps round-trip cleanly to a Galaxy `<requirement type="package">` line. `conda-forge::` deps are typically system-level (pigz, openjdk) and have to be matched against the Galaxy `requirement` namespace separately — they exist in Bioconda's mulled multi-package output but are not Bioconda recipes themselves.
+
+### Legacy: literal string
+
+```groovy
+conda "bioconda::fastqc=0.12.1"
+```
+
+— still parses; the cast skill should accept it as identical to a single-dep `environment.yml` and populate `tools[].bioconda` from the literal string.
+
+## Tool name and version derivation
+
+In rough order of reliability:
+
+1. **`environment.yml` `dependencies[]`** — most reliable. `bioconda::<name>=<version>` directly yields `(name, version)`. Pair with `<name>:<version>` grep against the container URL to confirm.
+2. **Galaxy depot / quay URL path basename** — `<name>:<version>--<build>`. Reliable for non-mulled forms.
+3. **Wave Docker / Wave ORAS URL path basename** — `library/<name>:<version>--<digest>`. Reliable.
+4. **Wave-CR Singularity URL** — only a content digest; **name + version not recoverable from this URL**. Resolve from sibling docker branch or `environment.yml`.
+5. **Mulled-v2** — hash-only; resolve from sibling `environment.yml`.
+6. **Generic Docker** — best-effort path-basename split.
+
+For the `tools[]` deduplication step in the Mold's §5: dedupe by `(name, version)` after the resolution pass. Mulled-v2 entries dedupe under their synthetic name and the underlying Bioconda deps are *not* split into separate `tools[]` entries (they belong to one container). This is the field-name parity gxy-sketches `ToolSpec` was designed for: one `tools[]` entry per container/env, not per binary.
+
+## Edge cases the resolver must recognize
+
+These are not warnings to log; they are forms the bucketing rules above must continue to handle correctly. Listed in order of how often the cast skill is likely to hit them.
+
+- **Modern ternary predicate variant.** `workflow.containerEngine in ['singularity', 'apptainer']` (current nf-core template) and `workflow.containerEngine == 'singularity'` (older form, still in the Mold's prose) must both parse.
+- **`task.ext.singularity_pull_docker_container` toggle.** Per-task override that flips the ternary to the docker branch even under Singularity. Effectively unused in committed nf-core configs (0 hits), but the directive expression must still parse cleanly.
+- **`conf/modules.config` `withName:` overrides.** Pipeline-level `process { withName: 'PROC' { container = '...' } }` blocks override the module-level directive. The pipeline template ships these by convention — see `nf_core/pipeline-template/conf/modules.config`. The cast skill cannot resolve these statically with regex over `.nf` files; either run `nextflow inspect` (which honors them) or surface the override as an unresolved directive.
+- **`params.*` interpolation in directives.** `container = "registry/${params.image_tag}"` resolves at config-build time. Without a `-params-file` or CLI override, interpolation produces `null`. See `[[component-nextflow-inspect]]` for the runtime behavior; the static walker should report the raw string.
+- **Closure-form directives.** `container = { task.ext.foo ? 'A' : 'B' }`. Nextflow allows the directive itself to be a closure rather than a GString. Less common than the GString ternary, but legal.
+- **Multi-tool processes.** A single process running multiple binaries (e.g. `dragmap | samtools`) backed by a mulled-v2 container. The Mold notes `Process.tool` is nullable for these — populate by linking to the `tools[]` mulled entry, not by splitting one process across multiple `tools[]` entries.
+- **Mixed BioContainer + Wave in one pipeline.** Common in 2025 nf-core: fastqc still ships a quay BioContainer, multiqc has migrated to Wave. Both forms appear in the same pipeline's `tools[]`. No special handling required if URL-prefix bucketing is used.
+
+## Galaxy translation (handoff to `[[author-galaxy-tool-wrapper]]`)
+
+The `tools[]` block this Mold produces is the input contract for Galaxy `<requirements>` translation. The mapping is:
+
+- `tools[].bioconda` (`bioconda::<name>=<version>`) → `<requirement type="package" version="<version>">name</requirement>`. Galaxy resolves this through the same Bioconda → BioContainers chain documented above.
+- `tools[].biocontainer` / `tools[].singularity` → cross-validation that the Bioconda requirement resolves to a real BioContainer image. If `tools[].bioconda` is absent (Wave-only modules), the cast skill cannot emit a clean `<requirement>` and must fall back to the `environment.yml` deps.
+- `tools[].wave` alone → no Galaxy round-trip. The wrapper authoring Mold must surface this as an unresolved tool.
+- `tools[].docker` alone → no Galaxy round-trip; emit as a tool that requires a Galaxy `<container>` directive rather than `<requirement>`.
+
+The `[[author-galaxy-tool-wrapper]]` Mold owns this translation; this note documents the contract on the producer side.
 
 The safest default for newly authored Galaxy wrappers is:
 

--- a/content/molds/author-galaxy-tool-wrapper/index.md
+++ b/content/molds/author-galaxy-tool-wrapper/index.md
@@ -15,6 +15,15 @@ related_notes:
   - "[[nextflow-patterns]]"
   - "[[summary-nextflow]]"
 summary: "Author a new Galaxy tool wrapper (XML) when discovery yields nothing acceptable."
+output_artifacts:
+  - id: galaxy-tool-pin
+    kind: json
+    default_filename: galaxy-tool-pin.json
+    description: "Pin for a freshly-authored local wrapper (owner/repo/tool_id/version), parallel to a Tool Shed pin so downstream Molds consume one shape."
+  - id: galaxy-tool-wrapper
+    kind: text
+    default_filename: tool.xml
+    description: "Galaxy tool wrapper XML for a tool not present on the Tool Shed; conforms to Galaxy's tool XSD."
 references:
   - kind: schema
     ref: "[[summary-nextflow]]"

--- a/content/molds/compare-against-iwc-exemplar/index.md
+++ b/content/molds/compare-against-iwc-exemplar/index.md
@@ -12,6 +12,14 @@ revised: 2026-05-03
 revision: 4
 ai_generated: true
 summary: "Find nearest IWC exemplar(s) and surface a structural diff against a draft."
+input_artifacts:
+  - id: galaxy-workflow-draft
+    description: "gxformat2 skeleton from a *-summary-to-galaxy-template Mold; the draft compared against IWC exemplars."
+output_artifacts:
+  - id: iwc-comparison-notes
+    kind: markdown
+    default_filename: iwc-comparison-notes.md
+    description: "Structural diff against the nearest IWC exemplar(s); guidance for authoring before more concrete step work."
 references:
   - kind: research
     ref: "[[iwc-exemplar-runtime-discovery]]"

--- a/content/molds/cwl-summary-to-galaxy-data-flow/index.md
+++ b/content/molds/cwl-summary-to-galaxy-data-flow/index.md
@@ -14,6 +14,16 @@ revised: 2026-05-05
 revision: 1
 ai_generated: true
 summary: "Translate a CWL summary into a Galaxy data-flow design brief."
+input_artifacts:
+  - id: summary-cwl
+    description: "Structured CWL summary emitted by [[summarize-cwl]]; consumed alongside the Galaxy interface brief."
+  - id: cwl-galaxy-interface
+    description: "Preceding Galaxy interface brief from [[cwl-summary-to-galaxy-interface]] that pins inputs, outputs, and labels."
+output_artifacts:
+  - id: cwl-galaxy-data-flow
+    kind: markdown
+    default_filename: cwl-galaxy-data-flow.md
+    description: "Reviewable Markdown brief: abstract topology, Galaxy collection semantics, placeholder transformations, unresolved Galaxy tool needs."
 references:
   - kind: research
     ref: "[[galaxy-data-flow-draft-contract]]"

--- a/content/molds/cwl-summary-to-galaxy-interface/index.md
+++ b/content/molds/cwl-summary-to-galaxy-interface/index.md
@@ -14,6 +14,14 @@ revised: 2026-05-05
 revision: 1
 ai_generated: true
 summary: "Map a CWL summary into a Galaxy workflow interface design brief."
+input_artifacts:
+  - id: summary-cwl
+    description: "Structured CWL summary emitted by [[summarize-cwl]]; the source-of-truth JSON for Galaxy interface choices."
+output_artifacts:
+  - id: cwl-galaxy-interface
+    kind: markdown
+    default_filename: cwl-galaxy-interface.md
+    description: "Reviewable Markdown brief: Galaxy workflow inputs, outputs, labels, exposed and checkpoint outputs, source provenance, confidence."
 references:
   - kind: research
     ref: "[[galaxy-workflow-testability-design]]"

--- a/content/molds/cwl-summary-to-galaxy-template/index.md
+++ b/content/molds/cwl-summary-to-galaxy-template/index.md
@@ -14,6 +14,18 @@ revised: 2026-05-05
 revision: 1
 ai_generated: true
 summary: "gxformat2 skeleton with per-step TODOs from a CWL summary and prior Galaxy design briefs."
+input_artifacts:
+  - id: summary-cwl
+    description: "Structured CWL summary emitted by [[summarize-cwl]]; consulted while emitting placeholder steps."
+  - id: cwl-galaxy-interface
+    description: "Galaxy interface brief from [[cwl-summary-to-galaxy-interface]] that pins workflow inputs, outputs, labels."
+  - id: cwl-galaxy-data-flow
+    description: "Galaxy data-flow brief from [[cwl-summary-to-galaxy-data-flow]] that pins abstract operations and collection choices."
+output_artifacts:
+  - id: galaxy-workflow-draft
+    kind: yaml
+    default_filename: galaxy-workflow-draft.gxwf.yml
+    description: "gxformat2 skeleton: workflow inputs, outputs, placeholder steps, rough connections, TODO slots for later implementation Molds."
 references:
   - kind: research
     ref: "[[galaxy-workflow-testability-design]]"

--- a/content/molds/cwl-test-to-galaxy-test-plan/index.md
+++ b/content/molds/cwl-test-to-galaxy-test-plan/index.md
@@ -12,6 +12,14 @@ revised: 2026-05-03
 revision: 2
 ai_generated: true
 summary: "Translate CWL test fixtures into a Galaxy workflow test plan."
+input_artifacts:
+  - id: summary-cwl
+    description: "Structured CWL summary from [[summarize-cwl]]; carries test fixtures, job inputs, expected outputs."
+output_artifacts:
+  - id: galaxy-test-plan
+    kind: markdown
+    default_filename: galaxy-test-plan.md
+    description: "Reviewable Galaxy workflow test plan derived from CWL test fixtures, job inputs, expected outputs, assertion evidence."
 ---
 # cwl-test-to-galaxy-test-plan
 

--- a/content/molds/discover-shed-tool/index.md
+++ b/content/molds/discover-shed-tool/index.md
@@ -14,6 +14,12 @@ ai_generated: true
 summary: "Search the Tool Shed for an existing wrapper, drill from hit to a pinnable changeset, classify candidates, and recommend or fall through."
 output_schemas:
   - "[[galaxy-tool-discovery]]"
+output_artifacts:
+  - id: galaxy-tool-pin
+    kind: json
+    default_filename: galaxy-tool-pin.json
+    schema: "[[galaxy-tool-discovery]]"
+    description: "(owner, repo, tool_id, version, changeset_revision) pin for a Tool Shed wrapper plus discovery classification."
 cli_commands:
   - "[[tool-search]]"
   - "[[tool-versions]]"

--- a/content/molds/find-test-data/index.md
+++ b/content/molds/find-test-data/index.md
@@ -10,6 +10,11 @@ revised: 2026-04-30
 revision: 1
 ai_generated: true
 summary: "Search IWC fixtures and public sources for test data matching a data-flow shape."
+output_artifacts:
+  - id: test-data-refs
+    kind: json
+    default_filename: test-data-refs.json
+    description: "Test data matched from IWC fixtures or public sources, expressed as URLs/paths plus expected shapes for downstream test authoring."
 ---
 # find-test-data
 

--- a/content/molds/implement-cwl-tool-step/index.md
+++ b/content/molds/implement-cwl-tool-step/index.md
@@ -12,6 +12,16 @@ revised: 2026-04-30
 revision: 1
 ai_generated: true
 summary: "Convert an abstract step into a concrete CWL CommandLineTool + step."
+input_artifacts:
+  - id: cwl-tool-summary
+    description: "Compact CWL tool summary from [[summarize-cwl-tool]]; binds the abstract step to a concrete CommandLineTool."
+  - id: cwl-workflow-draft
+    description: "CWL Workflow skeleton being filled in step by step; the step replaces a placeholder in this draft."
+output_artifacts:
+  - id: cwl-workflow-draft
+    kind: yaml
+    default_filename: cwl-workflow-draft.cwl
+    description: "CWL Workflow skeleton with one more abstract step replaced by a concrete CommandLineTool step (loop iteration output)."
 ---
 # implement-cwl-tool-step
 

--- a/content/molds/implement-cwl-workflow-test/index.md
+++ b/content/molds/implement-cwl-workflow-test/index.md
@@ -12,6 +12,16 @@ revised: 2026-04-30
 revision: 1
 ai_generated: true
 summary: "Assemble CWL job file(s) and expected-output assertions."
+input_artifacts:
+  - id: cwl-test-plan
+    description: "Reviewable CWL test plan from [[nextflow-test-to-cwl-test-plan]] (or future CWL test-plan producers); job, fixture, assertion provenance."
+  - id: cwl-workflow-draft
+    description: "CWL Workflow being tested; provides input/output ports and shapes the job + assertions must match."
+output_artifacts:
+  - id: cwl-workflow-test
+    kind: yaml
+    default_filename: cwl-job.yml
+    description: "CWL job file(s) with inputs and expected-output assertions for the implemented workflow."
 ---
 # implement-cwl-workflow-test
 

--- a/content/molds/implement-galaxy-tool-step/index.md
+++ b/content/molds/implement-galaxy-tool-step/index.md
@@ -12,6 +12,16 @@ revised: 2026-05-03
 revision: 4
 ai_generated: true
 summary: "Convert an abstract step into a concrete gxformat2 step using a tool summary."
+input_artifacts:
+  - id: galaxy-tool-summary
+    description: "Compact Galaxy tool summary from [[summarize-galaxy-tool]]; binds the abstract step to a concrete tool's ports."
+  - id: galaxy-workflow-draft
+    description: "gxformat2 skeleton being filled in step by step; the step replaces a placeholder in this draft."
+output_artifacts:
+  - id: galaxy-workflow-draft
+    kind: yaml
+    default_filename: galaxy-workflow-draft.gxwf.yml
+    description: "gxformat2 skeleton with one more abstract step replaced by a concrete tool step (loop iteration output)."
 references:
   - kind: research
     ref: "[[galaxy-workflow-testability-design]]"

--- a/content/molds/implement-galaxy-workflow-test/index.md
+++ b/content/molds/implement-galaxy-workflow-test/index.md
@@ -20,6 +20,18 @@ related_notes:
 cli_commands:
   - "[[validate-tests]]"
 summary: "Assemble Galaxy workflow test fixtures and assertions."
+input_artifacts:
+  - id: galaxy-test-plan
+    description: "Reviewable Galaxy test plan from a *-test-to-galaxy-test-plan Mold; profile, fixtures, snapshot/assertion provenance."
+  - id: galaxy-workflow-draft
+    description: "gxformat2 workflow being tested; provides labels, outputs, and shapes the test must assert against."
+  - id: test-data-refs
+    description: "Resolved test data references (URLs, paths, expected shapes) from paper-to-test-data or find-test-data."
+output_artifacts:
+  - id: galaxy-workflow-test
+    kind: yaml
+    default_filename: galaxy-workflow-tests.yml
+    description: "Galaxy workflow test file (tests-format) with job inputs, expected outputs, assertions; passes static schema + label cross-check."
 references:
   - kind: cli-command
     ref: "[[validate-tests]]"

--- a/content/molds/nextflow-summary-to-cwl-data-flow/index.md
+++ b/content/molds/nextflow-summary-to-cwl-data-flow/index.md
@@ -14,6 +14,16 @@ revised: 2026-05-05
 revision: 1
 ai_generated: true
 summary: "Translate a Nextflow summary into a CWL data-flow design brief."
+input_artifacts:
+  - id: summary-nextflow
+    description: "Structured Nextflow pipeline summary emitted by [[summarize-nextflow]]; consumed alongside the CWL interface brief."
+  - id: nextflow-cwl-interface
+    description: "Preceding CWL interface brief from [[nextflow-summary-to-cwl-interface]] that pins inputs, outputs, and labels."
+output_artifacts:
+  - id: nextflow-cwl-data-flow
+    kind: markdown
+    default_filename: nextflow-cwl-data-flow.md
+    description: "Reviewable Markdown brief: abstract topology, scatter/gather choices, value transformations, unresolved CommandLineTool needs, confidence."
 references:
   - kind: schema
     ref: "[[summary-nextflow]]"

--- a/content/molds/nextflow-summary-to-cwl-interface/index.md
+++ b/content/molds/nextflow-summary-to-cwl-interface/index.md
@@ -14,6 +14,14 @@ revised: 2026-05-05
 revision: 1
 ai_generated: true
 summary: "Map a Nextflow summary into a CWL Workflow interface design brief."
+input_artifacts:
+  - id: summary-nextflow
+    description: "Structured Nextflow pipeline summary emitted by [[summarize-nextflow]]; the source-of-truth JSON for CWL interface choices."
+output_artifacts:
+  - id: nextflow-cwl-interface
+    kind: markdown
+    default_filename: nextflow-cwl-interface.md
+    description: "Reviewable Markdown brief: CWL Workflow inputs, outputs, labels, array/record/File shapes, checkpoint outputs, source provenance."
 references:
   - kind: schema
     ref: "[[summary-nextflow]]"

--- a/content/molds/nextflow-summary-to-galaxy-data-flow/index.md
+++ b/content/molds/nextflow-summary-to-galaxy-data-flow/index.md
@@ -14,6 +14,16 @@ revised: 2026-05-05
 revision: 1
 ai_generated: true
 summary: "Translate a Nextflow summary into a Galaxy data-flow design brief."
+input_artifacts:
+  - id: summary-nextflow
+    description: "Structured Nextflow pipeline summary emitted by [[summarize-nextflow]]; the JSON the data-flow translation reads."
+  - id: nextflow-galaxy-interface
+    description: "Preceding Galaxy interface brief from [[nextflow-summary-to-galaxy-interface]] that pins inputs, outputs, and labels."
+output_artifacts:
+  - id: nextflow-galaxy-data-flow
+    kind: markdown
+    default_filename: nextflow-galaxy-data-flow.md
+    description: "Reviewable Markdown brief: abstract operations, collection map/reduce choices, shape-changing placeholder steps, unresolved Galaxy tool needs, confidence, open questions."
 references:
   - kind: schema
     ref: "[[summary-nextflow]]"

--- a/content/molds/nextflow-summary-to-galaxy-interface/index.md
+++ b/content/molds/nextflow-summary-to-galaxy-interface/index.md
@@ -14,6 +14,14 @@ revised: 2026-05-05
 revision: 1
 ai_generated: true
 summary: "Map a Nextflow summary into a Galaxy workflow interface design brief."
+input_artifacts:
+  - id: summary-nextflow
+    description: "Structured Nextflow pipeline summary emitted by [[summarize-nextflow]]; the source-of-truth JSON for interface choices."
+output_artifacts:
+  - id: nextflow-galaxy-interface
+    kind: markdown
+    default_filename: nextflow-galaxy-interface.md
+    description: "Reviewable Markdown brief: Galaxy workflow inputs, outputs, labels, collection shapes, checkpoint outputs, source provenance."
 references:
   - kind: schema
     ref: "[[summary-nextflow]]"

--- a/content/molds/nextflow-summary-to-galaxy-template/index.md
+++ b/content/molds/nextflow-summary-to-galaxy-template/index.md
@@ -14,6 +14,18 @@ revised: 2026-05-05
 revision: 1
 ai_generated: true
 summary: "gxformat2 skeleton with per-step TODOs from a Nextflow summary and prior Galaxy design briefs."
+input_artifacts:
+  - id: summary-nextflow
+    description: "Structured Nextflow pipeline summary emitted by [[summarize-nextflow]]; consulted while emitting placeholder steps."
+  - id: nextflow-galaxy-interface
+    description: "Galaxy interface brief from [[nextflow-summary-to-galaxy-interface]] that pins workflow inputs, outputs, labels."
+  - id: nextflow-galaxy-data-flow
+    description: "Galaxy data-flow brief from [[nextflow-summary-to-galaxy-data-flow]] that pins abstract operations and collection choices."
+output_artifacts:
+  - id: galaxy-workflow-draft
+    kind: yaml
+    default_filename: galaxy-workflow-draft.gxwf.yml
+    description: "gxformat2 skeleton: workflow inputs, outputs, placeholder steps, rough connections, TODO slots for later implementation Molds."
 references:
   - kind: schema
     ref: "[[summary-nextflow]]"

--- a/content/molds/nextflow-test-to-cwl-test-plan/index.md
+++ b/content/molds/nextflow-test-to-cwl-test-plan/index.md
@@ -13,6 +13,14 @@ revised: 2026-05-03
 revision: 1
 ai_generated: true
 summary: "Translate Nextflow test evidence into a CWL workflow test plan."
+input_artifacts:
+  - id: summary-nextflow
+    description: "Structured Nextflow summary from [[summarize-nextflow]]; carries test_fixtures, nf_tests, snapshot evidence."
+output_artifacts:
+  - id: cwl-test-plan
+    kind: markdown
+    default_filename: cwl-test-plan.md
+    description: "Reviewable CWL workflow test plan: job inputs, expected outputs, assertions, fixtures, rationale provenance."
 related_notes:
   - "[[summary-nextflow]]"
 references:

--- a/content/molds/nextflow-test-to-galaxy-test-plan/index.md
+++ b/content/molds/nextflow-test-to-galaxy-test-plan/index.md
@@ -12,6 +12,14 @@ revised: 2026-05-05
 revision: 4
 ai_generated: true
 summary: "Translate Nextflow test evidence into a Galaxy workflow test plan."
+input_artifacts:
+  - id: summary-nextflow
+    description: "Structured Nextflow summary from [[summarize-nextflow]]; carries test_fixtures, nf_tests, snapshot evidence."
+output_artifacts:
+  - id: galaxy-test-plan
+    kind: markdown
+    default_filename: galaxy-test-plan.md
+    description: "Reviewable Galaxy workflow test plan: profile, fixture, snapshot, ignored-file, expected-output, rationale provenance."
 references:
   - kind: schema
     ref: "[[summary-nextflow]]"

--- a/content/molds/paper-summary-to-cwl-design/index.md
+++ b/content/molds/paper-summary-to-cwl-design/index.md
@@ -14,6 +14,14 @@ revised: 2026-05-05
 revision: 1
 ai_generated: true
 summary: "Translate a paper summary into a CWL workflow design brief."
+input_artifacts:
+  - id: summary-paper
+    description: "Paper extraction emitted by [[summarize-paper]]; methods, tools, sample data, references."
+output_artifacts:
+  - id: paper-cwl-design
+    kind: markdown
+    default_filename: paper-cwl-design.md
+    description: "Combined CWL interface + data-flow design brief; a single reviewable handoff until paper examples justify a split."
 ---
 # paper-summary-to-cwl-design
 

--- a/content/molds/paper-summary-to-galaxy-design/index.md
+++ b/content/molds/paper-summary-to-galaxy-design/index.md
@@ -14,6 +14,14 @@ revised: 2026-05-05
 revision: 1
 ai_generated: true
 summary: "Translate a paper summary into a Galaxy workflow design brief."
+input_artifacts:
+  - id: summary-paper
+    description: "Paper extraction emitted by [[summarize-paper]]; methods, tools, sample data, references."
+output_artifacts:
+  - id: paper-galaxy-design
+    kind: markdown
+    default_filename: paper-galaxy-design.md
+    description: "Combined Galaxy interface + data-flow design brief; a single reviewable handoff until paper examples justify a split."
 references:
   - kind: research
     ref: "[[galaxy-data-flow-draft-contract]]"

--- a/content/molds/paper-summary-to-galaxy-template/index.md
+++ b/content/molds/paper-summary-to-galaxy-template/index.md
@@ -14,6 +14,16 @@ revised: 2026-05-05
 revision: 1
 ai_generated: true
 summary: "gxformat2 skeleton with per-step TODOs from a paper summary and the paper-to-Galaxy design brief."
+input_artifacts:
+  - id: summary-paper
+    description: "Paper summary emitted by [[summarize-paper]]; consulted while emitting placeholder steps."
+  - id: paper-galaxy-design
+    description: "Combined Galaxy design brief from [[paper-summary-to-galaxy-design]] that pins interface and data-flow choices."
+output_artifacts:
+  - id: galaxy-workflow-draft
+    kind: yaml
+    default_filename: galaxy-workflow-draft.gxwf.yml
+    description: "gxformat2 skeleton: workflow inputs, outputs, placeholder steps, rough connections, TODO slots for later implementation Molds."
 references:
   - kind: research
     ref: "[[galaxy-workflow-testability-design]]"

--- a/content/molds/paper-to-test-data/index.md
+++ b/content/molds/paper-to-test-data/index.md
@@ -12,6 +12,14 @@ revised: 2026-04-30
 revision: 1
 ai_generated: true
 summary: "Derive workflow test inputs and expected outputs from a paper."
+input_artifacts:
+  - id: summary-paper
+    description: "Paper summary from [[summarize-paper]]; sample data and reference evidence the test fixtures derive from."
+output_artifacts:
+  - id: test-data-refs
+    kind: json
+    default_filename: test-data-refs.json
+    description: "Resolved workflow test inputs and expected outputs derived from paper evidence (URLs, file shapes, expected hashes)."
 ---
 # paper-to-test-data
 

--- a/content/molds/summarize-cwl-tool/index.md
+++ b/content/molds/summarize-cwl-tool/index.md
@@ -12,6 +12,11 @@ revised: 2026-04-30
 revision: 1
 ai_generated: true
 summary: "Derive a CommandLineTool description (container, baseCommand, IO) for a CWL target."
+output_artifacts:
+  - id: cwl-tool-summary
+    kind: json
+    default_filename: cwl-tool-summary.json
+    description: "Compact CWL CommandLineTool summary: container, baseCommand, inputs, outputs, requirements, version metadata."
 ---
 # summarize-cwl-tool
 

--- a/content/molds/summarize-cwl/index.md
+++ b/content/molds/summarize-cwl/index.md
@@ -12,6 +12,11 @@ revised: 2026-04-30
 revision: 1
 ai_generated: true
 summary: "Surface CWL Workflow + CommandLineTool inputs, outputs, scatter, conditionals."
+output_artifacts:
+  - id: summary-cwl
+    kind: json
+    default_filename: summary-cwl.json
+    description: "Structured summary of a CWL Workflow + CommandLineTool tree: inputs, outputs, scatter, conditionals, requirements."
 ---
 # summarize-cwl
 

--- a/content/molds/summarize-galaxy-tool/index.md
+++ b/content/molds/summarize-galaxy-tool/index.md
@@ -12,6 +12,14 @@ revised: 2026-05-04
 revision: 4
 ai_generated: true
 summary: "Pull JSON schema, container, source, inputs/outputs for a Galaxy tool."
+input_artifacts:
+  - id: galaxy-tool-pin
+    description: "Pin from [[discover-shed-tool]] or [[author-galaxy-tool-wrapper]]; identifies which cached ParsedTool to summarize."
+output_artifacts:
+  - id: galaxy-tool-summary
+    kind: json
+    default_filename: galaxy-tool-summary.json
+    description: "Compact tool summary derived from a cached ParsedTool: input/output ports, schema, container, source, version metadata."
 references:
   - kind: research
     ref: "[[galaxy-tool-summary-input-source]]"

--- a/content/molds/summarize-nextflow/index.md
+++ b/content/molds/summarize-nextflow/index.md
@@ -61,7 +61,7 @@ references:
     ref: "[[component-nextflow-containers-and-envs]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: verbatim
     evidence: corpus-observed
     purpose: "Resolve container, conda, Wave, and Bioconda/Biocontainers environment evidence."
     trigger: "When extracting tools, versions, containers, conda directives, or environment equivalences."

--- a/content/molds/summarize-nextflow/index.md
+++ b/content/molds/summarize-nextflow/index.md
@@ -13,6 +13,12 @@ revision: 9
 ai_generated: true
 output_schemas:
   - "[[summary-nextflow]]"
+output_artifacts:
+  - id: summary-nextflow
+    kind: json
+    default_filename: summary-nextflow.json
+    schema: "[[summary-nextflow]]"
+    description: "Structured summary of a Nextflow pipeline: processes, channels, params, containers, tools, test fixtures, nf-tests."
 references:
   - kind: schema
     ref: "[[summary-nextflow]]"

--- a/content/molds/summarize-paper/index.md
+++ b/content/molds/summarize-paper/index.md
@@ -12,6 +12,11 @@ revised: 2026-04-30
 revision: 1
 ai_generated: true
 summary: "Extract methods, tools, sample data, and references from a paper."
+output_artifacts:
+  - id: summary-paper
+    kind: markdown
+    default_filename: summary-paper.md
+    description: "Methods, tools, sample data, and reference extraction from a primary paper, formatted for downstream design Molds."
 ---
 # summarize-paper
 

--- a/content/molds/summary-to-cwl-template/index.md
+++ b/content/molds/summary-to-cwl-template/index.md
@@ -12,6 +12,15 @@ revised: 2026-05-05
 revision: 2
 ai_generated: true
 summary: "CWL Workflow skeleton with per-step TODOs from source and design handoffs."
+# input_artifacts intentionally omitted: this Mold is target-specific and reads
+# different upstream summaries/design briefs depending on the source pipeline
+# (Nextflow vs paper). Heterogeneous inputs aren't expressible without
+# polymorphism; the harness binds them per-pipeline.
+output_artifacts:
+  - id: cwl-workflow-draft
+    kind: yaml
+    default_filename: cwl-workflow-draft.cwl
+    description: "CWL Workflow skeleton: inputs, outputs, placeholder steps, rough connections, TODO slots for later implementation Molds."
 related_notes:
   - "[[nextflow-summary-to-cwl-interface]]"
   - "[[nextflow-summary-to-cwl-data-flow]]"

--- a/meta_schema.yml
+++ b/meta_schema.yml
@@ -168,6 +168,47 @@ properties:
     items:
       type: string
       pattern: "^\\[\\[.+\\]\\]$"
+  # Typed artifact handoffs between Molds. Producer side: this Mold emits
+  # `id` as one of its outputs. Consumer side (input_artifacts): this Mold
+  # requires `id` to be supplied by a prior Mold in a Pipeline run. ids are
+  # bare slugs (kebab); the cross-file validator checks every consumer id
+  # resolves to some producer id in the corpus. Multiple Molds may produce
+  # the same id (e.g. branch outputs that satisfy a single downstream input).
+  output_artifacts:
+    type: array
+    items:
+      type: object
+      required: [id, kind, default_filename, description]
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          pattern: "^[a-z][a-z0-9-]*$"
+        kind:
+          type: string
+          enum: [json, markdown, yaml, text, other]
+        default_filename:
+          type: string
+          minLength: 1
+        schema:
+          type: string
+          pattern: "^\\[\\[.+\\]\\]$"
+        description:
+          type: string
+          minLength: 20
+  input_artifacts:
+    type: array
+    items:
+      type: object
+      required: [id, description]
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          pattern: "^[a-z][a-z0-9-]*$"
+        description:
+          type: string
+          minLength: 20
   examples:
     type: array
     items:

--- a/packages/build-cli/src/commands/cast-mold.ts
+++ b/packages/build-cli/src/commands/cast-mold.ts
@@ -377,6 +377,24 @@ interface ProvenanceRefEntry {
   model?: { name: string; version?: string };
 }
 
+interface ProvenanceArtifactOutput {
+  id: string;
+  kind: string;
+  default_filename: string;
+  schema?: string;
+  description: string;
+}
+
+interface ProvenanceArtifactInput {
+  id: string;
+  description: string;
+}
+
+interface ProvenanceArtifacts {
+  produces: ProvenanceArtifactOutput[];
+  consumes: ProvenanceArtifactInput[];
+}
+
 interface Provenance {
   provenance_schema_version: number;
   cast_target: string;
@@ -394,7 +412,42 @@ interface Provenance {
   cast_revision?: number;
   cast_history?: Array<{ rev: number; date: string; note: string }>;
   refs: ProvenanceRefEntry[];
+  artifacts?: ProvenanceArtifacts;
   open_questions?: string[];
+}
+
+function readArtifactContracts(meta: Frontmatter): ProvenanceArtifacts | undefined {
+  const out: ProvenanceArtifactOutput[] = [];
+  const inp: ProvenanceArtifactInput[] = [];
+  const rawOut = meta.output_artifacts;
+  if (Array.isArray(rawOut)) {
+    for (const a of rawOut) {
+      if (!a || typeof a !== "object") continue;
+      const o = a as Record<string, unknown>;
+      if (typeof o.id !== "string") continue;
+      out.push({
+        id: o.id,
+        kind: typeof o.kind === "string" ? o.kind : "other",
+        default_filename: typeof o.default_filename === "string" ? o.default_filename : "",
+        schema: typeof o.schema === "string" ? o.schema : undefined,
+        description: typeof o.description === "string" ? o.description : "",
+      });
+    }
+  }
+  const rawIn = meta.input_artifacts;
+  if (Array.isArray(rawIn)) {
+    for (const a of rawIn) {
+      if (!a || typeof a !== "object") continue;
+      const o = a as Record<string, unknown>;
+      if (typeof o.id !== "string") continue;
+      inp.push({
+        id: o.id,
+        description: typeof o.description === "string" ? o.description : "",
+      });
+    }
+  }
+  if (out.length === 0 && inp.length === 0) return undefined;
+  return { produces: out, consumes: inp };
 }
 
 interface LegacyProvenanceCarryOver {
@@ -726,6 +779,7 @@ export async function runCastMoldCommand(argv = process.argv.slice(2)): Promise<
     cast_revision: carry.cast_revision,
     cast_history: carry.cast_history,
     refs: refEntries,
+    artifacts: readArtifactContracts(moldParsed.meta),
     open_questions: carry.open_questions,
   };
 

--- a/packages/build-cli/src/commands/validate.ts
+++ b/packages/build-cli/src/commands/validate.ts
@@ -659,6 +659,7 @@ function validatePipelinePhases(
     findings.push(...r.findings);
     for (const p of r.refs.moldPaths) moldsReferenced.add(p);
     for (const p of r.refs.branchedMoldPaths) moldsReferenced.add(p);
+    findings.push(...validatePipelineArtifactBindings(f, phases, slugMap, metaByPath));
   }
   // Inventory coverage warning: non-draft Molds should appear in at least one pipeline.
   const orphans: string[] = [];
@@ -674,6 +675,88 @@ function validatePipelinePhases(
       message: `Molds with zero pipeline membership: ${orphans.sort().join(", ")}`,
     });
   }
+  return findings;
+}
+
+/**
+ * Pipeline artifact binding ordering: every Mold-shaped phase's input_artifacts
+ * must be produced by some prior phase in the same pipeline (Mold-shaped or via
+ * branch/chain). Branch/chain phases are treated as the union of their inner
+ * Molds' artifact contracts (any branch's output may satisfy a downstream
+ * input — discover-or-author shape).
+ */
+function validatePipelineArtifactBindings(
+  file: FileMeta,
+  phases: unknown[],
+  slugMap: Map<string, string>,
+  metaByPath: Map<string, Frontmatter>,
+): CrossFileFinding[] {
+  const findings: CrossFileFinding[] = [];
+  const phaseDecls: { out: Set<string>; in: { id: string; idx: number }[] }[] = [];
+
+  const collectMoldPathsFromPhase = (phase: unknown): string[] => {
+    const out: string[] = [];
+    const visit = (n: unknown) => {
+      if (typeof n === "string") {
+        if (WIKI_LINK_RE.test(n)) {
+          const tp = resolveWikiLink(n, slugMap);
+          if (tp && metaByPath.get(tp)?.type === "mold") out.push(tp);
+        }
+        return;
+      }
+      if (!n || typeof n !== "object") return;
+      const obj = n as Record<string, unknown>;
+      if (typeof obj.mold === "string") visit(obj.mold);
+      if (typeof obj.fallthrough === "string") visit(obj.fallthrough);
+      if (Array.isArray(obj.branches)) obj.branches.forEach(visit);
+      if (Array.isArray(obj.chain)) obj.chain.forEach(visit);
+    };
+    visit(phase);
+    return out;
+  };
+
+  phases.forEach((phase, idx) => {
+    const out = new Set<string>();
+    const inputs: { id: string; idx: number }[] = [];
+    for (const moldPath of collectMoldPathsFromPhase(phase)) {
+      const meta = metaByPath.get(moldPath);
+      if (!meta) continue;
+      const o = meta.output_artifacts;
+      if (Array.isArray(o)) {
+        for (const a of o) {
+          if (a && typeof a === "object" && typeof (a as { id?: unknown }).id === "string") {
+            out.add((a as { id: string }).id);
+          }
+        }
+      }
+      const inp = meta.input_artifacts;
+      if (Array.isArray(inp)) {
+        for (const a of inp) {
+          if (a && typeof a === "object" && typeof (a as { id?: unknown }).id === "string") {
+            inputs.push({ id: (a as { id: string }).id, idx });
+          }
+        }
+      }
+    }
+    phaseDecls.push({ out, in: inputs });
+  });
+
+  // Build cumulative produced ids, walking phases in order.
+  const cumulative = new Set<string>();
+  phaseDecls.forEach((decl, i) => {
+    for (const inp of decl.in) {
+      // Self-loop allowance: the same phase may produce and consume (loop phases re-feeding themselves).
+      if (!cumulative.has(inp.id) && !decl.out.has(inp.id)) {
+        findings.push({
+          path: file.path,
+          severity: "warning",
+          message: `phases[${i}]: input_artifact '${inp.id}' has no prior phase producing it in this pipeline`,
+        });
+      }
+    }
+    for (const id of decl.out) cumulative.add(id);
+  });
+
   return findings;
 }
 

--- a/packages/build-cli/src/commands/validate.ts
+++ b/packages/build-cli/src/commands/validate.ts
@@ -611,7 +611,8 @@ function validateArtifactGraph(
 
 function validateSchemaVendoring(files: FileMeta[], contentRoot: string): CrossFileFinding[] {
   const findings: CrossFileFinding[] = [];
-  const repoRoot = path.basename(contentRoot) === "content" ? path.dirname(contentRoot) : contentRoot;
+  const repoRoot =
+    path.basename(contentRoot) === "content" ? path.dirname(contentRoot) : contentRoot;
   for (const f of files) {
     if (f.meta.type !== "schema") continue;
     const upstream = typeof f.meta.upstream === "string" ? f.meta.upstream : "";

--- a/packages/build-cli/src/commands/validate.ts
+++ b/packages/build-cli/src/commands/validate.ts
@@ -538,6 +538,77 @@ function collectPhaseMoldRefs(
   return { findings, refs };
 }
 
+/**
+ * Mold artifact handoff validation.
+ *   - Every `input_artifacts[].id` must resolve to some `output_artifacts[].id`
+ *     declared by another Mold (multi-producer is allowed; same id can come
+ *     from a discover-or-author branch).
+ *   - When `output_artifacts[].schema` is set, the wiki-link must resolve to a
+ *     `type: schema` note.
+ */
+function validateArtifactGraph(
+  files: FileMeta[],
+  slugMap: Map<string, string>,
+  metaByPath: Map<string, Frontmatter>,
+): CrossFileFinding[] {
+  const findings: CrossFileFinding[] = [];
+  const producerIds = new Set<string>();
+  for (const f of files) {
+    if (f.meta.type !== "mold") continue;
+    const out = f.meta.output_artifacts;
+    if (!Array.isArray(out)) continue;
+    for (const a of out) {
+      if (a && typeof a === "object" && typeof (a as { id?: unknown }).id === "string") {
+        producerIds.add((a as { id: string }).id);
+      }
+    }
+  }
+  for (const f of files) {
+    if (f.meta.type !== "mold") continue;
+    const out = f.meta.output_artifacts;
+    if (Array.isArray(out)) {
+      out.forEach((a, i) => {
+        if (!a || typeof a !== "object") return;
+        const schema = (a as { schema?: unknown }).schema;
+        if (typeof schema !== "string") return;
+        const tp = resolveWikiLink(schema, slugMap);
+        if (!tp) {
+          findings.push({
+            path: f.path,
+            severity: "error",
+            message: `output_artifacts[${i}].schema: wiki link ${schema} did not resolve`,
+          });
+          return;
+        }
+        const targetType = metaByPath.get(tp)?.type;
+        if (targetType !== "schema") {
+          findings.push({
+            path: f.path,
+            severity: "error",
+            message: `output_artifacts[${i}].schema: wiki link ${schema} resolves to type=${targetType ?? "(none)"}, expected schema`,
+          });
+        }
+      });
+    }
+    const inp = f.meta.input_artifacts;
+    if (Array.isArray(inp)) {
+      inp.forEach((a, i) => {
+        if (!a || typeof a !== "object") return;
+        const id = (a as { id?: unknown }).id;
+        if (typeof id !== "string") return;
+        if (!producerIds.has(id)) {
+          findings.push({
+            path: f.path,
+            severity: "error",
+            message: `input_artifacts[${i}].id '${id}' has no producer (no Mold declares it in output_artifacts)`,
+          });
+        }
+      });
+    }
+  }
+  return findings;
+}
+
 function validatePipelinePhases(
   files: FileMeta[],
   slugMap: Map<string, string>,
@@ -970,6 +1041,7 @@ export function validateDirectory(opts: ValidateOptions): {
   crossFindings.push(...validateMoldRefs(validFiles, slugMap, metaByPath, opts.directory));
   crossFindings.push(...validateSourcePatternRefs(validFiles, slugMap, metaByPath));
   crossFindings.push(...validatePipelinePhases(validFiles, slugMap, metaByPath));
+  crossFindings.push(...validateArtifactGraph(validFiles, slugMap, metaByPath));
   crossFindings.push(
     ...validateMoldSourceLayout(
       opts.directory,

--- a/packages/build-cli/src/commands/validate.ts
+++ b/packages/build-cli/src/commands/validate.ts
@@ -609,6 +609,41 @@ function validateArtifactGraph(
   return findings;
 }
 
+function validateSchemaVendoring(files: FileMeta[], contentRoot: string): CrossFileFinding[] {
+  const findings: CrossFileFinding[] = [];
+  const repoRoot = path.basename(contentRoot) === "content" ? path.dirname(contentRoot) : contentRoot;
+  for (const f of files) {
+    if (f.meta.type !== "schema") continue;
+    const upstream = typeof f.meta.upstream === "string" ? f.meta.upstream : "";
+    if (!upstream || upstream.includes("github.com/jmchilton/foundry/")) continue;
+    if (typeof f.meta.license !== "string") {
+      findings.push({
+        path: f.path,
+        severity: "error",
+        message: "vendored schema with external upstream must declare license",
+      });
+    }
+    const licenseFile = typeof f.meta.license_file === "string" ? f.meta.license_file : "";
+    if (!licenseFile) {
+      findings.push({
+        path: f.path,
+        severity: "error",
+        message: "vendored schema with external upstream must declare license_file",
+      });
+      continue;
+    }
+    const fullPath = path.join(repoRoot, licenseFile);
+    if (!existsSync(fullPath) || !statSync(fullPath).isFile() || statSync(fullPath).size === 0) {
+      findings.push({
+        path: f.path,
+        severity: "error",
+        message: `license_file: file does not exist or is empty: ${licenseFile}`,
+      });
+    }
+  }
+  return findings;
+}
+
 function validatePipelinePhases(
   files: FileMeta[],
   slugMap: Map<string, string>,
@@ -1042,6 +1077,7 @@ export function validateDirectory(opts: ValidateOptions): {
   crossFindings.push(...validateSourcePatternRefs(validFiles, slugMap, metaByPath));
   crossFindings.push(...validatePipelinePhases(validFiles, slugMap, metaByPath));
   crossFindings.push(...validateArtifactGraph(validFiles, slugMap, metaByPath));
+  crossFindings.push(...validateSchemaVendoring(validFiles, opts.directory));
   crossFindings.push(
     ...validateMoldSourceLayout(
       opts.directory,

--- a/scripts/cast-skill-verify.ts
+++ b/scripts/cast-skill-verify.ts
@@ -14,6 +14,7 @@ import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import AjvImport from "ajv";
+import Ajv2020Import from "ajv/dist/2020.js";
 import addFormatsImport from "ajv-formats";
 import yaml from "js-yaml";
 
@@ -21,6 +22,8 @@ import { readMarkdown } from "./lib/frontmatter.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const Ajv = ((AjvImport as any).default ?? AjvImport) as typeof AjvImport;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const Ajv2020 = ((Ajv2020Import as any).default ?? Ajv2020Import) as typeof Ajv2020Import;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const addFormats = ((addFormatsImport as any).default ?? addFormatsImport) as typeof addFormatsImport;
 
@@ -60,6 +63,7 @@ interface TargetConfig {
 interface ProvenanceRefEntry {
   kind: string;
   mode: string;
+  ref?: string;
   src: string;
   dst: string;
   used_at: string;
@@ -192,13 +196,20 @@ function main(): void {
   }
 
   // runs/*/summary.json validates against the bundled schema (when present).
-  const schemaRef = (prov.refs ?? []).find((r) => r.kind === "schema");
+  const schemaRef =
+    (prov.refs ?? []).find((r) => r.kind === "schema" && r.ref === "[[summary-nextflow]]") ??
+    (prov.refs ?? []).find((r) => r.kind === "schema");
   if (schemaRef) {
     const schemaAbs = path.join(bundleRoot, schemaRef.dst);
     if (existsSync(schemaAbs)) {
       try {
         const schemaJson = JSON.parse(readFileSync(schemaAbs, "utf8"));
-        const validate = ajv.compile(schemaJson);
+        const schemaUri = typeof schemaJson?.$schema === "string" ? schemaJson.$schema : "";
+        const runAjv = schemaUri.includes("2020-12")
+          ? new Ajv2020({ allErrors: true, strict: false })
+          : new Ajv({ allErrors: true, strict: false });
+        addFormats(runAjv);
+        const validate = runAjv.compile(schemaJson);
         const runsDir = path.join(bundleRoot, "runs");
         if (existsSync(runsDir)) {
           for (const summary of walkAndFind(runsDir, "summary.json")) {

--- a/scripts/lib/schemas/cast-provenance.schema.json
+++ b/scripts/lib/schemas/cast-provenance.schema.json
@@ -47,6 +47,41 @@
     "open_questions": {
       "type": "array",
       "items": { "type": "string" }
+    },
+    "artifacts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["produces", "consumes"],
+      "description": "Pipeline artifact handoff contract copied from the Mold's frontmatter so harnesses can wire prior-step paths to a stable id.",
+      "properties": {
+        "produces": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "kind", "default_filename", "description"],
+            "properties": {
+              "id": { "type": "string" },
+              "kind": { "type": "string" },
+              "default_filename": { "type": "string" },
+              "schema": { "type": "string" },
+              "description": { "type": "string" }
+            }
+          }
+        },
+        "consumes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "description"],
+            "properties": {
+              "id": { "type": "string" },
+              "description": { "type": "string" }
+            }
+          }
+        }
+      }
     }
   },
   "definitions": {

--- a/site/src/components/IncomingRefs.astro
+++ b/site/src/components/IncomingRefs.astro
@@ -18,6 +18,7 @@ const FIELD_LABELS: Record<string, string> = {
   cli_commands: 'cli command of mold',
   prompts: 'prompt of mold',
   phases: 'phase of pipeline',
+  output_artifact_schema: 'schema of artifact output',
 };
 
 function fileTitle(entry: CollectionEntry<'content'>): string {

--- a/site/src/components/MoldBody.astro
+++ b/site/src/components/MoldBody.astro
@@ -3,13 +3,16 @@ import type { CollectionEntry } from 'astro:content';
 import { resolveWikiLink, type WikiLinkTarget } from '../lib/wiki-links';
 import ReferenceContract from './ReferenceContract.astro';
 import CastArtifacts from './CastArtifacts.astro';
+import { artifactHref, type ArtifactGraph } from '../lib/artifacts';
 
 interface Props {
   entry: CollectionEntry<'content'>;
   linkMap: Map<string, WikiLinkTarget>;
+  artifactGraph?: ArtifactGraph;
+  entryById?: Map<string, CollectionEntry<'content'>>;
 }
 
-const { entry, linkMap } = Astro.props;
+const { entry, linkMap, artifactGraph, entryById } = Astro.props;
 const data = entry.data as any;
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 
@@ -24,6 +27,36 @@ const prompts = resolveAll(data.prompts);
 
 const axisChip = data.axis;
 const specifier = data.source ?? data.target ?? data.tool ?? null;
+
+function entryName(id: string): string {
+  const e = entryById?.get(id);
+  if (!e) return id;
+  const d = e.data as any;
+  return d.name || d.title || id.split('/').pop() || id;
+}
+
+function entryHref(id: string): string {
+  return `${base}/${id}/`;
+}
+
+const outputArtifacts: any[] = Array.isArray(data.output_artifacts) ? data.output_artifacts : [];
+const inputArtifacts: any[] = Array.isArray(data.input_artifacts) ? data.input_artifacts : [];
+
+function consumersOf(id: string): { moldId: string; description: string }[] {
+  const node = artifactGraph?.get(id);
+  if (!node) return [];
+  return node.consumers
+    .filter(c => c.moldId !== entry.id)
+    .map(c => ({ moldId: c.moldId, description: c.decl.description }));
+}
+
+function producersOf(id: string): { moldId: string; description: string }[] {
+  const node = artifactGraph?.get(id);
+  if (!node) return [];
+  return node.producers
+    .filter(p => p.moldId !== entry.id)
+    .map(p => ({ moldId: p.moldId, description: p.decl.description }));
+}
 ---
 <dl class="mold-strip">
   <div class="mold-strip-cell mold-strip-cell-axis">
@@ -103,6 +136,178 @@ const specifier = data.source ?? data.target ?? data.tool ?? null;
 <ReferenceContract references={data.references} linkMap={linkMap} />
 
 <CastArtifacts moldSlug={data.name} />
+
+{(outputArtifacts.length + inputArtifacts.length) > 0 && (
+  <section class="artifacts-section">
+    <div class="section-rule">
+      <h2>Artifact handoffs</h2>
+      <span class="section-tail">/ pipeline contract</span>
+    </div>
+    {outputArtifacts.length > 0 && (
+      <div class="artifact-block">
+        <h3 class="artifact-side">Produces</h3>
+        <ul class="artifact-list">
+          {outputArtifacts.map((a: any) => {
+            const schemaLink = a.schema ? resolveWikiLink(a.schema, linkMap, base) : null;
+            const consumers = consumersOf(a.id);
+            return (
+              <li class="artifact-card">
+                <div class="artifact-head">
+                  <a href={artifactHref(base, a.id)} class="artifact-id">{a.id}</a>
+                  <span class="artifact-kind">{a.kind}</span>
+                  <code class="artifact-filename">{a.default_filename}</code>
+                </div>
+                <p class="artifact-desc">{a.description}</p>
+                <dl class="artifact-meta">
+                  {schemaLink && (
+                    <>
+                      <dt>schema</dt>
+                      <dd>
+                        {schemaLink.href
+                          ? <a href={schemaLink.href} class="text-(--color-link) hover:underline">{schemaLink.label}</a>
+                          : <span class="dangling">{schemaLink.label}</span>}
+                      </dd>
+                    </>
+                  )}
+                  {consumers.length > 0 && (
+                    <>
+                      <dt>consumed by</dt>
+                      <dd>
+                        <ul class="partner-list">
+                          {consumers.map(c => (
+                            <li><a href={entryHref(c.moldId)} class="text-(--color-link) hover:underline">{entryName(c.moldId)}</a></li>
+                          ))}
+                        </ul>
+                      </dd>
+                    </>
+                  )}
+                </dl>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    )}
+    {inputArtifacts.length > 0 && (
+      <div class="artifact-block">
+        <h3 class="artifact-side">Consumes</h3>
+        <ul class="artifact-list">
+          {inputArtifacts.map((a: any) => {
+            const producers = producersOf(a.id);
+            return (
+              <li class="artifact-card">
+                <div class="artifact-head">
+                  <a href={artifactHref(base, a.id)} class="artifact-id">{a.id}</a>
+                </div>
+                <p class="artifact-desc">{a.description}</p>
+                {producers.length > 0 && (
+                  <dl class="artifact-meta">
+                    <dt>produced by</dt>
+                    <dd>
+                      <ul class="partner-list">
+                        {producers.map(p => (
+                          <li><a href={entryHref(p.moldId)} class="text-(--color-link) hover:underline">{entryName(p.moldId)}</a></li>
+                        ))}
+                      </ul>
+                    </dd>
+                  </dl>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    )}
+  </section>
+)}
+
+<style>
+  .artifacts-section {
+    margin: 1.25rem 0 1.5rem;
+  }
+  .artifact-block + .artifact-block {
+    margin-top: 1rem;
+  }
+  .artifact-side {
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    color: var(--color-text-muted);
+    margin: 0 0 0.5rem 0;
+  }
+  .artifact-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.6rem;
+  }
+  .artifact-card {
+    border: 1px solid var(--color-border);
+    border-radius: 0.5rem;
+    padding: 0.65rem 0.85rem;
+    background: var(--color-surface-raised);
+  }
+  .artifact-head {
+    display: flex;
+    align-items: baseline;
+    gap: 0.55rem;
+    flex-wrap: wrap;
+  }
+  .artifact-id {
+    font-family: var(--font-mono);
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--color-link);
+    text-decoration: none;
+    border-bottom: 1px solid color-mix(in srgb, var(--color-link) 25%, transparent);
+  }
+  .artifact-id:hover { color: var(--color-link-hover); }
+  .artifact-kind {
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    padding: 0.1rem 0.45rem;
+    border-radius: 0.2rem;
+    background: color-mix(in srgb, var(--color-galaxy-grey) 18%, transparent);
+    color: var(--color-text-secondary);
+  }
+  .artifact-filename {
+    font-size: 0.78rem;
+    color: var(--color-text-muted);
+  }
+  .artifact-desc {
+    margin: 0.35rem 0 0.4rem;
+    font-size: 0.88rem;
+    color: var(--color-text-secondary);
+  }
+  .artifact-meta {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 0.2rem 0.6rem;
+    margin: 0.25rem 0 0;
+    font-size: 0.8rem;
+  }
+  .artifact-meta dt {
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+    align-self: center;
+  }
+  .artifact-meta dd { margin: 0; }
+  .partner-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem 0.7rem;
+  }
+</style>
 
 {(patterns.length + cliCommands.length + prompts.length) > 0 && (
   <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-6">

--- a/site/src/components/PhaseGraph.astro
+++ b/site/src/components/PhaseGraph.astro
@@ -1,12 +1,17 @@
 ---
-import { resolveWikiLink, type WikiLinkTarget } from '../lib/wiki-links';
+import type { CollectionEntry } from 'astro:content';
+import { resolveWikiLink, resolveWikiLinkId, type WikiLinkTarget } from '../lib/wiki-links';
+import { artifactHref, type ArtifactGraph } from '../lib/artifacts';
 
 interface Props {
   phases: any[];
   linkMap: Map<string, WikiLinkTarget>;
+  pipelineId?: string;
+  artifactGraph?: ArtifactGraph;
+  entryById?: Map<string, CollectionEntry<'content'>>;
 }
 
-const { phases, linkMap } = Astro.props;
+const { phases, linkMap, pipelineId, artifactGraph, entryById } = Astro.props;
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 
 function pad2(n: number): string {
@@ -20,6 +25,82 @@ function resolved(wl: string) {
 function isWikiLink(s: string): boolean {
   return /^\[\[.+\]\]$/.test(s);
 }
+
+interface PhaseArtifacts {
+  produces: { id: string; consumedAt: number[] }[];
+  consumes: { id: string; producedAt: number[]; satisfied: boolean }[];
+}
+
+// For each phase index, collect every Mold's declared artifacts (from phase's Mold ref or branch/chain inner Molds).
+function moldRefsAt(phase: any): string[] {
+  const out: string[] = [];
+  const visit = (n: any) => {
+    if (typeof n === 'string') {
+      if (isWikiLink(n)) out.push(n);
+      return;
+    }
+    if (!n || typeof n !== 'object') return;
+    if (typeof n.mold === 'string') out.push(n.mold);
+    if (typeof n.fallthrough === 'string') out.push(n.fallthrough);
+    if (Array.isArray(n.branches)) n.branches.forEach(visit);
+    if (Array.isArray(n.chain)) n.chain.forEach(visit);
+  };
+  visit(phase);
+  return out;
+}
+
+function declsForPhase(phase: any): { out: any[]; in: any[] } {
+  const out: any[] = [];
+  const inp: any[] = [];
+  if (!entryById) return { out, in: inp };
+  for (const wl of moldRefsAt(phase)) {
+    const id = resolveWikiLinkId(wl, linkMap);
+    if (!id) continue;
+    const e = entryById.get(id);
+    if (!e) continue;
+    const d = e.data as any;
+    if (d.type !== 'mold') continue;
+    if (Array.isArray(d.output_artifacts)) out.push(...d.output_artifacts);
+    if (Array.isArray(d.input_artifacts)) inp.push(...d.input_artifacts);
+  }
+  return { out, in: inp };
+}
+
+const phaseArtifacts: PhaseArtifacts[] = phases.map(() => ({ produces: [], consumes: [] }));
+if (artifactGraph && entryById && pipelineId) {
+  // Build per-phase produces/consumes from declared mold artifacts.
+  const allDecls = phases.map(p => declsForPhase(p));
+  // Build a map from artifact id → list of phase indices that produce it.
+  const producedBy = new Map<string, number[]>();
+  allDecls.forEach((d, i) => {
+    for (const o of d.out) {
+      const list = producedBy.get(o.id) ?? [];
+      if (!list.includes(i + 1)) list.push(i + 1);
+      producedBy.set(o.id, list);
+    }
+  });
+  allDecls.forEach((d, i) => {
+    const phaseNum = i + 1;
+    const seenOut = new Set<string>();
+    for (const o of d.out) {
+      if (seenOut.has(o.id)) continue;
+      seenOut.add(o.id);
+      const allConsumers = (producedBy.get(o.id) ? Array.from((artifactGraph!.get(o.id)?.pipelines.get(pipelineId)?.consumeAt) ?? []) : []);
+      phaseArtifacts[i].produces.push({ id: o.id, consumedAt: allConsumers.filter(c => c !== phaseNum) });
+    }
+    const seenIn = new Set<string>();
+    for (const ip of d.in) {
+      if (seenIn.has(ip.id)) continue;
+      seenIn.add(ip.id);
+      const priorProducers = (producedBy.get(ip.id) ?? []).filter(p => p < phaseNum);
+      phaseArtifacts[i].consumes.push({
+        id: ip.id,
+        producedAt: priorProducers,
+        satisfied: priorProducers.length > 0,
+      });
+    }
+  });
+}
 ---
 
 <ol class="subway not-prose">
@@ -27,6 +108,7 @@ function isWikiLink(s: string): boolean {
     const num = pad2(idx + 1);
     if (p.mold) {
       const r = resolved(p.mold);
+      const pa = phaseArtifacts[idx];
       return (
         <li class:list={['stop', 'stop-mold', p.loop && 'stop-loop']}>
           <span class="stop-num font-mono" aria-hidden="true">{num}</span>
@@ -36,11 +118,30 @@ function isWikiLink(s: string): boolean {
               ? <a href={r.href} title={r.summary || undefined} class="stop-link">{r.label}</a>
               : <span class="dangling">{r.label}</span>}
             {p.loop && <span class="stop-tag stop-tag-loop">loop</span>}
+            {(pa.produces.length + pa.consumes.length) > 0 && (
+              <div class="phase-artifacts">
+                {pa.consumes.map(c => (
+                  <span class:list={['art-pill', 'art-in', !c.satisfied && 'art-unsat']}>
+                    <span class="art-arrow">←</span>
+                    <a href={artifactHref(base, c.id)} class="art-id">{c.id}</a>
+                    {c.producedAt.length > 0 && <span class="art-from">@{c.producedAt.map(pad2).join(',')}</span>}
+                    {!c.satisfied && <span class="art-warn" title="no prior phase produces this">unbound</span>}
+                  </span>
+                ))}
+                {pa.produces.map(p => (
+                  <span class="art-pill art-out">
+                    <span class="art-arrow">→</span>
+                    <a href={artifactHref(base, p.id)} class="art-id">{p.id}</a>
+                  </span>
+                ))}
+              </div>
+            )}
           </div>
         </li>
       );
     }
     if (p.branch) {
+      const pa = phaseArtifacts[idx];
       return (
         <li class:list={['stop', 'stop-branch', p.loop && 'stop-loop']}>
           <span class="stop-num font-mono" aria-hidden="true">{num}</span>
@@ -81,6 +182,24 @@ function isWikiLink(s: string): boolean {
                   return null;
                 })}
               </ul>
+            )}
+            {(pa.produces.length + pa.consumes.length) > 0 && (
+              <div class="phase-artifacts">
+                {pa.consumes.map(c => (
+                  <span class:list={['art-pill', 'art-in', !c.satisfied && 'art-unsat']}>
+                    <span class="art-arrow">←</span>
+                    <a href={artifactHref(base, c.id)} class="art-id">{c.id}</a>
+                    {c.producedAt.length > 0 && <span class="art-from">@{c.producedAt.map(pad2).join(',')}</span>}
+                    {!c.satisfied && <span class="art-warn" title="no prior phase produces this">unbound</span>}
+                  </span>
+                ))}
+                {pa.produces.map(prod => (
+                  <span class="art-pill art-out">
+                    <span class="art-arrow">→</span>
+                    <a href={artifactHref(base, prod.id)} class="art-id">{prod.id}</a>
+                  </span>
+                ))}
+              </div>
             )}
             {p.chain && (
               <ol class="branch-chain" aria-label="chain">
@@ -308,6 +427,47 @@ function isWikiLink(s: string): boolean {
     opacity: 0.6;
   }
 
+  .phase-artifacts {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3rem 0.45rem;
+    margin-top: 0.35rem;
+  }
+  .art-pill {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.25rem;
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    padding: 0.08rem 0.45rem;
+    border-radius: 0.2rem;
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    color: var(--color-text-secondary);
+  }
+  .art-out { border-color: color-mix(in srgb, var(--color-galaxy-primary) 35%, transparent); }
+  .art-in  { border-color: color-mix(in srgb, var(--color-accent) 35%, transparent); }
+  .art-unsat {
+    background: color-mix(in srgb, #d97706 12%, transparent);
+    border-color: #d97706;
+    color: #92400e;
+  }
+  .art-arrow { color: var(--color-text-muted); }
+  .art-id {
+    color: var(--color-link);
+    text-decoration: none;
+  }
+  .art-id:hover { text-decoration: underline; }
+  .art-from {
+    color: var(--color-text-muted);
+    font-size: 0.65rem;
+  }
+  .art-warn {
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-size: 0.6rem;
+    color: #92400e;
+  }
   @media (max-width: 540px) {
     .stop {
       grid-template-columns: 2rem 1.4rem 1fr;

--- a/site/src/components/PipelineBody.astro
+++ b/site/src/components/PipelineBody.astro
@@ -1,14 +1,17 @@
 ---
 import type { CollectionEntry } from 'astro:content';
 import type { WikiLinkTarget } from '../lib/wiki-links';
+import type { ArtifactGraph } from '../lib/artifacts';
 import PhaseGraph from './PhaseGraph.astro';
 
 interface Props {
   entry: CollectionEntry<'content'>;
   linkMap: Map<string, WikiLinkTarget>;
+  artifactGraph?: ArtifactGraph;
+  entryById?: Map<string, CollectionEntry<'content'>>;
 }
 
-const { entry, linkMap } = Astro.props;
+const { entry, linkMap, artifactGraph, entryById } = Astro.props;
 const data = entry.data as any;
 const phaseCount = Array.isArray(data.phases) ? data.phases.length : 0;
 ---
@@ -20,7 +23,7 @@ const phaseCount = Array.isArray(data.phases) ? data.phases.length : 0;
       {phaseCount} {phaseCount === 1 ? 'phase' : 'phases'}
     </span>
   </div>
-  <PhaseGraph phases={data.phases} linkMap={linkMap} />
+  <PhaseGraph phases={data.phases} linkMap={linkMap} pipelineId={entry.id} artifactGraph={artifactGraph} entryById={entryById} />
 </section>
 
 <style>

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -89,6 +89,21 @@ const branchPhase = z.object({
 
 const phase = z.union([moldPhase, branchPhase]);
 
+const artifactId = z.string().regex(/^[a-z][a-z0-9-]*$/, { message: 'must be a kebab id' });
+
+const outputArtifact = z.object({
+  id: artifactId,
+  kind: z.enum(['json', 'markdown', 'yaml', 'text', 'other']),
+  default_filename: z.string().min(1),
+  schema: wikiLink.optional(),
+  description: z.string().min(20),
+}).strict();
+
+const inputArtifact = z.object({
+  id: artifactId,
+  description: z.string().min(20),
+}).strict();
+
 const moldSchema = z.object({
   type: z.literal('mold'),
   name: z.string(),
@@ -101,6 +116,8 @@ const moldSchema = z.object({
   prompts: z.array(wikiLink).optional(),
   input_schemas: z.array(wikiLink).optional(),
   output_schemas: z.array(wikiLink).optional(),
+  output_artifacts: z.array(outputArtifact).optional(),
+  input_artifacts: z.array(inputArtifact).optional(),
   examples: z.array(z.string()).optional(),
   references: z.array(typedReference).optional(),
   ...baseFields,

--- a/site/src/lib/artifacts.ts
+++ b/site/src/lib/artifacts.ts
@@ -1,0 +1,149 @@
+import type { CollectionEntry } from 'astro:content';
+import { resolveWikiLinkId, type WikiLinkTarget } from './wiki-links';
+
+export interface OutputArtifactDecl {
+  id: string;
+  kind: string;
+  default_filename: string;
+  schema?: string;
+  description: string;
+}
+
+export interface InputArtifactDecl {
+  id: string;
+  description: string;
+}
+
+export interface ArtifactProducer {
+  moldId: string;
+  decl: OutputArtifactDecl;
+}
+
+export interface ArtifactConsumer {
+  moldId: string;
+  decl: InputArtifactDecl;
+}
+
+export interface ArtifactPipelineUse {
+  pipelineId: string;
+  /** Phase indices (1-based) where this artifact is produced. */
+  produceAt: number[];
+  /** Phase indices (1-based) where this artifact is consumed. */
+  consumeAt: number[];
+}
+
+export interface ArtifactNode {
+  id: string;
+  producers: ArtifactProducer[];
+  consumers: ArtifactConsumer[];
+  schemas: Set<string>;
+  defaultFilenames: Set<string>;
+  pipelines: Map<string, ArtifactPipelineUse>;
+}
+
+export type ArtifactGraph = Map<string, ArtifactNode>;
+
+function ensure(graph: ArtifactGraph, id: string): ArtifactNode {
+  let node = graph.get(id);
+  if (!node) {
+    node = {
+      id,
+      producers: [],
+      consumers: [],
+      schemas: new Set(),
+      defaultFilenames: new Set(),
+      pipelines: new Map(),
+    };
+    graph.set(id, node);
+  }
+  return node;
+}
+
+function pipelineUse(node: ArtifactNode, pipelineId: string): ArtifactPipelineUse {
+  let use = node.pipelines.get(pipelineId);
+  if (!use) {
+    use = { pipelineId, produceAt: [], consumeAt: [] };
+    node.pipelines.set(pipelineId, use);
+  }
+  return use;
+}
+
+function collectMoldRefsFromPhase(phase: unknown): string[] {
+  const out: string[] = [];
+  const visit = (node: unknown) => {
+    if (typeof node === 'string') {
+      if (/^\[\[.+\]\]$/.test(node)) out.push(node);
+      return;
+    }
+    if (!node || typeof node !== 'object') return;
+    const obj = node as Record<string, unknown>;
+    if (typeof obj.mold === 'string') out.push(obj.mold);
+    if (typeof obj.fallthrough === 'string') out.push(obj.fallthrough);
+    if (Array.isArray(obj.branches)) obj.branches.forEach(visit);
+    if (Array.isArray(obj.chain)) obj.chain.forEach(visit);
+  };
+  visit(phase);
+  return out;
+}
+
+export function buildArtifactGraph(
+  entries: CollectionEntry<'content'>[],
+  linkMap: Map<string, WikiLinkTarget>,
+): ArtifactGraph {
+  const graph: ArtifactGraph = new Map();
+  const moldDeclByEntry = new Map<string, { out: OutputArtifactDecl[]; in: InputArtifactDecl[] }>();
+
+  for (const entry of entries) {
+    const data = entry.data as any;
+    if (data.type !== 'mold') continue;
+    const out: OutputArtifactDecl[] = Array.isArray(data.output_artifacts) ? data.output_artifacts : [];
+    const inp: InputArtifactDecl[] = Array.isArray(data.input_artifacts) ? data.input_artifacts : [];
+    moldDeclByEntry.set(entry.id, { out, in: inp });
+    for (const o of out) {
+      const node = ensure(graph, o.id);
+      node.producers.push({ moldId: entry.id, decl: o });
+      if (o.schema) node.schemas.add(o.schema);
+      if (o.default_filename) node.defaultFilenames.add(o.default_filename);
+    }
+    for (const i of inp) {
+      const node = ensure(graph, i.id);
+      node.consumers.push({ moldId: entry.id, decl: i });
+    }
+  }
+
+  // Pipeline binding inference: walk phases in order, attribute artifact ids to phase indices
+  // by following each phase's referenced Mold(s)' declared artifacts.
+  for (const entry of entries) {
+    const data = entry.data as any;
+    if (data.type !== 'pipeline' || !Array.isArray(data.phases)) continue;
+    data.phases.forEach((phase: unknown, idx: number) => {
+      const phaseNum = idx + 1;
+      const moldRefs = collectMoldRefsFromPhase(phase);
+      for (const wl of moldRefs) {
+        const moldId = resolveWikiLinkId(wl, linkMap);
+        if (!moldId) continue;
+        const decls = moldDeclByEntry.get(moldId);
+        if (!decls) continue;
+        for (const o of decls.out) {
+          const use = pipelineUse(ensure(graph, o.id), entry.id);
+          if (!use.produceAt.includes(phaseNum)) use.produceAt.push(phaseNum);
+        }
+        for (const i of decls.in) {
+          const use = pipelineUse(ensure(graph, i.id), entry.id);
+          if (!use.consumeAt.includes(phaseNum)) use.consumeAt.push(phaseNum);
+        }
+      }
+    });
+  }
+
+  return graph;
+}
+
+/** id slug used in /artifacts/<slug>/ URLs. Artifact ids are already kebab. */
+export function artifactSlug(id: string): string {
+  return id;
+}
+
+export function artifactHref(base: string, id: string): string {
+  return `${base}/artifacts/${artifactSlug(id)}/`;
+}

--- a/site/src/lib/wiki-links.ts
+++ b/site/src/lib/wiki-links.ts
@@ -84,7 +84,8 @@ export type BacklinkField =
   | 'patterns'
   | 'cli_commands'
   | 'prompts'
-  | 'phases';
+  | 'phases'
+  | 'output_artifact_schema';
 
 export interface Backlink {
   sourceId: string;
@@ -140,6 +141,16 @@ export function buildBacklinkMap(
       for (const wl of collectPhaseRefs(data.phases)) {
         const tid = resolveWikiLinkId(wl, linkMap);
         if (tid) add(tid, entry.id, 'phases');
+      }
+    }
+
+    // Mold output_artifacts[].schema: link the schema note back to the producing Mold.
+    if (data.type === 'mold' && Array.isArray(data.output_artifacts)) {
+      for (const a of data.output_artifacts) {
+        const schema = a && typeof a === 'object' ? (a as any).schema : undefined;
+        if (typeof schema !== 'string') continue;
+        const tid = resolveWikiLinkId(schema, linkMap);
+        if (tid) add(tid, entry.id, 'output_artifact_schema');
       }
     }
   }

--- a/site/src/pages/[...slug].astro
+++ b/site/src/pages/[...slug].astro
@@ -13,6 +13,7 @@ import CliCommandBody from '../components/CliCommandBody.astro';
 import ResearchBody from '../components/ResearchBody.astro';
 import SchemaBody from '../components/SchemaBody.astro';
 import { buildWikiLinkMap, buildBacklinkMap } from '../lib/wiki-links';
+import { buildArtifactGraph } from '../lib/artifacts';
 
 export async function getStaticPaths() {
   const entries = await getCollection('content');
@@ -28,6 +29,7 @@ const { Content } = await render(entry);
 const allEntries = await getCollection('content');
 const linkMap = buildWikiLinkMap(allEntries);
 const backlinkMap = buildBacklinkMap(allEntries, linkMap);
+const artifactGraph = buildArtifactGraph(allEntries, linkMap);
 
 const entryMap = new Map(allEntries.map(e => [e.id, e]));
 const incoming = (backlinkMap.get(entry.id) ?? [])
@@ -78,8 +80,8 @@ const metaMode: 'full' | 'related-only' = data.type === 'mold' ? 'related-only' 
 
     {data.type === 'mold' && <MoldHealth entry={entry} linkMap={linkMap} entryById={entryMap} />}
     {data.type === 'pattern' && data.pattern_kind !== 'moc' && <PatternHealth entry={entry} linkMap={linkMap} entryById={entryMap} />}
-    {data.type === 'mold' && <MoldBody entry={entry} linkMap={linkMap} />}
-    {data.type === 'pipeline' && <PipelineBody entry={entry} linkMap={linkMap} />}
+    {data.type === 'mold' && <MoldBody entry={entry} linkMap={linkMap} artifactGraph={artifactGraph} entryById={entryMap} />}
+    {data.type === 'pipeline' && <PipelineBody entry={entry} linkMap={linkMap} artifactGraph={artifactGraph} entryById={entryMap} />}
     {data.type === 'pattern' && <PatternBody entry={entry} linkMap={linkMap} placement="before" />}
     {data.type === 'cli-command' && <CliCommandBody entry={entry} />}
     {data.type === 'research' && <ResearchBody entry={entry} />}

--- a/site/src/pages/artifacts/[id].astro
+++ b/site/src/pages/artifacts/[id].astro
@@ -1,0 +1,115 @@
+---
+import { getCollection } from 'astro:content';
+import Base from '../../layouts/Base.astro';
+import { buildWikiLinkMap, resolveWikiLink } from '../../lib/wiki-links';
+import { buildArtifactGraph } from '../../lib/artifacts';
+
+export async function getStaticPaths() {
+  const entries = await getCollection('content');
+  const linkMap = buildWikiLinkMap(entries);
+  const graph = buildArtifactGraph(entries, linkMap);
+  return Array.from(graph.values()).map(node => ({
+    params: { id: node.id },
+    props: { id: node.id },
+  }));
+}
+
+const { id } = Astro.props;
+const entries = await getCollection('content');
+const linkMap = buildWikiLinkMap(entries);
+const graph = buildArtifactGraph(entries, linkMap);
+const node = graph.get(id);
+const entryById = new Map(entries.map(e => [e.id, e]));
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+
+function entryName(entryId: string): string {
+  const e = entryById.get(entryId);
+  if (!e) return entryId;
+  const d = e.data as any;
+  return d.name || d.title || entryId.split('/').pop() || entryId;
+}
+
+function entryHref(entryId: string): string {
+  return `${base}/${entryId}/`;
+}
+---
+<Base title={`artifact: ${id}`}>
+  <header class="mb-4">
+    <p class="text-xs font-mono uppercase tracking-widest text-(--color-text-muted) mb-1">artifact</p>
+    <h1 class="text-2xl font-mono font-semibold m-0">{id}</h1>
+    {node && node.defaultFilenames.size > 0 && (
+      <p class="text-sm text-(--color-text-secondary) mt-2">
+        default filename(s): {Array.from(node.defaultFilenames).map(f => <code class="mr-2">{f}</code>)}
+      </p>
+    )}
+  </header>
+
+  {!node && <p class="text-sm text-(--color-text-secondary)">Unknown artifact id.</p>}
+
+  {node && (
+    <div class="grid gap-4">
+      <section class="p-3 rounded-lg border border-(--color-border)">
+        <h2 class="text-base font-semibold m-0 mb-2">Producers <span class="text-sm font-normal text-(--color-text-secondary)">({node.producers.length})</span></h2>
+        {node.producers.length === 0 && <p class="text-sm text-(--color-text-secondary) m-0">No Mold declares this artifact in <code>output_artifacts</code>.</p>}
+        <ul class="list-none p-0 m-0 grid gap-2">
+          {node.producers.map(p => (
+            <li>
+              <a href={entryHref(p.moldId)} class="text-(--color-link) hover:underline font-semibold">{entryName(p.moldId)}</a>
+              <span class="ml-2 text-xs text-(--color-text-muted) font-mono">{p.decl.kind} · {p.decl.default_filename}</span>
+              <p class="m-0 text-sm text-(--color-text-secondary)">{p.decl.description}</p>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section class="p-3 rounded-lg border border-(--color-border)">
+        <h2 class="text-base font-semibold m-0 mb-2">Consumers <span class="text-sm font-normal text-(--color-text-secondary)">({node.consumers.length})</span></h2>
+        {node.consumers.length === 0 && <p class="text-sm text-(--color-text-secondary) m-0">No Mold declares this artifact in <code>input_artifacts</code>.</p>}
+        <ul class="list-none p-0 m-0 grid gap-2">
+          {node.consumers.map(c => (
+            <li>
+              <a href={entryHref(c.moldId)} class="text-(--color-link) hover:underline font-semibold">{entryName(c.moldId)}</a>
+              <p class="m-0 text-sm text-(--color-text-secondary)">{c.decl.description}</p>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {node.schemas.size > 0 && (
+        <section class="p-3 rounded-lg border border-(--color-border)">
+          <h2 class="text-base font-semibold m-0 mb-2">Schemas</h2>
+          <ul class="list-none p-0 m-0 grid gap-1">
+            {Array.from(node.schemas).map(wl => {
+              const r = resolveWikiLink(wl, linkMap, base);
+              return (
+                <li>
+                  {r.href
+                    ? <a href={r.href} class="text-(--color-link) hover:underline font-mono">{r.label}</a>
+                    : <span class="dangling font-mono">{r.label}</span>}
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      )}
+
+      {node.pipelines.size > 0 && (
+        <section class="p-3 rounded-lg border border-(--color-border)">
+          <h2 class="text-base font-semibold m-0 mb-2">Pipelines</h2>
+          <ul class="list-none p-0 m-0 grid gap-2">
+            {Array.from(node.pipelines.values()).map(use => (
+              <li>
+                <a href={entryHref(use.pipelineId)} class="text-(--color-link) hover:underline font-semibold">{entryName(use.pipelineId)}</a>
+                <span class="ml-2 text-xs text-(--color-text-muted) font-mono">
+                  {use.produceAt.length > 0 && <>produced @ phase {use.produceAt.join(', ')}</>}
+                  {use.produceAt.length > 0 && use.consumeAt.length > 0 && ' · '}
+                  {use.consumeAt.length > 0 && <>consumed @ phase {use.consumeAt.join(', ')}</>}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  )}
+</Base>

--- a/site/src/pages/artifacts/index.astro
+++ b/site/src/pages/artifacts/index.astro
@@ -1,0 +1,43 @@
+---
+import { getCollection } from 'astro:content';
+import Base from '../../layouts/Base.astro';
+import { buildWikiLinkMap } from '../../lib/wiki-links';
+import { buildArtifactGraph, artifactHref } from '../../lib/artifacts';
+
+const entries = await getCollection('content');
+const linkMap = buildWikiLinkMap(entries);
+const graph = buildArtifactGraph(entries, linkMap);
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+
+const rows = Array.from(graph.values()).sort((a, b) => a.id.localeCompare(b.id));
+---
+<Base title="Artifacts">
+  <header class="mb-4">
+    <p class="text-xs font-mono uppercase tracking-widest text-(--color-text-muted) mb-1">index</p>
+    <h1 class="text-2xl font-semibold m-0">Artifacts</h1>
+    <p class="text-sm text-(--color-text-secondary) mt-2 m-0">
+      Pipeline handoffs declared by Molds via <code>output_artifacts</code> / <code>input_artifacts</code>.
+    </p>
+  </header>
+
+  <table class="w-full text-sm border-collapse">
+    <thead>
+      <tr class="border-b border-(--color-border)">
+        <th class="text-left py-1 pr-2 font-semibold">id</th>
+        <th class="text-left py-1 pr-2 font-semibold">producers</th>
+        <th class="text-left py-1 pr-2 font-semibold">consumers</th>
+        <th class="text-left py-1 font-semibold">pipelines</th>
+      </tr>
+    </thead>
+    <tbody>
+      {rows.map(node => (
+        <tr class="border-b border-(--color-border) align-top">
+          <td class="py-1 pr-2"><a href={artifactHref(base, node.id)} class="text-(--color-link) hover:underline font-mono">{node.id}</a></td>
+          <td class="py-1 pr-2">{node.producers.length}</td>
+          <td class="py-1 pr-2">{node.consumers.length}</td>
+          <td class="py-1">{node.pipelines.size}</td>
+        </tr>
+      ))}
+    </tbody>
+  </table>
+</Base>

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -1132,4 +1132,64 @@ describe("validateDirectory (cross-file)", () => {
     });
     expect(r.errors).toBe(0);
   });
+
+  it("warns when a pipeline phase consumes an artifact no prior phase produces", () => {
+    writeFm(path.join(dir, "molds/producer/index.md"), {
+      ...baseRequired({
+        type: "mold",
+        tags: ["mold"],
+        name: "producer",
+        axis: "generic",
+        output_artifacts: [
+          {
+            id: "summary-x",
+            kind: "json",
+            default_filename: "summary-x.json",
+            description: "Structured summary that downstream Molds bind to.",
+          },
+        ],
+      }),
+    });
+    writeFm(path.join(dir, "molds/consumer/index.md"), {
+      ...baseRequired({
+        type: "mold",
+        tags: ["mold"],
+        name: "consumer",
+        axis: "generic",
+        input_artifacts: [
+          { id: "summary-x", description: "Upstream structured summary." },
+        ],
+      }),
+    });
+    // Out-of-order pipeline: consumer first, producer second.
+    writeFm(path.join(dir, "pipelines/bad-order.md"), {
+      ...baseRequired({
+        type: "pipeline",
+        tags: ["pipeline"],
+        title: "Bad Order",
+        phases: [
+          { mold: "[[consumer]]" },
+          { mold: "[[producer]]" },
+        ],
+      }),
+    });
+
+    const before = process.stdout.write;
+    let captured = "";
+    process.stdout.write = (chunk: any) => {
+      captured += String(chunk);
+      return true;
+    };
+    try {
+      const r = validateDirectory({
+        directory: dir,
+        schemaPath: SCHEMA_PATH,
+        tagsPath: TAGS_PATH,
+      });
+      expect(r.errors).toBe(0);
+    } finally {
+      process.stdout.write = before;
+    }
+    expect(captured).toMatch(/input_artifact 'summary-x' has no prior phase producing it/);
+  });
 });

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -1001,4 +1001,135 @@ describe("validateDirectory (cross-file)", () => {
     expect(r.errors).toBe(0);
     expect(r.warnings).toBeGreaterThanOrEqual(1);
   });
+
+  it("accepts artifact handoff between two molds", () => {
+    writeFm(path.join(dir, "molds/producer/index.md"), {
+      ...baseRequired({
+        type: "mold",
+        tags: ["mold"],
+        name: "producer",
+        axis: "generic",
+        output_artifacts: [
+          {
+            id: "summary-x",
+            kind: "json",
+            default_filename: "summary-x.json",
+            description: "Structured summary that downstream Molds bind to.",
+          },
+        ],
+      }),
+    });
+    writeFm(path.join(dir, "molds/consumer/index.md"), {
+      ...baseRequired({
+        type: "mold",
+        tags: ["mold"],
+        name: "consumer",
+        axis: "generic",
+        input_artifacts: [
+          {
+            id: "summary-x",
+            description: "Structured summary produced by an upstream Mold.",
+          },
+        ],
+      }),
+    });
+
+    const r = validateDirectory({
+      directory: dir,
+      schemaPath: SCHEMA_PATH,
+      tagsPath: TAGS_PATH,
+    });
+    expect(r.errors).toBe(0);
+  });
+
+  it("rejects a consumer artifact with no producer", () => {
+    writeFm(path.join(dir, "molds/consumer/index.md"), {
+      ...baseRequired({
+        type: "mold",
+        tags: ["mold"],
+        name: "consumer",
+        axis: "generic",
+        input_artifacts: [
+          {
+            id: "summary-missing",
+            description: "Structured summary that nobody declares producing.",
+          },
+        ],
+      }),
+    });
+
+    const r = validateDirectory({
+      directory: dir,
+      schemaPath: SCHEMA_PATH,
+      tagsPath: TAGS_PATH,
+    });
+    expect(r.errors).toBeGreaterThanOrEqual(1);
+  });
+
+  it("rejects an artifact schema wiki-link that resolves to non-schema", () => {
+    writeFm(path.join(dir, "molds/producer/index.md"), {
+      ...baseRequired({
+        type: "mold",
+        tags: ["mold"],
+        name: "producer",
+        axis: "generic",
+        output_artifacts: [
+          {
+            id: "summary-x",
+            kind: "json",
+            default_filename: "summary-x.json",
+            schema: "[[not-a-schema]]",
+            description: "Structured summary tied to a wrong-typed wiki-link.",
+          },
+        ],
+      }),
+    });
+    writeFm(path.join(dir, "patterns/not-a-schema.md"), {
+      ...patternRequired({ title: "Not A Schema" }),
+    });
+
+    const r = validateDirectory({
+      directory: dir,
+      schemaPath: SCHEMA_PATH,
+      tagsPath: TAGS_PATH,
+    });
+    expect(r.errors).toBeGreaterThanOrEqual(1);
+  });
+
+  it("accepts an artifact schema wiki-link to a schema note", () => {
+    writeFm(path.join(dir, "molds/producer/index.md"), {
+      ...baseRequired({
+        type: "mold",
+        tags: ["mold"],
+        name: "producer",
+        axis: "generic",
+        output_artifacts: [
+          {
+            id: "summary-x",
+            kind: "json",
+            default_filename: "summary-x.json",
+            schema: "[[schema-x]]",
+            description: "Structured summary with a real schema declared.",
+          },
+        ],
+      }),
+    });
+    writeFm(path.join(dir, "schemas/schema-x.md"), {
+      ...baseRequired({
+        type: "schema",
+        tags: ["schema"],
+        name: "schema-x",
+        title: "Schema X",
+        package: "@example/schema-x",
+        package_export: "schemaX",
+      }),
+    });
+
+    const r = validateDirectory({
+      directory: dir,
+      schemaPath: SCHEMA_PATH,
+      tagsPath: TAGS_PATH,
+    });
+    expect(r.errors).toBe(0);
+  });
 });


### PR DESCRIPTION
Implements artifact contracts across Mold casts and Pipelines (closes #147).

## Foundation (earlier commits on this branch)

- `output_artifacts` / `input_artifacts` on Mold frontmatter (`meta_schema.yml`).
- ~28 Mold notes declare producer/consumer contracts.
- Cross-file validator: every consumer id must resolve to some producer id; `output_artifacts.schema` wiki-links must resolve to a `type: schema` note.

## Site rendering (new)

- Astro content schema accepts the new fields so the site builds.
- `site/src/lib/artifacts.ts` derives the artifact graph (id → producers, consumers, schemas, default filenames, pipelines).
- Mold pages get a `Produces` / `Consumes` section with kind/filename/schema chips and cross-mold partner links.
- `/artifacts/` index + `/artifacts/[id]/` virtual pages with producers, consumers, schemas, and pipelines-where-used (with phase indices).
- Schema pages backlink to producing Molds via `output_artifacts.schema` (new `output_artifact_schema` BacklinkField).

## Pipeline phase handoffs

- `PhaseGraph.astro` annotates each Mold-shaped and branch phase with `→ produces` / `← consumes` pills. Consumers show the producing phase number; unbound consumers get an "unbound" warning chip.

## Cast bundle contract

- `cast-mold` writes the Mold's artifact contract into `_provenance.json` under `artifacts: { produces, consumes }` so harnesses can wire prior-step paths from a stable id without re-reading Foundry source.
- `cast-provenance.schema.json` extended.
- `summarize-nextflow` provenance refreshed.

## Validator: pipeline ordering

- For every pipeline, every Mold-shaped phase's `input_artifacts.id` must be produced by some prior phase (Mold-shaped or via branch/chain inner Mold). Surfaces real ordering issues already (`test-data-refs`, `cwl-test-plan`, `galaxy-test-plan`).
- New unit test in `validate.test.ts`.

## Out of scope

- Auto-injecting a `Previous Artifacts` section into hand-authored `SKILL.md`. The bundle's `_provenance.json` carries the contract; SKILL prose stays human-curated. Trivial to revisit when a real harness needs it.
- Loop / branch artifact `scope` and `cardinality` fields — left for the first real loop validation need (#147 explicitly defers).

## Test plan

- [x] `npm run validate` passes (66 advisory warnings, 0 errors)
- [x] `npm run test` (75 passed)
- [x] `cd site && npm run build` (197 pages incl. /artifacts/* virtual pages)
- [x] `npx tsx scripts/cast-mold.ts summarize-nextflow --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)