### PR TITLE
wire cli metadata rendering

### DIFF
--- a/content/cli/gxwf/convert.md
+++ b/content/cli/gxwf/convert.md
@@ -2,13 +2,15 @@
 type: cli-command
 tool: gxwf
 command: convert
+package: "@galaxy-tool-util/cli"
+upstream: "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/gxwf.json"
 tags:
   - cli-command
   - cli/gxwf
 status: draft
 created: 2026-05-05
-revised: 2026-05-05
-revision: 1
+revised: 2026-05-06
+revision: 2
 ai_generated: true
 summary: "Convert a Galaxy workflow between native (.ga) and format2 (.gxwf.yml) representations."
 ---
@@ -17,43 +19,9 @@ summary: "Convert a Galaxy workflow between native (.ga) and format2 (.gxwf.yml)
 
 Convert a Galaxy workflow between the native `.ga` JSON and the `.gxwf.yml` format2 representation. Use this to normalize fetched IWC workflows into a consistent comparison representation.
 
-## Install
-
-Use the Foundry-supported `gxwf` CLI from `@galaxy-tool-util/cli`.
-
-## Synopsis
-
-```bash
-gxwf convert <file> [options]
-```
-
-## Options
-
-| Option | Description |
-|---|---|
-| `--to <format>` | Target format: `native` or `format2`; default infers the opposite of the source. |
-| `--output <file>` | Write result to file (default: stdout). |
-| `--compact` | Omit position info in format2 output. |
-| `--json` | Force JSON output. |
-| `--yaml` | Force YAML output. |
-| `--format <fmt>` | Force source format (auto-detected by default). |
-| `--stateful` | Use cached tool definitions for schema-aware tool-state re-encoding. |
-| `--cache-dir <dir>` | Tool cache directory (used with `--stateful`). |
-| `--strict` | Shorthand for `--strict-structure --strict-encoding --strict-state`. |
-| `--strict-structure` | Reject unknown envelope/step keys. |
-| `--strict-encoding` | Reject legacy JSON-string `tool_state` and format2 field misuse. |
-| `--strict-state` | Require every tool step to validate; no skipped tool-state checks. |
-
 ## Output
 
 Default output is the converted workflow on stdout. With `--output`, the result is written to a file. JSON output is selected with `--json` (or `--to native`); YAML output is selected with `--yaml` (or `--to format2`).
-
-## Exit codes
-
-| Code | Meaning |
-|---|---|
-| `0` | Conversion succeeded. |
-| non-zero | Source could not be loaded, target format could not be produced, or strict checks failed. |
 
 ## Examples
 

--- a/content/cli/gxwf/tool-revisions.md
+++ b/content/cli/gxwf/tool-revisions.md
@@ -2,13 +2,15 @@
 type: cli-command
 tool: gxwf
 command: tool-revisions
+package: "@galaxy-tool-util/cli"
+upstream: "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/gxwf.json"
 tags:
   - cli-command
   - cli/gxwf
 status: draft
 created: 2026-04-30
-revised: 2026-04-30
-revision: 1
+revised: 2026-05-06
+revision: 2
 ai_generated: true
 summary: "Resolve a Tool Shed tool to changeset revisions for reproducible workflow pinning. Final step in discover-and-pin."
 related_notes:
@@ -19,25 +21,7 @@ related_notes:
 
 Resolve a Tool Shed tool to the changeset revisions that publish it, ordered oldest→newest by `get_ordered_installable_revisions`. Needed when emitting a workflow that pins `(name, owner, changeset_revision)` for reproducible reinstall — TRS version strings alone are insufficient because the Tool Shed dedupes versions across changesets.
 
-## Install
-
-Use the Foundry-supported `gxwf` CLI from `@galaxy-tool-util/cli` or the Python package with the matching interface. Prefer the project-local executable when running inside a checked-out Foundry or galaxy-tool-util workspace.
-
-## Synopsis
-
-```
-gxwf tool-revisions <tool-id> [options]
-```
-
 `<tool-id>` accepts both TRS form (`owner~repo~tool_id`) and pretty form (`owner/repo/tool_id`).
-
-## Options
-
-| Option | Description |
-|---|---|
-| `--tool-version <v>` | Restrict to revisions that publish this exact tool version. The flag is `--tool-version` rather than `--version` because commander's program-level `--version` flag intercepts. |
-| `--latest` | Print only the newest matching revision. |
-| `--json` | Emit `{ trsToolId, version?, revisions: [{ changesetRevision, toolVersion }] }`. |
 
 ## Output
 
