### PR TITLE
Add deterministic Mold checks to foundry-build validate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,51 @@
+# pre-commit config for foundry
+#
+# Install hooks:   pre-commit install
+# Run on all:      pre-commit run --all-files
+# Update pins:     pre-commit autoupdate
+# Skip once:       SKIP=eslint git commit ...   (prefer fixing over skipping)
+
+# Skip generated/synced sources, test fixtures, and lockfiles — not ours to
+# reformat and hygiene hooks would cause noise or break vendored mirrors.
+exclude: |
+  (?x)^(
+    packages/tests-format-schema/src/tests\.schema\.|
+    packages/.*/test/fixtures/|
+    workflow-fixtures/|
+    site/\.astro/|
+    site/dist/|
+    pnpm-lock\.yaml$
+  )
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: [--maxkb=500]
+      - id: check-yaml
+      - id: check-json
+      - id: mixed-line-ending
+        args: [--fix=lf]
+
+  # Local hooks shell out to pnpm so versions track package.json, not a mirror.
+  # language: system means pre-commit won't create its own env — it uses the
+  # repo's already-installed pnpm/node (run `pnpm install` first).
+  - repo: local
+    hooks:
+      - id: prettier
+        name: prettier (write)
+        entry: pnpm exec prettier --write
+        language: system
+        files: ^packages/.*/(src|test)/.*\.ts$
+        pass_filenames: true
+
+      - id: eslint
+        name: eslint (fix)
+        entry: pnpm exec eslint --fix
+        language: system
+        files: ^packages/.*/(src|test)/.*\.ts$
+        pass_filenames: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,11 @@ npm run typecheck          # tsc --noEmit (foundry-internal scripts/)
 npm run packages-test      # vitest across packages/* via pnpm -r
 npm run packages-typecheck # tsc --noEmit across packages/* via pnpm -r
 npm run packages-build     # tsc emit across packages/*
