### PR TITLE
Run compare-against-iwc-exemplar before galaxy template molds

### DIFF
--- a/content/molds/compare-against-iwc-exemplar/eval.md
+++ b/content/molds/compare-against-iwc-exemplar/eval.md
@@ -3,25 +3,25 @@
 ## Case: nf-core rnaseq nearest exemplar
 
 - check: deterministic + llm-judged
-- fixture: Galaxy draft derived from nf-core/rnaseq.
+- fixture: Galaxy interface + data-flow design briefs derived from nf-core/rnaseq.
 - expectation: selects `transcriptomics/rnaseq-pe` (or sibling RNA-seq IWC workflow) at high confidence, citing the IWC URL plus alignment on domain, paired-FASTQ topology, align/count/report tool families, and MultiQC aggregation.
 
 ## Case: nf-core viralrecon nearest exemplar
 
 - check: deterministic + llm-judged
-- fixture: Galaxy draft derived from nf-core/viralrecon.
+- fixture: Galaxy interface + data-flow design briefs derived from nf-core/viralrecon.
 - expectation: selects an IWC SARS-CoV-2 variation-reporting exemplar at medium confidence, naming the shared variation-analysis structure and the workflow-scope mismatch.
 
 ## Case: nf-core mag nearest exemplar
 
 - check: deterministic + llm-judged
-- fixture: Galaxy draft derived from nf-core/mag.
+- fixture: Galaxy interface + data-flow design briefs derived from nf-core/mag.
 - expectation: selects an IWC microbiome MAG-generation exemplar at high confidence and calls out collection, binning, annotation, and report-assembly differences.
 
 ## Case: no acceptable exemplar
 
 - check: deterministic + llm-judged
-- fixture: Galaxy draft whose domain, tool families, topology, or output intent has no close IWC match.
+- fixture: Galaxy interface + data-flow design briefs whose domain, tool families, topology, or output intent has no close IWC match.
 - expectation: returns "no nearest exemplar" instead of forcing a nearest, lists the top weak candidates with rationale, and refuses high confidence on tool-overlap-only matches (`MultiQC`, `fastp`, `awk`, `datamash`).
 
 ## Case: IWC clone reuse

--- a/content/molds/compare-against-iwc-exemplar/index.md
+++ b/content/molds/compare-against-iwc-exemplar/index.md
@@ -8,18 +8,26 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-05-05
-revision: 5
+revised: 2026-05-06
+revision: 6
 ai_generated: true
-summary: "Find nearest IWC exemplar(s) and surface a structural diff against a draft."
+summary: "Find nearest IWC exemplar(s) and surface a structural diff against the upstream Galaxy design briefs to guide template authoring."
 input_artifacts:
-  - id: galaxy-workflow-draft
-    description: "gxformat2 skeleton from a *-summary-to-galaxy-template Mold; the draft compared against IWC exemplars."
+  - id: nextflow-galaxy-interface
+    description: "Galaxy interface brief from [[nextflow-summary-to-galaxy-interface]] when running the NEXTFLOW → GALAXY pipeline."
+  - id: nextflow-galaxy-data-flow
+    description: "Galaxy data-flow brief from [[nextflow-summary-to-galaxy-data-flow]] when running the NEXTFLOW → GALAXY pipeline."
+  - id: cwl-galaxy-interface
+    description: "Galaxy interface brief from [[cwl-summary-to-galaxy-interface]] when running the CWL → GALAXY pipeline."
+  - id: cwl-galaxy-data-flow
+    description: "Galaxy data-flow brief from [[cwl-summary-to-galaxy-data-flow]] when running the CWL → GALAXY pipeline."
+  - id: paper-galaxy-design
+    description: "Combined Galaxy interface + data-flow design brief from [[paper-summary-to-galaxy-design]] when running the PAPER → GALAXY pipeline."
 output_artifacts:
   - id: iwc-comparison-notes
     kind: markdown
     default_filename: iwc-comparison-notes.md
-    description: "Structural diff against the nearest IWC exemplar(s); guidance for authoring before more concrete step work."
+    description: "Structural diff against the nearest IWC exemplar(s); guidance for the downstream *-summary-to-galaxy-template Mold before per-step authoring."
 cli_commands:
   - "[[convert]]"
 references:
