### PR TITLE
wire galaxy-tool-summary into producer/consumer Molds

### DIFF
--- a/content/molds/implement-galaxy-tool-step/index.md
+++ b/content/molds/implement-galaxy-tool-step/index.md
@@ -8,13 +8,15 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-05-03
-revision: 4
+revised: 2026-05-05
+revision: 5
 ai_generated: true
 summary: "Convert an abstract step into a concrete gxformat2 step using a tool summary."
+input_schemas:
+  - "[[galaxy-tool-summary]]"
 input_artifacts:
   - id: galaxy-tool-summary
-    description: "Compact Galaxy tool summary from [[summarize-galaxy-tool]]; binds the abstract step to a concrete tool's ports."
+    description: "Galaxy tool summary manifest from [[summarize-galaxy-tool]] conforming to [[galaxy-tool-summary]]; binds the abstract step to a concrete tool's ports via the embedded `parsed_tool` and generated `input_schemas`."
   - id: galaxy-workflow-draft
     description: "gxformat2 skeleton being filled in step by step; the step replaces a placeholder in this draft."
 output_artifacts:
@@ -23,6 +25,13 @@ output_artifacts:
     default_filename: galaxy-workflow-draft.gxwf.yml
     description: "gxformat2 skeleton with one more abstract step replaced by a concrete tool step (loop iteration output)."
 references:
+  - kind: schema
+    ref: "[[galaxy-tool-summary]]"
+    used_at: runtime
+    load: upfront
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Bind the abstract step against the deterministic tool summary manifest emitted upstream — read `parsed_tool` for ports/datatypes and `input_schemas.workflow_step_linked` for valid step `tool_state` shape."
   - kind: research
     ref: "[[galaxy-workflow-testability-design]]"
     used_at: runtime

--- a/content/molds/summarize-galaxy-tool/index.md
+++ b/content/molds/summarize-galaxy-tool/index.md
@@ -8,10 +8,12 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-05-04
-revision: 4
+revised: 2026-05-05
+revision: 5
 ai_generated: true
 summary: "Pull JSON schema, container, source, inputs/outputs for a Galaxy tool."
+output_schemas:
+  - "[[galaxy-tool-summary]]"
 input_artifacts:
   - id: galaxy-tool-pin
     description: "Pin from [[discover-shed-tool]] or [[author-galaxy-tool-wrapper]]; identifies which cached ParsedTool to summarize."
@@ -19,8 +21,24 @@ output_artifacts:
   - id: galaxy-tool-summary
     kind: json
     default_filename: galaxy-tool-summary.json
-    description: "Compact tool summary derived from a cached ParsedTool: input/output ports, schema, container, source, version metadata."
+    schema: "[[galaxy-tool-summary]]"
+    description: "Deterministic Galaxy tool summary manifest emitted by `galaxy-tool-cache summarize`: cache provenance, embedded ParsedTool, generated input JSON Schemas."
 references:
+  - kind: schema
+    ref: "[[galaxy-tool-summary]]"
+    used_at: runtime
+    load: upfront
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Validate the manifest emitted by `galaxy-tool-cache summarize` before handing it to downstream step Molds."
+  - kind: schema
+    ref: "[[parsed-tool]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Resolve field-level questions about the upstream `ParsedTool` payload embedded under `parsed_tool`."
+    trigger: "When a downstream Mold needs a specific input/output/help/citation field from the embedded `ParsedTool`."
   - kind: research
     ref: "[[galaxy-tool-summary-input-source]]"
     used_at: runtime
@@ -65,49 +83,9 @@ The Mold expects:
 
 ## Outputs
 
-A single JSON document conforming to the future `summary-galaxy-tool` schema. Sketch shape:
+A single JSON document conforming to [[galaxy-tool-summary]] — the deterministic manifest emitted by `galaxy-tool-cache summarize` from `@galaxy-tool-util/cli`. Top-level fields: `schema_version`, `tool_id`, `tool_version`, `cache_key`, `source`, `artifacts`, `parsed_tool`, `input_schemas`, `warnings`. The `parsed_tool` subtree is the upstream [[parsed-tool]] payload verbatim; `input_schemas.workflow_step` and `input_schemas.workflow_step_linked` carry generated JSON Schemas describing the tool's inputs at workflow-step authoring time.
 
