### PR TITLE
clarify input_artifacts schema asymmetry, inherit producer schema

### DIFF
--- a/meta_schema.yml
+++ b/meta_schema.yml
@@ -196,6 +196,12 @@ properties:
         description:
           type: string
           minLength: 20
+  # Schema is producer-owned: declare `schema:` on the producer Mold's
+  # `output_artifacts[]` entry. Consumers inherit the contract by binding to
+  # the same `id`; cast-mold surfaces the inherited schema on each consumer
+  # input in the resolved provenance. To list a runtime-validation hint
+  # without a producer commitment (e.g. external/free-floating input), use
+  # the top-level `input_schemas` array instead.
   input_artifacts:
     type: array
     items:

--- a/packages/build-cli/src/commands/cast-mold.ts
+++ b/packages/build-cli/src/commands/cast-mold.ts
@@ -388,6 +388,8 @@ interface ProvenanceArtifactOutput {
 interface ProvenanceArtifactInput {
   id: string;
   description: string;
+  inherited_schema?: string;
+  producers?: string[];
 }
 
 interface ProvenanceArtifacts {
@@ -416,7 +418,44 @@ interface Provenance {
   open_questions?: string[];
 }
 
-function readArtifactContracts(meta: Frontmatter): ProvenanceArtifacts | undefined {
+interface ProducerInfo {
+  schema?: string;
+  producers: string[];
+}
+
+export function buildProducerIndex(
+  metaByPath: Map<string, Frontmatter>,
+): Map<string, ProducerInfo> {
+  const idx = new Map<string, ProducerInfo>();
+  for (const [rel, meta] of metaByPath) {
+    if (meta.type !== "mold") continue;
+    const producerSlug = fileSlug(rel);
+    const out = meta.output_artifacts;
+    if (!Array.isArray(out)) continue;
+    for (const a of out) {
+      if (!a || typeof a !== "object") continue;
+      const o = a as Record<string, unknown>;
+      if (typeof o.id !== "string") continue;
+      const info = idx.get(o.id) ?? { producers: [] };
+      info.producers.push(producerSlug);
+      const schema = typeof o.schema === "string" ? o.schema : undefined;
+      if (schema) {
+        if (info.schema && info.schema !== schema) {
+          info.schema = undefined; // disagreement — drop the inherited hint
+        } else {
+          info.schema = schema;
+        }
+      }
+      idx.set(o.id, info);
+    }
+  }
+  return idx;
+}
+
+export function readArtifactContracts(
+  meta: Frontmatter,
+  producerIndex: Map<string, ProducerInfo>,
+): ProvenanceArtifacts | undefined {
   const out: ProvenanceArtifactOutput[] = [];
   const inp: ProvenanceArtifactInput[] = [];
   const rawOut = meta.output_artifacts;
@@ -440,9 +479,12 @@ function readArtifactContracts(meta: Frontmatter): ProvenanceArtifacts | undefin
       if (!a || typeof a !== "object") continue;
       const o = a as Record<string, unknown>;
       if (typeof o.id !== "string") continue;
+      const info = producerIndex.get(o.id);
       inp.push({
         id: o.id,
         description: typeof o.description === "string" ? o.description : "",
+        inherited_schema: info?.schema,
+        producers: info && info.producers.length > 0 ? [...info.producers].sort() : undefined,
       });
     }
   }
@@ -779,7 +821,7 @@ export async function runCastMoldCommand(argv = process.argv.slice(2)): Promise<
     cast_revision: carry.cast_revision,
     cast_history: carry.cast_history,
     refs: refEntries,
-    artifacts: readArtifactContracts(moldParsed.meta),
+    artifacts: readArtifactContracts(moldParsed.meta, buildProducerIndex(metaByPath)),
     open_questions: carry.open_questions,
   };
 

--- a/packages/build-cli/src/commands/validate.ts
+++ b/packages/build-cli/src/commands/validate.ts
@@ -79,6 +79,13 @@ function validateSchema(data: Frontmatter, schema: JsonSchema): string[] {
     const loc = e.instancePath.replace(/^\//, "").replace(/\//g, ".") || "(root)";
     const params = e.params as Record<string, unknown> | undefined;
     const extra = params?.additionalProperty ? ` ('${String(params.additionalProperty)}')` : "";
+    if (
+      e.keyword === "additionalProperties" &&
+      params?.additionalProperty === "schema" &&
+      /^input_artifacts\.\d+$/.test(loc)
+    ) {
+      return `${loc}: 'schema' is producer-owned — declare it on the producer Mold's output_artifacts[].schema (consumers inherit via id). For a runtime-validation hint without a producer commitment, list the schema in the top-level 'input_schemas' array.`;
+    }
     return `${loc}: ${e.message ?? "validation failed"}${extra}`;
   });
 }

