### PR TITLE
Strip artifact pills from subway, align mold/pattern cards

### DIFF
--- a/site/src/components/PhaseGraph.astro
+++ b/site/src/components/PhaseGraph.astro
@@ -1,17 +1,12 @@
 ---
-import type { CollectionEntry } from 'astro:content';
-import { resolveWikiLink, resolveWikiLinkId, type WikiLinkTarget } from '../lib/wiki-links';
-import { artifactHref, type ArtifactGraph } from '../lib/artifacts';
+import { resolveWikiLink, type WikiLinkTarget } from '../lib/wiki-links';
 
 interface Props {
   phases: any[];
   linkMap: Map<string, WikiLinkTarget>;
-  pipelineId?: string;
-  artifactGraph?: ArtifactGraph;
-  entryById?: Map<string, CollectionEntry<'content'>>;
 }
 
-const { phases, linkMap, pipelineId, artifactGraph, entryById } = Astro.props;
+const { phases, linkMap } = Astro.props;
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 
 function pad2(n: number): string {
@@ -25,82 +20,6 @@ function resolved(wl: string) {
 function isWikiLink(s: string): boolean {
   return /^\[\[.+\]\]$/.test(s);
 }
-
-interface PhaseArtifacts {
-  produces: { id: string; consumedAt: number[] }[];
-  consumes: { id: string; producedAt: number[]; satisfied: boolean }[];
-}
-
-// For each phase index, collect every Mold's declared artifacts (from phase's Mold ref or branch/chain inner Molds).
-function moldRefsAt(phase: any): string[] {
-  const out: string[] = [];
-  const visit = (n: any) => {
-    if (typeof n === 'string') {
-      if (isWikiLink(n)) out.push(n);
-      return;
-    }
-    if (!n || typeof n !== 'object') return;
-    if (typeof n.mold === 'string') out.push(n.mold);
-    if (typeof n.fallthrough === 'string') out.push(n.fallthrough);
-    if (Array.isArray(n.branches)) n.branches.forEach(visit);
-    if (Array.isArray(n.chain)) n.chain.forEach(visit);
-  };
-  visit(phase);
-  return out;
-}
-
-function declsForPhase(phase: any): { out: any[]; in: any[] } {
-  const out: any[] = [];
-  const inp: any[] = [];
-  if (!entryById) return { out, in: inp };
-  for (const wl of moldRefsAt(phase)) {
-    const id = resolveWikiLinkId(wl, linkMap);
-    if (!id) continue;
-    const e = entryById.get(id);
-    if (!e) continue;
-    const d = e.data as any;
-    if (d.type !== 'mold') continue;
-    if (Array.isArray(d.output_artifacts)) out.push(...d.output_artifacts);
-    if (Array.isArray(d.input_artifacts)) inp.push(...d.input_artifacts);
-  }
-  return { out, in: inp };
-}
-
-const phaseArtifacts: PhaseArtifacts[] = phases.map(() => ({ produces: [], consumes: [] }));
-if (artifactGraph && entryById && pipelineId) {
-  // Build per-phase produces/consumes from declared mold artifacts.
-  const allDecls = phases.map(p => declsForPhase(p));
-  // Build a map from artifact id → list of phase indices that produce it.
-  const producedBy = new Map<string, number[]>();
-  allDecls.forEach((d, i) => {
-    for (const o of d.out) {
-      const list = producedBy.get(o.id) ?? [];
-      if (!list.includes(i + 1)) list.push(i + 1);
-      producedBy.set(o.id, list);
-    }
-  });
-  allDecls.forEach((d, i) => {
-    const phaseNum = i + 1;
-    const seenOut = new Set<string>();
-    for (const o of d.out) {
-      if (seenOut.has(o.id)) continue;
-      seenOut.add(o.id);
-      const allConsumers = (producedBy.get(o.id) ? Array.from((artifactGraph!.get(o.id)?.pipelines.get(pipelineId)?.consumeAt) ?? []) : []);
-      phaseArtifacts[i].produces.push({ id: o.id, consumedAt: allConsumers.filter(c => c !== phaseNum) });
-    }
-    const seenIn = new Set<string>();
-    for (const ip of d.in) {
-      if (seenIn.has(ip.id)) continue;
-      seenIn.add(ip.id);
-      const priorProducers = (producedBy.get(ip.id) ?? []).filter(p => p < phaseNum);
-      phaseArtifacts[i].consumes.push({
-        id: ip.id,
-        producedAt: priorProducers,
-        satisfied: priorProducers.length > 0,
-      });
-    }
-  });
-}
 ---
 
 <ol class="subway not-prose">
@@ -108,7 +27,6 @@ if (artifactGraph && entryById && pipelineId) {
     const num = pad2(idx + 1);
     if (p.mold) {
       const r = resolved(p.mold);
-      const pa = phaseArtifacts[idx];
       return (
         <li class:list={['stop', 'stop-mold', p.loop && 'stop-loop']}>
           <span class="stop-num font-mono" aria-hidden="true">{num}</span>
@@ -118,30 +36,11 @@ if (artifactGraph && entryById && pipelineId) {
               ? <a href={r.href} title={r.summary || undefined} class="stop-link">{r.label}</a>
               : <span class="dangling">{r.label}</span>}
             {p.loop && <span class="stop-tag stop-tag-loop">loop</span>}
-            {(pa.produces.length + pa.consumes.length) > 0 && (
-              <div class="phase-artifacts">
-                {pa.consumes.map(c => (
-                  <span class:list={['art-pill', 'art-in', !c.satisfied && 'art-unsat']}>
-                    <span class="art-arrow">←</span>
-                    <a href={artifactHref(base, c.id)} class="art-id">{c.id}</a>
-                    {c.producedAt.length > 0 && <span class="art-from">@{c.producedAt.map(pad2).join(',')}</span>}
-                    {!c.satisfied && <span class="art-warn" title="no prior phase produces this">unbound</span>}
-                  </span>
-                ))}
-                {pa.produces.map(p => (
-                  <span class="art-pill art-out">
-                    <span class="art-arrow">→</span>
-                    <a href={artifactHref(base, p.id)} class="art-id">{p.id}</a>
-                  </span>
-                ))}
-              </div>
-            )}
           </div>
         </li>
       );
     }
     if (p.branch) {
-      const pa = phaseArtifacts[idx];
       return (
         <li class:list={['stop', 'stop-branch', p.loop && 'stop-loop']}>
           <span class="stop-num font-mono" aria-hidden="true">{num}</span>
@@ -182,24 +81,6 @@ if (artifactGraph && entryById && pipelineId) {
                   return null;
                 })}
               </ul>
-            )}
-            {(pa.produces.length + pa.consumes.length) > 0 && (
-              <div class="phase-artifacts">
-                {pa.consumes.map(c => (
-                  <span class:list={['art-pill', 'art-in', !c.satisfied && 'art-unsat']}>
-                    <span class="art-arrow">←</span>
-                    <a href={artifactHref(base, c.id)} class="art-id">{c.id}</a>
-                    {c.producedAt.length > 0 && <span class="art-from">@{c.producedAt.map(pad2).join(',')}</span>}
-                    {!c.satisfied && <span class="art-warn" title="no prior phase produces this">unbound</span>}
-                  </span>
-                ))}
-                {pa.produces.map(prod => (
-                  <span class="art-pill art-out">
-                    <span class="art-arrow">→</span>
-                    <a href={artifactHref(base, prod.id)} class="art-id">{prod.id}</a>
-                  </span>
-                ))}
-              </div>
             )}
             {p.chain && (
               <ol class="branch-chain" aria-label="chain">
@@ -427,47 +308,6 @@ if (artifactGraph && entryById && pipelineId) {
     opacity: 0.6;
   }
 
-  .phase-artifacts {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.3rem 0.45rem;
-    margin-top: 0.35rem;
-  }
-  .art-pill {
-    display: inline-flex;
-    align-items: baseline;
-    gap: 0.25rem;
-    font-family: var(--font-mono);
-    font-size: 0.7rem;
-    padding: 0.08rem 0.45rem;
-    border-radius: 0.2rem;
-    border: 1px solid var(--color-border);
-    background: var(--color-surface);
-    color: var(--color-text-secondary);
-  }
-  .art-out { border-color: color-mix(in srgb, var(--color-galaxy-primary) 35%, transparent); }
-  .art-in  { border-color: color-mix(in srgb, var(--color-accent) 35%, transparent); }
-  .art-unsat {
-    background: color-mix(in srgb, #d97706 12%, transparent);
-    border-color: #d97706;
-    color: #92400e;
-  }
-  .art-arrow { color: var(--color-text-muted); }
-  .art-id {
-    color: var(--color-link);
-    text-decoration: none;
-  }
-  .art-id:hover { text-decoration: underline; }
-  .art-from {
-    color: var(--color-text-muted);
-    font-size: 0.65rem;
-  }
-  .art-warn {
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    font-size: 0.6rem;
-    color: #92400e;
-  }
   @media (max-width: 540px) {
     .stop {
       grid-template-columns: 2rem 1.4rem 1fr;

--- a/site/src/components/PipelineBody.astro
+++ b/site/src/components/PipelineBody.astro
@@ -1,17 +1,14 @@
 ---
 import type { CollectionEntry } from 'astro:content';
 import type { WikiLinkTarget } from '../lib/wiki-links';
-import type { ArtifactGraph } from '../lib/artifacts';
 import PhaseGraph from './PhaseGraph.astro';
 
 interface Props {
   entry: CollectionEntry<'content'>;
   linkMap: Map<string, WikiLinkTarget>;
-  artifactGraph?: ArtifactGraph;
-  entryById?: Map<string, CollectionEntry<'content'>>;
 }
 
-const { entry, linkMap, artifactGraph, entryById } = Astro.props;
+const { entry, linkMap } = Astro.props;
 const data = entry.data as any;
 const phaseCount = Array.isArray(data.phases) ? data.phases.length : 0;
 ---
@@ -23,7 +20,7 @@ const phaseCount = Array.isArray(data.phases) ? data.phases.length : 0;
       {phaseCount} {phaseCount === 1 ? 'phase' : 'phases'}
     </span>
   </div>
-  <PhaseGraph phases={data.phases} linkMap={linkMap} pipelineId={entry.id} artifactGraph={artifactGraph} entryById={entryById} />
+  <PhaseGraph phases={data.phases} linkMap={linkMap} />
 </section>
 
 <style>

--- a/site/src/pages/[...slug].astro
+++ b/site/src/pages/[...slug].astro
@@ -81,7 +81,7 @@ const metaMode: 'full' | 'related-only' = data.type === 'mold' ? 'related-only' 
     {data.type === 'mold' && <MoldHealth entry={entry} linkMap={linkMap} entryById={entryMap} />}
     {data.type === 'pattern' && data.pattern_kind !== 'moc' && <PatternHealth entry={entry} linkMap={linkMap} entryById={entryMap} />}
     {data.type === 'mold' && <MoldBody entry={entry} linkMap={linkMap} artifactGraph={artifactGraph} entryById={entryMap} />}
-    {data.type === 'pipeline' && <PipelineBody entry={entry} linkMap={linkMap} artifactGraph={artifactGraph} entryById={entryMap} />}
+    {data.type === 'pipeline' && <PipelineBody entry={entry} linkMap={linkMap} />}
     {data.type === 'pattern' && <PatternBody entry={entry} linkMap={linkMap} placement="before" />}
     {data.type === 'cli-command' && <CliCommandBody entry={entry} />}
     {data.type === 'research' && <ResearchBody entry={entry} />}

--- a/site/src/pages/molds/index.astro
+++ b/site/src/pages/molds/index.astro
@@ -69,43 +69,69 @@ function healthFor(m: typeof molds[number]): 'ok' | 'warn' | 'error' {
     const list = byAxis.get(axis) ?? [];
     if (list.length === 0) return null;
     return (
-      <section class="mb-8">
-        <h2 class="text-xl font-bold border-b-2 border-(--color-accent)/20 pb-2 mb-3">
-          <span class="text-xs px-2 py-1 rounded bg-(--color-galaxy-primary) text-white font-mono align-middle">{axis}</span>
-          <span class="ml-2 text-sm font-normal text-(--color-text-muted)">({list.length})</span>
-        </h2>
-        <table class="data-table">
-          <thead><tr><th>Name</th><th>Specifier</th><th>Summary</th><th>Status</th><th>Health</th></tr></thead>
-          <tbody>
-            {list.map(m => {
-              const d = m.data as any;
-              const spec = d.source ?? d.target ?? d.tool ?? '—';
-              const health = healthFor(m);
-              return (
-                <tr>
-                  <td><a href={`${base}/${m.id}/`} class="font-mono">{d.name}</a></td>
-                  <td class="font-mono text-sm">{spec}</td>
-                  <td class="text-sm text-(--color-text-muted)">{d.summary}</td>
-                  <td><span class={`badge badge-${d.status}`}>{d.status}</span></td>
-                  <td><span class={`health health-${health}`}>{health}</span></td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
+      <section class="mold-group" aria-labelledby={`molds-${axis}`}>
+        <div class="section-rule">
+          <h2 id={`molds-${axis}`}>
+            <span class="axis-chip font-mono">{axis}</span>
+          </h2>
+          <span class="section-tail">/ {list.length} {list.length === 1 ? 'mold' : 'molds'}</span>
+        </div>
+        <div class="card-grid">
+          {list.map(m => {
+            const d = m.data as any;
+            const spec = d.source ?? d.target ?? d.tool ?? null;
+            const health = healthFor(m);
+            const evalPresent = hasEval(m.id);
+            const subjectTags = (d.tags as string[] ?? []).filter(t => t !== 'mold');
+            return (
+              <article class="card tinted-shadow tinted-shadow-hover">
+                <div class="card-top">
+                  <span class={`badge badge-${d.status}`}>{d.status}</span>
+                  {spec && <span class="card-top-chip">{spec}</span>}
+                </div>
+                <h3 class="card-title">
+                  <a href={`${base}/${m.id}/`} class="font-mono">{d.name}</a>
+                </h3>
+                <p class="card-summary">{d.summary}</p>
+                {subjectTags.length > 0 && (
+                  <div class="card-tags" aria-label="Tags">
+                    {subjectTags.slice(0, 4).map(tag => <span class="tag">{tag}</span>)}
+                  </div>
+                )}
+                <div class="card-meta" aria-label="Mold health">
+                  <span><span class="card-meta-label">health</span><span class={`health health-${health}`}>{health}</span></span>
+                  <span><span class="card-meta-label">eval</span>{evalPresent ? '✓' : '—'}</span>
+                </div>
+              </article>
+            );
+          })}
+        </div>
       </section>
     );
   })}
 </Base>
 
 <style>
+  .mold-group {
+    margin-bottom: 2rem;
+  }
+  .axis-chip {
+    display: inline-block;
+    padding: 0.18rem 0.55rem;
+    border-radius: 0.3rem;
+    background: var(--color-galaxy-primary);
+    color: white;
+    font-size: 0.72rem;
+    letter-spacing: 0.04em;
+    vertical-align: middle;
+  }
   .health {
     display: inline-flex;
     align-items: center;
     border-radius: 999px;
-    padding: 0.18rem 0.45rem;
+    padding: 0.05rem 0.4rem;
     font-family: var(--font-mono);
-    font-size: 0.68rem;
+    font-size: 0.65rem;
     text-transform: uppercase;
     color: white;
   }

--- a/site/src/pages/patterns/index.astro
+++ b/site/src/pages/patterns/index.astro
@@ -59,20 +59,20 @@ function formatDate(d: Date): string {
         <h2 id="pattern-maps-heading">Pattern Maps</h2>
         <span class="section-tail">/ start here</span>
       </div>
-      <div class="pattern-map-grid">
+      <div class="card-grid card-grid-wide">
         {maps.map(pattern => {
           const data = pattern.data as any;
           const linkedCount = data.related_patterns?.length ?? 0;
           const subjectTags = (data.tags as string[]).filter(t => t !== 'pattern');
           return (
-            <article class="pattern-map-card tinted-shadow tinted-shadow-hover">
-              <div class="pattern-card-top">
+            <article class="card card-feature tinted-shadow tinted-shadow-hover">
+              <div class="card-top">
                 <span class="badge badge-draft">map</span>
-                <span class="pattern-date font-mono">{linkedCount} links</span>
+                <span class="card-top-chip">{linkedCount} links</span>
               </div>
-              <h3 class="pattern-map-title"><a href={`${base}/${pattern.id}/`}>{data.title}</a></h3>
-              <p class="pattern-summary">{data.summary}</p>
-              <div class="pattern-tags" aria-label="Tags">
+              <h3 class="card-title card-title-feature"><a href={`${base}/${pattern.id}/`}>{data.title}</a></h3>
+              <p class="card-summary">{data.summary}</p>
+              <div class="card-tags" aria-label="Tags">
                 {subjectTags.map(tag => <a href={`${base}/tags/${tag}/`} class="tag no-underline">{tag}</a>)}
               </div>
             </article>
@@ -100,25 +100,29 @@ function formatDate(d: Date): string {
         <h2 id={`patterns-${group.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`}>{group}</h2>
         <span class="section-tail">/ {list.length} implementation {list.length === 1 ? 'pattern' : 'patterns'}</span>
       </div>
-      <div class="pattern-grid">
+      <div class="card-grid">
         {list.map(pattern => {
           const data = pattern.data as any;
           const subjectTags = (data.tags as string[]).filter(t => t !== 'pattern');
           return (
-            <article class="pattern-card tinted-shadow tinted-shadow-hover">
-              <div class="pattern-card-top">
+            <article class="card tinted-shadow tinted-shadow-hover">
+              <div class="card-top">
                 <span class={`badge badge-${data.status}`}>{data.status}</span>
-                <span class="pattern-date font-mono">{data.pattern_kind} · rev {data.revision} · {formatDate(data.revised)}</span>
+                <span class="card-top-chip">{data.pattern_kind}</span>
               </div>
-              <h3 class="pattern-card-title">
+              <h3 class="card-title">
                 <a href={`${base}/${pattern.id}/`}>{data.title}</a>
               </h3>
-              <p class="pattern-summary">{data.summary}</p>
+              <p class="card-summary">{data.summary}</p>
               {subjectTags.length > 0 && (
-                <div class="pattern-tags" aria-label="Tags">
+                <div class="card-tags" aria-label="Tags">
                   {subjectTags.map(tag => <span class="tag">{tag}</span>)}
                 </div>
               )}
+              <div class="card-meta" aria-label="Revision">
+                <span><span class="card-meta-label">rev</span>{data.revision}</span>
+                <span><span class="card-meta-label">revised</span>{formatDate(data.revised)}</span>
+              </div>
             </article>
           );
         })}
@@ -186,47 +190,6 @@ function formatDate(d: Date): string {
   .pattern-group {
     margin-bottom: 2rem;
   }
-  .pattern-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
-    gap: 1rem;
-  }
-  .pattern-map-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
-    gap: 1rem;
-  }
-  .pattern-map-card {
-    display: flex;
-    flex-direction: column;
-    gap: 0.85rem;
-    min-height: 12rem;
-    padding: 1.1rem;
-    border: 1px solid color-mix(in srgb, var(--color-galaxy-primary) 22%, var(--color-border-subtle));
-    border-radius: 0.75rem;
-    background:
-      linear-gradient(135deg, color-mix(in srgb, var(--color-galaxy-primary) 9%, transparent), transparent 46%),
-      var(--color-surface-raised);
-    transition: border-color 0.18s ease, transform 0.18s ease, box-shadow 0.18s ease;
-  }
-  .pattern-map-card:hover {
-    border-color: var(--color-accent);
-    transform: translateY(-2px);
-  }
-  .pattern-map-title {
-    margin: 0;
-    font-size: 1.35rem;
-    line-height: 1.2;
-    letter-spacing: -0.015em;
-  }
-  .pattern-map-title a {
-    color: var(--color-link);
-    text-decoration: none;
-  }
-  .pattern-map-title a:hover {
-    color: var(--color-link-hover);
-    text-decoration: underline;
-  }
   .pattern-topic-row {
     display: flex;
     flex-wrap: wrap;
@@ -247,58 +210,6 @@ function formatDate(d: Date): string {
   .topic-chip:hover {
     border-color: var(--color-accent);
     transform: translateY(-1px);
-  }
-  .pattern-card {
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-    min-height: 13rem;
-    padding: 1rem;
-    border: 1px solid var(--color-border-subtle);
-    border-radius: 0.65rem;
-    background: var(--color-surface-raised);
-    transition: border-color 0.18s ease, transform 0.18s ease, box-shadow 0.18s ease;
-  }
-  .pattern-card:hover {
-    border-color: var(--color-accent);
-    transform: translateY(-2px);
-  }
-  .pattern-card-top {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.75rem;
-  }
-  .pattern-date {
-    color: var(--color-text-muted);
-    font-size: 0.72rem;
-    white-space: nowrap;
-  }
-  .pattern-card-title {
-    margin: 0;
-    font-size: 1.15rem;
-    line-height: 1.25;
-    letter-spacing: -0.01em;
-  }
-  .pattern-card-title a {
-    color: var(--color-link);
-    text-decoration: none;
-  }
-  .pattern-card-title a:hover {
-    color: var(--color-link-hover);
-    text-decoration: underline;
-  }
-  .pattern-summary {
-    flex: 1;
-    margin: 0;
-    color: var(--color-text-secondary);
-    font-size: 0.9rem;
-    line-height: 1.55;
-  }
-  .pattern-tags {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.35rem;
   }
   @media (max-width: 700px) {
     .patterns-hero-grid {

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -384,6 +384,104 @@ a:hover .tag {
               0 16px 32px -10px color-mix(in srgb, var(--color-galaxy-primary) 28%, transparent);
 }
 
+/* --- Shared card grid (patterns, molds, …) --- */
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
+  gap: 1rem;
+}
+.card-grid-wide {
+  grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
+}
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+  min-height: 13rem;
+  padding: 1rem;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 0.65rem;
+  background: var(--color-surface-raised);
+  transition: border-color 0.18s ease, transform 0.18s ease, box-shadow 0.18s ease;
+}
+.card:hover {
+  border-color: var(--color-accent);
+  transform: translateY(-2px);
+}
+.card-feature {
+  border-color: color-mix(in srgb, var(--color-galaxy-primary) 22%, var(--color-border-subtle));
+  background:
+    linear-gradient(135deg, color-mix(in srgb, var(--color-galaxy-primary) 9%, transparent), transparent 46%),
+    var(--color-surface-raised);
+  border-radius: 0.75rem;
+}
+.card-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.75rem;
+}
+.card-top-chip {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+.card-title {
+  margin: 0;
+  font-size: 1.15rem;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+}
+.card-title-feature {
+  font-size: 1.35rem;
+  line-height: 1.2;
+  letter-spacing: -0.015em;
+}
+.card-title a {
+  color: var(--color-link);
+  text-decoration: none;
+}
+.card-title a:hover {
+  color: var(--color-link-hover);
+  text-decoration: underline;
+}
+.card-summary {
+  flex: 1;
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+  line-height: 1.55;
+}
+.card-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+.card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 0.6rem;
+  margin-top: auto;
+  padding-top: 0.5rem;
+  border-top: 1px dashed var(--color-border-subtle);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--color-text-muted);
+}
+.card-meta > span {
+  display: inline-flex;
+  align-items: baseline;
+}
+.card-meta-label {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-muted);
+  opacity: 0.75;
+  margin-right: 0.3rem;
+}
+
 /* --- Vendored MyST blocks --- */
 
 .vendored-myst {


### PR DESCRIPTION
Two related cleanups on top of #159's artifact-contracts work.

## Subway pills removed
The subway on pipeline pages got busy with `← in / → out` pills under every stop after #159. Most of that data (id/kind/schema/filename) is mold-static and already lives on the Mold detail page; only the phase-binding annotations are pipeline-specific. Strip the pills now and reintroduce the genuinely pipeline-specific bits as a Mold-box band below the subway in a follow-up.

- `PhaseGraph.astro`: drop `phase-artifacts` rendering + the per-phase produces/consumes computation. Props slimmed back to `phases` + `linkMap`.
- `PipelineBody.astro` / `[...slug].astro`: stop threading `artifactGraph` and `entryById` into the pipeline subway. The artifact graph is still computed at the slug level and used by Mold pages and `/artifacts/`.

## Mold + pattern cards aligned
- New shared `.card` / `.card-grid` / `.card-top` / `.card-title` / `.card-summary` / `.card-tags` / `.card-meta` / `.card-feature` classes in `global.css`. Pattern Maps keep their tinted-gradient feature treatment via `.card-feature`.
- `/patterns/`: refactored to the shared classes. **Fixes the date overflow** users were seeing at 4-up — `kind · rev N · YYYY-MM-DD` was a `white-space: nowrap` chip on the top row that exceeded card inner width. Now `kind` stays as a header chip, and `rev` + `revised` move to a wrappable `.card-meta` footer.
- `/molds/`: table → card grid with the same visual language. Status badge + specifier chip in header, mono mold name, summary, up-to-4 subject tags, footer with `health` pill + `eval ✓/—`.

## Test plan

- [x] `npm run validate` clean (0 errors, 86 advisory warnings)
- [x] `cd site && npm run build` (203 pages)
- [x] Visual check on `/molds/`, `/patterns/`, and a pipeline page in dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)