@@ -37,8 +45,8 @@ references:
     load: on-demand
     mode: verbatim
     evidence: hypothesis
-    purpose: "Compare against the draft's abstract intent without turning exemplar comparison into tool resolution."
-    trigger: "When deciding whether to compare abstract data-flow, gxformat2 skeleton structure, or concrete implementation details."
+    purpose: "Compare against the design briefs' abstract intent without turning exemplar comparison into tool resolution."
+    trigger: "When deciding whether to compare abstract data-flow shape, interface structure, or speculative implementation details."
     verification: "Promote after exemplar comparison flags structural issues without resolving concrete tool metadata."
   - kind: pattern
     ref: "[[galaxy-collection-patterns]]"
@@ -46,36 +54,38 @@ references:
     load: on-demand
     mode: verbatim
     evidence: corpus-observed
-    purpose: "Compare draft collection transformations against curated corpus-observed pattern guidance."
-    trigger: "When the draft workflow contains collection reshape, cleanup, relabel, synchronization, or collection-tabular bridge sections."
+    purpose: "Compare proposed collection transformations against curated corpus-observed pattern guidance."
+    trigger: "When the data-flow brief proposes collection reshape, cleanup, relabel, synchronization, or collection-tabular bridge sections."
   - kind: pattern
     ref: "[[galaxy-tabular-patterns]]"
     used_at: runtime
     load: on-demand
     mode: verbatim
     evidence: corpus-observed
-    purpose: "Compare draft tabular transformations against curated corpus-observed pattern guidance."
-    trigger: "When the draft workflow contains tabular filtering, projection, join, aggregation, SQL, or free-form text-processing sections."
+    purpose: "Compare proposed tabular transformations against curated corpus-observed pattern guidance."
+    trigger: "When the data-flow brief proposes tabular filtering, projection, join, aggregation, SQL, or free-form text-processing sections."
   - kind: research
     ref: "[[iwc-test-data-conventions]]"
     used_at: runtime
     load: on-demand
     mode: verbatim
     evidence: corpus-observed
-    purpose: "Compare test-data placement and fixture shapes against IWC conventions."
-    trigger: "When exemplar comparison includes workflow tests or input fixture organization."
+    purpose: "Compare proposed test-data placement and fixture shapes against IWC conventions."
+    trigger: "When the design briefs hint at workflow tests or input fixture organization."
   - kind: research
     ref: "[[iwc-shortcuts-anti-patterns]]"
     used_at: runtime
     load: on-demand
     mode: verbatim
     evidence: corpus-observed
-    purpose: "Flag draft shortcuts that are accepted in IWC versus shortcuts that should be treated as smells."
-    trigger: "When reviewing draft tests, assertions, labels, or expected-output comparisons."
+    purpose: "Flag proposed shortcuts that are accepted in IWC versus shortcuts that should be treated as smells."
+    trigger: "When the design briefs propose tests, assertions, labels, or expected-output comparisons."
 ---
 # compare-against-iwc-exemplar
 
-Find the nearest IWC exemplar workflow(s) for a Galaxy draft and emit a structural diff that can guide authoring before more effort is spent on concrete step implementation.
+Find the nearest IWC exemplar workflow(s) for the upstream Galaxy design briefs and emit a structural diff that guides the downstream `*-summary-to-galaxy-template` Mold before per-step authoring effort is spent.
+
+This Mold is the corpus-first check in Galaxy-targeting pipelines. It runs after the source-specific interface and data-flow briefs (or the combined paper design brief) and before the gxformat2 template Mold. Discovery, ranking, and comparison are one action — there is no separate retrieval Mold.
 
 ## Procedure
 
@@ -92,7 +102,7 @@ Find the nearest IWC exemplar workflow(s) for a Galaxy draft and emit a structur
 5. Output types and report shape.
 6. Test style and fixture topology.
 
-Domain comes first so a structurally similar workflow in the wrong science area does not become a misleading exemplar. Topology comes second because collection shape is one of the most important Galaxy-specific design decisions. Test style is useful after a workflow match, but should not drive initial retrieval.
+Domain comes first so a structurally similar workflow in the wrong science area does not become a misleading exemplar. Topology comes second because collection shape is one of the most important Galaxy-specific design decisions. Test style is useful after a workflow match, but should not drive initial retrieval. Briefs with no domain signal should not produce a high-confidence exemplar even if they share generic tools.
 
 ## Confidence Levels
 