--- a/tests/cast-mold.test.ts
+++ b/tests/cast-mold.test.ts
@@ -91,6 +91,106 @@ describe("cast-skill-verify (summarize-nextflow integration)", () => {
   });
 });
 
+describe("artifact-contract inheritance", () => {
+  it("consumer input inherits schema and producers from the producer's output_artifact", async () => {
+    const { buildProducerIndex, readArtifactContracts } = await import(
+      "../packages/build-cli/src/commands/cast-mold.js"
+    );
+    const meta = new Map<string, any>([
+      [
+        "content/molds/producer/index.md",
+        {
+          type: "mold",
+          output_artifacts: [
+            {
+              id: "summary-x",
+              kind: "json",
+              default_filename: "summary-x.json",
+              schema: "[[schema-x]]",
+              description: "Producer output that downstream consumers bind to.",
+            },
+          ],
+        },
+      ],
+      [
+        "content/molds/consumer/index.md",
+        {
+          type: "mold",
+          input_artifacts: [
+            { id: "summary-x", description: "Upstream summary used for binding." },
+          ],
+        },
+      ],
+    ]);
+    const idx = buildProducerIndex(meta);
+    const contracts = readArtifactContracts(
+      meta.get("content/molds/consumer/index.md")!,
+      idx,
+    );
+    expect(contracts).toBeDefined();
+    expect(contracts!.consumes).toEqual([
+      {
+        id: "summary-x",
+        description: "Upstream summary used for binding.",
+        inherited_schema: "[[schema-x]]",
+        producers: ["producer"],
+      },
+    ]);
+  });
+
+  it("drops inherited_schema when producers disagree on the schema", async () => {
+    const { buildProducerIndex, readArtifactContracts } = await import(
+      "../packages/build-cli/src/commands/cast-mold.js"
+    );
+    const meta = new Map<string, any>([
+      [
+        "content/molds/producer-a/index.md",
+        {
+          type: "mold",
+          output_artifacts: [
+            {
+              id: "shared",
+              kind: "json",
+              default_filename: "shared.json",
+              schema: "[[schema-a]]",
+              description: "Producer A output.",
+            },
+          ],
+        },
+      ],
+      [
+        "content/molds/producer-b/index.md",
+        {
+          type: "mold",
+          output_artifacts: [
+            {
+              id: "shared",
+              kind: "json",
+              default_filename: "shared.json",
+              schema: "[[schema-b]]",
+              description: "Producer B output.",
+            },
+          ],
+        },
+      ],
+      [
+        "content/molds/consumer/index.md",
+        {
+          type: "mold",
+          input_artifacts: [{ id: "shared", description: "Disagreement-test input." }],
+        },
+      ],
+    ]);
+    const idx = buildProducerIndex(meta);
+    const contracts = readArtifactContracts(
+      meta.get("content/molds/consumer/index.md")!,
+      idx,
+    );
+    expect(contracts!.consumes[0]?.inherited_schema).toBeUndefined();
+    expect(contracts!.consumes[0]?.producers).toEqual(["producer-a", "producer-b"]);
+  });
+});
+
 describe("cast-mold negative cases", () => {
   it("unknown mold fails fast", () => {
     const r = runTsx(castMold, ["does-not-exist", "--target=claude", "--check"]);

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -62,6 +62,29 @@ describe("validateData (per-file)", () => {
     expect(r.errors.some((e) => /bogus/.test(e))).toBe(true);
   });
 
+  it("redirects when 'schema' is set on an input_artifact", () => {
+    const r = validateData(
+      baseRequired({
+        type: "mold",
+        tags: ["mold"],
+        name: "consumer",
+        axis: "generic",
+        input_artifacts: [
+          {
+            id: "summary-x",
+            schema: "[[schema-x]]",
+            description: "Upstream structured summary used for binding.",
+          },
+        ],
+      }),
+      schema,
+    );
+    const msg = r.errors.find((e) => /input_artifacts\.0/.test(e)) ?? "";
+    expect(msg).toMatch(/'schema' is producer-owned/);
+    expect(msg).toMatch(/output_artifacts\[\]\.schema/);
+    expect(msg).toMatch(/input_schemas/);
+  });
+
   it("rejects pipeline missing phases", () => {
     const r = validateData(
       baseRequired({ type: "pipeline", tags: ["pipeline"], title: "X" }),


### PR DESCRIPTION
## Summary

Follow-up to #165. The schema asymmetry between `input_artifacts` and `output_artifacts` is intentional (schema is producer-owned, consumers inherit via `id`), but the generic AJV error pointed users in the wrong direction. Three discoverability fixes, no behavior changes for existing valid usage.

## Changes

**`meta_schema.yml`** — explanatory comment block above `input_artifacts`:

```yaml
# Schema is producer-owned: declare `schema:` on the producer Mold's
# `output_artifacts[]` entry. Consumers inherit the contract by binding to
# the same `id`; cast-mold surfaces the inherited schema on each consumer
# input in the resolved provenance. To list a runtime-validation hint
# without a producer commitment (e.g. external/free-floating input), use
# the top-level `input_schemas` array instead.
```

**`validate.ts`** — special-case the AJV `additionalProperties` error when someone sets `schema:` on an `input_artifacts` entry. Old message:

```
input_artifacts.0: must NOT have additional properties ('schema')
```

New message:

```
input_artifacts.0: 'schema' is producer-owned — declare it on the producer Mold's output_artifacts[].schema (consumers inherit via id). For a runtime-validation hint without a producer commitment, list the schema in the top-level 'input_schemas' array.
```

**`cast-mold.ts`** — extend `ProvenanceArtifactInput` with optional `inherited_schema` and `producers` fields. New `buildProducerIndex(metaByPath)` walks the corpus once per cast, builds an `id -> { schema, producers[] }` map, and `readArtifactContracts` consults it when serializing consumer inputs. When multiple producers declare different schemas for the same `id`, `inherited_schema` is dropped (the `producers` list is kept so the disagreement is still visible). No frontmatter change required from Mold authors.

## Tests

Three new tests, all passing (82 total, was 79):

- `validate.test.ts` — confirms the redirect message contains the key phrases (`'schema' is producer-owned`, `output_artifacts[].schema`, `input_schemas`).
- `cast-mold.test.ts` — synthetic two-Mold corpus; consumer's `inherited_schema` and sorted `producers` populate from the producer.
- `cast-mold.test.ts` — three-Mold corpus where two producers declare different schemas for the same `id`; `inherited_schema` is dropped, `producers` remains.

## Verification

- `npm run test` — 82/82 passing
- `npm run validate` — 0 errors
- `npm run packages-typecheck` — clean across all 6 workspace packages

Pre-existing failures unrelated to this change: `summarize-nextflow` integration tests (5/34), site `tsc` (Astro types). Both fail on bare `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)