### PR TITLE
Promote Nextflow sample sheets to first-class summary inputs

### DIFF
--- a/casts/claude/skills/summarize-nextflow/_provenance.json
+++ b/casts/claude/skills/summarize-nextflow/_provenance.json
@@ -4,13 +4,13 @@
   "mold": {
     "name": "summarize-nextflow",
     "path": "content/molds/summarize-nextflow/index.md",
-    "revision": 9,
-    "content_hash": "d55cdaf9e607df06003adae0d2d15ad37388859ad3cf5f079f4470be0879b1df",
-    "commit": "14ea2cac7f1632589c383fef0a43e46e411a526f"
+    "revision": 10,
+    "content_hash": "b0bc32df1a66c488457022a871e6c7871b8478a835325e6461f6501108c7ef63",
+    "commit": "3a32d273753664f60404d0a95851e771d6ed90f2"
   },
   "cast_method": "hand-cast",
   "cast_agent": "claude (manual transcription, no LLM cast prompt)",
-  "cast_at": "2026-05-06T02:48:48.800Z",
+  "cast_at": "2026-05-06T03:21:58.488Z",
   "cast_date": "2026-05-05",
   "cast_revision": 5,
   "cast_history": [
@@ -140,8 +140,8 @@
       "load": "upfront",
       "evidence": "cast-validated",
       "purpose": "Validate the emitted Nextflow summary JSON and provide downstream consumers the output contract.",
-      "src_hash": "8cb66f866a4f7b562f9ddbf160ec76fe7fe82caf4bc826f3b08d5992e4a113b2",
-      "dst_hash": "8cb66f866a4f7b562f9ddbf160ec76fe7fe82caf4bc826f3b08d5992e4a113b2",
+      "src_hash": "6af56bc9469e849549b97252d89d0babb30bfb82dbed3a8fc26930b362fc20ec",
+      "dst_hash": "6af56bc9469e849549b97252d89d0babb30bfb82dbed3a8fc26930b362fc20ec",
       "source": "deterministic"
     }
   ],

--- a/casts/claude/skills/summarize-nextflow/references/schemas/summary-nextflow.schema.json
+++ b/casts/claude/skills/summarize-nextflow/references/schemas/summary-nextflow.schema.json
@@ -11,996 +11,394 @@
       "description": "Top-level shape. Every Nextflow summary is exactly this object.",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "source",
-        "params",
-        "profiles",
-        "tools",
-        "processes",
-        "subworkflows",
-        "workflow",
-        "test_fixtures",
-        "nf_tests"
-      ],
+      "required": ["source", "params", "sample_sheets", "profiles", "tools", "processes", "subworkflows", "workflow", "test_fixtures", "nf_tests"],
       "properties": {
-        "source": {
-          "$ref": "#/$defs/SourceRecord"
-        },
-        "params": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/Param"
-          }
-        },
-        "profiles": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "tools": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/Tool"
-          }
-        },
-        "processes": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/Process"
-          }
-        },
-        "subworkflows": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/Subworkflow"
-          }
-        },
-        "workflow": {
-          "$ref": "#/$defs/Workflow"
-        },
-        "test_fixtures": {
-          "$ref": "#/$defs/TestFixtures",
-          "description": "Test-input data shape for the *selected* profile (the cast's `profile` argument, default `test`). For pipelines with multiple test profiles, see `nf_tests[]` for the full enumeration."
-        },
-        "nf_tests": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/NfTest"
-          },
-          "description": "All `tests/*.nf.test` files in the pipeline. Each entry captures one test-program — its profile, params overrides, and structured assertions. Empty array when the pipeline has no nf-test fixtures."
-        },
-        "warnings": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Cast-skill-emitted advisory messages (e.g. DSL1 detected, meta.yml/script disagreement, lossy assertion summarization). Empty array on a clean run."
-        }
+        "source":         { "$ref": "#/$defs/SourceRecord" },
+        "params":         { "type": "array", "items": { "$ref": "#/$defs/Param" } },
+        "sample_sheets":  { "type": "array", "items": { "$ref": "#/$defs/SampleSheet" }, "description": "Structured sample-sheet inputs. Each entry binds one `params[]` parameter to a row schema (column names, types, path-vs-meta classification, required flags, enums, patterns). Promoted from prose inside `params[].description` so downstream target translations (Galaxy `sample_sheet*` collections, CWL records-of-arrays) can choose collection variants without re-parsing the source pipeline. Empty array when no sample-sheet idiom is detected. Discovery sources: nf-schema `schema:` references, `samplesheetToList()` calls, and `splitCsv(header: true)` materializations." },
+        "profiles":       { "type": "array", "items": { "type": "string" } },
+        "tools":          { "type": "array", "items": { "$ref": "#/$defs/Tool" } },
+        "processes":      { "type": "array", "items": { "$ref": "#/$defs/Process" } },
+        "subworkflows":   { "type": "array", "items": { "$ref": "#/$defs/Subworkflow" } },
+        "workflow":       { "$ref": "#/$defs/Workflow" },
+        "test_fixtures":  { "$ref": "#/$defs/TestFixtures", "description": "Test-input data shape for the *selected* profile (the cast's `profile` argument, default `test`). For pipelines with multiple test profiles, see `nf_tests[]` for the full enumeration." },
+        "nf_tests":       { "type": "array", "items": { "$ref": "#/$defs/NfTest" }, "description": "All `tests/*.nf.test` files in the pipeline. Each entry captures one test-program — its profile, params overrides, and structured assertions. Empty array when the pipeline has no nf-test fixtures." },
+        "warnings":       { "type": "array", "items": { "type": "string" }, "description": "Cast-skill-emitted advisory messages (e.g. DSL1 detected, meta.yml/script disagreement, lossy assertion summarization). Empty array on a clean run." }
       }
     },
+
     "SourceRecord": {
       "title": "SourceRecord",
       "description": "Provenance block. Mirrors gxy-sketches SketchSource field names so a Foundry summary is structurally consumable by anyone using that shape.",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "ecosystem",
-        "workflow",
-        "url",
-        "version",
-        "slug"
-      ],
+      "required": ["ecosystem", "workflow", "url", "version", "slug"],
       "properties": {
         "ecosystem": {
           "type": "string",
-          "enum": [
-            "nf-core",
-            "nextflow"
-          ],
+          "enum": ["nf-core", "nextflow"],
           "description": "Pipeline flavor. `nf-core` when `manifest.name` is `nf-core/<slug>` and the canonical layout is present; `nextflow` for ad-hoc DSL2 pipelines. Superset of gxy-sketches' enum (which adds `iwc`, `snakemake-workflows`, `wdl` for its other ingestors)."
         },
-        "workflow": {
-          "type": "string",
-          "description": "Pipeline name (typically the part after `nf-core/`)."
-        },
-        "url": {
-          "type": "string",
-          "format": "uri",
-          "description": "Git remote URL of the pipeline repository."
-        },
-        "version": {
-          "type": "string",
-          "description": "Tag, branch, or commit SHA the summary was derived from."
-        },
-        "license": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "SPDX license identifier when detectable from a LICENSE file."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Kebab-case identifier; `<owner>-<repo>` for nf-core, repo basename otherwise."
-        }
+        "workflow": { "type": "string", "description": "Pipeline name (typically the part after `nf-core/`)." },
+        "url":      { "type": "string", "format": "uri", "description": "Git remote URL of the pipeline repository." },
+        "version":  { "type": "string", "description": "Tag, branch, or commit SHA the summary was derived from." },
+        "license":  { "type": ["string", "null"], "description": "SPDX license identifier when detectable from a LICENSE file." },
+        "slug":     { "type": "string", "description": "Kebab-case identifier; `<owner>-<repo>` for nf-core, repo basename otherwise." }
       }
     },
+
     "Param": {
       "title": "Param",
       "description": "One pipeline parameter. Sourced from `nextflow.config`'s `params { ... }` block, augmented from `nextflow_schema.json` when present (nf-core).",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "name",
-        "type",
-        "required"
-      ],
+      "required": ["name", "type", "required"],
       "properties": {
-        "name": {
-          "type": "string"
-        },
-        "type": {
-          "type": "string",
-          "description": "JSON Schema-style type when nextflow_schema.json supplies it (string, integer, number, boolean, path); free-form when inferred from a default value."
-        },
-        "default": {
-          "description": "Default value verbatim from the source. May be null."
-        },
-        "description": {
-          "type": "string"
-        },
-        "required": {
-          "type": "boolean"
-        },
-        "enum": {
-          "type": "array",
-          "items": {},
-          "description": "Allowed values when nextflow_schema.json declares them."
-        }
+        "name":        { "type": "string" },
+        "type":        { "type": "string", "description": "JSON Schema-style type when nextflow_schema.json supplies it (string, integer, number, boolean, path); free-form when inferred from a default value." },
+        "default":     { "description": "Default value verbatim from the source. May be null." },
+        "description": { "type": "string" },
+        "required":    { "type": "boolean" },
+        "enum":        { "type": "array", "items": {}, "description": "Allowed values when nextflow_schema.json declares them." }
       }
     },
+
+    "SampleSheet": {
+      "title": "SampleSheet",
+      "description": "One sample-sheet-shaped pipeline input. Captures the row schema, path-vs-meta column classification, and discovery provenance so downstream Molds can map onto Galaxy `sample_sheet[:variant]` collections, CWL records-of-arrays, or other target shapes without re-reading the source.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["param", "discovered_via", "columns"],
+      "properties": {
+        "param":          { "type": "string", "description": "Foreign key into `params[].name` — the parameter whose value points at the sample-sheet file." },
+        "schema_path":    { "type": ["string", "null"], "description": "Repo-relative path of the JSON Schema file describing rows (e.g. `assets/schema_input.json`), resolved from the param's nf-schema entry's `schema:` keyword. Null when discovered via `samplesheetToList` without a schema reference, or via `splitCsv(header: true)` ad-hoc parsing." },
+        "discovered_via": { "type": "string", "enum": ["nf-schema", "samplesheetToList", "splitCsv", "ad-hoc"], "description": "How the sample-sheet shape was detected. `nf-schema`: nextflow_schema.json entry has `schema:` keyword. `samplesheetToList`: workflow imports nf-schema's helper and calls it on the param. `splitCsv`: workflow uses `splitCsv(header: true)` on the param's path. `ad-hoc`: pipeline-specific CSV/TSV parsing inferred from script bodies." },
+        "format":         { "type": ["string", "null"], "enum": ["csv", "tsv", "csv-or-tsv", null], "description": "Tabular format declared by the param's `mimetype` or inferred from `samplesheetToList` / `splitCsv` semantics. Null when undeclared." },
+        "header":         { "type": ["boolean", "null"], "description": "Whether the file is expected to have a header row. Null when the discovery source doesn't pin it." },
+        "columns":        { "type": "array", "items": { "$ref": "#/$defs/SampleSheetColumn" }, "description": "Row schema in declaration order. nf-schema's `samplesheetToList` emits columns in property order, not source-column order — preserve property order here so downstream translations match runtime channel item layout." }
+      }
+    },
+
+    "SampleSheetColumn": {
+      "title": "SampleSheetColumn",
+      "description": "One column in a sample-sheet row schema. Type vocabulary is JSON Schema-style scalar; `kind` separates dataset-reference columns from per-row metadata. Validation hints (`pattern`, `enum`, `exists`, `mimetype`) are preserved verbatim — target Molds decide which of them survive translation (e.g. Galaxy's `sample_sheet` validator allowlist is regex/in_range/length).",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "type", "kind", "required"],
+      "properties": {
+        "name":        { "type": "string" },
+        "type":        { "type": "string", "enum": ["string", "integer", "number", "boolean"], "description": "JSON Schema-style scalar type. Path columns are typed `string` with a `format: file-path|directory-path|path` qualifier — see `format` and `kind`." },
+        "kind":        { "type": "string", "enum": ["data", "meta"], "description": "`data`: path-typed column whose values are dataset references (becomes element/inner-collection slot in Galaxy `sample_sheet`). `meta`: scalar metadata column (becomes a `column_definitions` entry, populated per row in `columns[]`). Includes the nf-schema `meta:` annotation when present; in its absence inferred from `format` (`file-path`/`directory-path`/`path` → `data`, anything else → `meta`)." },
+        "format":      { "type": ["string", "null"], "description": "JSON Schema `format` keyword. nf-schema vocabulary: `file-path`, `directory-path`, `path`, `file-path-pattern`. Null for scalar metadata columns without a format hint." },
+        "required":    { "type": "boolean" },
+        "default":     { "description": "Default value verbatim from the sample-sheet schema. May be null." },
+        "description": { "type": ["string", "null"] },
+        "enum":        { "type": "array", "items": {}, "description": "Allowed values when the column schema declares an `enum`. Empty array when absent." },
+        "pattern":     { "type": ["string", "null"], "description": "JSON Schema regex `pattern` when present." },
+        "exists":      { "type": ["boolean", "null"], "description": "nf-schema `exists` flag for path columns. True when the parser must verify the file exists." },
+        "mimetype":    { "type": ["string", "null"], "description": "nf-schema `mimetype` keyword (e.g. `text/csv`, `application/gzip`). Useful for target datatypes." }
+      }
+    },
+
     "Tool": {
       "title": "Tool",
       "description": "One tool/dependency the pipeline runs. Mirrors gxy-sketches ToolSpec (name + version) and augments it with the resolved container/conda strings the bridge to author-galaxy-tool-wrapper needs.",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "name",
-        "version"
-      ],
+      "required": ["name", "version"],
       "properties": {
-        "name": {
-          "type": "string",
-          "description": "Canonical tool name (e.g. `fastp`, `samtools`). Used as the foreign key from `processes[].tool`."
-        },
-        "version": {
-          "type": "string"
-        },
-        "biocontainer": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "BioContainers image reference when one was found. Includes both `quay.io/biocontainers/<name>:<version>--<build>` and the docker.io alias `biocontainers/<name>:<version>--<build>` (modern nf-core modules typically use the docker.io form in the docker branch and the depot.galaxyproject.org form in the singularity branch)."
-        },
-        "bioconda": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "`bioconda::<name>=<version>` spec when a `conda` directive provides one — directly or by reference to a `${moduleDir}/environment.yml` whose `dependencies:` list contains a single bioconda entry. The latter is the modern nf-core convention."
-        },
-        "docker": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "Non-biocontainer Docker registry image string when present."
-        },
-        "singularity": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "Singularity image reference when present (e.g. `https://depot.galaxyproject.org/singularity/...`)."
-        },
-        "wave": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "Seqera Wave / community-cr registry reference (e.g. `community.wave.seqera.io/library/<name>:<version>--<digest>` or `https://community-cr-prod.seqera.io/.../sha256/<digest>/data`). Wave-built containers are increasingly common in nf-core; kept distinct from `docker` because the resolution rules and provenance differ."
-        },
-        "mulled_components": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/ToolSpec"
-          },
-          "description": "Constituent Bioconda packages for an opaque `mulled-v2-*` multi-package container when resolved from a cached BioContainers multi-package-containers TSV. Omitted when no matching cached row is available."
-        }
+        "name":         { "type": "string", "description": "Canonical tool name (e.g. `fastp`, `samtools`). Used as the foreign key from `processes[].tool`." },
+        "version":      { "type": "string" },
+        "biocontainer": { "type": ["string", "null"], "description": "BioContainers image reference when one was found. Includes both `quay.io/biocontainers/<name>:<version>--<build>` and the docker.io alias `biocontainers/<name>:<version>--<build>` (modern nf-core modules typically use the docker.io form in the docker branch and the depot.galaxyproject.org form in the singularity branch)." },
+        "bioconda":     { "type": ["string", "null"], "description": "`bioconda::<name>=<version>` spec when a `conda` directive provides one — directly or by reference to a `${moduleDir}/environment.yml` whose `dependencies:` list contains a single bioconda entry. The latter is the modern nf-core convention." },
+        "docker":       { "type": ["string", "null"], "description": "Non-biocontainer Docker registry image string when present." },
+        "singularity":  { "type": ["string", "null"], "description": "Singularity image reference when present (e.g. `https://depot.galaxyproject.org/singularity/...`)." },
+        "wave":         { "type": ["string", "null"], "description": "Seqera Wave / community-cr registry reference (e.g. `community.wave.seqera.io/library/<name>:<version>--<digest>` or `https://community-cr-prod.seqera.io/.../sha256/<digest>/data`). Wave-built containers are increasingly common in nf-core; kept distinct from `docker` because the resolution rules and provenance differ." },
+        "mulled_components": { "type": "array", "items": { "$ref": "#/$defs/ToolSpec" }, "description": "Constituent Bioconda packages for an opaque `mulled-v2-*` multi-package container when resolved from a cached BioContainers multi-package-containers TSV. Omitted when no matching cached row is available." }
       }
     },
+
     "ToolSpec": {
       "title": "ToolSpec",
       "description": "One constituent package in a decomposed multi-package container.",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "name",
-        "version",
-        "bioconda"
-      ],
+      "required": ["name", "version", "bioconda"],
       "properties": {
-        "name": {
-          "type": "string"
-        },
-        "version": {
-          "type": "string"
-        },
-        "bioconda": {
-          "type": "string",
-          "description": "Exact Bioconda requirement spec, e.g. `bioconda::samtools=1.20`."
-        }
+        "name":     { "type": "string" },
+        "version":  { "type": "string" },
+        "bioconda": { "type": "string", "description": "Exact Bioconda requirement spec, e.g. `bioconda::samtools=1.20`." }
       }
     },
