### PR TITLE
Improve nf-test parsing fidelity

### DIFF
--- a/packages/summarize-nextflow/src/resolver.ts
+++ b/packages/summarize-nextflow/src/resolver.ts
@@ -1259,10 +1259,10 @@ function parseNfTestFileProfiles(text: string): string[] {
 
 function extractNfTestBlocks(text: string): { name: string; body: string }[] {
   const blocks: { name: string; body: string }[] = [];
-  for (const match of text.matchAll(/\btest\("([^"]+)"\)\s*\{/gu)) {
+  for (const match of text.matchAll(/\btest\(\s*(["'])(.*?)\1\s*\)\s*\{/gu)) {
     const openIndex = match.index + match[0].lastIndexOf("{");
     const body = extractBlockAt(text, openIndex);
-    if (body !== null) blocks.push({ name: match[1]!, body });
+    if (body !== null) blocks.push({ name: match[2]!, body });
   }
   return blocks.length > 0 ? blocks : [{ name: "unnamed", body: text }];
 }
@@ -1270,10 +1270,13 @@ function extractNfTestBlocks(text: string): { name: string; body: string }[] {
 function parseNfTestProfiles(text: string, name: string): string[] {
   const profiles = new Set<string>();
   for (const source of [text, name]) {
-    for (const match of source.matchAll(/-profile\s+([A-Za-z0-9_,]+)/gu)) {
-      for (const profile of match[1]!.split(",")) profiles.add(profile);
+    for (const match of source.matchAll(/-profile\s+(?:["']([^"']+)["']|([A-Za-z0-9_,.-]+))/gu)) {
+      for (const profile of (match[1] ?? match[2]!).split(",")) {
+        const trimmed = profile.trim();
+        if (trimmed) profiles.add(trimmed);
+      }
     }
-    for (const match of source.matchAll(/profile\s+["']([^"']+)["']/gu)) {
+    for (const match of source.matchAll(/(?:^|[^-])\bprofile\s+["']([^"']+)["']/gu)) {
       profiles.add(match[1]!);
     }
   }
@@ -1281,12 +1284,22 @@ function parseNfTestProfiles(text: string, name: string): string[] {
 }
 
 function parseParamsOverrides(text: string): Record<string, unknown> {
-  const block = matchOne(text, /params\s*\{([\s\S]*?)\}/u);
+  const block = extractNamedBlock(text, "params");
   const values: Record<string, unknown> = {};
-  for (const match of block?.matchAll(/([A-Za-z0-9_]+)\s*=\s*"([^"]+)"/gu) ?? []) {
-    values[match[1]!] = match[2]!;
+  for (const match of block?.matchAll(/^\s*([A-Za-z0-9_]+)\s*=\s*(.+?)\s*$/gmu) ?? []) {
+    values[match[1]!] = parseNfTestParamValue(match[2]!);
   }
   return values;
+}
+
+function parseNfTestParamValue(value: string): unknown {
+  const quoted = /^(?:"([^"]*)"|'([^']*)')$/u.exec(value);
+  if (quoted !== null) return quoted[1] ?? quoted[2]!;
+  if (value === "true") return true;
+  if (value === "false") return false;
+  if (value === "null") return null;
+  if (/^-?\d+(?:\.\d+)?$/u.test(value)) return Number(value);
+  return value;
 }
 
 function parseSnapshot(
@@ -1329,10 +1342,10 @@ function parseSnapshotSidecar(path: string, name: string): SnapshotContent[] {
 }
 
 function parseSnapshotContent(name: string, entry: unknown): SnapshotContent[] {
-  if (!isRecord(entry)) return [];
-  const content = entry["content"];
-  if (!Array.isArray(content)) return [];
-  return [{ name, channels: content.flatMap(parseSnapshotContentItem) }];
+  const content = isRecord(entry) && "content" in entry ? entry["content"] : entry;
+  if (content === undefined) return [];
+  const items = Array.isArray(content) ? content : [content];
+  return [{ name, channels: items.flatMap(parseSnapshotContentItem) }];
 }
 
 function parseSnapshotContentItem(item: unknown): SnapshotChannel[] {

--- a/packages/summarize-nextflow/test/resolver.test.ts
+++ b/packages/summarize-nextflow/test/resolver.test.ts
@@ -404,6 +404,117 @@ test("align module") {
     ]);
   });
 
+  test("captures nf-test single-quoted blocks and typed params", async () => {
+    const root = tempPipelineRoot();
+    write(root, "nextflow.config", "manifest { name = 'nf-core/quoted-tests' }\n");
+    write(root, "main.nf", "workflow QUOTED_TESTS { }\n");
+    write(
+      root,
+      "tests/quoted.nf.test",
+      `profile 'test_full'
+nextflow_pipeline {
+  test('-profile "test,test_full"') {
+    when {
+      params {
+        input = 'samplesheet.csv'
+        skip_multiqc = true
+        min_reads = 25
+        ratio = 0.5
+      }
+    }
+    then { assert workflow.success }
+  }
+}
+`,
+    );
+
+    const summary = await summarize(root);
+    const tests = (
+      summary as SummaryLike & {
+        nf_tests: {
+          name: string;
+          profiles: string[];
+          params_overrides: Record<string, unknown>;
+        }[];
+      }
+    ).nf_tests;
+
+    expect(tests).toEqual([
+      expect.objectContaining({
+        name: '-profile "test,test_full"',
+        profiles: ["test", "test_full"],
+        params_overrides: {
+          input: "samplesheet.csv",
+          skip_multiqc: true,
+          min_reads: 25,
+          ratio: 0.5,
+        },
+      }),
+    ]);
+  });
+
+  test("parses compact nf-test snapshot sidecars", async () => {
+    const root = tempPipelineRoot();
+    write(root, "nextflow.config", "manifest { name = 'nf-core/compact-snapshots' }\n");
+    write(root, "main.nf", "workflow COMPACT_SNAPSHOTS { }\n");
+    write(
+      root,
+      "tests/compact.nf.test",
+      `test("compact snapshot") {
+  then { assert snapshot(workflow.out).match() }
+}
+`,
+    );
+    write(
+      root,
+      "tests/compact.nf.test.snap",
+      JSON.stringify({
+        "compact snapshot": {
+          bam: ["results/sample.bam:md5,11111111111111111111111111111111"],
+          count: 2,
+        },
+      }),
+    );
+
+    const summary = await summarize(root);
+    const snapshot = (
+      summary as SummaryLike & {
+        nf_tests: {
+          snapshot: {
+            parsed_content: {
+              channels: {
+                key: string | null;
+                files: { path: string; basename: string; md5: string; stub: boolean }[];
+                values: unknown[];
+              }[];
+            }[];
+          } | null;
+        }[];
+      }
+    ).nf_tests[0]!.snapshot;
+
+    expect(snapshot?.parsed_content).toEqual([
+      {
+        name: "compact snapshot",
+        channels: [
+          {
+            key: "bam",
+            files: [
+              {
+                path: "results/sample.bam",
+                basename: "sample.bam",
+                md5: "11111111111111111111111111111111",
+                stub: false,
+              },
+            ],
+            values: [],
+          },
+          { key: "count", files: [], values: [2] },
+        ],
+      },
+    ]);
+  });
+
   test("captures same-file utility and wrapper subworkflow calls without choosing wrapper primary", async () => {
     const root = tempPipelineRoot();
     write(root, "nextflow.config", "manifest { name = 'nf-core/wrappers' }\n");


### PR DESCRIPTION
## Summary
- Support single-quoted nf-test `test(...)` blocks and quoted comma-separated `-profile` values.
- Preserve typed `params` overrides for strings, booleans, numbers, and null.
- Parse compact nf-test snapshot sidecars that do not wrap content in `{ content: [...] }`.

## Tests
- `pnpm exec vitest run test/resolver.test.ts`
- `pnpm --filter @galaxy-foundry/summarize-nextflow typecheck`
- `npm run packages-format`
- `npm run packages-lint`
- `pnpm --filter @galaxy-foundry/summarize-nextflow build`
- `pnpm exec vitest run test/integration/cli.test.ts -t "extracts one nf-test entry per test block with snapshot details"`

Refs #26