@@ -56,14 +40,6 @@ Default: lines of `<changesetRevision>\t<toolVersion>`.
 ```
 
 `--json` without `--tool-version` returns every installable revision for the tool, each tagged with whatever XML `version` it publishes.
-
-## Exit codes
-
-| Code | Meaning |
-|---|---|
-| `0` | At least one revision. |
-| `2` | Empty result (no matching revisions; e.g. `--tool-version` doesn't match). |
-| `3` | HTTP / fetch error. |
 
 ## Examples
 

--- a/content/cli/gxwf/tool-search.md
+++ b/content/cli/gxwf/tool-search.md
@@ -2,13 +2,15 @@
 type: cli-command
 tool: gxwf
 command: tool-search
+package: "@galaxy-tool-util/cli"
+upstream: "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/gxwf.json"
 tags:
   - cli-command
   - cli/gxwf
 status: draft
 created: 2026-04-30
-revised: 2026-04-30
-revision: 1
+revised: 2026-05-06
+revision: 2
 ai_generated: true
 summary: "Free-text Tool Shed search returning candidate tools as JSON; first step in the discover-and-pin sequence."
 related_notes:
@@ -21,30 +23,7 @@ Free-text search over the Galaxy Tool Shed's tool index. Designed to feed `galax
 
 Instance-agnostic; targets `https://toolshed.g2.bx.psu.edu` by default.
 
-## Install
-
-Use the Foundry-supported `gxwf` CLI from `@galaxy-tool-util/cli` or the Python package with the matching interface. Prefer the project-local executable when running inside a checked-out Foundry or galaxy-tool-util workspace.
-
-## Synopsis
-
-```
-gxwf tool-search <query> [options]
-```
-
 `<query>` is free text; whitespace separates terms. The Tool Shed wraps the term as `*term*` server-side, so noisy queries can match description and help text.
-
-## Options
-
-| Option | Description |
-|---|---|
-| `--page-size <n>` | Server-side page size (default `20`). |
-| `--max-results <n>` | Hard cap on hits returned (default `50`). |
-| `--page <n>` | Starting page (1-indexed; default `1`). |
-| `--owner <user>` | Restrict to one repo owner. **Client-side filter** — `tool-search` has no server `owner:` keyword. |
-| `--match-name` | Drop hits where the query is not a token in the tool name. Tightens noisy queries. |
-| `--json` | Emit `{ query, hits: [NormalizedToolHit, ...] }`. |
-| `--enrich` | Resolve each hit's `ParsedTool` (one fetch per hit) and attach as `parsedTool` on each JSON hit. Off by default. Best for skills that pick top 1–3; wasteful for paged exploration. |
-| `--cache-dir <dir>` | Tool cache used by `--enrich`. Defaults to `galaxy-tool-cache`'s location. |
 
 ## Output
 
@@ -70,14 +49,6 @@ Default: human-readable list.
 ```
 
 A hit identifies `(owner, repoName, toolId)` plus a `trsToolId` (`owner~repo~toolId`). It does **not** include a changeset revision or specific tool version — those come from [[tool-versions]] and [[tool-revisions]].
-
-## Exit codes
-
-| Code | Meaning |
-|---|---|
-| `0` | At least one hit. |
-| `2` | Empty result (no hits, including after `--match-name` / `--owner` filtering). |
-| `3` | HTTP / fetch error. |
 
 ## Examples
 

--- a/content/cli/gxwf/tool-versions.md
+++ b/content/cli/gxwf/tool-versions.md
@@ -2,13 +2,15 @@
 type: cli-command
 tool: gxwf
 command: tool-versions
+package: "@galaxy-tool-util/cli"
+upstream: "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/gxwf.json"
 tags:
   - cli-command
   - cli/gxwf
 status: draft
 created: 2026-04-30
-revised: 2026-04-30
-revision: 1
+revised: 2026-05-06
+revision: 2
 ai_generated: true
 summary: "List TRS-published versions of a Tool Shed tool, oldest→newest. Second step in the discover-and-pin sequence."
 related_notes:
@@ -19,28 +21,11 @@ related_notes:
 
 List the TRS-published versions of a Tool Shed tool, ordered oldest→newest (newest last). Used after [[tool-search]] has surfaced a candidate `trsToolId` and the caller needs to pick a version to cache.
 
-## Install
-
-Use the Foundry-supported `gxwf` CLI from `@galaxy-tool-util/cli` or the Python package with the matching interface. Prefer the project-local executable when running inside a checked-out Foundry or galaxy-tool-util workspace.
-
-## Synopsis
-
-```
-gxwf tool-versions <tool-id> [options]
-```
-
 `<tool-id>` accepts both forms:
 - TRS form: `owner~repo~tool_id` (e.g. `devteam~fastqc~fastqc`).
 - Pretty form: `owner/repo/tool_id` (e.g. `devteam/fastqc/fastqc`).
 
 The `~` form is the Tool Shed's TRS encoding (slashes break FastAPI path-param decoding); the CLI accepts both and normalizes.
-
-## Options
-
-| Option | Description |
-|---|---|
-| `--latest` | Print only the newest version. |
-| `--json` | Emit `{ trsToolId, versions: [...] }`. |
 
 ## Output
 
@@ -63,14 +48,6 @@ Default: one version string per line, oldest first.
   "versions": ["0.74+galaxy0"]
 }
 ```