+
     "ChannelIO": {
       "title": "ChannelIO",
       "description": "One declared input or output channel of a process. Channel shape is a string, not a structured type — `tuple(meta, [path,path])` is enough for downstream Molds and avoids a research project on NF channel typing.",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "name",
-        "shape"
-      ],
+      "required": ["name", "shape"],
       "properties": {
-        "name": {
-          "type": "string"
-        },
-        "shape": {
-          "type": "string",
-          "description": "String-encoded channel shape, e.g. `tuple(meta, [path,path])`, `path`, `val(integer)`."
-        },
-        "description": {
-          "type": "string"
-        },
-        "topic": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "Nextflow channel-topic name when this output is bound to a topic (e.g. `versions` for the standard nf-core version-aggregation topic). Topics are a Nextflow 24+ feature; the module-level `topic: <name>` annotation on a process output emits to a global named channel that any consumer can `channel.topic('<name>')` to read. Null for non-topic outputs and for all inputs."
-        }
+        "name":        { "type": "string" },
+        "shape":       { "type": "string", "description": "String-encoded channel shape, e.g. `tuple(meta, [path,path])`, `path`, `val(integer)`." },
+        "description": { "type": "string" },
+        "topic":       { "type": ["string", "null"], "description": "Nextflow channel-topic name when this output is bound to a topic (e.g. `versions` for the standard nf-core version-aggregation topic). Topics are a Nextflow 24+ feature; the module-level `topic: <name>` annotation on a process output emits to a global named channel that any consumer can `channel.topic('<name>')` to read. Null for non-topic outputs and for all inputs." }
       }
     },
+
     "Process": {
       "title": "Process",
       "description": "One Nextflow `process { ... }` block.",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "name",
-        "module_path",
-        "meta",
-        "module_tests",
-        "inputs",
-        "outputs"
-      ],
+      "required": ["name", "module_path", "meta", "module_tests", "inputs", "outputs"],
       "properties": {
-        "name": {
-          "type": "string",
-          "description": "Canonical process name (uppercase NF convention) as declared by the `process <NAME>` line in `module_path`."
-        },
-        "aliases": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Alias names this process is imported as in workflow scopes via `include { <NAME> as <ALIAS> }`. Real nf-core pipelines re-import a single module multiple times under different aliases to invoke it with distinct runtime args (e.g. `MINIMAP2_ALIGN as MINIMAP2_CONSENSUS`, `MINIMAP2_ALIGN as MINIMAP2_POLISH`). Each alias appears in `workflow.edges[].from`/`.to` exactly as written; the canonical `name` does not appear in edges unless an unaliased import exists. Default `[]` when the process is only imported under its canonical name."
-        },
-        "module_path": {
-          "type": "string",
-          "description": "Relative path from the pipeline root to the file declaring the process."
-        },
-        "meta": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ModuleMeta"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "Normalized `meta.yml` from the module directory when present. Null for local/ad-hoc processes without module metadata."
-        },
-        "module_tests": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/NfTest"
-          },
-          "description": "Module-scoped nf-test files under the module's `tests/` directory. Empty for local/ad-hoc modules without unit tests."
-        },
-        "tool": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "Foreign key into `tools[].name` when the process runs a single recognizable tool; null for multi-tool or pure-Groovy processes."
-        },
-        "container": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "Verbatim text of the process's `container` directive (or null). Modern nf-core modules use a ternary expression `\"${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ? '<singularity-uri>' : '<docker-uri>' }\"` — keep that text intact here. The two resolved branches are split out into `tools[].docker` / `tools[].singularity` (and `tools[].wave` / `tools[].biocontainer` as appropriate)."
-        },
-        "conda": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "Verbatim text of the process's `conda` directive (or null). Two common shapes: a literal `bioconda::<name>=<version>` (legacy) or a file reference `${moduleDir}/environment.yml` (modern nf-core convention). Either way the resolved bioconda spec lands in `tools[].bioconda`."
-        },
-        "inputs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/ChannelIO"
-          }
-        },
-        "outputs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/ChannelIO"
-          }
-        },
-        "when": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "Verbatim `when:` guard expression, or null if absent."
-        },
-        "script_summary": {
-          "type": "string",
-          "description": "One-line LLM-derived summary of what the `script:` body does. Free text."
-        },
-        "publish_dir": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "`publishDir` value when the process publishes outputs (or null)."
-        }
+        "name":            { "type": "string", "description": "Canonical process name (uppercase NF convention) as declared by the `process <NAME>` line in `module_path`." },
+        "aliases":         { "type": "array", "items": { "type": "string" }, "description": "Alias names this process is imported as in workflow scopes via `include { <NAME> as <ALIAS> }`. Real nf-core pipelines re-import a single module multiple times under different aliases to invoke it with distinct runtime args (e.g. `MINIMAP2_ALIGN as MINIMAP2_CONSENSUS`, `MINIMAP2_ALIGN as MINIMAP2_POLISH`). Each alias appears in `workflow.edges[].from`/`.to` exactly as written; the canonical `name` does not appear in edges unless an unaliased import exists. Default `[]` when the process is only imported under its canonical name." },
+        "module_path":     { "type": "string", "description": "Relative path from the pipeline root to the file declaring the process." },
+        "meta":            { "anyOf": [{ "$ref": "#/$defs/ModuleMeta" }, { "type": "null" }], "description": "Normalized `meta.yml` from the module directory when present. Null for local/ad-hoc processes without module metadata." },
+        "module_tests":    { "type": "array", "items": { "$ref": "#/$defs/NfTest" }, "description": "Module-scoped nf-test files under the module's `tests/` directory. Empty for local/ad-hoc modules without unit tests." },
+        "tool":            { "type": ["string", "null"], "description": "Foreign key into `tools[].name` when the process runs a single recognizable tool; null for multi-tool or pure-Groovy processes." },
+        "container":       { "type": ["string", "null"], "description": "Verbatim text of the process's `container` directive (or null). Modern nf-core modules use a ternary expression `\"${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ? '<singularity-uri>' : '<docker-uri>' }\"` — keep that text intact here. The two resolved branches are split out into `tools[].docker` / `tools[].singularity` (and `tools[].wave` / `tools[].biocontainer` as appropriate)." },
+        "conda":           { "type": ["string", "null"], "description": "Verbatim text of the process's `conda` directive (or null). Two common shapes: a literal `bioconda::<name>=<version>` (legacy) or a file reference `${moduleDir}/environment.yml` (modern nf-core convention). Either way the resolved bioconda spec lands in `tools[].bioconda`." },
+        "inputs":          { "type": "array", "items": { "$ref": "#/$defs/ChannelIO" } },
+        "outputs":         { "type": "array", "items": { "$ref": "#/$defs/ChannelIO" } },
+        "when":            { "type": ["string", "null"], "description": "Verbatim `when:` guard expression, or null if absent." },
+        "script_summary":  { "type": "string", "description": "One-line LLM-derived summary of what the `script:` body does. Free text." },
+        "publish_dir":     { "type": ["string", "null"], "description": "`publishDir` value when the process publishes outputs (or null)." }
       }
     },
+
     "ModuleMeta": {
       "title": "ModuleMeta",
       "description": "Normalized subset of nf-core module `meta.yml`, captured next to a process so module-scoped downstream Molds can consume `processes[i]` without reading the full pipeline summary.",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "keywords",
-        "authors",
-        "maintainers",
-        "tools",
-        "input",
-        "output"
-      ],
+      "required": ["keywords", "authors", "maintainers", "tools", "input", "output"],
       "properties": {
-        "description": {
-          "type": "string"
-        },
-        "keywords": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "authors": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "maintainers": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "tools": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/ModuleMetaEntry"
-          }
-        },
-        "input": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/ModuleMetaEntry"
-          }
-        },
-        "output": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/ModuleMetaEntry"
-          }
-        }
+        "description": { "type": "string" },
+        "keywords":    { "type": "array", "items": { "type": "string" } },
+        "authors":     { "type": "array", "items": { "type": "string" } },
+        "maintainers": { "type": "array", "items": { "type": "string" } },
+        "tools":       { "type": "array", "items": { "$ref": "#/$defs/ModuleMetaEntry" } },
+        "input":       { "type": "array", "items": { "$ref": "#/$defs/ModuleMetaEntry" } },
+        "output":      { "type": "array", "items": { "$ref": "#/$defs/ModuleMetaEntry" } }
       }
     },
+
     "ModuleMetaEntry": {
       "title": "ModuleMetaEntry",
       "description": "One named entry from a module `meta.yml` section, normalized from nf-core's single-key YAML maps into `{ name, ...fields }` objects.",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "properties": {
-        "name": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "homepage": {
-          "type": "string"
-        },
-        "documentation": {
-          "type": "string"
-        },
-        "tool_dev_url": {
-          "type": "string"
-        },
-        "doi": {
-          "type": "string"
-        },
-        "licence": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "identifier": {
-          "type": "string"
-        },
-        "type": {
-          "type": "string"
-        },
-        "pattern": {
-          "type": "string"
-        }
+        "name":          { "type": "string" },
+        "description":   { "type": "string" },
+        "homepage":      { "type": "string" },
+        "documentation": { "type": "string" },
+        "tool_dev_url":  { "type": "string" },
+        "doi":           { "type": "string" },
+        "licence":       { "type": "array", "items": { "type": "string" } },
+        "identifier":    { "type": "string" },
+        "type":          { "type": "string" },
+        "pattern":       { "type": "string" }
       }
     },
+
     "Subworkflow": {
       "title": "Subworkflow",
       "description": "One named `workflow <NAME> { ... }` block other than the primary workflow. Includes nf-core utility wrappers (PIPELINE_INITIALISATION, PIPELINE_COMPLETION, UTILS_NFCORE_PIPELINE) which exist to compose helper-function calls rather than to invoke processes.",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "name",
-        "path",
-        "kind",
-        "calls",
-        "tests"
-      ],
+      "required": ["name", "path", "kind", "calls", "tests"],
       "properties": {
-        "name": {
-          "type": "string"
-        },
-        "path": {
-          "type": "string",
-          "description": "Relative path from the pipeline root."
-        },
-        "kind": {
-          "type": "string",
-          "enum": [
-            "pipeline",
-            "utility"
-          ],
-          "description": "`pipeline` when the subworkflow invokes pipeline processes (data-flow contributor). `utility` when it composes helper functions only — common nf-core template subworkflows like PIPELINE_INITIALISATION (which calls `paramsHelp`, `samplesheetToList`, `UTILS_NFSCHEMA_PLUGIN`) and PIPELINE_COMPLETION (`completionEmail`, `completionSummary`). Utility subworkflows have empty `calls[]` for processes but may still expose channel outputs the primary workflow consumes."
-        },
-        "calls": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Names of processes and nested subworkflows this subworkflow invokes. Free-function calls (e.g. `paramsHelp`, `completionEmail`) are NOT recorded here; they're implied by `kind = utility`."
-        },
-        "inputs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/ChannelIO"
-          }
-        },
-        "outputs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/ChannelIO"
-          }
-        },
-        "tests": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/NfTest"
-          },
-          "description": "Subworkflow-scoped nf-test files under the subworkflow's `tests/` directory. Empty when absent."
-        }
+        "name":    { "type": "string" },
+        "path":    { "type": "string", "description": "Relative path from the pipeline root." },
+        "kind":    { "type": "string", "enum": ["pipeline", "utility"], "description": "`pipeline` when the subworkflow invokes pipeline processes (data-flow contributor). `utility` when it composes helper functions only — common nf-core template subworkflows like PIPELINE_INITIALISATION (which calls `paramsHelp`, `samplesheetToList`, `UTILS_NFSCHEMA_PLUGIN`) and PIPELINE_COMPLETION (`completionEmail`, `completionSummary`). Utility subworkflows have empty `calls[]` for processes but may still expose channel outputs the primary workflow consumes." },
+        "calls":   { "type": "array", "items": { "type": "string" }, "description": "Names of processes and nested subworkflows this subworkflow invokes. Free-function calls (e.g. `paramsHelp`, `completionEmail`) are NOT recorded here; they're implied by `kind = utility`." },
+        "inputs":  { "type": "array", "items": { "$ref": "#/$defs/ChannelIO" } },
+        "outputs": { "type": "array", "items": { "$ref": "#/$defs/ChannelIO" } },
+        "tests":   { "type": "array", "items": { "$ref": "#/$defs/NfTest" }, "description": "Subworkflow-scoped nf-test files under the subworkflow's `tests/` directory. Empty when absent." }
       }
     },
+
     "Channel": {
       "title": "Channel",
       "description": "One top-level channel constructed in the workflow. Sources include `Channel.fromPath`, `Channel.fromFilePairs`, `Channel.fromSamplesheet`, and `params.*`.",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "name",
-        "source",
-        "shape"
-      ],
+      "required": ["name", "source", "shape"],
       "properties": {
-        "name": {
-          "type": "string"
-        },
-        "source": {
-          "type": "string",
-          "description": "Verbatim channel-construction expression."
-        },
-        "shape": {
-          "type": "string",
-          "description": "String-encoded channel shape; same convention as ChannelIO."
-        }
+        "name":   { "type": "string" },
+        "source": { "type": "string", "description": "Verbatim channel-construction expression." },
+        "shape":  { "type": "string", "description": "String-encoded channel shape; same convention as ChannelIO." }
       }
     },
+
     "Edge": {
       "title": "Edge",
       "description": "One edge in the workflow's call graph. The deterministic parser records the literal operator chain in `via`; reconciliation of the source and target shapes is the LLM step.",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "from",
-        "to"
-      ],
+      "required": ["from", "to"],
       "properties": {
-        "from": {
-          "type": "string",
-          "description": "Channel name or `<PROCESS>.out.<chan>` reference."
-        },
-        "to": {
-          "type": "string",
-          "description": "Process or subworkflow name receiving this channel."
-        },
-        "via": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Operators on the path between source and target, in order (e.g. `[\"map\", \"join\", \"groupTuple\"]`). Empty for a direct edge."
-        },
-        "notes": {
-          "type": "string",
-          "description": "LLM-emitted note when the reconciliation is low-confidence (e.g. deeply nested closures)."
-        }
+        "from": { "type": "string", "description": "Channel name or `<PROCESS>.out.<chan>` reference." },
+        "to":   { "type": "string", "description": "Process or subworkflow name receiving this channel." },
+        "via":  { "type": "array", "items": { "type": "string" }, "description": "Operators on the path between source and target, in order (e.g. `[\"map\", \"join\", \"groupTuple\"]`). Empty for a direct edge." },
+        "notes": { "type": "string", "description": "LLM-emitted note when the reconciliation is low-confidence (e.g. deeply nested closures)." }
       }
     },
+
     "Conditional": {
       "title": "Conditional",
       "description": "One workflow-level conditional that gates a subgraph.",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "guard",
-        "branch",
-        "affects"
-      ],
+      "required": ["guard", "branch", "affects"],
       "properties": {
-        "guard": {
-          "type": "string",
-          "description": "Verbatim guard expression, e.g. `params.skip_alignment`."
-        },
-        "branch": {
-          "type": "string",
-          "enum": [
-            "default",
-            "alternate"
-          ],
-          "description": "Which side of the conditional this entry describes. `default` is the truthy branch; `alternate` is the else branch."
-        },
-        "affects": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Process or subworkflow names whose execution is gated by this conditional."
-        }
+        "guard":   { "type": "string", "description": "Verbatim guard expression, e.g. `params.skip_alignment`." },
+        "branch":  { "type": "string", "enum": ["default", "alternate"], "description": "Which side of the conditional this entry describes. `default` is the truthy branch; `alternate` is the else branch." },
+        "affects": { "type": "array", "items": { "type": "string" }, "description": "Process or subworkflow names whose execution is gated by this conditional." }
       }
     },
+
     "Workflow": {
       "title": "Workflow",
       "description": "Primary workflow: channel construction plus the call-graph DAG. Real nf-core pipelines have multiple named `workflow` blocks (an anonymous entrypoint `workflow {}` in main.nf that wires PIPELINE_INITIALISATION → NFCORE_<NAME> → PIPELINE_COMPLETION; a named NFCORE_<NAME> wrapper; a substantive named workflow under workflows/<name>.nf). The summary collapses this into one primary `workflow` plus `subworkflows[]`. Selection rule: pick the workflow that invokes the most pipeline processes — typically the one under `workflows/<name>.nf`. The anonymous `workflow {}` glue and the NFCORE_<NAME> wrapper land in `subworkflows[]`.",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "name",
-        "channels",
-        "edges"
-      ],
+      "required": ["name", "channels", "edges"],
       "properties": {
-        "name": {
-          "type": "string",
-          "description": "Name of the selected primary workflow (uppercase NF convention). The anonymous `workflow {}` entrypoint is never the primary; if it is the only workflow block, the pipeline is too small to summarize and the cast skill should emit a warning."
-        },
-        "channels": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/Channel"
-          }
-        },
-        "edges": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/Edge"
-          }
-        },
-        "conditionals": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/Conditional"
-          }
-        }
+        "name":         { "type": "string", "description": "Name of the selected primary workflow (uppercase NF convention). The anonymous `workflow {}` entrypoint is never the primary; if it is the only workflow block, the pipeline is too small to summarize and the cast skill should emit a warning." },
+        "channels":     { "type": "array", "items": { "$ref": "#/$defs/Channel" } },
+        "edges":        { "type": "array", "items": { "$ref": "#/$defs/Edge" } },
+        "conditionals": { "type": "array", "items": { "$ref": "#/$defs/Conditional" } }
       }
     },
+
     "TestDataRef": {
       "title": "TestDataRef",
       "description": "One test-fixture input. Field names mirror gxy-sketches' TestDataRef verbatim. The sketch-bundle constraint that `path` must live under `test_data/` is intentionally dropped; the Foundry summary describes fixtures as data, it does not bundle them.",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "role"
-      ],
+      "required": ["role"],
       "properties": {
-        "role": {
-          "type": "string",
-          "description": "Logical role of the input (e.g. `samplesheet`, `reference_fasta`)."
-        },
-        "path": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "Repo-relative path when the fixture lives in-tree, or local filesystem path when the CLI fetched the remote fixture into a caller-provided test-data directory."
-        },
-        "url": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "format": "uri"
-        },
-        "sha1": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "SHA-1 integrity hash when published alongside the fixture."
-        },
-        "filetype": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "File format, e.g. `fastq.gz`, `csv`."
-        },
-        "description": {
-          "type": [
-            "string",
-            "null"
-          ]
-        }
+        "role":        { "type": "string", "description": "Logical role of the input (e.g. `samplesheet`, `reference_fasta`)." },
+        "path":        { "type": ["string", "null"], "description": "Repo-relative path when the fixture lives in-tree, or local filesystem path when the CLI fetched the remote fixture into a caller-provided test-data directory." },
+        "url":         { "type": ["string", "null"], "format": "uri" },
+        "sha1":        { "type": ["string", "null"], "description": "SHA-1 integrity hash when published alongside the fixture." },
+        "filetype":    { "type": ["string", "null"], "description": "File format, e.g. `fastq.gz`, `csv`." },
+        "description": { "type": ["string", "null"] }
       },
       "anyOf": [
-        {
-          "required": [
-            "path"
-          ]
-        },
-        {
-          "required": [
-            "url"
-          ]
-        }
+        { "required": ["path"] },
+        { "required": ["url"] }
       ]
     },