@@ -102,6 +112,17 @@ Domain comes first so a structurally similar workflow in the wrong science area 
 | Medium | Same domain and topology, but partial tool-family or output match. Useful exemplar, not canonical. |
 | Low | Cross-domain structural match only. Useful for a pattern comparison, not a nearest domain exemplar. |
 | No nearest exemplar | Candidate lacks domain or topology alignment, or only shares generic tools such as MultiQC. |
+
+## Routing findings forward
+
+Each finding should name the authoring surface most likely to own the fix:
+
+- Template/data-flow issue: missing node, wrong collection shape, wrong branch, placeholder too vague — surfaced for the downstream `*-summary-to-galaxy-template` Mold to apply.
+- Pattern issue: recurring Galaxy idiom should become or update a pattern page.
+- Tool-step issue: exact wrapper or parameterization will be handled later in the per-step loop.
+- Test issue: defer to `*-test-to-galaxy-test-plan` or `implement-galaxy-workflow-test`.
+
+Do not block downstream authoring on low-confidence exemplar mismatches. Report them as review guidance for the template Mold and the user.
 
 ## Non-goals
 

--- a/content/molds/cwl-summary-to-galaxy-template/index.md
+++ b/content/molds/cwl-summary-to-galaxy-template/index.md
@@ -21,6 +21,8 @@ input_artifacts:
     description: "Galaxy interface brief from [[cwl-summary-to-galaxy-interface]] that pins workflow inputs, outputs, labels."
   - id: cwl-galaxy-data-flow
     description: "Galaxy data-flow brief from [[cwl-summary-to-galaxy-data-flow]] that pins abstract operations and collection choices."
+  - id: iwc-comparison-notes
+    description: "Structural diff guidance from [[compare-against-iwc-exemplar]] (run on the design briefs); steers the skeleton toward IWC-aligned structure before per-step authoring."
 output_artifacts:
   - id: galaxy-workflow-draft
     kind: yaml

--- a/content/molds/nextflow-summary-to-galaxy-template/index.md
+++ b/content/molds/nextflow-summary-to-galaxy-template/index.md
@@ -21,6 +21,8 @@ input_artifacts:
     description: "Galaxy interface brief from [[nextflow-summary-to-galaxy-interface]] that pins workflow inputs, outputs, labels."
   - id: nextflow-galaxy-data-flow
     description: "Galaxy data-flow brief from [[nextflow-summary-to-galaxy-data-flow]] that pins abstract operations and collection choices."
+  - id: iwc-comparison-notes
+    description: "Structural diff guidance from [[compare-against-iwc-exemplar]] (run on the design briefs); steers the skeleton toward IWC-aligned structure before per-step authoring."
 output_artifacts:
   - id: galaxy-workflow-draft
     kind: yaml

--- a/content/molds/paper-summary-to-galaxy-template/index.md
+++ b/content/molds/paper-summary-to-galaxy-template/index.md
@@ -19,6 +19,8 @@ input_artifacts:
     description: "Paper summary emitted by [[summarize-paper]]; consulted while emitting placeholder steps."
   - id: paper-galaxy-design
     description: "Combined Galaxy design brief from [[paper-summary-to-galaxy-design]] that pins interface and data-flow choices."
+  - id: iwc-comparison-notes
+    description: "Structural diff guidance from [[compare-against-iwc-exemplar]] (run on the design brief); steers the skeleton toward IWC-aligned structure before per-step authoring."
 output_artifacts:
   - id: galaxy-workflow-draft
     kind: yaml

--- a/content/pipelines/cwl-to-galaxy.md
+++ b/content/pipelines/cwl-to-galaxy.md
@@ -15,8 +15,8 @@ phases:
   - mold: "[[summarize-cwl]]"
   - mold: "[[cwl-summary-to-galaxy-interface]]"
   - mold: "[[cwl-summary-to-galaxy-data-flow]]"
-  - mold: "[[cwl-summary-to-galaxy-template]]"
   - mold: "[[compare-against-iwc-exemplar]]"