-
-## Exit codes
-
-| Code | Meaning |
-|---|---|
-| `0` | At least one version. |
-| `2` | Empty result (TRS tool exists but has no installable versions, or unknown tool id). |
-| `3` | HTTP / fetch error. |
 
 ## Examples
 

--- a/content/cli/gxwf/validate-tests.md
+++ b/content/cli/gxwf/validate-tests.md
@@ -2,13 +2,15 @@
 type: cli-command
 tool: gxwf
 command: validate-tests
+package: "@galaxy-tool-util/cli"
+upstream: "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/gxwf.json"
 tags:
   - cli-command
   - cli/gxwf
 status: draft
 created: 2026-05-03
-revised: 2026-05-04
-revision: 2
+revised: 2026-05-06
+revision: 3
 ai_generated: true
 summary: "Validate Galaxy workflow test files and optionally cross-check labels against their workflow."
 related_notes:
@@ -20,37 +22,13 @@ related_notes:
 
 Validate a Galaxy workflow test file (`*-tests.yml` or `*.gxwf-tests.yml`) against the Galaxy tests schema. Optionally cross-check the test file against a workflow so missing input labels, missing output labels, and type mismatches fail before a slow Planemo run.
 
-## Install
-
-Use the Foundry-supported `gxwf` CLI from `@galaxy-tool-util/cli` or the Python package with the matching interface. Inside this repo, `validate-tests-format` from `@galaxy-foundry/tests-format-schema` exposes the same schema gate plus workflow cross-check for harness and package tests.
-
-## Synopsis
-
-```bash
-gxwf validate-tests <file> [options]
-```
-
 `<file>` is a workflow test YAML file, usually named `<workflow>-tests.yml` or `<workflow>.gxwf-tests.yml`.
-
-## Options
-
-| Option | Description |
-|---|---|
-| `--json` | Emit a structured JSON validation report. Preferred for cast skills and harness routing. |
-| `--workflow <path>` | Cross-check job inputs and output assertions against a Galaxy workflow (`.ga` or `.gxwf.yml`). |
 
 ## Output
 
 Default output is human-readable validation diagnostics.
 
 With `--json`, the command emits a structured report describing schema errors and, when `--workflow` is supplied, workflow-coherence errors such as missing labels or incompatible input values.
-
-## Exit codes
-
-| Code | Meaning |
-|---|---|
-| `0` | Test file is schema-valid and any requested workflow cross-check passed. |
-| non-zero | The test file is invalid, the workflow cross-check failed, or an input file could not be loaded. |
 
 ## Examples
 

--- a/content/cli/gxwf/validate.md
+++ b/content/cli/gxwf/validate.md
@@ -2,13 +2,15 @@
 type: cli-command
 tool: gxwf
 command: validate
+package: "@galaxy-tool-util/cli"
+upstream: "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/gxwf.json"
 tags:
   - cli-command
   - cli/gxwf
 status: draft
 created: 2026-05-02
-revised: 2026-05-02
-revision: 2
+revised: 2026-05-06
+revision: 3
 ai_generated: true
 summary: "Validate Galaxy workflow structure, tool state, and optional connection compatibility before runtime execution."
 ---
@@ -17,43 +19,9 @@ summary: "Validate Galaxy workflow structure, tool state, and optional connectio
 
 Validate a Galaxy workflow source file before attempting runtime execution. Use this as the design-time guardrail after step implementation and again after final workflow assembly.
 