+
     "ExpectedOutputRef": {
       "title": "ExpectedOutputRef",
       "description": "One expected output. Field names mirror gxy-sketches' ExpectedOutputRef verbatim. At least one of path / url / assertions is required.",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "role"
-      ],
+      "required": ["role"],
       "properties": {
-        "role": {
-          "type": "string"
-        },
-        "path": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "url": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "format": "uri"
-        },
-        "kind": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "Coarse output kind: `report`, `tabular`, `image`, `archive`, `sequence`, `other`."
-        },
-        "description": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "assertions": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Assertion strings. Simple equality / regex / contains-string checks are preserved verbatim; complex Groovy assertions are summarized to prose with a `warnings[]` flag in the parent Summary."
-        }
+        "role":        { "type": "string" },
+        "path":        { "type": ["string", "null"] },
+        "url":         { "type": ["string", "null"], "format": "uri" },
+        "kind":        { "type": ["string", "null"], "description": "Coarse output kind: `report`, `tabular`, `image`, `archive`, `sequence`, `other`." },
+        "description": { "type": ["string", "null"] },
+        "assertions":  { "type": "array", "items": { "type": "string" }, "description": "Assertion strings. Simple equality / regex / contains-string checks are preserved verbatim; complex Groovy assertions are summarized to prose with a `warnings[]` flag in the parent Summary." }
       },
       "anyOf": [
-        {
-          "required": [
-            "path"
-          ]
-        },
-        {
-          "required": [
-            "url"
-          ]
-        },
-        {
-          "required": [
-            "assertions"
-          ]
-        }
+        { "required": ["path"] },
+        { "required": ["url"] },
+        { "required": ["assertions"] }
       ]
     },
+
     "TestFixtures": {
       "title": "TestFixtures",
       "description": "Test fixtures derived from a `conf/<profile>.config` for the cast's selected profile. Pipelines with multiple test profiles (bacass has 11) record only the selected profile here; the full nf-test enumeration lives in `nf_tests[]`.",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "profile",
-        "inputs",
-        "outputs"
-      ],
+      "required": ["profile", "inputs", "outputs"],
       "properties": {
-        "profile": {
-          "type": "string",
-          "description": "Which `conf/<profile>.config` produced these fixtures (typically `test`)."
-        },
-        "inputs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/TestDataRef"
-          }
-        },
-        "outputs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/ExpectedOutputRef"
-          }
-        }
+        "profile": { "type": "string", "description": "Which `conf/<profile>.config` produced these fixtures (typically `test`)." },
+        "inputs":  { "type": "array", "items": { "$ref": "#/$defs/TestDataRef" } },
+        "outputs": { "type": "array", "items": { "$ref": "#/$defs/ExpectedOutputRef" } }
       }
     },
+
     "NfTest": {
       "title": "NfTest",
       "description": "One `tests/*.nf.test` file. nf-core templates use a near-uniform shape: a `nextflow_pipeline { test(\"<desc>\") { when { params { ... } } then { assertAll(...) } } }` block, with one test() per profile, asserting `workflow.success` plus a snapshot match. This shape captures the data so downstream test-conversion molds (e.g. nextflow-test-to-target-tests) don't have to re-parse Groovy.",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "name",
-        "path",
-        "profiles",
-        "assert_workflow_success",
-        "prose_assertions"
-      ],
+      "required": ["name", "path", "profiles", "assert_workflow_success", "prose_assertions"],
       "properties": {
-        "name": {
-          "type": "string",
-          "description": "Description string passed to `test(\"...\")`. Often duplicates the profile name."
-        },
-        "path": {
-          "type": "string",
-          "description": "Repo-relative path of the .nf.test file (e.g. `tests/dfast.nf.test`)."
-        },
-        "profiles": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Profile name(s) the test runs under, from the file-level `profile \"<name>\"` declaration and/or per-test config overrides. Usually a single profile."
-        },
-        "params_overrides": {
-          "type": "object",
-          "additionalProperties": true,
-          "description": "The `when { params { ... } }` block as a key→value map. Most templates set only `outdir`; pipeline-specific overrides land here."
-        },
-        "assert_workflow_success": {
-          "type": "boolean",
-          "description": "Whether the test asserts `workflow.success`. Almost always true for nf-core templates."
-        },
-        "snapshot": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/SnapshotFixture"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "Structured representation of the `assert snapshot(...).match()` clause when present; null when the test uses no snapshot."
-        },
-        "prose_assertions": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Other assertions (regex matches, count checks, content equality on specific files) summarized to prose strings. Empty for snapshot-only tests, which is the common nf-core case."
-        }
+        "name":                    { "type": "string", "description": "Description string passed to `test(\"...\")`. Often duplicates the profile name." },
+        "path":                    { "type": "string", "description": "Repo-relative path of the .nf.test file (e.g. `tests/dfast.nf.test`)." },
+        "profiles":                { "type": "array", "items": { "type": "string" }, "description": "Profile name(s) the test runs under, from the file-level `profile \"<name>\"` declaration and/or per-test config overrides. Usually a single profile." },
+        "params_overrides":        { "type": "object", "additionalProperties": true, "description": "The `when { params { ... } }` block as a key→value map. Most templates set only `outdir`; pipeline-specific overrides land here." },
+        "assert_workflow_success": { "type": "boolean", "description": "Whether the test asserts `workflow.success`. Almost always true for nf-core templates." },
+        "snapshot":                { "anyOf": [{ "$ref": "#/$defs/SnapshotFixture" }, { "type": "null" }], "description": "Structured representation of the `assert snapshot(...).match()` clause when present; null when the test uses no snapshot." },
+        "prose_assertions":        { "type": "array", "items": { "type": "string" }, "description": "Other assertions (regex matches, count checks, content equality on specific files) summarized to prose strings. Empty for snapshot-only tests, which is the common nf-core case." }
       }
     },
+
     "SnapshotFixture": {
       "title": "SnapshotFixture",
       "description": "Structured shape of an nf-test `snapshot(...).match()` assertion. nf-core templates pass a small set of values into snapshot() — succeeded-task count, version YAML (with Nextflow version stripped), stable file-name list, stable file-content list — and prune the comparison via `getAllFilesFromDir(..., ignoreFile: ..., ignore: [...])` helpers. This breakdown lets downstream consumers reconstruct equivalent assertions in target test frameworks without re-parsing Groovy.",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "captures",
-        "helpers",
-        "ignore_files",
-        "ignore_globs"
-      ],
+      "required": ["captures", "helpers", "ignore_files", "ignore_globs"],
       "properties": {
-        "captures": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Logical names of values passed to snapshot(), in order. Common set: `succeeded_task_count`, `versions_yml`, `stable_names`, `stable_paths`. Free-form strings rather than an enum because pipelines can pass other values."
-        },
-        "helpers": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "nf-test helper functions invoked in the snapshot expression (e.g. `getAllFilesFromDir`, `removeNextflowVersion`). Used to detect whether a target framework can replicate the comparison."
-        },
-        "ignore_files": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Repo-relative paths passed as `ignoreFile:` to helpers (e.g. `tests/.nftignore`, `tests/.nftignore_files_entirely`). The files themselves are line-delimited globs."
-        },
-        "ignore_globs": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Inline `ignore: [...]` glob list passed to helpers (e.g. `['Prokka/**', '**/multiqc_busco.yaml']`). Distinct from ignore_files which references on-disk lists."
-        },
-        "snap_path": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "Repo-relative path of the corresponding `.nf.test.snap` file when present."
-        },
-        "parsed_content": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/SnapshotContent"
-          },
-          "description": "Parsed entries from the `.nf.test.snap` JSON sidecar. Empty when the sidecar is absent, too large for compact summary output, or not valid JSON. Each entry preserves the snapshot name plus channel-keyed file md5 assertions and non-file scalar values."
-        }
+        "captures":      { "type": "array", "items": { "type": "string" }, "description": "Logical names of values passed to snapshot(), in order. Common set: `succeeded_task_count`, `versions_yml`, `stable_names`, `stable_paths`. Free-form strings rather than an enum because pipelines can pass other values." },
+        "helpers":       { "type": "array", "items": { "type": "string" }, "description": "nf-test helper functions invoked in the snapshot expression (e.g. `getAllFilesFromDir`, `removeNextflowVersion`). Used to detect whether a target framework can replicate the comparison." },
+        "ignore_files":  { "type": "array", "items": { "type": "string" }, "description": "Repo-relative paths passed as `ignoreFile:` to helpers (e.g. `tests/.nftignore`, `tests/.nftignore_files_entirely`). The files themselves are line-delimited globs." },
+        "ignore_globs":  { "type": "array", "items": { "type": "string" }, "description": "Inline `ignore: [...]` glob list passed to helpers (e.g. `['Prokka/**', '**/multiqc_busco.yaml']`). Distinct from ignore_files which references on-disk lists." },
+        "snap_path":     { "type": ["string", "null"], "description": "Repo-relative path of the corresponding `.nf.test.snap` file when present." },
+        "parsed_content": { "type": "array", "items": { "$ref": "#/$defs/SnapshotContent" }, "description": "Parsed entries from the `.nf.test.snap` JSON sidecar. Empty when the sidecar is absent, too large for compact summary output, or not valid JSON. Each entry preserves the snapshot name plus channel-keyed file md5 assertions and non-file scalar values." }
       }
     },
+
     "SnapshotContent": {
       "title": "SnapshotContent",
       "description": "One top-level snapshot entry from an nf-test `.snap` JSON sidecar.",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "name",
-        "channels"
-      ],
+      "required": ["name", "channels"],
       "properties": {
-        "name": {
-          "type": "string",
-          "description": "Top-level key in the `.snap` file, usually the `test(\"...\")` name."
-        },
-        "channels": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/SnapshotChannel"
-          },
-          "description": "Channel-keyed snapshot values. Pipeline-template flat file lists use `key: null`."
-        }
+        "name":     { "type": "string", "description": "Top-level key in the `.snap` file, usually the `test(\"...\")` name." },
+        "channels": { "type": "array", "items": { "$ref": "#/$defs/SnapshotChannel" }, "description": "Channel-keyed snapshot values. Pipeline-template flat file lists use `key: null`." }
       }
     },
+
     "SnapshotChannel": {
       "title": "SnapshotChannel",
       "description": "One output channel or flat snapshot list inside a `.snap` entry.",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "key",
-        "files",
-        "values"
-      ],
+      "required": ["key", "files", "values"],
       "properties": {
-        "key": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "Channel key from the snapshot object, e.g. `0`, `1`, or `genome_gtf`; null for flat file-list snapshots."
-        },
-        "files": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/SnapshotFile"
-          },
-          "description": "File md5 assertions parsed from `<path>:md5,<hex>` strings."
-        },
-        "values": {
-          "type": "array",
-          "items": {},
-          "description": "Non-file snapshot values preserved verbatim for consumers that need versions, counts, or scalar tuple emissions."
-        }
+        "key":    { "type": ["string", "null"], "description": "Channel key from the snapshot object, e.g. `0`, `1`, or `genome_gtf`; null for flat file-list snapshots." },
+        "files":  { "type": "array", "items": { "$ref": "#/$defs/SnapshotFile" }, "description": "File md5 assertions parsed from `<path>:md5,<hex>` strings." },
+        "values": { "type": "array", "items": {}, "description": "Non-file snapshot values preserved verbatim for consumers that need versions, counts, or scalar tuple emissions." }
       }
     },
+
     "SnapshotFile": {
       "title": "SnapshotFile",
       "description": "One file digest assertion from a `.snap` sidecar.",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "basename",
-        "md5",
-        "stub"
-      ],
+      "required": ["path", "basename", "md5", "stub"],
       "properties": {
-        "path": {
-          "type": "string",
-          "description": "Path portion before `:md5,` exactly as stored in the sidecar."
-        },
-        "basename": {
-          "type": "string",
-          "description": "Final path segment, suitable for Galaxy test `file:` assertions when the snapshot stores only basenames."
-        },
-        "md5": {
-          "type": "string",
-          "pattern": "^[a-fA-F0-9]{32}$",
-          "description": "MD5 digest from the sidecar."
-        },
-        "stub": {
-          "type": "boolean",
-          "description": "True when the digest is the empty-file md5 emitted by many `-stub` tests."
-        }
+        "path":     { "type": "string", "description": "Path portion before `:md5,` exactly as stored in the sidecar." },
+        "basename": { "type": "string", "description": "Final path segment, suitable for Galaxy test `file:` assertions when the snapshot stores only basenames." },
+        "md5":      { "type": "string", "pattern": "^[a-fA-F0-9]{32}$", "description": "MD5 digest from the sidecar." },
+        "stub":     { "type": "boolean", "description": "True when the digest is the empty-file md5 emitted by many `-stub` tests." }
       }
     }
   }

--- a/casts/claude/skills/summarize-nextflow/references/schemas/summary-nextflow.schema.json
+++ b/casts/claude/skills/summarize-nextflow/references/schemas/summary-nextflow.schema.json
@@ -11,394 +11,1145 @@
       "description": "Top-level shape. Every Nextflow summary is exactly this object.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["source", "params", "sample_sheets", "profiles", "tools", "processes", "subworkflows", "workflow", "test_fixtures", "nf_tests"],
+      "required": [
+        "source",
+        "params",
+        "sample_sheets",
+        "profiles",
+        "tools",
+        "processes",
+        "subworkflows",
+        "workflow",
+        "test_fixtures",
+        "nf_tests"
+      ],
       "properties": {
-        "source":         { "$ref": "#/$defs/SourceRecord" },
-        "params":         { "type": "array", "items": { "$ref": "#/$defs/Param" } },
-        "sample_sheets":  { "type": "array", "items": { "$ref": "#/$defs/SampleSheet" }, "description": "Structured sample-sheet inputs. Each entry binds one `params[]` parameter to a row schema (column names, types, path-vs-meta classification, required flags, enums, patterns). Promoted from prose inside `params[].description` so downstream target translations (Galaxy `sample_sheet*` collections, CWL records-of-arrays) can choose collection variants without re-parsing the source pipeline. Empty array when no sample-sheet idiom is detected. Discovery sources: nf-schema `schema:` references, `samplesheetToList()` calls, and `splitCsv(header: true)` materializations." },
-        "profiles":       { "type": "array", "items": { "type": "string" } },
-        "tools":          { "type": "array", "items": { "$ref": "#/$defs/Tool" } },
-        "processes":      { "type": "array", "items": { "$ref": "#/$defs/Process" } },
-        "subworkflows":   { "type": "array", "items": { "$ref": "#/$defs/Subworkflow" } },
-        "workflow":       { "$ref": "#/$defs/Workflow" },
-        "test_fixtures":  { "$ref": "#/$defs/TestFixtures", "description": "Test-input data shape for the *selected* profile (the cast's `profile` argument, default `test`). For pipelines with multiple test profiles, see `nf_tests[]` for the full enumeration." },
-        "nf_tests":       { "type": "array", "items": { "$ref": "#/$defs/NfTest" }, "description": "All `tests/*.nf.test` files in the pipeline. Each entry captures one test-program — its profile, params overrides, and structured assertions. Empty array when the pipeline has no nf-test fixtures." },
-        "warnings":       { "type": "array", "items": { "type": "string" }, "description": "Cast-skill-emitted advisory messages (e.g. DSL1 detected, meta.yml/script disagreement, lossy assertion summarization). Empty array on a clean run." }
+        "source": {
+          "$ref": "#/$defs/SourceRecord"
+        },
+        "params": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Param"
+          }
+        },
+        "sample_sheets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SampleSheet"
+          },
+          "description": "Structured sample-sheet inputs. Each entry binds one `params[]` parameter to a row schema (column names, types, path-vs-meta classification, required flags, enums, patterns). Promoted from prose inside `params[].description` so downstream target translations (Galaxy `sample_sheet*` collections, CWL records-of-arrays) can choose collection variants without re-parsing the source pipeline. Empty array when no sample-sheet idiom is detected. Discovery sources: nf-schema `schema:` references, `samplesheetToList()` calls, and `splitCsv(header: true)` materializations."
+        },
+        "profiles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Tool"
+          }
+        },
+        "processes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Process"
+          }
+        },
+        "subworkflows": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Subworkflow"
+          }
+        },
+        "workflow": {
+          "$ref": "#/$defs/Workflow"
+        },
+        "test_fixtures": {
+          "$ref": "#/$defs/TestFixtures",
+          "description": "Test-input data shape for the *selected* profile (the cast's `profile` argument, default `test`). For pipelines with multiple test profiles, see `nf_tests[]` for the full enumeration."
+        },
+        "nf_tests": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/NfTest"
+          },
+          "description": "All `tests/*.nf.test` files in the pipeline. Each entry captures one test-program — its profile, params overrides, and structured assertions. Empty array when the pipeline has no nf-test fixtures."
+        },
+        "warnings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Cast-skill-emitted advisory messages (e.g. DSL1 detected, meta.yml/script disagreement, lossy assertion summarization). Empty array on a clean run."
+        }
       }
     },
