### PR TITLE
polish Galaxy output interface notes

### DIFF
--- a/content/molds/nextflow-summary-to-galaxy-template/index.md
+++ b/content/molds/nextflow-summary-to-galaxy-template/index.md
@@ -10,8 +10,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-05-05
-revised: 2026-05-05
-revision: 1
+revised: 2026-05-06
+revision: 2
 ai_generated: true
 summary: "gxformat2 skeleton with per-step TODOs from a Nextflow summary and prior Galaxy design briefs."
 input_artifacts:
@@ -34,6 +34,13 @@ references:
     mode: verbatim
     evidence: corpus-observed
     purpose: "Read process, channel, operator, and fixture structure when emitting placeholder steps and TODO context."
+  - kind: research
+    ref: "[[gxformat2-schema]]"
+    used_at: runtime
+    load: upfront
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Use the gxformat2 structural vocabulary for workflow inputs, outputs, steps, and producer-side output actions while emitting the skeleton."
   - kind: research
     ref: "[[galaxy-workflow-testability-design]]"
     used_at: runtime

--- a/content/research/galaxy-workflow-testability-design.md
+++ b/content/research/galaxy-workflow-testability-design.md
@@ -6,8 +6,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-05-03
-revised: 2026-05-03
-revision: 1
+revised: 2026-05-06
+revision: 2
 ai_generated: true
 related_notes:
   - "[[iwc-workflow-testability-survey]]"
@@ -16,7 +16,9 @@ related_notes:
   - "[[iwc-shortcuts-anti-patterns]]"
   - "[[planemo-workflow-test-architecture]]"
   - "[[implement-galaxy-workflow-test]]"
+  - "[[gxformat2-schema]]"
   - "[[gxformat2-workflow-inputs]]"
+  - "[[galaxy-datatypes-conf]]"
 summary: "Design guidance for Galaxy workflow inputs, outputs, and checkpoints that make IWC-style workflow tests possible."
 ---
 
@@ -109,6 +111,23 @@ Evidence:
 - 10x CellPlex job inputs include `fastq PE collection GEX`, `reference genome`, `gtf`, `cellranger_barcodes_3M-february-2018.txt`, `fastq PE collection CMO`, `sample name and CMO sequence collection`, and `Number of expected cells` (`$IWC/workflows/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:2-75`). The workflow declares matching collection, data, string, boolean, and int inputs (`$IWC_FORMAT2/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex.gxwf.yml:4-72`).
 - HyPhy accepts a `list` collection of unaligned sequences and preserves accession-like fixture identifiers through to output element assertions (`$IWC/workflows/comparative_genomics/hyphy/hyphy-core-tests.yml:7-30`; `$IWC_FORMAT2/comparative_genomics/hyphy/hyphy-core.gxwf.yml:14-25`).
 
+## 6. Know what a gxformat2 output entry contains
+
+Top-level gxformat2 `outputs:` is the public workflow-output surface. It is separate from per-step `out:` declarations and from step post-job actions such as `change_datatype` or `rename`.
+
+Authoring rules:
+
+- Use `label` as the stable public name tests and users will address.
+- Use `outputSource` to point at the producing step output; do not rely on positional output order.
+- Use `doc` for short user-facing context when the label is not self-explanatory.
+- Keep `type` aligned with the exposed value (`data`, `collection`, or scalar vocabulary from [[gxformat2-workflow-inputs]]) when the schema needs it.
+- Apply `change_datatype` at the producing step output when Galaxy needs a stronger datatype than the tool reports; choose values from [[galaxy-datatypes-conf]].
+- Use `rename` only for generated dataset names inside Galaxy histories. It is not a substitute for stable workflow-output `label`.
+- Treat `add_tags` and `remove_tags` as metadata helpers, not as the test API. IWC tests key by labels and collection element identifiers, not tags.
+- Avoid `hide` or `delete_intermediate_datasets` on outputs that are promoted as test checkpoints.
+
+Design inference: a workflow-output promotion decision should pick both the public `outputs:` entry and any producer-side post-job action needed to make that output useful. For example, a synthesized BED checkpoint needs a stable output `label` plus a producer-side `change_datatype: bed`; one without the other is incomplete for a testable workflow.
+
 ## Cross-references
 
 - [[iwc-workflow-testability-survey]] — corpus survey and distribution rationale.