-## Install
-
-Use the Foundry-supported `gxwf` CLI from `@galaxy-tool-util/cli` or the Python package with the matching interface. Prefer the project-local executable when running inside a checked-out Foundry or galaxy-tool-util workspace.
-
-## Synopsis
-
-```bash
-gxwf validate <file> [options]
-```
-
-## Options
-
-| Option | Description |
-|---|---|
-| `--format <fmt>` | Force source format: `native` or `format2`; otherwise auto-detected from file extension/content. |
-| `--json` | Emit a structured JSON validation report. Preferred for cast skills and harness routing. |
-| `--report-html [file]` | Write an HTML validation report to `file`, or stdout when the optional file value is omitted. |
-| `--no-tool-state` | Skip tool-state validation. Use only when tool metadata is unavailable and structural checks are still useful. |
-| `--cache-dir <dir>` | Tool cache directory used for tool-state validation. |
-| `--mode <mode>` | Validation backend. Upstream default is `effect`; `json-schema` is available for schema-backed/offline cases. |
-| `--tool-schema-dir <dir>` | Directory of pre-exported per-tool JSON Schemas for offline `json-schema` mode. |
-| `--connections` | Validate connection-type compatibility, including collection algebra and map-over/reduction compatibility. |
-| `--strict` | Shorthand for `--strict-structure --strict-encoding --strict-state`. |
-| `--strict-structure` | Reject unknown envelope/step keys. |
-| `--strict-encoding` | Reject legacy JSON-string `tool_state` and format2 field misuse. |
-| `--strict-state` | Require every tool step to validate; no skipped tool-state checks. |
-
 ## Output
 
 Default output is human-readable diagnostics. JSON output should be treated as the preferred cast-skill interface; free-text diagnostics are a fallback for humans.
-
-## Exit codes
-
-| Code | Meaning |
-|---|---|
-| `0` | Workflow validation passed. |
-| non-zero | Validation failed, the workflow could not be loaded, or a selected validation backend could not complete. |
 
 ## Examples
 

--- a/docs/COMPILATION_PIPELINE.md
+++ b/docs/COMPILATION_PIPELINE.md
@@ -11,7 +11,7 @@ Casting operates as **per-kind dispatch** over the manifest, not a single resolv
 | Reference kind | Source location | Casting transformation | Lands at | Status |
 |---|---|---|---|---|
 | `pattern` | `content/patterns/*.md` | Verbatim copy or LLM-condense per `mode` | `references/patterns/<slug>.md` | v1 |
-| `cli-command` | `content/cli/<tool>/<cmd>.md` | Deterministic JSON sidecar | `references/cli/<slug>.json` (flat — `<slug>` is the source basename) | v1 |
+| `cli-command` | `content/cli/<tool>/<cmd>.md` framing note plus registered upstream CLI metadata | Deterministic JSON sidecar sourced from registry metadata + framing markdown | `references/cli/<slug>.json` (flat — `<slug>` is the source basename) | v1 |
 | `schema` | `[[wiki-link]]` to a `type: schema` note in `content/schemas/`. The note declares `package` + `package_export`; cast imports the named runtime export at build time and serializes it. Foundry-authored: schemas in `packages/<name>-schema/src/<name>.schema.json` (e.g. `summary-nextflow`, `galaxy-tool-discovery`). Vendored: schemas synced from upstream packages into `packages/<name>-schema/src/` (e.g. `tests-format` from `@galaxy-tool-util/schema`). | Verbatim copy of the imported export, JSON-serialized | `references/schemas/<note-slug>.schema.json` | v1 |
 | `research` | `content/research/*.md` or paired structured sources under `content/research/` | Verbatim copy or LLM condense per `mode` | `references/notes/<source-basename>` (strict 1:1) | v1 |
 | `prompt` | `content/prompts/*.md` | Inlined verbatim, no LLM rewrite | `references/prompts/` (inlined or copied) | **deferred** — rejected by v1 caster as "not implemented" until a real Mold needs it |
@@ -115,7 +115,7 @@ To cast a Mold, the casting process consumes:
 
 Resolution policy is per-kind, not a single rule:
 - `pattern` — verbatim inline if under a size threshold; LLM-summarize otherwise. Casting hints (`inline: true` / `summarize: true`) may override.