+  - mold: "[[cwl-summary-to-galaxy-template]]"
   - branch: discover-or-author
     loop: true
     branches:

--- a/content/pipelines/nextflow-to-galaxy.md
+++ b/content/pipelines/nextflow-to-galaxy.md
@@ -15,8 +15,8 @@ phases:
   - mold: "[[summarize-nextflow]]"
   - mold: "[[nextflow-summary-to-galaxy-interface]]"
   - mold: "[[nextflow-summary-to-galaxy-data-flow]]"
-  - mold: "[[nextflow-summary-to-galaxy-template]]"
   - mold: "[[compare-against-iwc-exemplar]]"
+  - mold: "[[nextflow-summary-to-galaxy-template]]"
   - branch: discover-or-author
     loop: true
     branches:

--- a/content/pipelines/paper-to-galaxy.md
+++ b/content/pipelines/paper-to-galaxy.md
@@ -14,8 +14,8 @@ summary: "Direct path from a paper to a Galaxy gxformat2 workflow. No CWL interm
 phases:
   - mold: "[[summarize-paper]]"
   - mold: "[[paper-summary-to-galaxy-design]]"
-  - mold: "[[paper-summary-to-galaxy-template]]"
   - mold: "[[compare-against-iwc-exemplar]]"
+  - mold: "[[paper-summary-to-galaxy-template]]"
   - branch: discover-or-author
     loop: true
     branches:

--- a/docs/HARNESS_PIPELINES.md
+++ b/docs/HARNESS_PIPELINES.md
@@ -52,8 +52,8 @@ Other inline phase annotations may be coined as needs surface — e.g., `[gate]`
 
 1. `summarize-paper` — extract methods, named tools/algorithms, sample data, metrics, references to existing pipelines.
 2. `paper-summary-to-galaxy-design` — combined Galaxy interface and abstract data-flow design brief.
-3. `paper-summary-to-galaxy-template` — `gxformat2` skeleton with per-step TODOs from paper source evidence and prior handoffs.
-4. `compare-against-iwc-exemplar` — structural diff of the template against nearest IWC exemplar(s); flag divergences before sinking effort into per-step authoring.
+3. `compare-against-iwc-exemplar` — structural diff of the design brief against nearest IWC exemplar(s); guidance feeds template authoring.
+4. `paper-summary-to-galaxy-template` — `gxformat2` skeleton with per-step TODOs from paper source evidence, the design brief, and exemplar comparison notes.
 5. `[loop]` `[branch]` discover-or-author branch:
    - try `discover-shed-tool`.
    - on fallthrough, `author-galaxy-tool-wrapper`.
@@ -99,8 +99,8 @@ Other inline phase annotations may be coined as needs surface — e.g., `[gate]`
 1. `summarize-nextflow`
 2. `nextflow-summary-to-galaxy-interface`
 3. `nextflow-summary-to-galaxy-data-flow`
-4. `nextflow-summary-to-galaxy-template`
-5. `compare-against-iwc-exemplar` — structural diff of the template against nearest IWC exemplar(s).
+4. `compare-against-iwc-exemplar` — structural diff of the design briefs against nearest IWC exemplar(s); guidance feeds template authoring.
+5. `nextflow-summary-to-galaxy-template`
 6. `[loop]` `[branch]` discover-or-author branch (`discover-shed-tool` → fallthrough to `author-galaxy-tool-wrapper`).
 7. `[loop]` `summarize-galaxy-tool`
 8. `[loop]` `implement-galaxy-tool-step`
@@ -118,8 +118,8 @@ CWL is already structured; the upstream extraction work is much lighter.
 1. `summarize-cwl` — read CWL Workflow + referenced `CommandLineTool`s, identify inputs/outputs, scatter, conditional logic.
 2. `cwl-summary-to-galaxy-interface` — choose Galaxy workflow interface from CWL inputs/outputs.
 3. `cwl-summary-to-galaxy-data-flow` — re-shape into Galaxy-shaped data-flow idioms from a CWL summary that's already nearly a DAG.