@@ -116,3 +135,5 @@ Evidence:
 - [[planemo-asserts-idioms]] — assertion-family choice after an output is exposed.
 - [[iwc-shortcuts-anti-patterns]] — accepted shortcut vs smell calls for weak assertions and label coupling.
 - [[planemo-workflow-test-architecture]] — Planemo execution, output-problem ambiguity, and structured artifacts.
+- [[gxformat2-schema]] — structural vocabulary for top-level workflow outputs and step post-job actions.
+- [[galaxy-datatypes-conf]] — valid Galaxy datatype extensions for `format` and `change_datatype` choices.

--- a/content/research/gxformat2-schema.md
+++ b/content/research/gxformat2-schema.md
@@ -7,8 +7,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-05-05
-revised: 2026-05-05
-revision: 1
+revised: 2026-05-06
+revision: 2
 ai_generated: true
 related_notes:
   - "[[galaxy-collection-semantics]]"
@@ -40,6 +40,18 @@ Each entry under `inputs` carries:
 - `optional` — boolean.
 - `default` — opaque (`/schemas/unknown`); type-dependent.
 - `label`, `doc`, `id`, `position` — metadata.
+
+## Workflow output vocabulary
+
+Top-level `outputs` can be an array or object map. Each output entry carries:
+
+- `label` — public workflow-output name; tests and users should address this stable label.
+- `outputSource` — producing step output reference.
+- `doc` — optional prose context, string or string array.
+- `id` — optional identifier.
+- `type` — same permissive type vocabulary as inputs, when needed.
+
+Producer-side output actions are separate from top-level `outputs`. Step `out:` entries can carry `change_datatype`, `rename`, `add_tags`, `remove_tags`, `hide`, `delete_intermediate_datasets`, and `set_columns`, or a plain string output name. See [[galaxy-workflow-testability-design]] for authoring posture: `label` is the public API; producer-side actions make the dataset useful.
 
 ## Workflow step vocabulary
 

--- a/content/research/nextflow-workflow-io-semantics.md
+++ b/content/research/nextflow-workflow-io-semantics.md
@@ -8,7 +8,7 @@ tags:
 status: draft
 created: 2026-05-06
 revised: 2026-05-06
-revision: 2
+revision: 3
 ai_generated: true
 related_notes:
   - "[[component-nextflow-pipeline-anatomy]]"
@@ -283,6 +283,6 @@ For [[summarize-nextflow]] and downstream interface Molds, use this order:
 
 - Should `summary-nextflow` distinguish launch parameters from materialized workflow inputs as separate arrays?
 - ~~Should sample-sheet schemas become first-class structured inputs instead of prose inside a parameter entry?~~ **Resolved 2026-05-05 — yes.** Promoted to `Summary.sample_sheets[]` in [[summary-nextflow]] rev 6; resolution rationale and Galaxy-side mapping in [[galaxy-sample-sheet-collections]]; tracking issue jmchilton/foundry#177.
-- How should Galaxy targets expose Nextflow execution-control parameters such as `outdir`, `publish_dir_mode`, email, and `save_*` toggles?
+- ~~How should Galaxy targets expose Nextflow execution-control parameters such as `outdir`, `publish_dir_mode`, email, and `save_*` toggles?~~ **Resolved 2026-05-06 for v1 — classify by effect in [[nextflow-params-to-galaxy-inputs]]: exclude publish/runtime controls by default; keep booleans/enums only when they alter workflow shape, tool choice, or command outputs.**
 - Do workflow output `index` files deserve a target-side Galaxy pattern for preserving sample metadata beside published datasets?
 - How much legacy DSL1 support should the cast skill keep for `file` / `set` pipelines versus flagging them as low-confidence?


### PR DESCRIPTION
## Summary
- Adds gxformat2 workflow output-entry guidance to Galaxy workflow testability design.
- Documents top-level output vocabulary and producer-side output actions in the gxformat2 schema note.
- Wires the Nextflow-to-Galaxy template Mold to the gxformat2 structural vocabulary and marks the control-param question resolved for v1.

## Validation
- `npm run validate` (0 errors, existing advisory warnings)

Part of #168.