-- `cli-command` — always cast to JSON sidecar (deterministic structuring; no token-budget condensation needed because the sidecar is loaded only when the agent needs that command).
+- `cli-command` — always cast to JSON sidecar from registered upstream metadata plus the Foundry framing note; no token-budget condensation needed because the sidecar is loaded only when the agent needs that command.
 - `schema`, `example`, `prompt` — always verbatim copy unless the typed reference declares a future supported transformation.
 - `research` — operational background; copied or condensed according to `mode`, and loaded according to `used_at` / `load`. `mode: condense` is specified but not implemented in v1 tooling yet.
 - `eval` — never packaged.
@@ -238,7 +238,7 @@ cast_mold(mold_name, target):
     case ref.kind:
       pattern      -> verbatim copy or LLM-condense per mode
                       write to references/patterns/<source-basename>
-      cli-command  -> deterministic JSON sidecar from frontmatter + body
+      cli-command  -> deterministic JSON sidecar from registry metadata + framing body
                       write to references/cli/<source-slug>.json
       schema       -> copy verbatim to references/schemas/<source-basename>
       research     -> copy verbatim or condense per mode

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "vitest": "^2.1.0"
   },
   "dependencies": {
-    "@galaxy-tool-util/cli": "^1.1.0",
+    "@galaxy-tool-util/cli": "^1.4.0",
     "@galaxy-tool-util/schema": "^1.1.0"
   }
 }

--- a/packages/build-cli/src/commands/validate.ts
+++ b/packages/build-cli/src/commands/validate.ts
@@ -8,6 +8,7 @@ import process from "node:process";
 import type { ErrorObject } from "ajv";
 import AjvImport from "ajv";
 import addFormatsImport from "ajv-formats";
+import { galaxyToolCacheCliMeta, gxwfCliMeta } from "@galaxy-tool-util/cli/meta";
 import { readMarkdown } from "../lib/frontmatter.js";
 import { loadSchema, loadTags } from "../lib/schema.js";
 import type { FileMeta, Frontmatter, JsonSchema, ValidationResult } from "../lib/types.js";
@@ -41,6 +42,12 @@ const TYPE_TAG_MAP: Record<string, string> = {
   "research|design-spec": "research/design-spec",
   "schema|": "schema",
 };