-
     "SourceRecord": {
       "title": "SourceRecord",
       "description": "Provenance block. Mirrors gxy-sketches SketchSource field names so a Foundry summary is structurally consumable by anyone using that shape.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["ecosystem", "workflow", "url", "version", "slug"],
+      "required": [
+        "ecosystem",
+        "workflow",
+        "url",
+        "version",
+        "slug"
+      ],
       "properties": {
         "ecosystem": {
           "type": "string",
-          "enum": ["nf-core", "nextflow"],
+          "enum": [
+            "nf-core",
+            "nextflow"
+          ],
           "description": "Pipeline flavor. `nf-core` when `manifest.name` is `nf-core/<slug>` and the canonical layout is present; `nextflow` for ad-hoc DSL2 pipelines. Superset of gxy-sketches' enum (which adds `iwc`, `snakemake-workflows`, `wdl` for its other ingestors)."
         },
-        "workflow": { "type": "string", "description": "Pipeline name (typically the part after `nf-core/`)." },
-        "url":      { "type": "string", "format": "uri", "description": "Git remote URL of the pipeline repository." },
-        "version":  { "type": "string", "description": "Tag, branch, or commit SHA the summary was derived from." },
-        "license":  { "type": ["string", "null"], "description": "SPDX license identifier when detectable from a LICENSE file." },
-        "slug":     { "type": "string", "description": "Kebab-case identifier; `<owner>-<repo>` for nf-core, repo basename otherwise." }
+        "workflow": {
+          "type": "string",
+          "description": "Pipeline name (typically the part after `nf-core/`)."
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Git remote URL of the pipeline repository."
+        },
+        "version": {
+          "type": "string",
+          "description": "Tag, branch, or commit SHA the summary was derived from."
+        },
+        "license": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "SPDX license identifier when detectable from a LICENSE file."
+        },
+        "slug": {
+          "type": "string",
+          "description": "Kebab-case identifier; `<owner>-<repo>` for nf-core, repo basename otherwise."
+        }
       }
     },
-
     "Param": {
       "title": "Param",
       "description": "One pipeline parameter. Sourced from `nextflow.config`'s `params { ... }` block, augmented from `nextflow_schema.json` when present (nf-core).",
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "type", "required"],
+      "required": [
+        "name",
+        "type",
+        "required"
+      ],
       "properties": {
-        "name":        { "type": "string" },
-        "type":        { "type": "string", "description": "JSON Schema-style type when nextflow_schema.json supplies it (string, integer, number, boolean, path); free-form when inferred from a default value." },
-        "default":     { "description": "Default value verbatim from the source. May be null." },
-        "description": { "type": "string" },
-        "required":    { "type": "boolean" },
-        "enum":        { "type": "array", "items": {}, "description": "Allowed values when nextflow_schema.json declares them." }
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "description": "JSON Schema-style type when nextflow_schema.json supplies it (string, integer, number, boolean, path); free-form when inferred from a default value."
+        },
+        "default": {
+          "description": "Default value verbatim from the source. May be null."
+        },
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "enum": {
+          "type": "array",
+          "items": {},
+          "description": "Allowed values when nextflow_schema.json declares them."
+        }
       }
     },
-
     "SampleSheet": {
       "title": "SampleSheet",
       "description": "One sample-sheet-shaped pipeline input. Captures the row schema, path-vs-meta column classification, and discovery provenance so downstream Molds can map onto Galaxy `sample_sheet[:variant]` collections, CWL records-of-arrays, or other target shapes without re-reading the source.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["param", "discovered_via", "columns"],
+      "required": [
+        "param",
+        "discovered_via",
+        "columns"
+      ],
       "properties": {
-        "param":          { "type": "string", "description": "Foreign key into `params[].name` — the parameter whose value points at the sample-sheet file." },
-        "schema_path":    { "type": ["string", "null"], "description": "Repo-relative path of the JSON Schema file describing rows (e.g. `assets/schema_input.json`), resolved from the param's nf-schema entry's `schema:` keyword. Null when discovered via `samplesheetToList` without a schema reference, or via `splitCsv(header: true)` ad-hoc parsing." },
-        "discovered_via": { "type": "string", "enum": ["nf-schema", "samplesheetToList", "splitCsv", "ad-hoc"], "description": "How the sample-sheet shape was detected. `nf-schema`: nextflow_schema.json entry has `schema:` keyword. `samplesheetToList`: workflow imports nf-schema's helper and calls it on the param. `splitCsv`: workflow uses `splitCsv(header: true)` on the param's path. `ad-hoc`: pipeline-specific CSV/TSV parsing inferred from script bodies." },
-        "format":         { "type": ["string", "null"], "enum": ["csv", "tsv", "csv-or-tsv", null], "description": "Tabular format declared by the param's `mimetype` or inferred from `samplesheetToList` / `splitCsv` semantics. Null when undeclared." },
-        "header":         { "type": ["boolean", "null"], "description": "Whether the file is expected to have a header row. Null when the discovery source doesn't pin it." },
-        "columns":        { "type": "array", "items": { "$ref": "#/$defs/SampleSheetColumn" }, "description": "Row schema in declaration order. nf-schema's `samplesheetToList` emits columns in property order, not source-column order — preserve property order here so downstream translations match runtime channel item layout." }
+        "param": {
+          "type": "string",
+          "description": "Foreign key into `params[].name` — the parameter whose value points at the sample-sheet file."
+        },
+        "schema_path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Repo-relative path of the JSON Schema file describing rows (e.g. `assets/schema_input.json`), resolved from the param's nf-schema entry's `schema:` keyword. Null when discovered via `samplesheetToList` without a schema reference, or via `splitCsv(header: true)` ad-hoc parsing."
+        },
+        "discovered_via": {
+          "type": "string",
+          "enum": [
+            "nf-schema",
+            "samplesheetToList",
+            "splitCsv",
+            "ad-hoc"
+          ],
+          "description": "How the sample-sheet shape was detected. `nf-schema`: nextflow_schema.json entry has `schema:` keyword. `samplesheetToList`: workflow imports nf-schema's helper and calls it on the param. `splitCsv`: workflow uses `splitCsv(header: true)` on the param's path. `ad-hoc`: pipeline-specific CSV/TSV parsing inferred from script bodies."
+        },
+        "format": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "csv",
+            "tsv",
+            "csv-or-tsv",
+            null
+          ],
+          "description": "Tabular format declared by the param's `mimetype` or inferred from `samplesheetToList` / `splitCsv` semantics. Null when undeclared."
+        },
+        "header": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Whether the file is expected to have a header row. Null when the discovery source doesn't pin it."
+        },
+        "columns": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SampleSheetColumn"
+          },
+          "description": "Row schema in declaration order. nf-schema's `samplesheetToList` emits columns in property order, not source-column order — preserve property order here so downstream translations match runtime channel item layout."
+        }
       }
     },
-
     "SampleSheetColumn": {
       "title": "SampleSheetColumn",
       "description": "One column in a sample-sheet row schema. Type vocabulary is JSON Schema-style scalar; `kind` separates dataset-reference columns from per-row metadata. Validation hints (`pattern`, `enum`, `exists`, `mimetype`) are preserved verbatim — target Molds decide which of them survive translation (e.g. Galaxy's `sample_sheet` validator allowlist is regex/in_range/length).",
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "type", "kind", "required"],
+      "required": [
+        "name",
+        "type",
+        "kind",
+        "required"
+      ],
       "properties": {
-        "name":        { "type": "string" },
-        "type":        { "type": "string", "enum": ["string", "integer", "number", "boolean"], "description": "JSON Schema-style scalar type. Path columns are typed `string` with a `format: file-path|directory-path|path` qualifier — see `format` and `kind`." },
-        "kind":        { "type": "string", "enum": ["data", "meta"], "description": "`data`: path-typed column whose values are dataset references (becomes element/inner-collection slot in Galaxy `sample_sheet`). `meta`: scalar metadata column (becomes a `column_definitions` entry, populated per row in `columns[]`). Includes the nf-schema `meta:` annotation when present; in its absence inferred from `format` (`file-path`/`directory-path`/`path` → `data`, anything else → `meta`)." },
-        "format":      { "type": ["string", "null"], "description": "JSON Schema `format` keyword. nf-schema vocabulary: `file-path`, `directory-path`, `path`, `file-path-pattern`. Null for scalar metadata columns without a format hint." },
-        "required":    { "type": "boolean" },
-        "default":     { "description": "Default value verbatim from the sample-sheet schema. May be null." },
-        "description": { "type": ["string", "null"] },
-        "enum":        { "type": "array", "items": {}, "description": "Allowed values when the column schema declares an `enum`. Empty array when absent." },
-        "pattern":     { "type": ["string", "null"], "description": "JSON Schema regex `pattern` when present." },
-        "exists":      { "type": ["boolean", "null"], "description": "nf-schema `exists` flag for path columns. True when the parser must verify the file exists." },
-        "mimetype":    { "type": ["string", "null"], "description": "nf-schema `mimetype` keyword (e.g. `text/csv`, `application/gzip`). Useful for target datatypes." }
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "integer",
+            "number",
+            "boolean"
+          ],
+          "description": "JSON Schema-style scalar type. Path columns are typed `string` with a `format: file-path|directory-path|path` qualifier — see `format` and `kind`."
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "data",
+            "meta"
+          ],
+          "description": "`data`: path-typed column whose values are dataset references (becomes element/inner-collection slot in Galaxy `sample_sheet`). `meta`: scalar metadata column (becomes a `column_definitions` entry, populated per row in `columns[]`). Includes the nf-schema `meta:` annotation when present; in its absence inferred from `format` (`file-path`/`directory-path`/`path` → `data`, anything else → `meta`)."
+        },
+        "format": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "JSON Schema `format` keyword. nf-schema vocabulary: `file-path`, `directory-path`, `path`, `file-path-pattern`. Null for scalar metadata columns without a format hint."
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "default": {
+          "description": "Default value verbatim from the sample-sheet schema. May be null."
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "enum": {
+          "type": "array",
+          "items": {},
+          "description": "Allowed values when the column schema declares an `enum`. Empty array when absent."
+        },
+        "pattern": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "JSON Schema regex `pattern` when present."
+        },
+        "exists": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "nf-schema `exists` flag for path columns. True when the parser must verify the file exists."
+        },
+        "mimetype": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "nf-schema `mimetype` keyword (e.g. `text/csv`, `application/gzip`). Useful for target datatypes."
+        }
       }
     },
-
     "Tool": {
       "title": "Tool",
       "description": "One tool/dependency the pipeline runs. Mirrors gxy-sketches ToolSpec (name + version) and augments it with the resolved container/conda strings the bridge to author-galaxy-tool-wrapper needs.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "version"],
+      "required": [
+        "name",
+        "version"
+      ],
       "properties": {
-        "name":         { "type": "string", "description": "Canonical tool name (e.g. `fastp`, `samtools`). Used as the foreign key from `processes[].tool`." },
-        "version":      { "type": "string" },
-        "biocontainer": { "type": ["string", "null"], "description": "BioContainers image reference when one was found. Includes both `quay.io/biocontainers/<name>:<version>--<build>` and the docker.io alias `biocontainers/<name>:<version>--<build>` (modern nf-core modules typically use the docker.io form in the docker branch and the depot.galaxyproject.org form in the singularity branch)." },
-        "bioconda":     { "type": ["string", "null"], "description": "`bioconda::<name>=<version>` spec when a `conda` directive provides one — directly or by reference to a `${moduleDir}/environment.yml` whose `dependencies:` list contains a single bioconda entry. The latter is the modern nf-core convention." },
-        "docker":       { "type": ["string", "null"], "description": "Non-biocontainer Docker registry image string when present." },
-        "singularity":  { "type": ["string", "null"], "description": "Singularity image reference when present (e.g. `https://depot.galaxyproject.org/singularity/...`)." },
-        "wave":         { "type": ["string", "null"], "description": "Seqera Wave / community-cr registry reference (e.g. `community.wave.seqera.io/library/<name>:<version>--<digest>` or `https://community-cr-prod.seqera.io/.../sha256/<digest>/data`). Wave-built containers are increasingly common in nf-core; kept distinct from `docker` because the resolution rules and provenance differ." },
-        "mulled_components": { "type": "array", "items": { "$ref": "#/$defs/ToolSpec" }, "description": "Constituent Bioconda packages for an opaque `mulled-v2-*` multi-package container when resolved from a cached BioContainers multi-package-containers TSV. Omitted when no matching cached row is available." }
+        "name": {
+          "type": "string",
+          "description": "Canonical tool name (e.g. `fastp`, `samtools`). Used as the foreign key from `processes[].tool`."
+        },
+        "version": {
+          "type": "string"
+        },
+        "biocontainer": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "BioContainers image reference when one was found. Includes both `quay.io/biocontainers/<name>:<version>--<build>` and the docker.io alias `biocontainers/<name>:<version>--<build>` (modern nf-core modules typically use the docker.io form in the docker branch and the depot.galaxyproject.org form in the singularity branch)."
+        },
+        "bioconda": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "`bioconda::<name>=<version>` spec when a `conda` directive provides one — directly or by reference to a `${moduleDir}/environment.yml` whose `dependencies:` list contains a single bioconda entry. The latter is the modern nf-core convention."
+        },
+        "docker": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Non-biocontainer Docker registry image string when present."
+        },
+        "singularity": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Singularity image reference when present (e.g. `https://depot.galaxyproject.org/singularity/...`)."
+        },
+        "wave": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Seqera Wave / community-cr registry reference (e.g. `community.wave.seqera.io/library/<name>:<version>--<digest>` or `https://community-cr-prod.seqera.io/.../sha256/<digest>/data`). Wave-built containers are increasingly common in nf-core; kept distinct from `docker` because the resolution rules and provenance differ."
+        },
+        "mulled_components": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ToolSpec"
+          },
+          "description": "Constituent Bioconda packages for an opaque `mulled-v2-*` multi-package container when resolved from a cached BioContainers multi-package-containers TSV. Omitted when no matching cached row is available."
+        }
       }
     },
-
     "ToolSpec": {
       "title": "ToolSpec",
       "description": "One constituent package in a decomposed multi-package container.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "version", "bioconda"],
+      "required": [
+        "name",
+        "version",
+        "bioconda"
+      ],
       "properties": {
-        "name":     { "type": "string" },
-        "version":  { "type": "string" },
-        "bioconda": { "type": "string", "description": "Exact Bioconda requirement spec, e.g. `bioconda::samtools=1.20`." }
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "bioconda": {
+          "type": "string",
+          "description": "Exact Bioconda requirement spec, e.g. `bioconda::samtools=1.20`."
+        }
       }
     },
-
     "ChannelIO": {
       "title": "ChannelIO",
       "description": "One declared input or output channel of a process. Channel shape is a string, not a structured type — `tuple(meta, [path,path])` is enough for downstream Molds and avoids a research project on NF channel typing.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "shape"],
+      "required": [
+        "name",
+        "shape"
+      ],
       "properties": {
-        "name":        { "type": "string" },
-        "shape":       { "type": "string", "description": "String-encoded channel shape, e.g. `tuple(meta, [path,path])`, `path`, `val(integer)`." },
-        "description": { "type": "string" },
-        "topic":       { "type": ["string", "null"], "description": "Nextflow channel-topic name when this output is bound to a topic (e.g. `versions` for the standard nf-core version-aggregation topic). Topics are a Nextflow 24+ feature; the module-level `topic: <name>` annotation on a process output emits to a global named channel that any consumer can `channel.topic('<name>')` to read. Null for non-topic outputs and for all inputs." }
+        "name": {
+          "type": "string"
+        },
+        "shape": {
+          "type": "string",
+          "description": "String-encoded channel shape, e.g. `tuple(meta, [path,path])`, `path`, `val(integer)`."
+        },
+        "description": {
+          "type": "string"
+        },
+        "topic": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Nextflow channel-topic name when this output is bound to a topic (e.g. `versions` for the standard nf-core version-aggregation topic). Topics are a Nextflow 24+ feature; the module-level `topic: <name>` annotation on a process output emits to a global named channel that any consumer can `channel.topic('<name>')` to read. Null for non-topic outputs and for all inputs."
+        }
       }
     },
-
     "Process": {
       "title": "Process",
       "description": "One Nextflow `process { ... }` block.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "module_path", "meta", "module_tests", "inputs", "outputs"],
+      "required": [
+        "name",
+        "module_path",
+        "meta",
+        "module_tests",
+        "inputs",
+        "outputs"
+      ],
       "properties": {
-        "name":            { "type": "string", "description": "Canonical process name (uppercase NF convention) as declared by the `process <NAME>` line in `module_path`." },
-        "aliases":         { "type": "array", "items": { "type": "string" }, "description": "Alias names this process is imported as in workflow scopes via `include { <NAME> as <ALIAS> }`. Real nf-core pipelines re-import a single module multiple times under different aliases to invoke it with distinct runtime args (e.g. `MINIMAP2_ALIGN as MINIMAP2_CONSENSUS`, `MINIMAP2_ALIGN as MINIMAP2_POLISH`). Each alias appears in `workflow.edges[].from`/`.to` exactly as written; the canonical `name` does not appear in edges unless an unaliased import exists. Default `[]` when the process is only imported under its canonical name." },
-        "module_path":     { "type": "string", "description": "Relative path from the pipeline root to the file declaring the process." },
-        "meta":            { "anyOf": [{ "$ref": "#/$defs/ModuleMeta" }, { "type": "null" }], "description": "Normalized `meta.yml` from the module directory when present. Null for local/ad-hoc processes without module metadata." },
-        "module_tests":    { "type": "array", "items": { "$ref": "#/$defs/NfTest" }, "description": "Module-scoped nf-test files under the module's `tests/` directory. Empty for local/ad-hoc modules without unit tests." },
-        "tool":            { "type": ["string", "null"], "description": "Foreign key into `tools[].name` when the process runs a single recognizable tool; null for multi-tool or pure-Groovy processes." },
-        "container":       { "type": ["string", "null"], "description": "Verbatim text of the process's `container` directive (or null). Modern nf-core modules use a ternary expression `\"${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ? '<singularity-uri>' : '<docker-uri>' }\"` — keep that text intact here. The two resolved branches are split out into `tools[].docker` / `tools[].singularity` (and `tools[].wave` / `tools[].biocontainer` as appropriate)." },
-        "conda":           { "type": ["string", "null"], "description": "Verbatim text of the process's `conda` directive (or null). Two common shapes: a literal `bioconda::<name>=<version>` (legacy) or a file reference `${moduleDir}/environment.yml` (modern nf-core convention). Either way the resolved bioconda spec lands in `tools[].bioconda`." },
-        "inputs":          { "type": "array", "items": { "$ref": "#/$defs/ChannelIO" } },
-        "outputs":         { "type": "array", "items": { "$ref": "#/$defs/ChannelIO" } },
-        "when":            { "type": ["string", "null"], "description": "Verbatim `when:` guard expression, or null if absent." },
-        "script_summary":  { "type": "string", "description": "One-line LLM-derived summary of what the `script:` body does. Free text." },
-        "publish_dir":     { "type": ["string", "null"], "description": "`publishDir` value when the process publishes outputs (or null)." }
+        "name": {
+          "type": "string",
+          "description": "Canonical process name (uppercase NF convention) as declared by the `process <NAME>` line in `module_path`."
+        },
+        "aliases": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Alias names this process is imported as in workflow scopes via `include { <NAME> as <ALIAS> }`. Real nf-core pipelines re-import a single module multiple times under different aliases to invoke it with distinct runtime args (e.g. `MINIMAP2_ALIGN as MINIMAP2_CONSENSUS`, `MINIMAP2_ALIGN as MINIMAP2_POLISH`). Each alias appears in `workflow.edges[].from`/`.to` exactly as written; the canonical `name` does not appear in edges unless an unaliased import exists. Default `[]` when the process is only imported under its canonical name."
+        },
+        "module_path": {
+          "type": "string",
+          "description": "Relative path from the pipeline root to the file declaring the process."
+        },
+        "meta": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ModuleMeta"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Normalized `meta.yml` from the module directory when present. Null for local/ad-hoc processes without module metadata."
+        },
+        "module_tests": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/NfTest"
+          },
+          "description": "Module-scoped nf-test files under the module's `tests/` directory. Empty for local/ad-hoc modules without unit tests."
+        },
+        "tool": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Foreign key into `tools[].name` when the process runs a single recognizable tool; null for multi-tool or pure-Groovy processes."
+        },
+        "container": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Verbatim text of the process's `container` directive (or null). Modern nf-core modules use a ternary expression `\"${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ? '<singularity-uri>' : '<docker-uri>' }\"` — keep that text intact here. The two resolved branches are split out into `tools[].docker` / `tools[].singularity` (and `tools[].wave` / `tools[].biocontainer` as appropriate)."
+        },
+        "conda": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Verbatim text of the process's `conda` directive (or null). Two common shapes: a literal `bioconda::<name>=<version>` (legacy) or a file reference `${moduleDir}/environment.yml` (modern nf-core convention). Either way the resolved bioconda spec lands in `tools[].bioconda`."
+        },
+        "inputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ChannelIO"
+          }
+        },
+        "outputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ChannelIO"
+          }
+        },
+        "when": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Verbatim `when:` guard expression, or null if absent."
+        },
+        "script_summary": {
+          "type": "string",
+          "description": "One-line LLM-derived summary of what the `script:` body does. Free text."
+        },
+        "publish_dir": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "`publishDir` value when the process publishes outputs (or null)."
+        }
       }
     },