-```jsonc
-{
-  "source": {
-    "kind": "toolshed",
-    "tool_shed_url": "https://toolshed.g2.bx.psu.edu",
-    "owner": "devteam",
-    "repo": "fastqc",
-    "tool_id": "fastqc",
-    "version": "0.74+galaxy0",
-    "changeset_revision": "5ec9f6bceaee"
-  },
-  "tool": {
-    "id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.74+galaxy0",
-    "name": "FastQC",
-    "description": "Read quality reports",
-    "profile": "22.05",
-    "version_command": "fastqc --version"
-  },
-  "requirements": [
-    { "type": "package", "name": "fastqc", "version": "0.74" }
-  ],
-  "command": {
-    "template": "fastqc ...",
-    "strict_shell": true,
-    "stdio": [],
-    "environment": []
-  },
-  "inputs": [
-    { "name": "input_file", "type": "data", "format": ["fastq", "fastqsanger"], "optional": false }
-  ],
-  "outputs": [
-    { "name": "html_file", "type": "data", "format": "html", "from_work_dir": null }
-  ],
-  "conditionals": [],
-  "data_tables": [],
-  "tests": [],
-  "warnings": []
-}
-```
-
-Field-name parity with `summary-nextflow.tools[]` should be preserved where concepts match (`name`, `version`, container/package evidence), but Galaxy wrapper-specific structure belongs here rather than being forced into the Nextflow schema.
+This Mold does not hand-author the manifest — it invokes `galaxy-tool-cache summarize` against a cache populated for the Tool Shed pin. Wrapper-derived facts that are not yet exposed by upstream `ParsedTool` (currently: requirements, containers, stdio) flow into the manifest additively as Galaxy upstream extends `ParsedTool`; no Foundry-side schema change is needed when they ship.
 
 ## Procedure
 
@@ -184,4 +162,3 @@ Warnings should identify missing or lossy surfaces, especially:
 - **Wrapper authoring.** Use [[author-galaxy-tool-wrapper]] when no acceptable wrapper exists.
 - **Step implementation.** [[implement-galaxy-tool-step]] binds abstract workflow intent to this summary.
 - **Installed-Galaxy-only wrappers.** Deferred until a Galaxy API discovery/input path exists.
-- **Schema invention at runtime.** The generated skill should validate against `summary-galaxy-tool` once that schema is authored; until then, keep output shape close to this body and eval expectations.

--- a/content/schemas/galaxy-tool-summary.md
+++ b/content/schemas/galaxy-tool-summary.md
@@ -3,6 +3,7 @@ type: schema
 name: galaxy-tool-summary
 title: Galaxy tool summary manifest
 package: "@galaxy-foundry/galaxy-tool-summary-schema"
+package_export: "galaxyToolSummarySchema"
 upstream: "https://github.com/jmchilton/foundry/blob/main/packages/galaxy-tool-summary-schema/src/galaxy-tool-summary.schema.json"
 tags:
   - schema


### PR DESCRIPTION
## Summary

Follow-up to #164. The `galaxy-tool-summary` schema package landed but the two Molds on the data path weren't yet typed against it. This wires producer and consumer.

## Changes

**`summarize-galaxy-tool`** (producer):
- `output_schemas: [[galaxy-tool-summary]]`
- per-artifact `schema: [[galaxy-tool-summary]]` on the `galaxy-tool-summary` output
- `kind: schema` reference for `[[galaxy-tool-summary]]` (upfront, used to validate the manifest)
- `kind: schema` reference for `[[parsed-tool]]` (on-demand, triggered when a downstream Mold needs an embedded `parsed_tool` field)
- body: replaced the hand-sketched output JSON with a pointer to the real schema and clarified that this Mold invokes `galaxy-tool-cache summarize` rather than hand-authoring the manifest
- removed the now-obsolete "Schema invention at runtime" non-goal

**`implement-galaxy-tool-step`** (consumer):
- `input_schemas: [[galaxy-tool-summary]]`
- `kind: schema` reference for `[[galaxy-tool-summary]]` (upfront — bind ports via embedded `parsed_tool`, valid `tool_state` shape via `input_schemas.workflow_step_linked`)
- input artifact description restated against the manifest shape

**`content/schemas/galaxy-tool-summary.md`**:
- added missing `package_export: galaxyToolSummarySchema` so cast can resolve the typed wiki-link reference (validator caught this)

## Why these two and not others

- `discover-shed-tool` already wires its own `[[galaxy-tool-discovery]]` schema; doesn't produce or consume `galaxy-tool-summary`.
- `author-galaxy-tool-wrapper` produces `galaxy-tool-pin` + `tool.xml`. The summary is one hop downstream (via `summarize-galaxy-tool` against the cached wrapper); no direct wiring needed.
- `validate-galaxy-step` / `validate-galaxy-workflow` validate workflow structure, not tool manifests.

## Verification

- `npm run validate` — 0 errors. (Pre-existing warnings unchanged.)
- Validator caught two issues during iteration: `input_artifacts` schema rejects `schema:` (only `output_artifacts` allows it — moved the linkage into `input_schemas` + the artifact description), and `kind: schema` references require both `package` and `package_export` on the target note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)