+
+const CLI_METADATA_KEYS = new Set(
+  [gxwfCliMeta, galaxyToolCacheCliMeta].flatMap((program) =>
+    program.commands.map((command) => `${program.name}/${command.name}`),
+  ),
+);
 
 /** Single-value vs array wiki-link fields. Schema's regex catches missing brackets; this catches whitespace-only inner text. */
 const WIKI_LINK_FIELDS: Record<string, "single" | "array"> = {
@@ -967,9 +974,31 @@ function validateMoldStubBody(files: FileMeta[]): CrossFileFinding[] {
 
 function validateCliCommandDocs(files: FileMeta[]): CrossFileFinding[] {
   const findings: CrossFileFinding[] = [];
-  const requiredSections = ["Install", "Synopsis", "Output", "Exit codes", "Examples", "Gotchas"];
+  const requiredSections = ["Output", "Examples", "Gotchas"];
   for (const f of files) {
     if (f.meta.type !== "cli-command") continue;
+    const key = `${String(f.meta.tool)}/${String(f.meta.command)}`;
+    if (!CLI_METADATA_KEYS.has(key)) {
+      findings.push({
+        path: f.path,
+        severity: "error",
+        message: `cli-command ${key} is absent from @galaxy-tool-util/cli metadata`,
+      });
+    }
+    if (typeof f.meta.package !== "string" || f.meta.package.length === 0) {
+      findings.push({
+        path: f.path,
+        severity: "error",
+        message: "cli-command must declare package for metadata-backed rendering",
+      });
+    }
+    if (typeof f.meta.upstream !== "string" || f.meta.upstream.length === 0) {
+      findings.push({
+        path: f.path,
+        severity: "error",
+        message: "cli-command must declare upstream for metadata-backed rendering",
+      });
+    }
     const body = readMarkdown(f.path).body;
     for (const section of requiredSections) {
       if (new RegExp(`^##\\s+${section}\\b`, "m").test(body)) continue;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@galaxy-tool-util/cli':
-        specifier: ^1.1.0
-        version: 1.1.0
+        specifier: ^1.4.0
+        version: 1.4.0
       '@galaxy-tool-util/schema':
         specifier: ^1.1.0
         version: 1.1.0
@@ -599,12 +599,15 @@ packages:
     resolution: {integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@galaxy-tool-util/cli@1.1.0':
-    resolution: {integrity: sha512-eTOR1uzm5tM3wyf2C3PTZMGEy3BVEkhtsMRUkrvnM2I/qub/XZcK64GVqwq0O6SFM5cBL8kBOLAXCcVzQB5frA==}
+  '@galaxy-tool-util/cli@1.4.0':
+    resolution: {integrity: sha512-H8jazKK0R/LJPOw0ek6d98pIKCJ6q56IxREd3C8AQ6RDmiQlFW0DDRpYATHifcPoNHMk4vLxbo2HgZJ0a508wA==}
     hasBin: true
 
-  '@galaxy-tool-util/core@1.1.0':
-    resolution: {integrity: sha512-aOCt4s3bW8OYRrt2JPjtkS8pn2yTPJy86eED6lh3Nfy/KaFWMDUcXBjTm+5/7BgmcfW9x/d/6FVazsekH07OVg==}
+  '@galaxy-tool-util/connection-validation@1.2.0':
+    resolution: {integrity: sha512-LTDXriF6hcoTP889rU1wwDPwzc4+l5IuJVtHXLzWYR0pFJS2uTE1coov49G+HmX4pJXrqUeb3tFh0U4be7vqXQ==}
+
+  '@galaxy-tool-util/core@1.2.0':
+    resolution: {integrity: sha512-TcX6vrtQX56Ra3ibbYi0R9kJ3C8jEFtz0DLalcve7KcM7ZGumwZbj9pZCD7andZHSe6L7ZEqQihc8HsCHvce8A==}
 
   '@galaxy-tool-util/schema@1.1.0':
     resolution: {integrity: sha512-D0dMtBaTyRJhoAxH1Djx/42WnxQDAk3yuMhTd3k+MCez1jiGL1kFeYDQEk8yWSgY5Z4d+u24wbhaWG4Q2GTG1w==}
@@ -612,8 +615,11 @@ packages:
   '@galaxy-tool-util/schema@1.2.0':
     resolution: {integrity: sha512-0OOemrWHa/wGtxJZehCa4Y6D2thLxub1iAJ+Fmifj9TeRkTE0f1taZHAutwV4mJeBZ/xzgBgFUZu8ZWWzeKpPg==}
 
-  '@galaxy-tool-util/search@1.1.0':
-    resolution: {integrity: sha512-VSLDCUE68u/2+zKWH8J+wf0N080vOUDJd/nVFr5v7F81TJURjdC4oHRsl2YYs2Uwb8JkpWIvs9EAbtSB2rzF2g==}
+  '@galaxy-tool-util/search@1.2.0':
+    resolution: {integrity: sha512-0nQe6/JBE0bIuQ138H5RqM1HlPaB3BfJYN89ka5OIaU/n8wsgm+ToQirUPfJLM8Ltv816l7Q59FnAdkhpLlEnw==}
+
+  '@galaxy-tool-util/workflow-graph@1.2.0':
+    resolution: {integrity: sha512-S3a/2lHaNcKoE9pYWSZXPL6DPFh+DXU5JhMdVMMzYRx4BHDbpK0aqVPcwyq+uAlNP+PqwmhD6WLgdsVwBSDotQ==}
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -2053,11 +2059,12 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@galaxy-tool-util/cli@1.1.0':
+  '@galaxy-tool-util/cli@1.4.0':
     dependencies:
-      '@galaxy-tool-util/core': 1.1.0
-      '@galaxy-tool-util/schema': 1.1.0
-      '@galaxy-tool-util/search': 1.1.0
+      '@galaxy-tool-util/connection-validation': 1.2.0
+      '@galaxy-tool-util/core': 1.2.0
+      '@galaxy-tool-util/schema': 1.2.0
+      '@galaxy-tool-util/search': 1.2.0
       ajv: 8.20.0
       commander: 14.0.3
       effect: 3.21.2
@@ -2066,9 +2073,14 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@galaxy-tool-util/core@1.1.0':
+  '@galaxy-tool-util/connection-validation@1.2.0':
     dependencies:
-      '@galaxy-tool-util/schema': 1.1.0
+      '@galaxy-tool-util/schema': 1.2.0
+      '@galaxy-tool-util/workflow-graph': 1.2.0
+
+  '@galaxy-tool-util/core@1.2.0':
+    dependencies:
+      '@galaxy-tool-util/schema': 1.2.0
       effect: 3.21.2
       yaml: 2.8.3
 
@@ -2086,10 +2098,12 @@ snapshots:
       effect: 3.21.2
       yaml: 2.8.3
 
-  '@galaxy-tool-util/search@1.1.0':
+  '@galaxy-tool-util/search@1.2.0':
     dependencies:
-      '@galaxy-tool-util/core': 1.1.0
-      '@galaxy-tool-util/schema': 1.1.0
+      '@galaxy-tool-util/core': 1.2.0
+      '@galaxy-tool-util/schema': 1.2.0
+
+  '@galaxy-tool-util/workflow-graph@1.2.0': {}
 
   '@humanfs/core@0.19.2':
     dependencies:

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@fontsource/atkinson-hyperlegible": "^5.2.8",
-        "@galaxy-tool-util/cli": "^1.1.0",
+        "@galaxy-tool-util/cli": "^1.4.0",
         "@galaxy-tool-util/schema": "^1.1.0",
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.1.18",
@@ -614,14 +614,15 @@
       }
     },
     "node_modules/@galaxy-tool-util/cli": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@galaxy-tool-util/cli/-/cli-1.1.0.tgz",
-      "integrity": "sha512-eTOR1uzm5tM3wyf2C3PTZMGEy3BVEkhtsMRUkrvnM2I/qub/XZcK64GVqwq0O6SFM5cBL8kBOLAXCcVzQB5frA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@galaxy-tool-util/cli/-/cli-1.4.0.tgz",
+      "integrity": "sha512-H8jazKK0R/LJPOw0ek6d98pIKCJ6q56IxREd3C8AQ6RDmiQlFW0DDRpYATHifcPoNHMk4vLxbo2HgZJ0a508wA==",
       "license": "MIT",
       "dependencies": {
-        "@galaxy-tool-util/core": "1.1.0",
-        "@galaxy-tool-util/schema": "1.1.0",
-        "@galaxy-tool-util/search": "1.1.0",
+        "@galaxy-tool-util/connection-validation": "1.2.0",
+        "@galaxy-tool-util/core": "1.2.0",
+        "@galaxy-tool-util/schema": "1.2.0",
+        "@galaxy-tool-util/search": "1.2.0",
         "ajv": "^8.18.0",
         "commander": "^14.0.0",
         "effect": "^3.21.0",
@@ -676,21 +677,31 @@
         "node": ">= 6"
       }
     },
-    "node_modules/@galaxy-tool-util/core": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@galaxy-tool-util/core/-/core-1.1.0.tgz",
-      "integrity": "sha512-aOCt4s3bW8OYRrt2JPjtkS8pn2yTPJy86eED6lh3Nfy/KaFWMDUcXBjTm+5/7BgmcfW9x/d/6FVazsekH07OVg==",
+    "node_modules/@galaxy-tool-util/connection-validation": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@galaxy-tool-util/connection-validation/-/connection-validation-1.2.0.tgz",
+      "integrity": "sha512-LTDXriF6hcoTP889rU1wwDPwzc4+l5IuJVtHXLzWYR0pFJS2uTE1coov49G+HmX4pJXrqUeb3tFh0U4be7vqXQ==",
       "license": "MIT",
       "dependencies": {
-        "@galaxy-tool-util/schema": "1.1.0",
+        "@galaxy-tool-util/schema": "1.2.0",
+        "@galaxy-tool-util/workflow-graph": "1.2.0"
+      }
+    },
+    "node_modules/@galaxy-tool-util/core": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@galaxy-tool-util/core/-/core-1.2.0.tgz",
+      "integrity": "sha512-TcX6vrtQX56Ra3ibbYi0R9kJ3C8jEFtz0DLalcve7KcM7ZGumwZbj9pZCD7andZHSe6L7ZEqQihc8HsCHvce8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@galaxy-tool-util/schema": "1.2.0",
         "effect": "^3.21.0",
         "yaml": "^2.8.3"
       }
     },
     "node_modules/@galaxy-tool-util/schema": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@galaxy-tool-util/schema/-/schema-1.1.0.tgz",