-
     "ModuleMeta": {
       "title": "ModuleMeta",
       "description": "Normalized subset of nf-core module `meta.yml`, captured next to a process so module-scoped downstream Molds can consume `processes[i]` without reading the full pipeline summary.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["keywords", "authors", "maintainers", "tools", "input", "output"],
+      "required": [
+        "keywords",
+        "authors",
+        "maintainers",
+        "tools",
+        "input",
+        "output"
+      ],
       "properties": {
-        "description": { "type": "string" },
-        "keywords":    { "type": "array", "items": { "type": "string" } },
-        "authors":     { "type": "array", "items": { "type": "string" } },
-        "maintainers": { "type": "array", "items": { "type": "string" } },
-        "tools":       { "type": "array", "items": { "$ref": "#/$defs/ModuleMetaEntry" } },
-        "input":       { "type": "array", "items": { "$ref": "#/$defs/ModuleMetaEntry" } },
-        "output":      { "type": "array", "items": { "$ref": "#/$defs/ModuleMetaEntry" } }
+        "description": {
+          "type": "string"
+        },
+        "keywords": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "authors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "maintainers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ModuleMetaEntry"
+          }
+        },
+        "input": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ModuleMetaEntry"
+          }
+        },
+        "output": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ModuleMetaEntry"
+          }
+        }
       }
     },
-
     "ModuleMetaEntry": {
       "title": "ModuleMetaEntry",
       "description": "One named entry from a module `meta.yml` section, normalized from nf-core's single-key YAML maps into `{ name, ...fields }` objects.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "properties": {
-        "name":          { "type": "string" },
-        "description":   { "type": "string" },
-        "homepage":      { "type": "string" },
-        "documentation": { "type": "string" },
-        "tool_dev_url":  { "type": "string" },
-        "doi":           { "type": "string" },
-        "licence":       { "type": "array", "items": { "type": "string" } },
-        "identifier":    { "type": "string" },
-        "type":          { "type": "string" },
-        "pattern":       { "type": "string" }
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "homepage": {
+          "type": "string"
+        },
+        "documentation": {
+          "type": "string"
+        },
+        "tool_dev_url": {
+          "type": "string"
+        },
+        "doi": {
+          "type": "string"
+        },
+        "licence": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "identifier": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "pattern": {
+          "type": "string"
+        }
       }
     },
-
     "Subworkflow": {
       "title": "Subworkflow",
       "description": "One named `workflow <NAME> { ... }` block other than the primary workflow. Includes nf-core utility wrappers (PIPELINE_INITIALISATION, PIPELINE_COMPLETION, UTILS_NFCORE_PIPELINE) which exist to compose helper-function calls rather than to invoke processes.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "path", "kind", "calls", "tests"],
+      "required": [
+        "name",
+        "path",
+        "kind",
+        "calls",
+        "tests"
+      ],
       "properties": {
-        "name":    { "type": "string" },
-        "path":    { "type": "string", "description": "Relative path from the pipeline root." },
-        "kind":    { "type": "string", "enum": ["pipeline", "utility"], "description": "`pipeline` when the subworkflow invokes pipeline processes (data-flow contributor). `utility` when it composes helper functions only — common nf-core template subworkflows like PIPELINE_INITIALISATION (which calls `paramsHelp`, `samplesheetToList`, `UTILS_NFSCHEMA_PLUGIN`) and PIPELINE_COMPLETION (`completionEmail`, `completionSummary`). Utility subworkflows have empty `calls[]` for processes but may still expose channel outputs the primary workflow consumes." },
-        "calls":   { "type": "array", "items": { "type": "string" }, "description": "Names of processes and nested subworkflows this subworkflow invokes. Free-function calls (e.g. `paramsHelp`, `completionEmail`) are NOT recorded here; they're implied by `kind = utility`." },
-        "inputs":  { "type": "array", "items": { "$ref": "#/$defs/ChannelIO" } },
-        "outputs": { "type": "array", "items": { "$ref": "#/$defs/ChannelIO" } },
-        "tests":   { "type": "array", "items": { "$ref": "#/$defs/NfTest" }, "description": "Subworkflow-scoped nf-test files under the subworkflow's `tests/` directory. Empty when absent." }
+        "name": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string",
+          "description": "Relative path from the pipeline root."
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "pipeline",
+            "utility"
+          ],
+          "description": "`pipeline` when the subworkflow invokes pipeline processes (data-flow contributor). `utility` when it composes helper functions only — common nf-core template subworkflows like PIPELINE_INITIALISATION (which calls `paramsHelp`, `samplesheetToList`, `UTILS_NFSCHEMA_PLUGIN`) and PIPELINE_COMPLETION (`completionEmail`, `completionSummary`). Utility subworkflows have empty `calls[]` for processes but may still expose channel outputs the primary workflow consumes."
+        },
+        "calls": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Names of processes and nested subworkflows this subworkflow invokes. Free-function calls (e.g. `paramsHelp`, `completionEmail`) are NOT recorded here; they're implied by `kind = utility`."
+        },
+        "inputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ChannelIO"
+          }
+        },
+        "outputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ChannelIO"
+          }
+        },
+        "tests": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/NfTest"
+          },
+          "description": "Subworkflow-scoped nf-test files under the subworkflow's `tests/` directory. Empty when absent."
+        }
       }
     },
-
     "Channel": {
       "title": "Channel",
       "description": "One top-level channel constructed in the workflow. Sources include `Channel.fromPath`, `Channel.fromFilePairs`, `Channel.fromSamplesheet`, and `params.*`.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "source", "shape"],
+      "required": [
+        "name",
+        "source",
+        "shape"
+      ],
       "properties": {
-        "name":   { "type": "string" },
-        "source": { "type": "string", "description": "Verbatim channel-construction expression." },
-        "shape":  { "type": "string", "description": "String-encoded channel shape; same convention as ChannelIO." }
+        "name": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string",
+          "description": "Verbatim channel-construction expression."
+        },
+        "shape": {
+          "type": "string",
+          "description": "String-encoded channel shape; same convention as ChannelIO."
+        }
       }
     },
-
     "Edge": {
       "title": "Edge",
       "description": "One edge in the workflow's call graph. The deterministic parser records the literal operator chain in `via`; reconciliation of the source and target shapes is the LLM step.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["from", "to"],
+      "required": [
+        "from",
+        "to"
+      ],
       "properties": {
-        "from": { "type": "string", "description": "Channel name or `<PROCESS>.out.<chan>` reference." },
-        "to":   { "type": "string", "description": "Process or subworkflow name receiving this channel." },
-        "via":  { "type": "array", "items": { "type": "string" }, "description": "Operators on the path between source and target, in order (e.g. `[\"map\", \"join\", \"groupTuple\"]`). Empty for a direct edge." },
-        "notes": { "type": "string", "description": "LLM-emitted note when the reconciliation is low-confidence (e.g. deeply nested closures)." }
+        "from": {
+          "type": "string",
+          "description": "Channel name or `<PROCESS>.out.<chan>` reference."
+        },
+        "to": {
+          "type": "string",
+          "description": "Process or subworkflow name receiving this channel."
+        },
+        "via": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Operators on the path between source and target, in order (e.g. `[\"map\", \"join\", \"groupTuple\"]`). Empty for a direct edge."
+        },
+        "notes": {
+          "type": "string",
+          "description": "LLM-emitted note when the reconciliation is low-confidence (e.g. deeply nested closures)."
+        }
       }
     },
-
     "Conditional": {
       "title": "Conditional",
       "description": "One workflow-level conditional that gates a subgraph.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["guard", "branch", "affects"],
+      "required": [
+        "guard",
+        "branch",
+        "affects"
+      ],
       "properties": {
-        "guard":   { "type": "string", "description": "Verbatim guard expression, e.g. `params.skip_alignment`." },
-        "branch":  { "type": "string", "enum": ["default", "alternate"], "description": "Which side of the conditional this entry describes. `default` is the truthy branch; `alternate` is the else branch." },
-        "affects": { "type": "array", "items": { "type": "string" }, "description": "Process or subworkflow names whose execution is gated by this conditional." }
+        "guard": {
+          "type": "string",
+          "description": "Verbatim guard expression, e.g. `params.skip_alignment`."
+        },
+        "branch": {
+          "type": "string",
+          "enum": [
+            "default",
+            "alternate"
+          ],
+          "description": "Which side of the conditional this entry describes. `default` is the truthy branch; `alternate` is the else branch."
+        },
+        "affects": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Process or subworkflow names whose execution is gated by this conditional."
+        }
       }
     },
-
     "Workflow": {
       "title": "Workflow",
       "description": "Primary workflow: channel construction plus the call-graph DAG. Real nf-core pipelines have multiple named `workflow` blocks (an anonymous entrypoint `workflow {}` in main.nf that wires PIPELINE_INITIALISATION → NFCORE_<NAME> → PIPELINE_COMPLETION; a named NFCORE_<NAME> wrapper; a substantive named workflow under workflows/<name>.nf). The summary collapses this into one primary `workflow` plus `subworkflows[]`. Selection rule: pick the workflow that invokes the most pipeline processes — typically the one under `workflows/<name>.nf`. The anonymous `workflow {}` glue and the NFCORE_<NAME> wrapper land in `subworkflows[]`.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "channels", "edges"],
+      "required": [
+        "name",
+        "channels",
+        "edges"
+      ],
       "properties": {
-        "name":         { "type": "string", "description": "Name of the selected primary workflow (uppercase NF convention). The anonymous `workflow {}` entrypoint is never the primary; if it is the only workflow block, the pipeline is too small to summarize and the cast skill should emit a warning." },
-        "channels":     { "type": "array", "items": { "$ref": "#/$defs/Channel" } },
-        "edges":        { "type": "array", "items": { "$ref": "#/$defs/Edge" } },
-        "conditionals": { "type": "array", "items": { "$ref": "#/$defs/Conditional" } }
+        "name": {
+          "type": "string",
+          "description": "Name of the selected primary workflow (uppercase NF convention). The anonymous `workflow {}` entrypoint is never the primary; if it is the only workflow block, the pipeline is too small to summarize and the cast skill should emit a warning."
+        },
+        "channels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Channel"
+          }
+        },
+        "edges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Edge"
+          }
+        },
+        "conditionals": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Conditional"
+          }
+        }
       }
     },
-
     "TestDataRef": {
       "title": "TestDataRef",
       "description": "One test-fixture input. Field names mirror gxy-sketches' TestDataRef verbatim. The sketch-bundle constraint that `path` must live under `test_data/` is intentionally dropped; the Foundry summary describes fixtures as data, it does not bundle them.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["role"],
+      "required": [
+        "role"
+      ],
       "properties": {
-        "role":        { "type": "string", "description": "Logical role of the input (e.g. `samplesheet`, `reference_fasta`)." },
-        "path":        { "type": ["string", "null"], "description": "Repo-relative path when the fixture lives in-tree, or local filesystem path when the CLI fetched the remote fixture into a caller-provided test-data directory." },
-        "url":         { "type": ["string", "null"], "format": "uri" },
-        "sha1":        { "type": ["string", "null"], "description": "SHA-1 integrity hash when published alongside the fixture." },
-        "filetype":    { "type": ["string", "null"], "description": "File format, e.g. `fastq.gz`, `csv`." },
-        "description": { "type": ["string", "null"] }
+        "role": {
+          "type": "string",
+          "description": "Logical role of the input (e.g. `samplesheet`, `reference_fasta`)."
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Repo-relative path when the fixture lives in-tree, or local filesystem path when the CLI fetched the remote fixture into a caller-provided test-data directory."
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uri"
+        },
+        "sha1": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "SHA-1 integrity hash when published alongside the fixture."
+        },
+        "filetype": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "File format, e.g. `fastq.gz`, `csv`."
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
       },
       "anyOf": [
-        { "required": ["path"] },
-        { "required": ["url"] }
+        {
+          "required": [
+            "path"
+          ]
+        },
+        {
+          "required": [
+            "url"
+          ]
+        }
       ]
     },
-
     "ExpectedOutputRef": {
       "title": "ExpectedOutputRef",
       "description": "One expected output. Field names mirror gxy-sketches' ExpectedOutputRef verbatim. At least one of path / url / assertions is required.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["role"],
+      "required": [
+        "role"
+      ],
       "properties": {
-        "role":        { "type": "string" },
-        "path":        { "type": ["string", "null"] },
-        "url":         { "type": ["string", "null"], "format": "uri" },
-        "kind":        { "type": ["string", "null"], "description": "Coarse output kind: `report`, `tabular`, `image`, `archive`, `sequence`, `other`." },
-        "description": { "type": ["string", "null"] },
-        "assertions":  { "type": "array", "items": { "type": "string" }, "description": "Assertion strings. Simple equality / regex / contains-string checks are preserved verbatim; complex Groovy assertions are summarized to prose with a `warnings[]` flag in the parent Summary." }
+        "role": {
+          "type": "string"
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uri"
+        },
+        "kind": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Coarse output kind: `report`, `tabular`, `image`, `archive`, `sequence`, `other`."
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "assertions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Assertion strings. Simple equality / regex / contains-string checks are preserved verbatim; complex Groovy assertions are summarized to prose with a `warnings[]` flag in the parent Summary."
+        }
       },
       "anyOf": [
-        { "required": ["path"] },
-        { "required": ["url"] },
-        { "required": ["assertions"] }
+        {
+          "required": [
+            "path"
+          ]
+        },
+        {
+          "required": [
+            "url"
+          ]
+        },
+        {
+          "required": [
+            "assertions"
+          ]
+        }
       ]
     },
-
     "TestFixtures": {
       "title": "TestFixtures",
       "description": "Test fixtures derived from a `conf/<profile>.config` for the cast's selected profile. Pipelines with multiple test profiles (bacass has 11) record only the selected profile here; the full nf-test enumeration lives in `nf_tests[]`.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["profile", "inputs", "outputs"],
+      "required": [
+        "profile",
+        "inputs",
+        "outputs"
+      ],
       "properties": {
-        "profile": { "type": "string", "description": "Which `conf/<profile>.config` produced these fixtures (typically `test`)." },
-        "inputs":  { "type": "array", "items": { "$ref": "#/$defs/TestDataRef" } },
-        "outputs": { "type": "array", "items": { "$ref": "#/$defs/ExpectedOutputRef" } }
+        "profile": {
+          "type": "string",
+          "description": "Which `conf/<profile>.config` produced these fixtures (typically `test`)."
+        },
+        "inputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TestDataRef"
+          }
+        },
+        "outputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ExpectedOutputRef"
+          }
+        }
       }
     },