+npm run packages-format    # prettier --check across packages/*
+npm run packages-lint      # eslint across packages/*
 ```
+
+Format/lint enforcement also runs via `pre-commit` (`.pre-commit-config.yaml`). Install once per clone with `pre-commit install`; mirrors the galaxy-tool-util setup.
 
 The top-level `Makefile` mirrors common entry points:
 

--- a/packages/build-cli/src/commands/validate.ts
+++ b/packages/build-cli/src/commands/validate.ts
@@ -326,6 +326,13 @@ function validateTypedReference(
   };
 
   if (ref.kind === "schema") {
+    if (ref.evidence === "hypothesis") {
+      findings.push({
+        path: filePath,
+        severity: "warning",
+        message: `references[${index}]: schema ref with evidence=hypothesis is suspicious — schema is the cast contract, expect cast-validated`,
+      });
+    }
     // Schema refs are wiki-links to a `type: schema` note that declares both
     // `package` and `package_export` (cast-mold imports the named export).
     if (!WIKI_LINK_RE.test(ref.ref)) {
@@ -712,6 +719,62 @@ function validateRefinementEntry(
   }
 }
 
+const BODY_WIKI_LINK_RE = /\[\[([^\]\n]+)\]\]/g;
+const FENCED_CODE_RE = /```[\s\S]*?```/g;
+const INLINE_CODE_RE = /(`+)[\s\S]+?\1/g;
+
+function validateBodyWikiLinks(
+  files: FileMeta[],
+  slugMap: Map<string, string>,
+): CrossFileFinding[] {
+  const findings: CrossFileFinding[] = [];
+  for (const f of files) {
+    const body = readMarkdown(f.path)
+      .body.replace(FENCED_CODE_RE, "")
+      .replace(INLINE_CODE_RE, "");
+    const seen = new Set<string>();
+    BODY_WIKI_LINK_RE.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = BODY_WIKI_LINK_RE.exec(body)) !== null) {
+      const raw = m[1];
+      if (raw === undefined) continue;
+      const inner = raw.trim();
+      if (!inner) continue;
+      const wl = `[[${inner}]]`;
+      if (seen.has(wl)) continue;
+      seen.add(wl);
+      if (!resolveWikiLink(wl, slugMap)) {
+        findings.push({
+          path: f.path,
+          severity: "warning",
+          message: `body wiki-link ${wl} did not resolve`,
+        });
+      }
+    }
+  }
+  return findings;
+}
+
+const STUB_BODY_RE = /^Stub\.\s+Replace with real/m;
+
+function validateMoldStubBody(files: FileMeta[]): CrossFileFinding[] {
+  const findings: CrossFileFinding[] = [];
+  for (const f of files) {
+    if (f.meta.type !== "mold") continue;
+    const refs = f.meta.references;
+    if (!Array.isArray(refs) || refs.length === 0) continue;
+    const body = readMarkdown(f.path).body;
+    if (STUB_BODY_RE.test(body)) {
+      findings.push({
+        path: f.path,
+        severity: "warning",
+        message: `mold body is a stub but declares ${refs.length} reference(s) — cast bundles them with no procedure to apply`,
+      });
+    }
+  }
+  return findings;
+}
+
 function validateCliCommandDocs(files: FileMeta[]): CrossFileFinding[] {
   const findings: CrossFileFinding[] = [];
   const requiredSections = ["Install", "Synopsis", "Output", "Exit codes", "Examples", "Gotchas"];
@@ -917,6 +980,8 @@ export function validateDirectory(opts: ValidateOptions): {
   );
   crossFindings.push(...validateCliCommandDocs(validFiles));
   crossFindings.push(...validatePatternVerificationEvidence(validFiles));
+  crossFindings.push(...validateBodyWikiLinks(validFiles, slugMap));
+  crossFindings.push(...validateMoldStubBody(validFiles));
 
   for (const f of crossFindings) {
     printHeader(f.path);

--- a/packages/build-cli/src/commands/validate.ts
+++ b/packages/build-cli/src/commands/validate.ts
@@ -729,9 +729,7 @@ function validateBodyWikiLinks(
 ): CrossFileFinding[] {
   const findings: CrossFileFinding[] = [];
   for (const f of files) {
-    const body = readMarkdown(f.path)
-      .body.replace(FENCED_CODE_RE, "")
-      .replace(INLINE_CODE_RE, "");
+    const body = readMarkdown(f.path).body.replace(FENCED_CODE_RE, "").replace(INLINE_CODE_RE, "");
     const seen = new Set<string>();
     BODY_WIKI_LINK_RE.lastIndex = 0;
     let m: RegExpExecArray | null;

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -879,6 +879,101 @@ describe("validateDirectory (cross-file)", () => {
     expect(r.warnings).toBeGreaterThanOrEqual(1);
   });
 
+  it("warns on body wiki-links that do not resolve", () => {
+    mkdirSync(path.dirname(path.join(dir, "patterns/pattern-x.md")), { recursive: true });
+    writeFileSync(
+      path.join(dir, "patterns/pattern-x.md"),
+      `---\n${Object.entries(patternRequired({ title: "Pattern X" }))
+        .map(([k, v]) => `${k}: ${JSON.stringify(v)}`)
+        .join("\n")}\n---\n\nBody cites [[ghost-target]] in prose.\n`,
+    );
+
+    const r = validateDirectory({
+      directory: dir,
+      schemaPath: SCHEMA_PATH,
+      tagsPath: TAGS_PATH,
+    });
+    expect(r.errors).toBe(0);
+    expect(r.warnings).toBeGreaterThanOrEqual(1);
+  });
+
+  it("ignores body wiki-links inside fenced or inline code", () => {
+    const fm = baseRequired({ type: "research", tags: ["research/component"], subtype: "component" });
+    mkdirSync(path.dirname(path.join(dir, "research/component-x.md")), { recursive: true });
+    writeFileSync(
+      path.join(dir, "research/component-x.md"),
+      `---\n${Object.entries(fm).map(([k, v]) => `${k}: ${JSON.stringify(v)}`).join("\n")}\n---\n\nInline \`[[ghost-inline]]\` and fenced:\n\n\`\`\`\n[[ghost-fenced]]\n\`\`\`\n`,
+    );
+
+    const r = validateDirectory({
+      directory: dir,
+      schemaPath: SCHEMA_PATH,
+      tagsPath: TAGS_PATH,
+    });
+    expect(r.errors).toBe(0);
+    expect(r.warnings).toBe(0);
+  });
+
+  it("warns on schema reference with evidence=hypothesis", () => {
+    writeFm(path.join(dir, "molds/m/index.md"), {
+      ...baseRequired({
+        type: "mold",
+        tags: ["mold"],
+        name: "m",
+        axis: "generic",
+        references: [
+          { kind: "schema", ref: "[[schema-x]]", used_at: "both", load: "upfront", mode: "verbatim", evidence: "hypothesis", verification: "Run cast and confirm output validates." },
+        ],
+      }),
+    });
+    writeFm(path.join(dir, "schemas/schema-x.md"), {
+      ...baseRequired({
+        type: "schema",
+        tags: ["schema"],
+        name: "schema-x",
+        title: "Schema X",
+        package: "@example/schema-x",
+        package_export: "schemaX",
+      }),
+    });
+
+    const r = validateDirectory({
+      directory: dir,
+      schemaPath: SCHEMA_PATH,
+      tagsPath: TAGS_PATH,
+    });
+    expect(r.errors).toBe(0);
+    expect(r.warnings).toBeGreaterThanOrEqual(1);
+  });
+
+  it("warns when a stub mold body declares references", () => {
+    mkdirSync(path.join(dir, "molds/m"), { recursive: true });
+    const fm = baseRequired({
+      type: "mold",
+      tags: ["mold"],
+      name: "m",
+      axis: "generic",
+      references: [
+        { kind: "research", ref: "[[component-x]]", used_at: "runtime", load: "on-demand", mode: "verbatim", evidence: "corpus-observed", trigger: "x" },
+      ],
+    });
+    writeFileSync(
+      path.join(dir, "molds/m/index.md"),
+      `---\n${Object.entries(fm).map(([k, v]) => `${k}: ${JSON.stringify(v)}`).join("\n")}\n---\n\n# m\n\nStub. Replace with real content later.\n`,
+    );
+    writeFm(path.join(dir, "research/component-x.md"), {
+      ...baseRequired({ type: "research", tags: ["research/component"], subtype: "component" }),
+    });
+
+    const r = validateDirectory({
+      directory: dir,
+      schemaPath: SCHEMA_PATH,
+      tagsPath: TAGS_PATH,
+    });
+    expect(r.errors).toBe(0);
+    expect(r.warnings).toBeGreaterThanOrEqual(1);
+  });
+
   it("warns on refinement journal entries with bad decision vocab", () => {
     writeFm(path.join(dir, "molds/m/index.md"), {
       ...baseRequired({


### PR DESCRIPTION
## Summary
- Closes #157.
- Promotes three mechanical checks out of `/review-mold` into `packages/build-cli/src/commands/validate.ts`:
  - **Body wiki-link resolution** — scans markdown bodies (after stripping fenced + inline code) for `[[…]]` and warns on unresolved targets.
  - **Schema-ref evidence floor** — warns when a typed reference has `kind: schema` + `evidence: hypothesis`.
  - **Stub body + populated manifest** — warns when a Mold body still starts with `Stub. Replace with real…` but declares non-empty `references[]`.
- All three are warnings (not errors), keeping the build green during cleanup.

## Surface effect
- `npm run validate`: 0 errors → 0 errors; 62 warnings → 70 warnings.
- New findings match the audit predictions in #157:
  - 2 body-link warnings (`[[GXY_SKETCHES_ALIGNMENT]]` ×N — see #156, plus one other miss)
  - 1 schema/hypothesis warning on `discover-shed-tool`
  - 5 stub-body Molds with populated references

## Test plan
- [x] `npx vitest run tests/validate.test.ts` — 4 new tests pass (body-link warn, code-fenced/inline ignore, schema-evidence warn, stub-body warn). 2 pre-existing `license_file` failures on `main` are unrelated.
- [x] `npm run validate` — surfaces the predicted findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)