### PR TITLE
fix site build: drop stale GXY_SKETCHES design-docs entry; CI guard

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -27,14 +27,17 @@ jobs:
       - name: Validate content
         run: npm run validate
 
-      - name: Run repo tests
-        run: npm run test
-
       - name: Typecheck packages
         run: npm run packages-typecheck
 
       - name: Build packages
         run: npm run packages-build
+
+      - name: Install site dependencies
+        run: npm --prefix site ci
+
+      - name: Run repo tests
+        run: npm run test
 
       - name: Test packages
         run: npm run packages-test
@@ -50,9 +53,6 @@ jobs:
 
       - name: Cast drift check
         run: npm run cast -- summarize-nextflow --check
-
-      - name: Install site dependencies
-        run: npm --prefix site ci
 
       - name: Build site
         run: npm run site:build

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Validate content
         run: npm run validate
 
+      - name: Run repo tests
+        run: npm run test
+
       - name: Typecheck packages
         run: npm run packages-typecheck
 
@@ -47,3 +50,9 @@ jobs:
 
       - name: Cast drift check
         run: npm run cast -- summarize-nextflow --check
+
+      - name: Install site dependencies
+        run: npm --prefix site ci
+
+      - name: Build site
+        run: npm run site:build

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -34,7 +34,7 @@ jobs:
         run: npm run packages-build
 
       - name: Install site dependencies
-        run: npm --prefix site ci
+        run: npm --prefix site install --no-audit --no-fund
 
       - name: Run repo tests
         run: npm run test

--- a/casts/claude/skills/summarize-nextflow/_provenance.json
+++ b/casts/claude/skills/summarize-nextflow/_provenance.json
@@ -6,11 +6,11 @@
     "path": "content/molds/summarize-nextflow/index.md",
     "revision": 9,
     "content_hash": "d55cdaf9e607df06003adae0d2d15ad37388859ad3cf5f079f4470be0879b1df",
-    "commit": "9b78cdcc13f8da6ea36cd81d80835c0cf2f5a537"
+    "commit": "dc74ccaf05ab75860e9d0b07c3d6f2ae7ee6bf03"
   },
   "cast_method": "hand-cast",
   "cast_agent": "claude (manual transcription, no LLM cast prompt)",
-  "cast_at": "2026-05-05T21:05:15.824Z",
+  "cast_at": "2026-05-05T21:14:18.172Z",
   "cast_date": "2026-05-05",
   "cast_revision": 5,
   "cast_history": [
@@ -140,8 +140,8 @@
       "load": "upfront",
       "evidence": "cast-validated",
       "purpose": "Validate the emitted Nextflow summary JSON and provide downstream consumers the output contract.",
-      "src_hash": "60ba335117f620f8fa9b5a73444e7610e64a58c2c370417ceb8a86a765756374",
-      "dst_hash": "60ba335117f620f8fa9b5a73444e7610e64a58c2c370417ceb8a86a765756374",
+      "src_hash": "8cb66f866a4f7b562f9ddbf160ec76fe7fe82caf4bc826f3b08d5992e4a113b2",
+      "dst_hash": "8cb66f866a4f7b562f9ddbf160ec76fe7fe82caf4bc826f3b08d5992e4a113b2",
       "source": "deterministic"
     }
   ],

--- a/casts/claude/skills/summarize-nextflow/_provenance.json
+++ b/casts/claude/skills/summarize-nextflow/_provenance.json
@@ -5,12 +5,12 @@
     "name": "summarize-nextflow",
     "path": "content/molds/summarize-nextflow/index.md",
     "revision": 9,
-    "content_hash": "7c64dabadfdf98c5ee3fde3c0977a2297ccc3d81bd83db5c0762556ddf88bb56",
-    "commit": "a3c1e82d0cef7f53a28d10dd790141dce3c53c48"
+    "content_hash": "d55cdaf9e607df06003adae0d2d15ad37388859ad3cf5f079f4470be0879b1df",
+    "commit": "9b78cdcc13f8da6ea36cd81d80835c0cf2f5a537"
   },
   "cast_method": "hand-cast",
   "cast_agent": "claude (manual transcription, no LLM cast prompt)",