-
     "NfTest": {
       "title": "NfTest",
       "description": "One `tests/*.nf.test` file. nf-core templates use a near-uniform shape: a `nextflow_pipeline { test(\"<desc>\") { when { params { ... } } then { assertAll(...) } } }` block, with one test() per profile, asserting `workflow.success` plus a snapshot match. This shape captures the data so downstream test-conversion molds (e.g. nextflow-test-to-target-tests) don't have to re-parse Groovy.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "path", "profiles", "assert_workflow_success", "prose_assertions"],
+      "required": [
+        "name",
+        "path",
+        "profiles",
+        "assert_workflow_success",
+        "prose_assertions"
+      ],
       "properties": {
-        "name":                    { "type": "string", "description": "Description string passed to `test(\"...\")`. Often duplicates the profile name." },
-        "path":                    { "type": "string", "description": "Repo-relative path of the .nf.test file (e.g. `tests/dfast.nf.test`)." },
-        "profiles":                { "type": "array", "items": { "type": "string" }, "description": "Profile name(s) the test runs under, from the file-level `profile \"<name>\"` declaration and/or per-test config overrides. Usually a single profile." },
-        "params_overrides":        { "type": "object", "additionalProperties": true, "description": "The `when { params { ... } }` block as a key→value map. Most templates set only `outdir`; pipeline-specific overrides land here." },
-        "assert_workflow_success": { "type": "boolean", "description": "Whether the test asserts `workflow.success`. Almost always true for nf-core templates." },
-        "snapshot":                { "anyOf": [{ "$ref": "#/$defs/SnapshotFixture" }, { "type": "null" }], "description": "Structured representation of the `assert snapshot(...).match()` clause when present; null when the test uses no snapshot." },
-        "prose_assertions":        { "type": "array", "items": { "type": "string" }, "description": "Other assertions (regex matches, count checks, content equality on specific files) summarized to prose strings. Empty for snapshot-only tests, which is the common nf-core case." }
+        "name": {
+          "type": "string",
+          "description": "Description string passed to `test(\"...\")`. Often duplicates the profile name."
+        },
+        "path": {
+          "type": "string",
+          "description": "Repo-relative path of the .nf.test file (e.g. `tests/dfast.nf.test`)."
+        },
+        "profiles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Profile name(s) the test runs under, from the file-level `profile \"<name>\"` declaration and/or per-test config overrides. Usually a single profile."
+        },
+        "params_overrides": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "The `when { params { ... } }` block as a key→value map. Most templates set only `outdir`; pipeline-specific overrides land here."
+        },
+        "assert_workflow_success": {
+          "type": "boolean",
+          "description": "Whether the test asserts `workflow.success`. Almost always true for nf-core templates."
+        },
+        "snapshot": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SnapshotFixture"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Structured representation of the `assert snapshot(...).match()` clause when present; null when the test uses no snapshot."
+        },
+        "prose_assertions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Other assertions (regex matches, count checks, content equality on specific files) summarized to prose strings. Empty for snapshot-only tests, which is the common nf-core case."
+        }
       }
     },
-
     "SnapshotFixture": {
       "title": "SnapshotFixture",
       "description": "Structured shape of an nf-test `snapshot(...).match()` assertion. nf-core templates pass a small set of values into snapshot() — succeeded-task count, version YAML (with Nextflow version stripped), stable file-name list, stable file-content list — and prune the comparison via `getAllFilesFromDir(..., ignoreFile: ..., ignore: [...])` helpers. This breakdown lets downstream consumers reconstruct equivalent assertions in target test frameworks without re-parsing Groovy.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["captures", "helpers", "ignore_files", "ignore_globs"],
+      "required": [
+        "captures",
+        "helpers",
+        "ignore_files",
+        "ignore_globs"
+      ],
       "properties": {
-        "captures":      { "type": "array", "items": { "type": "string" }, "description": "Logical names of values passed to snapshot(), in order. Common set: `succeeded_task_count`, `versions_yml`, `stable_names`, `stable_paths`. Free-form strings rather than an enum because pipelines can pass other values." },
-        "helpers":       { "type": "array", "items": { "type": "string" }, "description": "nf-test helper functions invoked in the snapshot expression (e.g. `getAllFilesFromDir`, `removeNextflowVersion`). Used to detect whether a target framework can replicate the comparison." },
-        "ignore_files":  { "type": "array", "items": { "type": "string" }, "description": "Repo-relative paths passed as `ignoreFile:` to helpers (e.g. `tests/.nftignore`, `tests/.nftignore_files_entirely`). The files themselves are line-delimited globs." },
-        "ignore_globs":  { "type": "array", "items": { "type": "string" }, "description": "Inline `ignore: [...]` glob list passed to helpers (e.g. `['Prokka/**', '**/multiqc_busco.yaml']`). Distinct from ignore_files which references on-disk lists." },
-        "snap_path":     { "type": ["string", "null"], "description": "Repo-relative path of the corresponding `.nf.test.snap` file when present." },
-        "parsed_content": { "type": "array", "items": { "$ref": "#/$defs/SnapshotContent" }, "description": "Parsed entries from the `.nf.test.snap` JSON sidecar. Empty when the sidecar is absent, too large for compact summary output, or not valid JSON. Each entry preserves the snapshot name plus channel-keyed file md5 assertions and non-file scalar values." }
+        "captures": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Logical names of values passed to snapshot(), in order. Common set: `succeeded_task_count`, `versions_yml`, `stable_names`, `stable_paths`. Free-form strings rather than an enum because pipelines can pass other values."
+        },
+        "helpers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "nf-test helper functions invoked in the snapshot expression (e.g. `getAllFilesFromDir`, `removeNextflowVersion`). Used to detect whether a target framework can replicate the comparison."
+        },
+        "ignore_files": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Repo-relative paths passed as `ignoreFile:` to helpers (e.g. `tests/.nftignore`, `tests/.nftignore_files_entirely`). The files themselves are line-delimited globs."
+        },
+        "ignore_globs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Inline `ignore: [...]` glob list passed to helpers (e.g. `['Prokka/**', '**/multiqc_busco.yaml']`). Distinct from ignore_files which references on-disk lists."
+        },
+        "snap_path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Repo-relative path of the corresponding `.nf.test.snap` file when present."
+        },
+        "parsed_content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SnapshotContent"
+          },
+          "description": "Parsed entries from the `.nf.test.snap` JSON sidecar. Empty when the sidecar is absent, too large for compact summary output, or not valid JSON. Each entry preserves the snapshot name plus channel-keyed file md5 assertions and non-file scalar values."
+        }
       }
     },
-
     "SnapshotContent": {
       "title": "SnapshotContent",
       "description": "One top-level snapshot entry from an nf-test `.snap` JSON sidecar.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "channels"],
+      "required": [
+        "name",
+        "channels"
+      ],
       "properties": {
-        "name":     { "type": "string", "description": "Top-level key in the `.snap` file, usually the `test(\"...\")` name." },
-        "channels": { "type": "array", "items": { "$ref": "#/$defs/SnapshotChannel" }, "description": "Channel-keyed snapshot values. Pipeline-template flat file lists use `key: null`." }
+        "name": {
+          "type": "string",
+          "description": "Top-level key in the `.snap` file, usually the `test(\"...\")` name."
+        },
+        "channels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SnapshotChannel"
+          },
+          "description": "Channel-keyed snapshot values. Pipeline-template flat file lists use `key: null`."
+        }
       }
     },
-
     "SnapshotChannel": {
       "title": "SnapshotChannel",
       "description": "One output channel or flat snapshot list inside a `.snap` entry.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["key", "files", "values"],
+      "required": [
+        "key",
+        "files",
+        "values"
+      ],
       "properties": {
-        "key":    { "type": ["string", "null"], "description": "Channel key from the snapshot object, e.g. `0`, `1`, or `genome_gtf`; null for flat file-list snapshots." },
-        "files":  { "type": "array", "items": { "$ref": "#/$defs/SnapshotFile" }, "description": "File md5 assertions parsed from `<path>:md5,<hex>` strings." },
-        "values": { "type": "array", "items": {}, "description": "Non-file snapshot values preserved verbatim for consumers that need versions, counts, or scalar tuple emissions." }
+        "key": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Channel key from the snapshot object, e.g. `0`, `1`, or `genome_gtf`; null for flat file-list snapshots."
+        },
+        "files": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SnapshotFile"
+          },
+          "description": "File md5 assertions parsed from `<path>:md5,<hex>` strings."
+        },
+        "values": {
+          "type": "array",
+          "items": {},
+          "description": "Non-file snapshot values preserved verbatim for consumers that need versions, counts, or scalar tuple emissions."
+        }
       }
     },
-
     "SnapshotFile": {
       "title": "SnapshotFile",
       "description": "One file digest assertion from a `.snap` sidecar.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["path", "basename", "md5", "stub"],
+      "required": [
+        "path",
+        "basename",
+        "md5",
+        "stub"
+      ],
       "properties": {
-        "path":     { "type": "string", "description": "Path portion before `:md5,` exactly as stored in the sidecar." },
-        "basename": { "type": "string", "description": "Final path segment, suitable for Galaxy test `file:` assertions when the snapshot stores only basenames." },
-        "md5":      { "type": "string", "pattern": "^[a-fA-F0-9]{32}$", "description": "MD5 digest from the sidecar." },
-        "stub":     { "type": "boolean", "description": "True when the digest is the empty-file md5 emitted by many `-stub` tests." }
+        "path": {
+          "type": "string",
+          "description": "Path portion before `:md5,` exactly as stored in the sidecar."
+        },
+        "basename": {
+          "type": "string",
+          "description": "Final path segment, suitable for Galaxy test `file:` assertions when the snapshot stores only basenames."
+        },
+        "md5": {
+          "type": "string",
+          "pattern": "^[a-fA-F0-9]{32}$",
+          "description": "MD5 digest from the sidecar."
+        },
+        "stub": {
+          "type": "boolean",
+          "description": "True when the digest is the empty-file md5 emitted by many `-stub` tests."
+        }
       }
     }
   }

--- a/casts/claude/skills/summarize-nextflow/runs/nf-core__bacass/summary.json
+++ b/casts/claude/skills/summarize-nextflow/runs/nf-core__bacass/summary.json
@@ -279,6 +279,89 @@
       "required": false
     }
   ],
+  "sample_sheets": [
+    {
+      "param": "input",
+      "schema_path": "assets/schema_input.json",
+      "discovered_via": "nf-schema",
+      "format": "csv",
+      "header": true,
+      "columns": [
+        {
+          "name": "ID",
+          "type": "string",
+          "kind": "meta",
+          "format": null,
+          "required": true,
+          "description": null,
+          "enum": [],
+          "pattern": "^\\S+$",
+          "exists": null,
+          "mimetype": null
+        },
+        {
+          "name": "R1",
+          "type": "string",
+          "kind": "data",
+          "format": "file-path",
+          "required": false,
+          "description": null,
+          "enum": [],
+          "pattern": "^(\\S+\\.f(ast)?q\\.gz|NA)$",
+          "exists": null,
+          "mimetype": null
+        },
+        {
+          "name": "R2",
+          "type": "string",
+          "kind": "data",
+          "format": "file-path",
+          "required": false,
+          "description": null,
+          "enum": [],
+          "pattern": "^(\\S+\\.f(ast)?q\\.gz|NA)$",
+          "exists": null,
+          "mimetype": null
+        },
+        {
+          "name": "LongFastQ",
+          "type": "string",
+          "kind": "data",
+          "format": "file-path",
+          "required": false,
+          "description": null,
+          "enum": [],
+          "pattern": "^(\\S+\\.f(ast)?q\\.gz|NA)$",
+          "exists": null,
+          "mimetype": null
+        },
+        {
+          "name": "Fast5",
+          "type": "string",
+          "kind": "data",
+          "format": "directory-path",
+          "required": false,
+          "description": null,
+          "enum": [],
+          "pattern": "^(\\/[\\S\\s]*|NA)$",
+          "exists": null,
+          "mimetype": null
+        },
+        {
+          "name": "GenomeSize",
+          "type": "string",
+          "kind": "meta",
+          "format": null,
+          "required": false,
+          "description": null,
+          "enum": [],
+          "pattern": "(\\b\\d+\\.\\d+m\\b|NA)",
+          "exists": null,
+          "mimetype": null
+        }
+      ]
+    }
+  ],
   "profiles": [
     "debug",
     "conda",

--- a/casts/claude/skills/summarize-nextflow/runs/nf-core__demo/summary.json
+++ b/casts/claude/skills/summarize-nextflow/runs/nf-core__demo/summary.json
@@ -226,6 +226,53 @@
       "required": false
     }
   ],