-4. `cwl-summary-to-galaxy-template`
-5. `compare-against-iwc-exemplar` — structural diff of the template against nearest IWC exemplar(s).
+4. `compare-against-iwc-exemplar` — structural diff of the design briefs against nearest IWC exemplar(s); guidance feeds template authoring.
+5. `cwl-summary-to-galaxy-template`
 6. `[loop]` `[branch]` discover-or-author branch (`discover-shed-tool` → fallthrough to `author-galaxy-tool-wrapper`).
 7. `[loop]` `summarize-galaxy-tool`
 8. `[loop]` `implement-galaxy-tool-step`
@@ -154,6 +154,6 @@ Custom-Galaxy-tool authoring is split: a **pattern page** (reference and guidanc
 ## Open questions
 
 - Whether to surface `PAPER → CWL → GALAXY` and `NEXTFLOW → CWL → GALAXY` as distinct named harnesses or leave them as runtime compositions of two harnesses. (Either way the Mold inventory is unchanged — both paths reuse existing Molds.)
-- Whether `compare-against-iwc-exemplar` should also fire post-implementation (after the per-step loop) in addition to its post-template position, to catch divergences that only appear at full step granularity.
+- Whether `compare-against-iwc-exemplar` should also fire post-template or post-implementation (after the per-step loop) in addition to its pre-template position, to catch divergences that only appear once draft structure or full step granularity exist.
 - Whether `run-workflow-test` factors cleanly across Galaxy and CWL targets via Planemo, or splits into per-target variants once we hit real test execution.
 - Whether the `<source>-test-to-<target>-tests` Molds factor through a shared intermediate or stay per-pair.

--- a/docs/MOLDS.md
+++ b/docs/MOLDS.md
@@ -128,7 +128,7 @@ CLI command docs live under `content/cli/<tool>/<command>.md`. Action Molds refe
 
 ### Corpus-grounding (Galaxy-specific, generic in source)
 
-- `compare-against-iwc-exemplar` — given a draft template or implemented workflow, find the nearest IWC exemplar(s) and surface a **structural diff** (this branch differs / IWC consistently uses pattern X here / unexpected step ordering / missing common pre-step). Retrieval is part of the comparison — there is no separate retrieval Mold. Galaxy-target only; this is the corpus-first principle delivered at authoring time.
+- `compare-against-iwc-exemplar` — given the upstream Galaxy design briefs (interface + data-flow), find the nearest IWC exemplar(s) and surface a **structural diff** (this branch differs / IWC consistently uses pattern X here / unexpected step ordering / missing common pre-step) to guide template authoring. Retrieval is part of the comparison — there is no separate retrieval Mold. Galaxy-target only; this is the corpus-first principle delivered before per-step effort begins.
 
 ## Not Molds
 


### PR DESCRIPTION
## Summary

The exemplar comparison's purpose is to guide template authoring, so it should run **before** the `*-summary-to-galaxy-template` Mold rather than diff against an existing draft.

- Swap order in `NEXTFLOW → GALAXY`, `CWL → GALAXY`, `PAPER → GALAXY` pipelines.
- Reshape `compare-against-iwc-exemplar` to consume the upstream design briefs (interface + data-flow, or the combined paper design) instead of `galaxy-workflow-draft`. Updates prose, `eval.md` fixtures, and structural-diff field names (`draft_*` → `briefs_*`).
- Thread `iwc-comparison-notes` into the three `*-summary-to-galaxy-template` Molds as an input artifact.
- Update `HARNESS_PIPELINES.md` narrative for all three pipelines, reframe the open-question bullet (whether the Mold should *also* fire post-template/post-implementation), and refresh the `MOLDS.md` corpus-grounding bullet.

## Notes

- `npm run validate` → 0 errors. 4 new advisory warnings on the pipelines because the shared Mold declares all five source-specific input alternates while each pipeline only feeds one — the schema has no `optional: true` flag for input artifacts; would need a schema extension to silence cleanly.
- `cast-mold` test failures observed locally are pre-existing (missing `@galaxy-foundry/summary-nextflow-schema` install), unrelated to this change.

## Test plan

- [ ] `npm run validate` passes
- [ ] Pipeline pages render with the new ordering
- [ ] Generated dashboards still resolve all wiki-links

🤖 Generated with [Claude Code](https://claude.com/claude-code)