-  "cast_at": "2026-05-05T19:33:24.620Z",
+  "cast_at": "2026-05-05T21:05:15.824Z",
   "cast_date": "2026-05-05",
   "cast_revision": 5,
   "cast_history": [

--- a/casts/claude/skills/summarize-nextflow/references/schemas/summary-nextflow.schema.json
+++ b/casts/claude/skills/summarize-nextflow/references/schemas/summary-nextflow.schema.json
@@ -3,7 +3,7 @@
   "$id": "https://galaxyproject.org/foundry/schemas/summary-nextflow.schema.json",
   "$comment": "Canonical source: packages/summary-nextflow-schema/src/summary-nextflow.schema.json in jmchilton/foundry. Mold frontmatter cites this schema via [[summary-nextflow]] wiki-links; the cast pipeline imports the `summaryNextflowSchema` runtime export and serializes it into cast bundles.",
   "title": "Nextflow Pipeline Summary",
-  "description": "Structured per-source summary emitted by the summarize-nextflow Mold.\n\nPer-source schema by design — paper, Nextflow, and CWL each have their own summary shape; downstream Molds (data flow, templates, tool wrappers) consume any source's summary and handle the polymorphism.\n\nField names mirror gxy-sketches' SketchSource / ToolSpec / TestDataRef / ExpectedOutputRef where parity exists; see docs/GXY_SKETCHES_ALIGNMENT.md.",
+  "description": "Structured per-source summary emitted by the summarize-nextflow Mold.\n\nPer-source schema by design — paper, Nextflow, and CWL each have their own summary shape; downstream Molds (data flow, templates, tool wrappers) consume any source's summary and handle the polymorphism.\n\nField names mirror gxy-sketches' SketchSource / ToolSpec / TestDataRef / ExpectedOutputRef where parity exists; see content/research/gxy-sketches-alignment.md.",
   "$ref": "#/$defs/Summary",
   "$defs": {
     "Summary": {

--- a/packages/summary-nextflow-schema/src/summary-nextflow.schema.generated.ts
+++ b/packages/summary-nextflow-schema/src/summary-nextflow.schema.generated.ts
@@ -5,7 +5,7 @@ export const summaryNextflowSchema = {
   "$id": "https://galaxyproject.org/foundry/schemas/summary-nextflow.schema.json",
   "$comment": "Canonical source: packages/summary-nextflow-schema/src/summary-nextflow.schema.json in jmchilton/foundry. Mold frontmatter cites this schema via [[summary-nextflow]] wiki-links; the cast pipeline imports the `summaryNextflowSchema` runtime export and serializes it into cast bundles.",
   "title": "Nextflow Pipeline Summary",
-  "description": "Structured per-source summary emitted by the summarize-nextflow Mold.\n\nPer-source schema by design — paper, Nextflow, and CWL each have their own summary shape; downstream Molds (data flow, templates, tool wrappers) consume any source's summary and handle the polymorphism.\n\nField names mirror gxy-sketches' SketchSource / ToolSpec / TestDataRef / ExpectedOutputRef where parity exists; see docs/GXY_SKETCHES_ALIGNMENT.md.",
+  "description": "Structured per-source summary emitted by the summarize-nextflow Mold.\n\nPer-source schema by design — paper, Nextflow, and CWL each have their own summary shape; downstream Molds (data flow, templates, tool wrappers) consume any source's summary and handle the polymorphism.\n\nField names mirror gxy-sketches' SketchSource / ToolSpec / TestDataRef / ExpectedOutputRef where parity exists; see content/research/gxy-sketches-alignment.md.",
   "$ref": "#/$defs/Summary",
   "$defs": {
     "Summary": {

--- a/packages/summary-nextflow-schema/src/summary-nextflow.schema.json
+++ b/packages/summary-nextflow-schema/src/summary-nextflow.schema.json
@@ -3,7 +3,7 @@
   "$id": "https://galaxyproject.org/foundry/schemas/summary-nextflow.schema.json",
   "$comment": "Canonical source: packages/summary-nextflow-schema/src/summary-nextflow.schema.json in jmchilton/foundry. Mold frontmatter cites this schema via [[summary-nextflow]] wiki-links; the cast pipeline imports the `summaryNextflowSchema` runtime export and serializes it into cast bundles.",
   "title": "Nextflow Pipeline Summary",
-  "description": "Structured per-source summary emitted by the summarize-nextflow Mold.\n\nPer-source schema by design — paper, Nextflow, and CWL each have their own summary shape; downstream Molds (data flow, templates, tool wrappers) consume any source's summary and handle the polymorphism.\n\nField names mirror gxy-sketches' SketchSource / ToolSpec / TestDataRef / ExpectedOutputRef where parity exists; see docs/GXY_SKETCHES_ALIGNMENT.md.",
+  "description": "Structured per-source summary emitted by the summarize-nextflow Mold.\n\nPer-source schema by design — paper, Nextflow, and CWL each have their own summary shape; downstream Molds (data flow, templates, tool wrappers) consume any source's summary and handle the polymorphism.\n\nField names mirror gxy-sketches' SketchSource / ToolSpec / TestDataRef / ExpectedOutputRef where parity exists; see content/research/gxy-sketches-alignment.md.",
   "$ref": "#/$defs/Summary",
   "$defs": {
     "Summary": {

--- a/site/src/lib/design-docs.ts
+++ b/site/src/lib/design-docs.ts
@@ -63,13 +63,6 @@ export const DESIGN_DOCS: DesignDoc[] = [
     category: 'infrastructure',
   },
   {
-    slug: 'gxy-sketches',
-    title: 'gxy-sketches Alignment',
-    source: 'GXY_SKETCHES_ALIGNMENT.md',
-    summary: 'Adjacent-project alignment notes for shared workflow summaries, test manifests, and future sketch targets.',
-    category: 'infrastructure',
-  },
-  {
     slug: 'cli-metadata',
     title: 'CLI Metadata Integration',
     source: 'CLI_META_INTEGRATION.md',

--- a/tests/design-docs.test.ts
+++ b/tests/design-docs.test.ts
@@ -1,0 +1,27 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const DESIGN_DOCS_FILE = path.join(REPO_ROOT, "site/src/lib/design-docs.ts");
+const DOCS_DIR = path.join(REPO_ROOT, "docs");
+
+function extractSources(): string[] {
+  const text = fs.readFileSync(DESIGN_DOCS_FILE, "utf-8");
+  const matches = text.matchAll(/source:\s*['"]([^'"]+)['"]/g);
+  return [...matches].map((m) => m[1]);
+}
+
+describe("site design-docs", () => {
+  it("references at least one source", () => {
+    expect(extractSources().length).toBeGreaterThan(0);
+  });
+
+  it("every DESIGN_DOCS source exists in docs/", () => {
+    const missing = extractSources().filter(
+      (source) => !fs.existsSync(path.join(DOCS_DIR, source)),
+    );
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- GitHub Pages deploy broke after #161 migrated `docs/GXY_SKETCHES_ALIGNMENT.md` to `content/research/`; `site/src/lib/design-docs.ts` still pointed at the old path and astro build crashed with ENOENT.
- Drop the stale entry, refresh the path in the summary-nextflow schema description (and regen `.generated.ts`).
- Add `tests/design-docs.test.ts` asserting every `DESIGN_DOCS[*].source` resolves under `docs/`, and run `npm run test` + `npm run site:build` in PR CI so a missing source fails before merge instead of after deploy.

## Test plan
- [x] \`npm run test\` (81 passed)
- [x] \`npm run packages-test\`
- [x] \`npm run site:build\` succeeds locally
- [x] \`npm run validate\`, \`npm run packages-format\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)