-      "integrity": "sha512-D0dMtBaTyRJhoAxH1Djx/42WnxQDAk3yuMhTd3k+MCez1jiGL1kFeYDQEk8yWSgY5Z4d+u24wbhaWG4Q2GTG1w==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@galaxy-tool-util/schema/-/schema-1.2.0.tgz",
+      "integrity": "sha512-0OOemrWHa/wGtxJZehCa4Y6D2thLxub1iAJ+Fmifj9TeRkTE0f1taZHAutwV4mJeBZ/xzgBgFUZu8ZWWzeKpPg==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.18.0",
@@ -700,14 +711,20 @@
       }
     },
     "node_modules/@galaxy-tool-util/search": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@galaxy-tool-util/search/-/search-1.1.0.tgz",
-      "integrity": "sha512-VSLDCUE68u/2+zKWH8J+wf0N080vOUDJd/nVFr5v7F81TJURjdC4oHRsl2YYs2Uwb8JkpWIvs9EAbtSB2rzF2g==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@galaxy-tool-util/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-0nQe6/JBE0bIuQ138H5RqM1HlPaB3BfJYN89ka5OIaU/n8wsgm+ToQirUPfJLM8Ltv816l7Q59FnAdkhpLlEnw==",
       "license": "MIT",
       "dependencies": {
-        "@galaxy-tool-util/core": "1.1.0",
-        "@galaxy-tool-util/schema": "1.1.0"
+        "@galaxy-tool-util/core": "1.2.0",
+        "@galaxy-tool-util/schema": "1.2.0"
       }