+  "sample_sheets": [
+    {
+      "param": "input",
+      "schema_path": "assets/schema_input.json",
+      "discovered_via": "nf-schema",
+      "format": "csv",
+      "header": true,
+      "columns": [
+        {
+          "name": "sample",
+          "type": "string",
+          "kind": "meta",
+          "format": null,
+          "required": true,
+          "description": null,
+          "enum": [],
+          "pattern": "^\\S+$",
+          "exists": null,
+          "mimetype": null
+        },
+        {
+          "name": "fastq_1",
+          "type": "string",
+          "kind": "data",
+          "format": "file-path",
+          "required": true,
+          "description": null,
+          "enum": [],
+          "pattern": "^([\\S\\s]*\\/)?[^\\s\\/]+\\.f(ast)?q\\.gz$",
+          "exists": true,
+          "mimetype": null
+        },
+        {
+          "name": "fastq_2",
+          "type": "string",
+          "kind": "data",
+          "format": "file-path",
+          "required": false,
+          "description": null,
+          "enum": [],
+          "pattern": "^([\\S\\s]*\\/)?[^\\s\\/]+\\.f(ast)?q\\.gz$",
+          "exists": true,
+          "mimetype": null
+        }
+      ]
+    }
+  ],
   "profiles": [
     "debug",
     "conda",

--- a/content/molds/nextflow-summary-to-galaxy-data-flow/index.md
+++ b/content/molds/nextflow-summary-to-galaxy-data-flow/index.md
@@ -70,6 +70,14 @@ references:
     evidence: corpus-observed
     purpose: "Ground tabular bridge and table-operation choices in curated, corpus-observed operation patterns."
     trigger: "When data-flow translation needs filtering, joining, aggregation, pivoting, or tabular-collection bridges."
+  - kind: research
+    ref: "[[galaxy-sample-sheet-collections]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Preserve per-row metadata on the data-flow side: keep sample_sheet column_definitions wired through identifier-keyed steps instead of dropping into parallel parameter inputs, and re-attach metadata after map-over steps that lose it."
+    trigger: "When the upstream interface brief carries a sample_sheet[:paired|:paired_or_unpaired|:record] input, or when the Nextflow summary shows tuple(meta, path...) channel shape originating from samplesheetToList or splitCsv(header: true)."
 related_notes:
   - "[[summary-nextflow]]"
   - "[[nextflow-summary-to-galaxy-interface]]"

--- a/content/molds/nextflow-summary-to-galaxy-interface/index.md
+++ b/content/molds/nextflow-summary-to-galaxy-interface/index.md
@@ -45,6 +45,14 @@ references:
     evidence: corpus-observed
     purpose: "Choose stable workflow input/output labels and promoted checkpoint outputs that future tests can address."
     trigger: "When deciding labels, public outputs, checkpoint outputs, or fixture-compatible collection inputs."
+  - kind: research
+    ref: "[[galaxy-sample-sheet-collections]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Pick the right sample_sheet variant and translate nf-schema column metadata into Galaxy column_definitions when the source pipeline uses sample-sheet-shaped inputs."
+    trigger: "When the Nextflow summary reports a samplesheetToList materialization, a parameter whose nf-schema entry sets schema: assets/schema_*.json, or a channel built from splitCsv(header: true) over a tabular params input."
 related_notes:
   - "[[summary-nextflow]]"
 ---

--- a/content/molds/summarize-nextflow/changes.md
+++ b/content/molds/summarize-nextflow/changes.md
@@ -2,6 +2,7 @@
 
 Revision history for the `summarize-nextflow` Mold. Maintained alongside `index.md` but never packaged into casts.
 
+- **rev 8 (2026-05-05)** — sample-sheet schemas promoted to a first-class top-level `sample_sheets[]` field with structured `SampleSheet` and `SampleSheetColumn` shapes. New §3.5 procedure step covers resolution from `nf-schema`, `samplesheetToList`, `splitCsv`, and `ad-hoc` discovery branches. Resolves the open question in [[nextflow-workflow-io-semantics]] and jmchilton/foundry#177; downstream variant selection lives in [[nextflow-summary-to-galaxy-interface]] / [[nextflow-summary-to-galaxy-data-flow]] backed by [[galaxy-sample-sheet-collections]]. Schema bumped to rev 6 in lockstep.
 - **rev 7 (2026-05-02)** — CLI package now sweeps `include { X as Y } from ...` statements across workflow and subworkflow files to populate `processes[].aliases`, tested against bacass repeated imports (`MINIMAP2_ALIGN`, `FASTQC`).
 - **rev 6 (2026-05-02)** — CLI package now parses multi-dependency module `environment.yml` files into separate Bioconda-backed `tools[]` entries, tested against bacass modules such as `minimap2/align` and `samtools/sort`.
 - **rev 5 (2026-05-02)** — CLI package hardened against `nf-core/bacass` profile config expressions: resolves `params.pipelines_testdata_base_path + '...'`, fetches samplesheet-referenced remote files, hashes them, and optionally localizes them under `--test-data-dir` while preserving original URLs.

--- a/content/molds/summarize-nextflow/index.md
+++ b/content/molds/summarize-nextflow/index.md
@@ -9,7 +9,7 @@ tags:
 status: draft
 created: 2026-04-30
 revised: 2026-05-05
-revision: 9
+revision: 10
 ai_generated: true
 output_schemas:
   - "[[summary-nextflow]]"
@@ -116,6 +116,22 @@ A single JSON document conforming to [[summary-nextflow]] (`packages/summary-nex
     { "name": "input", "type": "path", "default": null,
       "description": "Samplesheet CSV", "required": true }
   ],
+  "sample_sheets": [
+    { "param": "input",
+      "schema_path": "assets/schema_input.json",
+      "discovered_via": "nf-schema",
+      "format": "csv", "header": true,
+      "columns": [
+        { "name": "sample",     "type": "string", "kind": "meta", "required": true,
+          "pattern": "^\\S+$" },
+        { "name": "fastq_1",    "type": "string", "kind": "data", "format": "file-path",
+          "required": true,  "exists": true, "pattern": "^\\S+\\.f(ast)?q\\.gz$" },
+        { "name": "fastq_2",    "type": "string", "kind": "data", "format": "file-path",
+          "required": false, "exists": true, "pattern": "^\\S+\\.f(ast)?q\\.gz$" },
+        { "name": "strandedness","type": "string", "kind": "meta", "required": true,
+          "enum": ["forward", "reverse", "unstranded", "auto"] }
+      ] }
+  ],
   "profiles": ["test", "test_full", "docker", "singularity", "conda"],
   "tools": [                                   // mirrors gxy-sketches ToolSpec, augmented
     { "name": "fastp", "version": "0.23.4",
@@ -220,6 +236,23 @@ Populate `source` from `git remote get-url`, `git rev-parse HEAD` (or the user-s
 ### 3. Parse parameters and profiles
 
 Read `nextflow.config` `params { ... }` block for defaults. When `nextflow_schema.json` exists (nf-core), prefer it as the source of truth for `type`, `description`, and `required` — it is real JSON Schema, copy verbatim. Enumerate `profiles { ... }` keys.
+
+### 3.5. Resolve sample-sheet schemas
+
+Sample-sheet inputs are the dominant structured-input idiom in modern nf-core pipelines and the most lossy thing to leave as prose inside `params[].description`. For each candidate sample-sheet parameter, populate one `sample_sheets[]` entry capturing the row schema deterministically. Discovery has three branches, recorded in `discovered_via`:
+
+- `nf-schema`: the param's `nextflow_schema.json` entry has a `schema:` keyword pointing at a sibling JSON Schema file (`assets/schema_*.json`). Read that file. Each property in the row schema maps to one `SampleSheetColumn`. Preserve **property order**, not source-column order — `samplesheetToList()` emits columns in property order, and downstream channel item layout depends on it.
+- `samplesheetToList`: the workflow imports `samplesheetToList` from nf-schema and calls it on the param. When the call cites a schema path, follow it. Without a schema path, emit the entry with `schema_path: null` and infer columns from `splitCsv`-shaped fallback if any; otherwise emit `columns: []` and a `warnings[]` note.
+- `splitCsv`: a `Channel.fromPath(params.X).splitCsv(header: true)` materialization. Header inference only — emit columns by name, leave `type: string`, `kind` inferred from downstream `path()` consumption when traceable, else `meta`. Mark `discovered_via: splitCsv`.
+- `ad-hoc`: pipeline-specific CSV/TSV parsing detected from script bodies (e.g. row-zero/row-one indexing). Emit a minimal entry with `columns: []` plus a `warnings[]` advisory; downstream Molds will need to handle these by hand.
+
+Column field rules:
+
+- `kind`: `data` when nf-schema `format` is `file-path`/`directory-path`/`path` or when the column is annotated `meta:` is **absent** and the value is consumed as a `path()` downstream. `meta` otherwise (including all `meta: true` annotations and all non-path scalars). Nest the nf-schema `meta:` annotation here even when implicit — translation Molds key on it to decide which columns become Galaxy `column_definitions[]` versus element/inner-collection slots.
+- `type`: copy verbatim from the row schema (`string`/`integer`/`number`/`boolean`). Path columns are `string` with a `format` qualifier; do not collapse `path` into a synthetic type.
+- `required`, `default`, `enum`, `pattern`, `exists`, `mimetype`, `description`: copy verbatim when present, leaving null/empty defaults otherwise.
+
+This step does not reshape onto any target idiom (Galaxy `sample_sheet:paired` vs `list:paired` is not decided here). It records what the source pipeline declares; the variant choice belongs to [[nextflow-summary-to-galaxy-interface]] and [[nextflow-summary-to-cwl-interface]].
 
 ### 4. Enumerate processes
 

--- a/content/research/galaxy-sample-sheet-collections.md
+++ b/content/research/galaxy-sample-sheet-collections.md
@@ -1,0 +1,143 @@
+---
+type: research
+subtype: component
+title: "Galaxy sample_sheet collection types"
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-05-05
+revised: 2026-05-05
+revision: 1
+ai_generated: true
+related_notes:
+  - "[[galaxy-collection-semantics]]"
+  - "[[galaxy-collection-tools]]"
+  - "[[nextflow-workflow-io-semantics]]"
+  - "[[nextflow-to-galaxy-channel-shape-mapping]]"
+related_molds:
+  - "[[nextflow-summary-to-galaxy-interface]]"
+  - "[[nextflow-summary-to-galaxy-data-flow]]"
+sources:
+  - "Galaxy PR #19305 (Implement Sample Sheets), merged 2025-07-30"
+  - "lib/galaxy/model/dataset_collections/types/sample_sheet.py"
+  - "lib/galaxy/model/dataset_collections/types/sample_sheet_util.py"
+  - "lib/galaxy/model/dataset_collections/type_description.py"
+  - "lib/galaxy/schema/schema.py (SampleSheetColumnDefinition, SampleSheetRow)"
+  - "lib/galaxy/tools/wrappers.py (DatasetCollectionWrapper.sample_sheet_row)"
+  - "lib/galaxy/tools/sample_sheet_to_tabular.xml"
+  - "lib/galaxy/webapps/galaxy/api/dataset_collections.py (sample_sheet_workbook endpoints)"
+  - "lib/galaxy/model/migrations/alembic/versions_gxy/3af58c192752_implement_sample_sheets.py"
+summary: "Galaxy's sample_sheet collection family: typed column metadata, four variants, mapping rules, validator allowlist."
+---
+
+# Galaxy sample_sheet collection types
+
+Reference for the Galaxy backend shape that targets structured per-row metadata — the natural landing zone for Nextflow `samplesheetToList` parameters and for any source-side idiom that pairs typed metadata columns with dataset references.
+
+## Shape
+
+A `sample_sheet` is a list-shaped collection where each element carries a typed `columns` row, and the parent collection carries a `column_definitions` schema. The model (`lib/galaxy/model/__init__.py`) adds two nullable JSON columns: `dataset_collection.column_definitions` and `dataset_collection_element.columns`. Existing collections are unaffected.
+
+```
+DatasetCollection
+  collection_type: "sample_sheet"
+  column_definitions: [{name, type, optional, ...}]
+  elements:
+    DatasetCollectionElement(element_identifier, columns: [v1, v2, ...], hda or child_collection)
+```
+
+## Column definition vocabulary
+
+`SampleSheetColumnDefinition` (lib/galaxy/schema/schema.py:384-405):
+
+```
+type:        "string" | "int" | "float" | "boolean" | "element_identifier"
+optional:    bool
+default_value, validators[], restrictions[], suggestions[]
+```
+
+- `element_identifier` cross-references another row's identifier in the same collection. Captures patterns like nf-core `control_sample`. Within-collection only — no cross-collection refs.
+- `restrictions[]` enumerates allowed values (maps to nf-schema `enum`).
+- `validators[]` is restricted to the **safe allowlist** (`AnySafeValidatorModel`, lib/galaxy/tool_util_models/parameter_validators.py): `regex`, `in_range`, `length`. `expression` and other arbitrary-Python validators are rejected. Translation from richer nf-schema validation must drop to prose or fall through.
+- String values and column names are restricted to `[\w\-_ ?]*` — no tabs, newlines, quotes, or most specials. Necessary for safe CSV/TSV serialization.
+
+## Variants
+
+Enforced by `COLLECTION_TYPE_REGEX` in `type_description.py`:
+
+| Variant | Inner element shape | Typical source |
+|---|---|---|
+| `sample_sheet` | one dataset per row | one path column in nf-schema |
+| `sample_sheet:paired` | `paired` (forward/reverse) | two path columns, paired-end fastq |
+| `sample_sheet:paired_or_unpaired` | mixed single or pair | mixed-library sample sheets |
+| `sample_sheet:record` | `record` (named typed slots) | heterogeneous per-sample artifacts |
+
+Constraints to plan around:
+
+- `sample_sheet` must be **outermost**. `list:sample_sheet` and `sample_sheet:list` are invalid.
+- `prototype_elements()` is not implemented — sample-sheet-shaped pre-creation isn't possible because element count is unknown until data exists.
+
+## Mapping rules
+
+`allow_implicit_mapping` is `True` for everything except `record`, so sample sheets behave like lists for mapping:
+
+- `sample_sheet` over a `(dataset → dataset)` tool produces an implicit `sample_sheet`-shaped output. **`column_definitions` and `columns` are not propagated** — metadata lives only on the input collection.
+- `sample_sheet:paired` over a `paired` input produces a `sample_sheet`-shaped output (one job per row).
+- A `sample_sheet` can be reduced by a `multiple=true` data input.
+- Two sample sheets with identical structure can be linked for dot-product execution.
+
+## Tool-side access
+
+Tools read columns at runtime through `DatasetCollectionWrapper.sample_sheet_row(element_identifier)` (lib/galaxy/tools/wrappers.py:643-707), which builds a `{element_identifier: row}` dict from element `columns`. The built-in `__SAMPLE_SHEET_TO_TABULAR__` tool (lib/galaxy/tools/sample_sheet_to_tabular.xml) iterates and tab-joins for downstream tabular consumers. Tool inputs declare acceptance via `data_collection collection_type="sample_sheet,sample_sheet:paired,..."`.
+
+`DataCollectionToolParameter` carries `column_definitions` through `to_dict()`, which lets the workflow editor render column-definition forms for sample-sheet inputs.
+
+## API surfaces
+
+- `POST /api/dataset_collections` accepts `column_definitions` and `rows` (a `{element_identifier: [values]}` dict).
+- `POST /api/tools/fetch` carries `column_definitions` at target level and per-element `row` for remote-URI sample-sheet creation.
+- Workbook endpoints (`/api/sample_sheet_workbook[/parse]`, `/api/dataset_collections/{id}/sample_sheet_workbook[/parse]`) generate and parse XLSX/CSV/TSV using openpyxl, with header rows, dropdowns for `restrictions`, type validation, and an instructions sheet.
+
+## Workflow integration
+
+`InputCollectionModule` (lib/galaxy/workflow/modules.py) validates `column_definitions` at workflow save and propagates them to the runtime form. Galaxy workflow YAML accepts:
+
+```yaml
+inputs:
+  chipseq_data:
+    type: collection
+    collection_type: sample_sheet:paired
+    column_definitions:
+      - {type: string, name: condition, optional: false}
+      - {type: int, name: replicate, optional: false}
+      - {type: element_identifier, name: control_sample, optional: true}
+```
+
+This is the structured-input lever a Nextflow → Galaxy translation reaches for when source pipelines use `samplesheetToList(params.input, "assets/schema_input.json")`.
+
+## Mapping from Nextflow sample sheets
+
+| Nextflow / nf-schema | Galaxy `sample_sheet*` |
+|---|---|
+| `samplesheetToList(params.x, schema)` materialization | `sample_sheet` collection input bound to `params.x` |
+| nf-schema column `type: string\|integer\|number\|boolean` | column `type: string\|int\|float\|boolean` |
+| Column annotated `meta:` (carried in `meta` map) | non-path column in `columns[]` |
+| Path-typed column (one per row) | element dataset (variant `sample_sheet`) |
+| Two path columns (fastq pair) | inner `paired` (variant `sample_sheet:paired`) |
+| Mixed single/paired rows | inner `paired_or_unpaired` |
+| Heterogeneous typed per-row artifacts | inner `record` (variant `sample_sheet:record`) |
+| nf-schema `enum` | `restrictions[]` |
+| nf-schema `pattern` | `regex` validator |
+| nf-core `control_sample` style cross-row reference | `element_identifier` column type |
+
+Edges to flag, not silently squash, when translating:
+
+- nf-schema validation richer than regex/in_range/length cannot be expressed; downgrade to prose with confidence note.
+- Cross-sample-sheet references have no Galaxy expression — keep as plain `string` and warn.
+- Ad-hoc `splitCsv(header: true)` parsing without an `assets/schema_*.json` produces no column types — translation needs ad-hoc inference; this note's mapping does not apply.
+- Output side has no automatic propagation: a tool mapped over a `sample_sheet` produces a `sample_sheet`-shaped collection without `column_definitions`. Carry-forward must be explicit (re-attaching metadata via `__SAMPLE_SHEET_TO_TABULAR__` or rules DSL `add_column_from_sample_sheet_index`).
+
+## Why this matters for the Foundry
+
+Without sample_sheet shape awareness, `nextflow-summary-to-galaxy-interface` defaults nf-core sample-sheet inputs to `list:paired` or a flat file input, dropping per-row metadata. Surfacing the column schema lets the interface Mold pick the right variant and lets the data-flow Mold preserve `meta` fields through identifier-keyed wiring instead of inventing parallel parameter inputs.

--- a/content/research/nextflow-workflow-io-semantics.md
+++ b/content/research/nextflow-workflow-io-semantics.md
@@ -280,7 +280,7 @@ For [[summarize-nextflow]] and downstream interface Molds, use this order:
 ## Open questions
 
 - Should `summary-nextflow` distinguish launch parameters from materialized workflow inputs as separate arrays?
-- Should sample-sheet schemas become first-class structured inputs instead of prose inside a parameter entry?
+- ~~Should sample-sheet schemas become first-class structured inputs instead of prose inside a parameter entry?~~ **Resolved 2026-05-05 — yes.** Promoted to `Summary.sample_sheets[]` in [[summary-nextflow]] rev 6; resolution rationale and Galaxy-side mapping in [[galaxy-sample-sheet-collections]]; tracking issue jmchilton/foundry#177.
 - How should Galaxy targets expose Nextflow execution-control parameters such as `outdir`, `publish_dir_mode`, email, and `save_*` toggles?
 - Do workflow output `index` files deserve a target-side Galaxy pattern for preserving sample metadata beside published datasets?
 - How much legacy DSL1 support should the cast skill keep for `file` / `set` pipelines versus flagging them as low-confidence?

--- a/content/schemas/summary-nextflow.md
+++ b/content/schemas/summary-nextflow.md
@@ -12,7 +12,7 @@ tags:
 status: draft
 created: 2026-04-30
 revised: 2026-05-05
-revision: 5
+revision: 6
 ai_generated: true
 related_notes:
   - "[[summarize-nextflow]]"
@@ -101,6 +101,18 @@ Snapshot-sidecar parsing landed for module and subworkflow tests whose interesti
 - **`SnapshotFixture.parsed_content: SnapshotContent[]` added.** Each parsed sidecar entry preserves the snapshot name plus channel-keyed `SnapshotChannel` values.
 - **`SnapshotFile` added.** `<path>:md5,<hex>` strings become file digest assertions with `path`, `basename`, `md5`, and a `stub` flag for empty-file md5s.
 - **Non-file values preserved.** Version tuples, counts, and other scalar snapshot values remain in `SnapshotChannel.values` so downstream test-plan Molds do not re-read `.snap` files.
+
+## Revision 6 — 2026-05-05
+
+Sample-sheet schemas became first-class structured inputs. Resolves the open question raised in [[nextflow-workflow-io-semantics]] §"Open questions" and tracked in jmchilton/foundry#177.
+
+- **`Summary.sample_sheets: SampleSheet[]` added** (required; empty array when none). Promotes sample-sheet shape out of `params[].description` prose so downstream target Molds can pick collection variants without re-parsing the source pipeline.
+- **`SampleSheet` shape added.** Binds one `params[]` parameter (`param`) to a row schema (`columns`) plus discovery provenance (`discovered_via`: `nf-schema` | `samplesheetToList` | `splitCsv` | `ad-hoc`), optional `schema_path`, `format`, and `header`.
+- **`SampleSheetColumn` shape added.** Captures `name`, JSON Schema-style scalar `type`, `kind` (`data` for path-typed dataset references vs `meta` for per-row metadata), `format`, `required`, `default`, `enum`, `pattern`, `exists`, `mimetype`, `description`. Validation hints stay verbatim — target Molds decide which survive translation (e.g. Galaxy's `sample_sheet` validator allowlist is regex/in_range/length only; richer nf-schema validation downgrades to prose with confidence note).
+
+Why now: nf-core's `samplesheetToList(params.input, "assets/schema_input.json")` idiom maps almost 1:1 onto Galaxy's `sample_sheet[:paired|:paired_or_unpaired|:record]` collection types (`column_definitions`, typed columns including `element_identifier` cross-row refs, `restrictions[]` for enums, regex validators). Without structured columns the interface Mold cannot pick `sample_sheet:paired` vs `list:paired` vs flat-file principally, and per-row `meta` fields silently fall to parallel parameter inputs. See [[galaxy-sample-sheet-collections]] for the target-side mapping table consumed by [[nextflow-summary-to-galaxy-interface]] and [[nextflow-summary-to-galaxy-data-flow]].
+
+What was *not* changed: `Param.type` still records the param's own type (`string`/`path`) — the sample-sheet relationship is expressed by `sample_sheets[].param` referencing `params[].name`, not by mutating the param entry.
 
 ## Revision 5 — 2026-05-05
 

--- a/packages/summarize-nextflow/src/resolver.ts
+++ b/packages/summarize-nextflow/src/resolver.ts
@@ -4,9 +4,33 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSy
 import { basename, dirname, join, relative, resolve, sep } from "node:path";
 import YAML from "yaml";
 
+interface SampleSheetColumn {
+  name: string;
+  type: "string" | "integer" | "number" | "boolean";
+  kind: "data" | "meta";
+  format: string | null;
+  required: boolean;
+  default?: unknown;
+  description: string | null;
+  enum: unknown[];
+  pattern: string | null;
+  exists: boolean | null;
+  mimetype: string | null;
+}
+
+interface SampleSheet {
+  param: string;
+  schema_path: string | null;
+  discovered_via: "nf-schema" | "samplesheetToList" | "splitCsv" | "ad-hoc";
+  format: "csv" | "tsv" | "csv-or-tsv" | null;
+  header: boolean | null;
+  columns: SampleSheetColumn[];
+}
+
 interface Summary {
   source: Record<string, unknown>;
   params: Param[];
+  sample_sheets: SampleSheet[];
   profiles: string[];
   tools: Tool[];
   processes: Process[];
@@ -221,6 +245,7 @@ export async function resolveNextflowSummary(
       slug: workflowName.replace("/", "-"),
     },
     params: parseParams(pipelineRoot),
+    sample_sheets: parseSampleSheets(pipelineRoot),
     profiles: parseProfiles(config),
     tools,
     processes: processes.map((process) => ({
@@ -370,6 +395,90 @@ function parseParams(pipelineRoot: string): Param[] {
     }
   }
   return [...params.values()];
+}
+
+function parseSampleSheets(pipelineRoot: string): SampleSheet[] {
+  const schemaPath = join(pipelineRoot, "nextflow_schema.json");
+  if (!existsSync(schemaPath)) return [];
+  const schema = JSON.parse(readText(schemaPath)) as {
+    $defs?: Record<string, { properties?: Record<string, Record<string, unknown>> }>;
+  };
+  const sheets: SampleSheet[] = [];
+  for (const section of Object.values(schema.$defs ?? {})) {
+    for (const [paramName, property] of Object.entries(section.properties ?? {})) {
+      const rowSchemaRef = typeof property.schema === "string" ? property.schema : null;
+      if (!rowSchemaRef) continue;
+      const rowSchemaPath = join(pipelineRoot, rowSchemaRef);
+      if (!existsSync(rowSchemaPath)) continue;
+      const mimetype = typeof property.mimetype === "string" ? property.mimetype : null;
+      const format =
+        mimetype === "text/csv" ? "csv" : mimetype === "text/tab-separated-values" ? "tsv" : null;
+      sheets.push({
+        param: paramName,
+        schema_path: rowSchemaRef,
+        discovered_via: "nf-schema",
+        format,
+        header: true,
+        columns: parseSampleSheetColumns(rowSchemaPath),
+      });
+    }
+  }
+  return sheets;
+}
+
+function parseSampleSheetColumns(rowSchemaPath: string): SampleSheetColumn[] {
+  const rowSchema = JSON.parse(readText(rowSchemaPath)) as {
+    items?: { properties?: Record<string, Record<string, unknown>>; required?: string[] };
+  };
+  const items = rowSchema.items ?? {};
+  const required = new Set(items.required ?? []);
+  const columns: SampleSheetColumn[] = [];
+  for (const [name, raw] of Object.entries(items.properties ?? {})) {
+    const property = collapseAnyOf(raw);
+    const declaredType = pickScalarType(property.type);
+    const type: SampleSheetColumn["type"] =
+      declaredType === "integer" || declaredType === "number" || declaredType === "boolean"
+        ? declaredType
+        : "string";
+    const format = typeof property.format === "string" ? property.format : null;
+    const isMeta = Array.isArray(property.meta);
+    const isPathFormat = format === "file-path" || format === "directory-path" || format === "path";
+    const kind: SampleSheetColumn["kind"] = isMeta || !isPathFormat ? "meta" : "data";
+    columns.push({
+      name,
+      type,
+      kind,
+      format,
+      required: required.has(name),
+      default: property.default ?? null,
+      description: typeof property.description === "string" ? property.description : null,
+      enum: Array.isArray(property.enum) ? property.enum : [],
+      pattern: typeof property.pattern === "string" ? property.pattern : null,
+      exists: typeof property.exists === "boolean" ? property.exists : null,
+      mimetype: typeof property.mimetype === "string" ? property.mimetype : null,
+    });
+  }
+  return columns;
+}
+
+function collapseAnyOf(property: Record<string, unknown>): Record<string, unknown> {
+  if (!Array.isArray(property.anyOf)) return property;
+  const merged: Record<string, unknown> = { ...property };
+  for (const branch of property.anyOf as Record<string, unknown>[]) {
+    for (const [key, value] of Object.entries(branch)) {
+      if (merged[key] === undefined && value !== undefined) merged[key] = value;
+    }
+  }
+  return merged;
+}
+
+function pickScalarType(value: unknown): string | null {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) {
+    const nonNull = value.find((entry) => typeof entry === "string" && entry !== "null");
+    return typeof nonNull === "string" ? nonNull : null;
+  }
+  return null;
 }
 
 function detectPipelineRoot(path: string): { path: string; warnings: string[] } {

--- a/packages/summary-nextflow-schema/src/summary-nextflow.schema.generated.ts
+++ b/packages/summary-nextflow-schema/src/summary-nextflow.schema.generated.ts
@@ -16,6 +16,7 @@ export const summaryNextflowSchema = {
       "required": [
         "source",
         "params",
+        "sample_sheets",
         "profiles",
         "tools",
         "processes",
@@ -33,6 +34,13 @@ export const summaryNextflowSchema = {
           "items": {
             "$ref": "#/$defs/Param"
           }
+        },
+        "sample_sheets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SampleSheet"
+          },
+          "description": "Structured sample-sheet inputs. Each entry binds one `params[]` parameter to a row schema (column names, types, path-vs-meta classification, required flags, enums, patterns). Promoted from prose inside `params[].description` so downstream target translations (Galaxy `sample_sheet*` collections, CWL records-of-arrays) can choose collection variants without re-parsing the source pipeline. Empty array when no sample-sheet idiom is detected. Discovery sources: nf-schema `schema:` references, `samplesheetToList()` calls, and `splitCsv(header: true)` materializations."
         },
         "profiles": {
           "type": "array",
@@ -159,6 +167,147 @@ export const summaryNextflowSchema = {
           "type": "array",
           "items": {},
           "description": "Allowed values when nextflow_schema.json declares them."
+        }
+      }
+    },
+    "SampleSheet": {
+      "title": "SampleSheet",
+      "description": "One sample-sheet-shaped pipeline input. Captures the row schema, path-vs-meta column classification, and discovery provenance so downstream Molds can map onto Galaxy `sample_sheet[:variant]` collections, CWL records-of-arrays, or other target shapes without re-reading the source.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "param",
+        "discovered_via",
+        "columns"
+      ],
+      "properties": {
+        "param": {
+          "type": "string",
+          "description": "Foreign key into `params[].name` — the parameter whose value points at the sample-sheet file."
+        },
+        "schema_path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Repo-relative path of the JSON Schema file describing rows (e.g. `assets/schema_input.json`), resolved from the param's nf-schema entry's `schema:` keyword. Null when discovered via `samplesheetToList` without a schema reference, or via `splitCsv(header: true)` ad-hoc parsing."
+        },
+        "discovered_via": {
+          "type": "string",
+          "enum": [
+            "nf-schema",
+            "samplesheetToList",
+            "splitCsv",
+            "ad-hoc"
+          ],
+          "description": "How the sample-sheet shape was detected. `nf-schema`: nextflow_schema.json entry has `schema:` keyword. `samplesheetToList`: workflow imports nf-schema's helper and calls it on the param. `splitCsv`: workflow uses `splitCsv(header: true)` on the param's path. `ad-hoc`: pipeline-specific CSV/TSV parsing inferred from script bodies."
+        },
+        "format": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "csv",
+            "tsv",
+            "csv-or-tsv",
+            null
+          ],
+          "description": "Tabular format declared by the param's `mimetype` or inferred from `samplesheetToList` / `splitCsv` semantics. Null when undeclared."
+        },
+        "header": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Whether the file is expected to have a header row. Null when the discovery source doesn't pin it."
+        },
+        "columns": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SampleSheetColumn"
+          },
+          "description": "Row schema in declaration order. nf-schema's `samplesheetToList` emits columns in property order, not source-column order — preserve property order here so downstream translations match runtime channel item layout."
+        }
+      }
+    },
+    "SampleSheetColumn": {
+      "title": "SampleSheetColumn",
+      "description": "One column in a sample-sheet row schema. Type vocabulary is JSON Schema-style scalar; `kind` separates dataset-reference columns from per-row metadata. Validation hints (`pattern`, `enum`, `exists`, `mimetype`) are preserved verbatim — target Molds decide which of them survive translation (e.g. Galaxy's `sample_sheet` validator allowlist is regex/in_range/length).",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "type",
+        "kind",
+        "required"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "integer",
+            "number",
+            "boolean"
+          ],
+          "description": "JSON Schema-style scalar type. Path columns are typed `string` with a `format: file-path|directory-path|path` qualifier — see `format` and `kind`."
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "data",
+            "meta"
+          ],
+          "description": "`data`: path-typed column whose values are dataset references (becomes element/inner-collection slot in Galaxy `sample_sheet`). `meta`: scalar metadata column (becomes a `column_definitions` entry, populated per row in `columns[]`). Includes the nf-schema `meta:` annotation when present; in its absence inferred from `format` (`file-path`/`directory-path`/`path` → `data`, anything else → `meta`)."
+        },
+        "format": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "JSON Schema `format` keyword. nf-schema vocabulary: `file-path`, `directory-path`, `path`, `file-path-pattern`. Null for scalar metadata columns without a format hint."
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "default": {
+          "description": "Default value verbatim from the sample-sheet schema. May be null."
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "enum": {
+          "type": "array",
+          "items": {},
+          "description": "Allowed values when the column schema declares an `enum`. Empty array when absent."
+        },
+        "pattern": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "JSON Schema regex `pattern` when present."
+        },
+        "exists": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "nf-schema `exists` flag for path columns. True when the parser must verify the file exists."
+        },
+        "mimetype": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "nf-schema `mimetype` keyword (e.g. `text/csv`, `application/gzip`). Useful for target datatypes."
         }
       }
     },

--- a/packages/summary-nextflow-schema/src/summary-nextflow.schema.json
+++ b/packages/summary-nextflow-schema/src/summary-nextflow.schema.json
@@ -11,10 +11,11 @@
       "description": "Top-level shape. Every Nextflow summary is exactly this object.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["source", "params", "profiles", "tools", "processes", "subworkflows", "workflow", "test_fixtures", "nf_tests"],
+      "required": ["source", "params", "sample_sheets", "profiles", "tools", "processes", "subworkflows", "workflow", "test_fixtures", "nf_tests"],
       "properties": {
         "source":         { "$ref": "#/$defs/SourceRecord" },
         "params":         { "type": "array", "items": { "$ref": "#/$defs/Param" } },
+        "sample_sheets":  { "type": "array", "items": { "$ref": "#/$defs/SampleSheet" }, "description": "Structured sample-sheet inputs. Each entry binds one `params[]` parameter to a row schema (column names, types, path-vs-meta classification, required flags, enums, patterns). Promoted from prose inside `params[].description` so downstream target translations (Galaxy `sample_sheet*` collections, CWL records-of-arrays) can choose collection variants without re-parsing the source pipeline. Empty array when no sample-sheet idiom is detected. Discovery sources: nf-schema `schema:` references, `samplesheetToList()` calls, and `splitCsv(header: true)` materializations." },
         "profiles":       { "type": "array", "items": { "type": "string" } },
         "tools":          { "type": "array", "items": { "$ref": "#/$defs/Tool" } },
         "processes":      { "type": "array", "items": { "$ref": "#/$defs/Process" } },
@@ -59,6 +60,43 @@
         "description": { "type": "string" },
         "required":    { "type": "boolean" },
         "enum":        { "type": "array", "items": {}, "description": "Allowed values when nextflow_schema.json declares them." }
+      }
+    },
+
+    "SampleSheet": {
+      "title": "SampleSheet",
+      "description": "One sample-sheet-shaped pipeline input. Captures the row schema, path-vs-meta column classification, and discovery provenance so downstream Molds can map onto Galaxy `sample_sheet[:variant]` collections, CWL records-of-arrays, or other target shapes without re-reading the source.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["param", "discovered_via", "columns"],
+      "properties": {
+        "param":          { "type": "string", "description": "Foreign key into `params[].name` — the parameter whose value points at the sample-sheet file." },
+        "schema_path":    { "type": ["string", "null"], "description": "Repo-relative path of the JSON Schema file describing rows (e.g. `assets/schema_input.json`), resolved from the param's nf-schema entry's `schema:` keyword. Null when discovered via `samplesheetToList` without a schema reference, or via `splitCsv(header: true)` ad-hoc parsing." },
+        "discovered_via": { "type": "string", "enum": ["nf-schema", "samplesheetToList", "splitCsv", "ad-hoc"], "description": "How the sample-sheet shape was detected. `nf-schema`: nextflow_schema.json entry has `schema:` keyword. `samplesheetToList`: workflow imports nf-schema's helper and calls it on the param. `splitCsv`: workflow uses `splitCsv(header: true)` on the param's path. `ad-hoc`: pipeline-specific CSV/TSV parsing inferred from script bodies." },
+        "format":         { "type": ["string", "null"], "enum": ["csv", "tsv", "csv-or-tsv", null], "description": "Tabular format declared by the param's `mimetype` or inferred from `samplesheetToList` / `splitCsv` semantics. Null when undeclared." },
+        "header":         { "type": ["boolean", "null"], "description": "Whether the file is expected to have a header row. Null when the discovery source doesn't pin it." },
+        "columns":        { "type": "array", "items": { "$ref": "#/$defs/SampleSheetColumn" }, "description": "Row schema in declaration order. nf-schema's `samplesheetToList` emits columns in property order, not source-column order — preserve property order here so downstream translations match runtime channel item layout." }
+      }
+    },
+
+    "SampleSheetColumn": {
+      "title": "SampleSheetColumn",
+      "description": "One column in a sample-sheet row schema. Type vocabulary is JSON Schema-style scalar; `kind` separates dataset-reference columns from per-row metadata. Validation hints (`pattern`, `enum`, `exists`, `mimetype`) are preserved verbatim — target Molds decide which of them survive translation (e.g. Galaxy's `sample_sheet` validator allowlist is regex/in_range/length).",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "type", "kind", "required"],
+      "properties": {
+        "name":        { "type": "string" },
+        "type":        { "type": "string", "enum": ["string", "integer", "number", "boolean"], "description": "JSON Schema-style scalar type. Path columns are typed `string` with a `format: file-path|directory-path|path` qualifier — see `format` and `kind`." },
+        "kind":        { "type": "string", "enum": ["data", "meta"], "description": "`data`: path-typed column whose values are dataset references (becomes element/inner-collection slot in Galaxy `sample_sheet`). `meta`: scalar metadata column (becomes a `column_definitions` entry, populated per row in `columns[]`). Includes the nf-schema `meta:` annotation when present; in its absence inferred from `format` (`file-path`/`directory-path`/`path` → `data`, anything else → `meta`)." },
+        "format":      { "type": ["string", "null"], "description": "JSON Schema `format` keyword. nf-schema vocabulary: `file-path`, `directory-path`, `path`, `file-path-pattern`. Null for scalar metadata columns without a format hint." },
+        "required":    { "type": "boolean" },
+        "default":     { "description": "Default value verbatim from the sample-sheet schema. May be null." },
+        "description": { "type": ["string", "null"] },
+        "enum":        { "type": "array", "items": {}, "description": "Allowed values when the column schema declares an `enum`. Empty array when absent." },
+        "pattern":     { "type": ["string", "null"], "description": "JSON Schema regex `pattern` when present." },
+        "exists":      { "type": ["boolean", "null"], "description": "nf-schema `exists` flag for path columns. True when the parser must verify the file exists." },
+        "mimetype":    { "type": ["string", "null"], "description": "nf-schema `mimetype` keyword (e.g. `text/csv`, `application/gzip`). Useful for target datatypes." }
       }
     },
 


### PR DESCRIPTION
## Summary

Resolves #177. Sample-sheet schemas become a first-class top-level field on `summary-nextflow` instead of prose inside `params[].description`.

- **Schema rev 6** — adds `Summary.sample_sheets: SampleSheet[]` with `SampleSheet` (`param`, `schema_path`, `discovered_via`, `format`, `header`, `columns`) and `SampleSheetColumn` (`name`, `type`, `kind` ∈ {`data`, `meta`}, `format`, `required`, `default`, `enum`, `pattern`, `exists`, `mimetype`, `description`). Discovery provenance vocabulary: `nf-schema | samplesheetToList | splitCsv | ad-hoc`.
- **CLI** — `parseSampleSheets()` resolves nf-schema-discovered sample sheets (the dominant nf-core idiom) by walking `nextflow_schema.json` for `schema:` keywords and parsing the referenced `assets/schema_*.json`. `samplesheetToList` / `splitCsv` / `ad-hoc` discovery branches are documented in the Mold §3.5 and deferred until a fixture forces them.
- **Mold** — new procedure step §3.5 in `summarize-nextflow` covering all four discovery branches and column-field rules; revision bumped to 10. Stays target-agnostic — Galaxy variant selection (`sample_sheet:paired` vs `list:paired`) is explicitly downstream.
- **Target-side research note** — new `content/research/galaxy-sample-sheet-collections.md` distilling Galaxy's `sample_sheet*` collection family (PR #19305) into the Foundry, with a column-by-column nf-schema → Galaxy `column_definitions` mapping table and translation-edge callouts (validator allowlist, special-character restrictions, outermost-only rule, within-collection `element_identifier`).
- **Wiring** — research note linked into `nextflow-summary-to-galaxy-interface` and `nextflow-summary-to-galaxy-data-flow` as `kind: research` / `load: on-demand` references with technical triggers keyed off `samplesheetToList`, `nextflow_schema.json` `schema:` keywords, `splitCsv(header: true)`, and `tuple(meta, path...)` channel shape in the upstream interface brief.
- **Casts backfilled** — `nf-core/demo` and `nf-core/bacass` cast artifacts updated to populate `sample_sheets[]` from their respective `assets/schema_input.json` files (3 columns and 6 columns respectively); bundled schema copy refreshed.
- **Open question resolved** — the matching question in `content/research/nextflow-workflow-io-semantics.md` is struck through with pointers to schema rev 6 and this issue.

## Why

nf-core's `samplesheetToList(params.input, "assets/schema_input.json")` materializes channels of `tuple(meta, path1, path2, ...)` — exactly the shape Galaxy's `sample_sheet[:paired|:paired_or_unpaired|:record]` collection types were designed to express. Without structured columns the interface Mold can't pick `sample_sheet:paired` vs `list:paired` vs flat-file principally, and per-row `meta` fields silently fall to parallel parameter inputs. Mapping is near 1:1: nf-schema column types → Galaxy types, `enum` → `restrictions`, `pattern` → `regex` validator (one of three safe validators), `meta:` annotation vs path columns → `column_definitions` entry vs element/inner-collection slot, `control_sample`-style cross-row refs → `element_identifier` column type.

## Test plan

- [x] `npm run validate` — 0 errors, 90 pre-existing warnings.
- [x] `pnpm --filter @galaxy-foundry/summary-nextflow-schema test` — passes; both committed cast artifacts (demo, bacass) validate against rev 6 schema.
- [x] `pnpm --filter @galaxy-foundry/summarize-nextflow build` — typecheck clean.
- [x] CLI smoke test — running against `workflow-fixtures/pipelines/nf-core__bacass` emits well-formed `sample_sheets[]` (6 columns, ID + R1/R2/LongFastQ/Fast5 + GenomeSize, kinds correct, `meta` annotation honored).
- [ ] 5 pre-existing `summarize-nextflow` integration tests on bacass fail under `pnpm test` due to `spawnSync` `maxBuffer` clipping ~1MB stdout — confirmed unchanged from baseline (`git stash` repro). Worth a follow-up issue but not in scope here.

## Follow-ups

- CLI implementation for `samplesheetToList` / `splitCsv` / `ad-hoc` discovery branches.
- Test infra: bump `spawnSync` `maxBuffer` so bacass integration tests stop clipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)