### PR TITLE
Migrate GXY_SKETCHES_ALIGNMENT into content/research/

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ Long-form design narrative under `docs/`:
 - `COMPILATION_PIPELINE.md` — casting design.
 - `CORPUS_INGESTION.md` — IWC grounding; pattern-bodies-cite-by-URL principle.
 - `SCHEMA_PACKAGES.md` — standard package shape for Foundry-authored JSON Schemas and CLI validators.
-- `GXY_SKETCHES_ALIGNMENT.md` — field-name parity with `gxy-sketches`.
 - `COMPONENT_ARCHON.md` — research on Archon as a heavyweight harness option.
 
 ## Status

--- a/content/molds/summarize-nextflow/index.md
+++ b/content/molds/summarize-nextflow/index.md
@@ -79,7 +79,7 @@ Read a Nextflow pipeline source tree (nf-core or ad-hoc DSL2) and emit a structu
 
 This Mold owns **only the read-and-structure step**. Every cross-source-and-target translation lives downstream; this Mold is responsible for surfacing what exists in the NF tree honestly, not for reshaping it toward Galaxy or CWL idioms.
 
-The output schema is per-source by design — see [[GXY_SKETCHES_ALIGNMENT]] for why a forced-shared cross-source summary shape was rejected.
+The output schema is per-source by design — see [[gxy-sketches-alignment]] for why a forced-shared cross-source summary shape was rejected.
 
 ## Inputs
 
@@ -187,7 +187,7 @@ A single JSON document conforming to [[summary-nextflow]] (`packages/summary-nex
 }
 ```
 
-Field-name parity with gxy-sketches (`SketchSource`, `ToolSpec`, `TestDataRef`, `ExpectedOutputRef`) is intentional and load-bearing — see [[GXY_SKETCHES_ALIGNMENT]] §1-3.
+Field-name parity with gxy-sketches (`SketchSource`, `ToolSpec`, `TestDataRef`, `ExpectedOutputRef`) is intentional and load-bearing — see [[gxy-sketches-alignment]] §1-3.
 
 ## Procedure
 
@@ -260,7 +260,7 @@ Free-function calls in the workflow body itself (`paramsSummaryMap`, `softwareVe
 
 When fixture fetching is enabled, hash each fetched remote file with SHA-1. When a test-data directory is provided, write the samplesheet and every referenced remote file under that directory using a deterministic URL-derived path and record that local filesystem path in `path` while preserving the original `url`.
 
-Each entry follows `TestDataRef` (inputs) / `ExpectedOutputRef` (outputs) field names verbatim. The `path` vs `url` rules from gxy-sketches' `TestDataRef` carry over, with one extension: `path` may be the local fetched path for a remote URL. The "must be under `test_data/`" constraint does **not** — see [[GXY_SKETCHES_ALIGNMENT]] §1.
+Each entry follows `TestDataRef` (inputs) / `ExpectedOutputRef` (outputs) field names verbatim. The `path` vs `url` rules from gxy-sketches' `TestDataRef` carry over, with one extension: `path` may be the local fetched path for a remote URL. The "must be under `test_data/`" constraint does **not** — see [[gxy-sketches-alignment]] §1.
 
 **`nf_tests[]`** — enumerate every `tests/*.nf.test` file. Real pipelines have one .nf.test per test profile (bacass has 9). For each:
 

--- a/content/research/gxy-sketches-alignment.md
+++ b/content/research/gxy-sketches-alignment.md
@@ -1,7 +1,27 @@
+---
+type: research
+subtype: design-spec
+title: "Alignment: gxy-sketches ↔ Galaxy Workflow Foundry"
+tags:
+  - research/design-spec
+status: draft
+created: 2026-04-30
+revised: 2026-05-05
+revision: 1
+ai_generated: true
+related_molds:
+  - "[[summarize-nextflow]]"
+  - "[[summarize-cwl]]"
+  - "[[summarize-paper]]"
+related_notes:
+  - "[[summary-nextflow]]"
+summary: "Where the Foundry's per-source summary Molds align with gxy-sketches on field names and source/test-fixture vocabulary, and where they intentionally do not."
+---
+
 # Alignment: gxy-sketches ↔ Galaxy Workflow Foundry
 
 Project-infrastructure research for an adjacent workflow-sketch project. This note records where
-the Foundry's per-source summary Molds (`summarize-paper`, `summarize-nextflow`, `summarize-cwl`) and
+the Foundry's per-source summary Molds ([[summarize-paper]], [[summarize-nextflow]], [[summarize-cwl]]) and
 a possible future `summarize-galaxy-workflow` should align with `gxy-sketches`, so the two projects
 stay legible to each other without becoming dependent.
 

--- a/content/schemas/summary-nextflow.md
+++ b/content/schemas/summary-nextflow.md
@@ -50,7 +50,7 @@ Paper, Nextflow, and CWL are different enough that forcing a shared cross-source
 
 ## Field-name parity with gxy-sketches
 
-Three sub-shapes mirror gxy-sketches verbatim — see `docs/GXY_SKETCHES_ALIGNMENT.md` for the rationale:
+Three sub-shapes mirror gxy-sketches verbatim — see [[gxy-sketches-alignment]] for the rationale:
 
 - `SourceRecord` — mirrors `SketchSource` (`ecosystem`, `workflow`, `url`, `version`, `license`, `slug`).
 - `Tool` — extends `ToolSpec` (`name`, `version`) with the resolved container/conda strings the bridge to [[author-galaxy-tool-wrapper]] needs.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -397,7 +397,6 @@ foundry/
 │   ├── MOLDS.md
 │   ├── COMPILATION_PIPELINE.md
 │   ├── CORPUS_INGESTION.md
-│   ├── GXY_SKETCHES_ALIGNMENT.md
 │   └── COMPONENT_ARCHON.md
 ├── content/
 │   ├── Dashboard.md                      # generated; --check


### PR DESCRIPTION
## Summary

- Body of `content/molds/summarize-nextflow/index.md` cited `[[GXY_SKETCHES_ALIGNMENT]]` three times, but target was at `docs/GXY_SKETCHES_ALIGNMENT.md` — outside `content/`. Validator only resolves frontmatter wiki-links, so these body links were silently broken.
- Migrate the doc to `content/research/gxy-sketches-alignment.md` (`subtype: design-spec`), retitle wiki-link target to `[[gxy-sketches-alignment]]`, fix citing notes (Mold body, `summary-nextflow` schema note), drop entries from `README.md` and `docs/ARCHITECTURE.md` tree.

Closes #156. The follow-up validator hardening (resolve body wiki-links, not just frontmatter) called out in the issue is left for a separate PR.

## Test plan

- [x] `npm run validate` → 131 files, 0 errors
- [ ] Visually scan rendered note once Astro site is in place (no site yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)