+    },
+    "node_modules/@galaxy-tool-util/workflow-graph": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@galaxy-tool-util/workflow-graph/-/workflow-graph-1.2.0.tgz",
+      "integrity": "sha512-S3a/2lHaNcKoE9pYWSZXPL6DPFh+DXU5JhMdVMMzYRx4BHDbpK0aqVPcwyq+uAlNP+PqwmhD6WLgdsVwBSDotQ==",
+      "license": "MIT"
     },
     "node_modules/@img/colour": {
       "version": "1.1.0",

--- a/site/package.json
+++ b/site/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@fontsource/atkinson-hyperlegible": "^5.2.8",
-    "@galaxy-tool-util/cli": "^1.1.0",
+    "@galaxy-tool-util/cli": "^1.4.0",
     "@galaxy-tool-util/schema": "^1.1.0",
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.1.18",

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -145,6 +145,8 @@ const cliCommandSchema = z.object({
   type: z.literal('cli-command'),
   tool: z.enum(['gxwf', 'planemo']),
   command: z.string(),
+  package: z.string().optional(),
+  upstream: z.string().optional(),
   ...baseFields,
 }).strict();
 

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -514,7 +514,14 @@ describe("validateDirectory (cross-file)", () => {
       }),
     });
     writeFm(path.join(dir, "cli/gxwf/validate.md"), {
-      ...baseRequired({ type: "cli-command", tags: ["cli-command", "cli/gxwf"], tool: "gxwf", command: "validate" }),
+      ...baseRequired({
+        type: "cli-command",
+        tags: ["cli-command", "cli/gxwf"],
+        tool: "gxwf",
+        command: "validate",
+        package: "@galaxy-tool-util/cli",
+        upstream: "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/gxwf.json",
+      }),
     });
 
     const r = validateDirectory({
@@ -523,6 +530,26 @@ describe("validateDirectory (cross-file)", () => {
       tagsPath: TAGS_PATH,
     });
     expect(r.errors).toBe(0);
+  });
+
+  it("rejects CLI command notes missing upstream metadata", () => {
+    writeFm(path.join(dir, "cli/gxwf/not-real.md"), {
+      ...baseRequired({
+        type: "cli-command",
+        tags: ["cli-command", "cli/gxwf"],
+        tool: "gxwf",
+        command: "not-real",
+        package: "@galaxy-tool-util/cli",
+        upstream: "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/gxwf.json",
+      }),
+    });
+
+    const r = validateDirectory({
+      directory: dir,
+      schemaPath: SCHEMA_PATH,
+      tagsPath: TAGS_PATH,
+    });
+    expect(r.errors).toBeGreaterThanOrEqual(1);
   });
 
   it("rejects typed references that resolve to the wrong type", () => {


### PR DESCRIPTION
## Summary
- bump `@galaxy-tool-util/cli` to a metadata-exporting release for root and site installs
- convert gxwf command notes from hand-authored command tables to framing notes backed by package metadata
- validate cli-command notes against upstream metadata and document cast sidecar sourcing

## Testing
- npm run validate
- npm run site:build
- npm run test
- npm run packages-typecheck

Note: `npm run typecheck` still fails on existing root/site TypeScript issues unrelated to this branch.