### PR TITLE
Wire process artifact validation

### DIFF
--- a/casts/claude/skills/summarize-nextflow/_provenance.json
+++ b/casts/claude/skills/summarize-nextflow/_provenance.json
@@ -6,11 +6,11 @@
     "path": "content/molds/summarize-nextflow/index.md",
     "revision": 11,
     "content_hash": "8d3400077caa35cc3341cd81becb39466047c3d6406286d7d56459864bb82f69",
-    "commit": "eef25246cac31f45b9826028ca08c670bb6dcb7e"
+    "commit": "4d58a870033b83fa61d9b0ff417c446bf91e2f76"
   },
   "cast_method": "hand-cast",
   "cast_agent": "claude (manual transcription, no LLM cast prompt)",
-  "cast_at": "2026-05-06T15:16:08.648Z",
+  "cast_at": "2026-05-06T15:34:12.172Z",
   "cast_date": "2026-05-06",
   "cast_revision": 6,
   "cast_history": [
@@ -164,5 +164,19 @@
   },
   "open_questions": [
     "The three notes are stubs; first-paragraph contents will come from running this cast against nf-core/rnaseq — see issue #17."
+  ],
+  "validation_results": [
+    {
+      "artifact_id": "summary-nextflow",
+      "path": "casts/claude/skills/summarize-nextflow/runs/nf-core__demo/summary.json",
+      "validator_bin": "validate-summary-nextflow",
+      "status": "passed",
+      "exit_code": 0,
+      "artifact_hash": "9193bc9b6f94ac57d04ccbb72047f94eaf612a8c736297f84d5e37685c175208",
+      "stdout": "casts/claude/skills/summarize-nextflow/runs/nf-core__demo/summary.json: valid\n",
+      "stderr": "",
+      "stdout_hash": "6a46379bfea97b008c65073ec062ee9d06013867110e3a53a0551ba6e0b67d3d",
+      "stderr_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    }
   ]
 }

--- a/casts/claude/skills/summarize-nextflow/_verify.json
+++ b/casts/claude/skills/summarize-nextflow/_verify.json
@@ -1,0 +1,16 @@
+{
+  "verify_schema_version": 1,
+  "entries": [
+    {
+      "artifact_id": "summary-nextflow",
+      "direction": "output",
+      "kind": "json",
+      "default_filename": "summary-nextflow.json",
+      "schema": "[[summary-nextflow]]",
+      "validator_bin": "validate-summary-nextflow",
+      "args": [
+        "{artifact_path}"
+      ]
+    }
+  ]
+}

--- a/content/schemas/tests-format.md
+++ b/content/schemas/tests-format.md
@@ -2,8 +2,9 @@
 type: schema
 name: tests-format
 title: Galaxy workflow test format
-package: "@galaxy-tool-util/schema"
-package_export: "testsSchema"
+package: "@galaxy-foundry/tests-format-schema"
+package_export: "testsFormatSchema"
+validator_bin: validate-tests-format
 upstream: "https://github.com/jmchilton/galaxy-tool-util-ts/blob/main/packages/schema/src/test-format/tests.schema.json"
 license: MIT
 license_file: LICENSES/galaxy-tool-util-ts.LICENSE
@@ -32,6 +33,6 @@ This page is auto-rendered from the JSON Schema vendored in `@galaxy-tool-util/s
 
 1. `lib/galaxy/tool_util_models/__init__.py` (`Tests` Pydantic model) in [galaxyproject/galaxy](https://github.com/galaxyproject/galaxy) — see [PR #22566](https://github.com/galaxyproject/galaxy/pull/22566).
 2. `scripts/dump-test-format-schema.py` + `make sync-test-format-schema` in [jmchilton/galaxy-tool-util-ts](https://github.com/jmchilton/galaxy-tool-util-ts) write `tests.schema.json` with a `.sha256` integrity file — see [PR #75](https://github.com/jmchilton/galaxy-tool-util-ts/pull/75).
-3. Published as `@galaxy-tool-util/schema` on npm; the Foundry pins a version in `package.json` / `site/package.json`, `@galaxy-foundry/tests-format-schema` syncs the JSON into `packages/tests-format-schema/src/tests.schema.json`, and the site re-renders. Mold frontmatter cites it via [[tests-format]] wiki-links; cast imports the `testsSchema` runtime export from `@galaxy-tool-util/schema` (declared in this note's `package` / `package_export` frontmatter) and serializes it into cast bundles.
+3. Published as `@galaxy-tool-util/schema` on npm; the Foundry pins a version in `package.json`, `@galaxy-foundry/tests-format-schema` syncs the JSON into `packages/tests-format-schema/src/tests.schema.json`, and the site re-renders. Mold frontmatter cites it via [[tests-format]] wiki-links; cast imports the `testsFormatSchema` runtime export from `@galaxy-foundry/tests-format-schema` (declared in this note's `package` / `package_export` frontmatter) and serializes it into cast bundles.
 
 **At runtime in cast skills:** the same vendored schema is copied verbatim into `references/schemas/tests.schema.json` per the casting policy in `docs/COMPILATION_PIPELINE.md`. The schema package additionally exports `validateTestsFile` (AJV gate) and `checkTestsAgainstWorkflow` (label/type cross-check against a `.ga` or format2 workflow); `validate-tests-format` wraps both as a CLI for cast skills and harnesses.

--- a/docs/SCHEMA_PACKAGES.md
+++ b/docs/SCHEMA_PACKAGES.md
@@ -32,3 +32,4 @@ Current packages:
 
 - `@galaxy-foundry/summary-nextflow-schema` -> `validate-summary-nextflow`
 - `@galaxy-foundry/galaxy-tool-discovery-schema` -> `validate-galaxy-tool-discovery`
+- `@galaxy-foundry/tests-format-schema` -> `validate-tests-format`

--- a/packages/build-cli/package.json
+++ b/packages/build-cli/package.json
@@ -4,7 +4,8 @@
   "description": "Build and authoring CLI for Galaxy Workflow Foundry source trees.",
   "type": "module",
   "bin": {
-    "foundry-build": "dist/bin/foundry-build.js"
+    "foundry-build": "dist/bin/foundry-build.js",
+    "foundry-validate": "dist/bin/foundry-validate.js"
   },
   "exports": {
     ".": {

--- a/packages/build-cli/src/bin/foundry-build.ts
+++ b/packages/build-cli/src/bin/foundry-build.ts
@@ -4,9 +4,16 @@ import process from "node:process";
 import { runCastMoldCommand } from "../commands/cast-mold.js";
 import { runGenerateDashboardCommand } from "../commands/generate-dashboard.js";
 import { runGenerateIndexCommand } from "../commands/generate-index.js";
+import { runValidateArtifactCommand } from "../commands/validate-artifact.js";
 import { runValidateCommand } from "../commands/validate.js";
 
-const COMMANDS = ["validate", "generate-index", "generate-dashboard", "cast"] as const;
+const COMMANDS = [
+  "validate",
+  "generate-index",
+  "generate-dashboard",
+  "cast",
+  "validate-artifact",
+] as const;
 
 async function main(argv = process.argv.slice(2)): Promise<void> {
   const [command, ...rest] = argv;
@@ -19,6 +26,7 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
   else if (command === "generate-index") runGenerateIndexCommand(rest);
   else if (command === "generate-dashboard") runGenerateDashboardCommand(rest);
   else if (command === "cast") await runCastMoldCommand(rest);
+  else if (command === "validate-artifact") runValidateArtifactCommand(rest);
   else {
     process.stderr.write(`unknown command: ${command}\n\n`);
     printHelp();

--- a/packages/build-cli/src/bin/foundry-validate.ts
+++ b/packages/build-cli/src/bin/foundry-validate.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+import { runValidateArtifactCommand } from "../commands/validate-artifact.js";
+
+try {
+  runValidateArtifactCommand();
+} catch (e) {
+  console.error(e instanceof Error ? e.message : String(e));
+  process.exit(1);
+}

--- a/packages/build-cli/src/commands/cast-mold.ts
+++ b/packages/build-cli/src/commands/cast-mold.ts
@@ -10,39 +10,15 @@
 
 import { execSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import {
-  copyFileSync,
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  readdirSync,
-  writeFileSync,
-} from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import process from "node:process";
-import type { ErrorObject } from "ajv";
-import AjvImport from "ajv";
-import Ajv2020Import from "ajv/dist/2020.js";
-import addFormatsImport from "ajv-formats";
 import yaml from "js-yaml";
 
 import { readMarkdown } from "../lib/frontmatter.js";
 import type { Frontmatter } from "../lib/types.js";
 import { fileSlug, findMdFiles } from "../lib/walk.js";
 import { resolveWikiLink, slugify, WIKI_LINK_RE } from "../lib/wiki-links.js";
-
-type AjvValidator = {
-  compile: (schema: unknown) => ((data: unknown) => boolean) & { errors?: ErrorObject[] | null };
-};
-const Ajv = AjvImport as unknown as new (opts: {
-  allErrors: boolean;
-  strict: boolean;
-}) => AjvValidator;
-const Ajv2020 = Ajv2020Import as unknown as new (opts: {
-  allErrors: boolean;
-  strict: boolean;
-}) => AjvValidator;
-const addFormats = addFormatsImport as unknown as (ajv: AjvValidator) => unknown;
 
 // ---- argv ----
 
@@ -324,37 +300,6 @@ function buildCliSidecar(srcAbs: string, srcRel: string, meta: Frontmatter): Cli
   return sidecar;
 }
 
-// ---- runs/*/summary.json schema validation ----
-
-function loadAjvForSchema(schemaPath: string): ReturnType<AjvValidator["compile"]> {
-  const schema = JSON.parse(readFileSync(schemaPath, "utf8"));
-  const schemaUri = typeof schema?.$schema === "string" ? schema.$schema : "";
-  const ajv = schemaUri.includes("2020-12")
-    ? new Ajv2020({ allErrors: true, strict: false })
-    : new Ajv({ allErrors: true, strict: false });
-  addFormats(ajv);
-  return ajv.compile(schema);
-}
-
-function validateRuns(bundleRoot: string, schemaAbs: string): string[] {
-  const errors: string[] = [];
-  const runsDir = path.join(bundleRoot, "runs");
-  if (!existsSync(runsDir)) return errors;
-  const validate = loadAjvForSchema(schemaAbs);
-  for (const entry of readdirSync(runsDir)) {
-    const summaryPath = path.join(runsDir, entry, "summary.json");
-    if (!existsSync(summaryPath)) continue;
-    const data = JSON.parse(readFileSync(summaryPath, "utf8"));
-    if (!validate(data)) {
-      const messages = (validate.errors ?? []).map(
-        (e) => `    ${e.instancePath || "(root)"}: ${e.message}`,
-      );
-      errors.push(`runs/${entry}/summary.json:\n${messages.join("\n")}`);
-    }
-  }
-  return errors;
-}
-
 // ---- provenance ----
 
 interface ProvenanceRefEntry {
@@ -415,13 +360,45 @@ interface Provenance {
   cast_history?: Array<{ rev: number; date: string; note: string }>;
   refs: ProvenanceRefEntry[];
   artifacts?: ProvenanceArtifacts;
+  validation_results?: ValidationResult[];
   open_questions?: string[];
 }
 
 interface ProducerInfo {
   schema?: string;
+  kind?: string;
+  default_filename?: string;
   producers: string[];
   hasSchemaGap?: boolean;
+}
+
+export interface VerifyManifestEntry {
+  artifact_id: string;
+  direction: "input" | "output";
+  kind?: string;
+  default_filename?: string;
+  schema: string;
+  validator_bin: string;
+  args: string[];
+}
+
+export interface VerifyManifest {
+  verify_schema_version: 1;
+  entries: VerifyManifestEntry[];
+}
+
+interface ValidationResult {
+  artifact_id: string;
+  path: string;
+  status: "passed" | "failed" | "error";
+  validator_bin: string;
+  artifact_hash?: string;
+  stdout: string;
+  stderr: string;
+  stdout_hash?: string;
+  stderr_hash?: string;
+  exit_code?: number | null;
+  error?: string;
 }
 
 export function buildProducerIndex(
@@ -439,6 +416,10 @@ export function buildProducerIndex(
       if (typeof o.id !== "string") continue;
       const info = idx.get(o.id) ?? { producers: [] };
       info.producers.push(producerSlug);
+      if (typeof o.kind === "string" && !info.kind) info.kind = o.kind;
+      if (typeof o.default_filename === "string" && !info.default_filename) {
+        info.default_filename = o.default_filename;
+      }
       const schema = typeof o.schema === "string" ? o.schema : undefined;
       if (!schema) {
         info.schema = undefined;
@@ -454,6 +435,72 @@ export function buildProducerIndex(
     }
   }
   return idx;
+}
+
+function schemaValidatorBin(
+  schemaRef: string,
+  slugMap: Map<string, string>,
+  metaByPath: Map<string, Frontmatter>,
+): string | undefined {
+  const target = resolveWikiLink(schemaRef, slugMap);
+  if (!target) return undefined;
+  const meta = metaByPath.get(target);
+  return typeof meta?.validator_bin === "string" ? meta.validator_bin : undefined;
+}
+
+export function buildVerifyManifest(
+  meta: Frontmatter,
+  producerIndex: Map<string, ProducerInfo>,
+  slugMap: Map<string, string>,
+  metaByPath: Map<string, Frontmatter>,
+): VerifyManifest {
+  const entries: VerifyManifestEntry[] = [];
+  const rawOut = meta.output_artifacts;
+  if (Array.isArray(rawOut)) {
+    for (const a of rawOut) {
+      if (!a || typeof a !== "object") continue;
+      const o = a as Record<string, unknown>;
+      if (typeof o.id !== "string" || typeof o.schema !== "string") continue;
+      const validatorBin = schemaValidatorBin(o.schema, slugMap, metaByPath);
+      if (!validatorBin) continue;
+      entries.push({
+        artifact_id: o.id,
+        direction: "output",
+        kind: typeof o.kind === "string" ? o.kind : undefined,
+        default_filename: typeof o.default_filename === "string" ? o.default_filename : undefined,
+        schema: o.schema,
+        validator_bin: validatorBin,
+        args: ["{artifact_path}"],
+      });
+    }
+  }
+  const rawIn = meta.input_artifacts;
+  if (Array.isArray(rawIn)) {
+    for (const a of rawIn) {
+      if (!a || typeof a !== "object") continue;
+      const o = a as Record<string, unknown>;
+      if (typeof o.id !== "string") continue;
+      const producer = producerIndex.get(o.id);
+      if (!producer?.schema) continue;
+      const validatorBin = schemaValidatorBin(producer.schema, slugMap, metaByPath);
+      if (!validatorBin) continue;
+      entries.push({
+        artifact_id: o.id,
+        direction: "input",
+        kind: producer.kind,
+        default_filename: producer.default_filename,
+        schema: producer.schema,
+        validator_bin: validatorBin,
+        args: ["{artifact_path}"],
+      });
+    }
+  }
+  entries.sort((a, b) =>
+    a.direction === b.direction
+      ? a.artifact_id.localeCompare(b.artifact_id)
+      : a.direction.localeCompare(b.direction),
+  );
+  return { verify_schema_version: 1, entries };
 }
 
 export function readArtifactContracts(
@@ -503,6 +550,7 @@ interface LegacyProvenanceCarryOver {
   cast_revision?: number;
   cast_history?: Array<{ rev: number; date: string; note: string }>;
   open_questions?: string[];
+  validation_results?: ValidationResult[];
   prior_refs?: Map<string, ProvenanceRefEntry>;
 }
 
@@ -519,6 +567,9 @@ function readExistingProvenance(provenancePath: string): LegacyProvenanceCarryOv
       : undefined,
     open_questions: Array.isArray(data.open_questions)
       ? (data.open_questions as string[])
+      : undefined,
+    validation_results: Array.isArray(data.validation_results)
+      ? (data.validation_results as ValidationResult[])
       : undefined,
   };
   // For schema v2 provenance, capture prior refs by src so condense LLM output and prompt provenance carry over.
@@ -744,6 +795,7 @@ export async function runCastMoldCommand(argv = process.argv.slice(2)): Promise<
   const carry = readExistingProvenance(provenancePath);
 
   const { slugMap, metaByPath } = buildSlugMap(repoRoot);
+  const producerIndex = buildProducerIndex(metaByPath);
 
   const rawRefs = Array.isArray(moldParsed.meta.references)
     ? (moldParsed.meta.references as unknown[])
@@ -771,14 +823,17 @@ export async function runCastMoldCommand(argv = process.argv.slice(2)): Promise<
     if (result.drift) drift.push({ src: r.src, reason: result.drift });
   }
 
-  // runs/*/summary.json validation — find a schema ref for this mold and validate any committed runs.
-  const schemaRefEntry =
-    refEntries.find((r) => r.kind === "schema" && r.ref === "[[summary-nextflow]]") ??
-    refEntries.find((r) => r.kind === "schema");
-  if (schemaRefEntry) {
-    const schemaAbs = path.join(bundleRoot, schemaRefEntry.dst);
-    if (existsSync(schemaAbs)) {
-      errors.push(...validateRuns(bundleRoot, schemaAbs));
+  const verify = buildVerifyManifest(moldParsed.meta, producerIndex, slugMap, metaByPath);
+  const verifyText = JSON.stringify(verify, null, 2) + "\n";
+  const verifyPath = path.join(bundleRoot, "_verify.json");
+  if (args.check) {
+    const existingVerifyHash = existsSync(verifyPath) ? sha256(verifyPath) : null;
+    const expectedVerifyHash = sha256OfBuffer(verifyText);
+    if (existingVerifyHash !== expectedVerifyHash) {
+      drift.push({
+        src: "_verify.json",
+        reason: existingVerifyHash ? "verify manifest content drifted" : "verify manifest missing",
+      });
     }
   }
 
@@ -825,7 +880,8 @@ export async function runCastMoldCommand(argv = process.argv.slice(2)): Promise<
     cast_revision: carry.cast_revision,
     cast_history: carry.cast_history,
     refs: refEntries,
-    artifacts: readArtifactContracts(moldParsed.meta, buildProducerIndex(metaByPath)),
+    artifacts: readArtifactContracts(moldParsed.meta, producerIndex),
+    validation_results: carry.validation_results,
     open_questions: carry.open_questions,
   };
 
@@ -841,6 +897,7 @@ export async function runCastMoldCommand(argv = process.argv.slice(2)): Promise<
   }
 
   writeFileSync(provenancePath, JSON.stringify(next, null, 2) + "\n");
+  writeFileSync(verifyPath, verifyText);
   console.log(`wrote ${path.relative(repoRoot, provenancePath)}`);
   if (drift.length) console.log(`reconciled ${drift.length} drifted ref(s)`);
   if (refEntries.some((r) => r.pending_llm)) {

--- a/packages/build-cli/src/commands/validate-artifact.ts
+++ b/packages/build-cli/src/commands/validate-artifact.ts
@@ -1,0 +1,168 @@
+#!/usr/bin/env tsx
+// Process-based artifact validator runner. Exit code is the contract; stdout and
+// stderr are captured as diagnostic evidence without requiring a JSON shape.
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import type { VerifyManifest, VerifyManifestEntry } from "./cast-mold.js";
+
+interface Args {
+  artifactId: string;
+  artifactPath: string;
+  verifyPath: string;
+  provenancePath?: string;
+  root: string | null;
+}
+
+export interface ProcessValidationResult {
+  artifact_id: string;
+  path: string;
+  validator_bin: string;
+  status: "passed" | "failed" | "error";
+  exit_code: number | null;
+  artifact_hash?: string;
+  stdout: string;
+  stderr: string;
+  stdout_hash: string;
+  stderr_hash: string;
+  error?: string;
+}
+
+function parseArgs(argv: string[]): Args {
+  const positional: string[] = [];
+  let verifyPath = "_verify.json";
+  let provenancePath: string | undefined;
+  let root: string | null = null;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]!;
+    if (a.startsWith("--verify=")) verifyPath = a.slice("--verify=".length);
+    else if (a === "--verify") verifyPath = argv[++i] ?? verifyPath;
+    else if (a.startsWith("--provenance=")) provenancePath = a.slice("--provenance=".length);
+    else if (a === "--provenance") provenancePath = argv[++i];
+    else if (a.startsWith("--root=")) root = a.slice("--root=".length);
+    else if (a === "--root") root = argv[++i] ?? ".";
+    else if (!a.startsWith("--")) positional.push(a);
+    else throw new Error(`unknown flag: ${a}`);
+  }
+  if (positional.length !== 2) {
+    throw new Error(
+      "usage: foundry-build validate-artifact <artifact-id> <path> [--verify _verify.json] [--provenance _provenance.json]",
+    );
+  }
+  return {
+    artifactId: positional[0]!,
+    artifactPath: positional[1]!,
+    verifyPath,
+    provenancePath,
+    root,
+  };
+}
+
+function sha256Text(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}
+
+function sha256File(filePath: string): string {
+  return createHash("sha256").update(readFileSync(filePath)).digest("hex");
+}
+
+function loadVerifyEntry(verifyPath: string, artifactId: string): VerifyManifestEntry {
+  const manifest = JSON.parse(readFileSync(verifyPath, "utf8")) as VerifyManifest;
+  if (manifest.verify_schema_version !== 1 || !Array.isArray(manifest.entries)) {
+    throw new Error(`${verifyPath}: invalid verify manifest`);
+  }
+  const entry = manifest.entries.find((candidate) => candidate.artifact_id === artifactId);
+  if (!entry) throw new Error(`${verifyPath}: no validator for artifact id '${artifactId}'`);
+  return entry;
+}
+
+function withArtifactPath(args: string[], artifactPath: string): string[] {
+  return args.length
+    ? args.map((arg) => arg.replaceAll("{artifact_path}", artifactPath))
+    : [artifactPath];
+}
+
+export function runProcessValidation(
+  entry: VerifyManifestEntry,
+  artifactPath: string,
+  cwd = process.cwd(),
+): ProcessValidationResult {
+  const artifact_hash = existsSync(artifactPath) ? sha256File(artifactPath) : undefined;
+  const result = spawnSync(entry.validator_bin, withArtifactPath(entry.args, artifactPath), {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const stdout = result.stdout ?? "";
+  const stderr = result.stderr ?? "";
+  const exitCode = typeof result.status === "number" ? result.status : null;
+  const status = result.error ? "error" : exitCode === 0 ? "passed" : "failed";
+  return {
+    artifact_id: entry.artifact_id,
+    path: artifactPath,
+    validator_bin: entry.validator_bin,
+    status,
+    exit_code: exitCode,
+    artifact_hash,
+    stdout,
+    stderr,
+    stdout_hash: sha256Text(stdout),
+    stderr_hash: sha256Text(stderr),
+    error: result.error?.message,
+  };
+}
+
+function recordProvenanceValidation(
+  provenancePath: string,
+  validation: ProcessValidationResult,
+): void {
+  const provenance = JSON.parse(readFileSync(provenancePath, "utf8")) as Record<string, unknown>;
+  const existing = Array.isArray(provenance.validation_results)
+    ? (provenance.validation_results as ProcessValidationResult[])
+    : [];
+  provenance.validation_results = [
+    ...existing.filter(
+      (entry) =>
+        entry.artifact_id !== validation.artifact_id ||
+        entry.path !== validation.path ||
+        entry.validator_bin !== validation.validator_bin,
+    ),
+    validation,
+  ];
+  writeFileSync(provenancePath, JSON.stringify(provenance, null, 2) + "\n");
+}
+
+function displayPath(filePath: string, cwd: string): string {
+  const abs = path.resolve(filePath);
+  const rel = path.relative(cwd, abs);
+  return rel && !rel.startsWith("..") && !path.isAbsolute(rel) ? rel : filePath;
+}
+
+export function runValidateArtifactCommand(argv = process.argv.slice(2)): void {
+  const args = parseArgs(argv);
+  if (args.root) process.chdir(args.root);
+  const verifyPath = path.resolve(args.verifyPath);
+  const artifactPath = args.artifactPath;
+  const entry = loadVerifyEntry(verifyPath, args.artifactId);
+  const validation = runProcessValidation(entry, artifactPath);
+  validation.path = displayPath(artifactPath, process.cwd());
+  if (args.provenancePath)
+    recordProvenanceValidation(path.resolve(args.provenancePath), validation);
+  if (validation.stdout) process.stdout.write(validation.stdout);
+  if (validation.stderr) process.stderr.write(validation.stderr);
+  if (validation.error) process.stderr.write(`${validation.error}\n`);
+  process.exit(validation.status === "passed" ? 0 : 1);
+}
+
+const isDirectInvocation = import.meta.url === `file://${process.argv[1]}`;
+if (isDirectInvocation) {
+  try {
+    runValidateArtifactCommand();
+  } catch (e) {
+    console.error(e instanceof Error ? e.message : String(e));
+    process.exit(1);
+  }
+}

--- a/scripts/cast-skill-verify.ts
+++ b/scripts/cast-skill-verify.ts
@@ -14,7 +14,6 @@ import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import AjvImport from "ajv";
-import Ajv2020Import from "ajv/dist/2020.js";
 import addFormatsImport from "ajv-formats";
 import yaml from "js-yaml";
 
@@ -22,8 +21,6 @@ import { readMarkdown } from "./lib/frontmatter.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const Ajv = ((AjvImport as any).default ?? AjvImport) as typeof AjvImport;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const Ajv2020 = ((Ajv2020Import as any).default ?? Ajv2020Import) as typeof Ajv2020Import;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const addFormats = ((addFormatsImport as any).default ?? addFormatsImport) as typeof addFormatsImport;
 
@@ -83,6 +80,17 @@ interface Provenance {
   refs: ProvenanceRefEntry[];
 }
 
+interface VerifyManifest {
+  verify_schema_version: number;
+  entries: Array<{
+    artifact_id?: unknown;
+    direction?: unknown;
+    schema?: unknown;
+    validator_bin?: unknown;
+    args?: unknown;
+  }>;
+}
+
 function main(): void {
   const args = parseArgs(process.argv.slice(2));
   const repoRoot = process.cwd();
@@ -112,6 +120,41 @@ function main(): void {
   if (!validateProv(prov)) {
     for (const err of validateProv.errors ?? []) {
       errors.push(`_provenance.json: ${err.instancePath || "(root)"} ${err.message}`);
+    }
+  }
+
+  const verifyPath = path.join(bundleRoot, "_verify.json");
+  if (!existsSync(verifyPath)) {
+    errors.push("missing _verify.json in cast bundle");
+  } else {
+    try {
+      const verify = JSON.parse(readFileSync(verifyPath, "utf8")) as VerifyManifest;
+      if (verify.verify_schema_version !== 1) {
+        errors.push("_verify.json: verify_schema_version must be 1");
+      }
+      if (!Array.isArray(verify.entries)) {
+        errors.push("_verify.json: entries must be an array");
+      } else {
+        verify.entries.forEach((entry, index) => {
+          if (typeof entry.artifact_id !== "string") {
+            errors.push(`_verify.json: entries[${index}].artifact_id must be a string`);
+          }
+          if (entry.direction !== "input" && entry.direction !== "output") {
+            errors.push(`_verify.json: entries[${index}].direction must be input or output`);
+          }
+          if (typeof entry.schema !== "string") {
+            errors.push(`_verify.json: entries[${index}].schema must be a string`);
+          }
+          if (typeof entry.validator_bin !== "string") {
+            errors.push(`_verify.json: entries[${index}].validator_bin must be a string`);
+          }
+          if (!Array.isArray(entry.args) || !entry.args.every((arg) => typeof arg === "string")) {
+            errors.push(`_verify.json: entries[${index}].args must be a string array`);
+          }
+        });
+      }
+    } catch (e) {
+      errors.push(`_verify.json does not parse as JSON: ${(e as Error).message}`);
     }
   }
 
@@ -193,37 +236,6 @@ function main(): void {
   for (const forbidden of target.skill_constraints.forbid_packaged_files) {
     const matches = walkAndFind(bundleRoot, forbidden);
     if (matches.length) errors.push(`forbidden file packaged: ${matches.join(", ")}`);
-  }
-
-  // runs/*/summary.json validates against the bundled schema (when present).
-  const schemaRef =
-    (prov.refs ?? []).find((r) => r.kind === "schema" && r.ref === "[[summary-nextflow]]") ??
-    (prov.refs ?? []).find((r) => r.kind === "schema");
-  if (schemaRef) {
-    const schemaAbs = path.join(bundleRoot, schemaRef.dst);
-    if (existsSync(schemaAbs)) {
-      try {
-        const schemaJson = JSON.parse(readFileSync(schemaAbs, "utf8"));
-        const schemaUri = typeof schemaJson?.$schema === "string" ? schemaJson.$schema : "";
-        const runAjv = schemaUri.includes("2020-12")
-          ? new Ajv2020({ allErrors: true, strict: false })
-          : new Ajv({ allErrors: true, strict: false });
-        addFormats(runAjv);
-        const validate = runAjv.compile(schemaJson);
-        const runsDir = path.join(bundleRoot, "runs");
-        if (existsSync(runsDir)) {
-          for (const summary of walkAndFind(runsDir, "summary.json")) {
-            const data = JSON.parse(readFileSync(summary, "utf8"));
-            if (!validate(data)) {
-              const messages = (validate.errors ?? []).map((e) => `${e.instancePath || "(root)"} ${e.message}`).join("; ");
-              errors.push(`${path.relative(bundleRoot, summary)} fails bundled schema: ${messages}`);
-            }
-          }
-        }
-      } catch (e) {
-        errors.push(`bundled schema unusable for runs validation: ${(e as Error).message}`);
-      }
-    }
   }
 
   if (errors.length) {

--- a/scripts/lib/schemas/cast-provenance.schema.json
+++ b/scripts/lib/schemas/cast-provenance.schema.json
@@ -77,9 +77,46 @@
             "required": ["id", "description"],
             "properties": {
               "id": { "type": "string" },
-              "description": { "type": "string" }
+              "description": { "type": "string" },
+              "inherited_schema": { "type": "string" },
+              "producers": {
+                "type": "array",
+                "items": { "type": "string" }
+              }
             }
           }
+        }
+      }
+    },
+    "validation_results": {
+      "type": "array",
+      "description": "Process evidence from artifact validator CLI runs. Exit code is authoritative; stdout/stderr are captured as opaque diagnostics.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "artifact_id",
+          "path",
+          "validator_bin",
+          "status",
+          "exit_code",
+          "stdout",
+          "stderr",
+          "stdout_hash",
+          "stderr_hash"
+        ],
+        "properties": {
+          "artifact_id": { "type": "string" },
+          "path": { "type": "string" },
+          "validator_bin": { "type": "string" },
+          "status": { "enum": ["passed", "failed", "error"] },
+          "exit_code": { "type": ["integer", "null"] },
+          "artifact_hash": { "type": "string" },
+          "stdout": { "type": "string" },
+          "stderr": { "type": "string" },
+          "stdout_hash": { "type": "string" },
+          "stderr_hash": { "type": "string" },
+          "error": { "type": "string" }
         }
       }
     }

--- a/site/src/lib/schema-registry.ts
+++ b/site/src/lib/schema-registry.ts
@@ -3,12 +3,12 @@
 //
 // Each entry: { schema: <JSON Schema object>, version: <package version string> }.
 
-import { testsSchema } from '@galaxy-tool-util/schema';
 import galaxyToolDiscoverySchema from '../../../packages/galaxy-tool-discovery-schema/src/galaxy-tool-discovery.schema.json';
 import galaxyToolDiscoverySchemaPkg from '../../../packages/galaxy-tool-discovery-schema/package.json';
 import summaryNextflowSchema from '../../../packages/summary-nextflow-schema/src/summary-nextflow.schema.json';
 import summaryNextflowSchemaPkg from '../../../packages/summary-nextflow-schema/package.json';
-import { readInstalledPackageVersion } from './package-version';
+import testsFormatSchema from '../../../packages/tests-format-schema/src/tests.schema.json';
+import testsFormatSchemaPkg from '../../../packages/tests-format-schema/package.json';
 
 export interface SchemaEntry {
   schema: Record<string, unknown>;
@@ -17,8 +17,8 @@ export interface SchemaEntry {
 
 export const schemaRegistry: Record<string, SchemaEntry> = {
   'tests-format': {
-    schema: testsSchema as unknown as Record<string, unknown>,
-    version: readInstalledPackageVersion('@galaxy-tool-util/schema'),
+    schema: testsFormatSchema as unknown as Record<string, unknown>,
+    version: (testsFormatSchemaPkg as { version?: string }).version ?? '',
   },
   'summary-nextflow': {
     schema: summaryNextflowSchema as unknown as Record<string, unknown>,

--- a/tests/cast-mold.test.ts
+++ b/tests/cast-mold.test.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
@@ -39,6 +40,19 @@ describe("cast-mold (summarize-nextflow integration)", () => {
     const r = runTsx(foundryBuild, ["cast", "summarize-nextflow", "--target=claude", "--check"]);
     expect(r.code, `stderr: ${r.stderr}\nstdout: ${r.stdout}`).toBe(0);
     expect(r.stdout).toContain("clean");
+  });
+
+  it("foundry-build cast --check catches stale _verify.json", () => {
+    const verifyPath = path.join(repoRoot, "casts", "claude", "skills", "summarize-nextflow", "_verify.json");
+    const original = readFileSync(verifyPath, "utf8");
+    try {
+      writeFileSync(verifyPath, JSON.stringify({ verify_schema_version: 1, entries: [] }, null, 2) + "\n");
+      const r = runTsx(foundryBuild, ["cast", "summarize-nextflow", "--target=claude", "--check"]);
+      expect(r.code).not.toBe(0);
+      expect(r.stderr).toContain("_verify.json");
+    } finally {
+      writeFileSync(verifyPath, original);
+    }
   });
 
   it("provenance is schema v2 and lists deterministic refs", () => {
@@ -83,6 +97,7 @@ describe("cast-skill-verify (summarize-nextflow integration)", () => {
     const bundle = path.join(repoRoot, "casts", "claude", "skills", "summarize-nextflow");
     expect(existsSync(path.join(bundle, "SKILL.md"))).toBe(true);
     expect(existsSync(path.join(bundle, "_provenance.json"))).toBe(true);
+    expect(existsSync(path.join(bundle, "_verify.json"))).toBe(true);
   });
 
   it("rejects unknown flags", () => {
@@ -138,6 +153,86 @@ describe("artifact-contract inheritance", () => {
     ]);
   });
 
+  it("builds a process-based verify manifest for output and inherited input schemas", async () => {
+    const { buildProducerIndex, buildVerifyManifest } = await import(
+      "../packages/build-cli/src/commands/cast-mold.js"
+    );
+    const meta = new Map<string, any>([
+      [
+        "content/molds/producer/index.md",
+        {
+          type: "mold",
+          output_artifacts: [
+            {
+              id: "summary-x",
+              kind: "json",
+              default_filename: "summary-x.json",
+              schema: "[[schema-x]]",
+              description: "Producer output.",
+            },
+          ],
+        },
+      ],
+      [
+        "content/molds/consumer/index.md",
+        {
+          type: "mold",
+          input_artifacts: [{ id: "summary-x", description: "Upstream summary." }],
+          output_artifacts: [
+            {
+              id: "summary-y",
+              kind: "json",
+              default_filename: "summary-y.json",
+              schema: "[[schema-y]]",
+              description: "Consumer output.",
+            },
+          ],
+        },
+      ],
+      [
+        "content/schemas/schema-x.md",
+        { type: "schema", name: "schema-x", validator_bin: "validate-schema-x" },
+      ],
+      [
+        "content/schemas/schema-y.md",
+        { type: "schema", name: "schema-y", validator_bin: "validate-schema-y" },
+      ],
+    ]);
+    const slugMap = new Map([
+      ["schema-x", "content/schemas/schema-x.md"],
+      ["schema-y", "content/schemas/schema-y.md"],
+    ]);
+    const manifest = buildVerifyManifest(
+      meta.get("content/molds/consumer/index.md")!,
+      buildProducerIndex(meta),
+      slugMap,
+      meta,
+    );
+    expect(manifest).toEqual({
+      verify_schema_version: 1,
+      entries: [
+        {
+          artifact_id: "summary-x",
+          direction: "input",
+          kind: "json",
+          default_filename: "summary-x.json",
+          schema: "[[schema-x]]",
+          validator_bin: "validate-schema-x",
+          args: ["{artifact_path}"],
+        },
+        {
+          artifact_id: "summary-y",
+          direction: "output",
+          kind: "json",
+          default_filename: "summary-y.json",
+          schema: "[[schema-y]]",
+          validator_bin: "validate-schema-y",
+          args: ["{artifact_path}"],
+        },
+      ],
+    });
+  });
+
   it("drops inherited_schema when producers disagree on the schema", async () => {
     const { buildProducerIndex, readArtifactContracts } = await import(
       "../packages/build-cli/src/commands/cast-mold.js"
@@ -188,6 +283,153 @@ describe("artifact-contract inheritance", () => {
     );
     expect(contracts!.consumes[0]?.inherited_schema).toBeUndefined();
     expect(contracts!.consumes[0]?.producers).toEqual(["producer-a", "producer-b"]);
+  });
+});
+
+describe("validate-artifact process runner", () => {
+  it("uses exit code and captures stdout/stderr as opaque evidence", async () => {
+    const { runProcessValidation } = await import(
+      "../packages/build-cli/src/commands/validate-artifact.js"
+    );
+    const dir = mkdtempSync(path.join(os.tmpdir(), "foundry-validate-"));
+    const artifact = path.join(dir, "artifact.json");
+    writeFileSync(artifact, "{}\n");
+    const result = runProcessValidation(
+      {
+        artifact_id: "artifact-x",
+        direction: "output",
+        schema: "[[schema-x]]",
+        validator_bin: process.execPath,
+        args: ["-e", "console.log('diagnostic only')", "{artifact_path}"],
+      },
+      artifact,
+    );
+    expect(result.status).toBe("passed");
+    expect(result.exit_code).toBe(0);
+    expect(result.stdout).toContain("diagnostic only");
+    expect(result.artifact_hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.stdout_hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("foundry-build validate-artifact records process evidence in provenance", () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "foundry-validate-cli-"));
+    const artifact = path.join(dir, "artifact.json");
+    const verify = path.join(dir, "_verify.json");
+    const provenance = path.join(dir, "_provenance.json");
+    writeFileSync(artifact, "{}\n");
+    writeFileSync(
+      verify,
+      JSON.stringify(
+        {
+          verify_schema_version: 1,
+          entries: [
+            {
+              artifact_id: "artifact-x",
+              direction: "output",
+              schema: "[[schema-x]]",
+              validator_bin: process.execPath,
+              args: ["-e", "console.error('diagnostic stderr')", "{artifact_path}"],
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+    );
+    writeFileSync(
+      provenance,
+      JSON.stringify(
+        {
+          provenance_schema_version: 2,
+          cast_target: "test",
+          mold: { name: "m", path: "content/molds/m/index.md" },
+          refs: [],
+        },
+        null,
+        2,
+      ),
+    );
+
+    const r = runTsx(foundryBuild, [
+      "validate-artifact",
+      "artifact-x",
+      artifact,
+      "--verify",
+      verify,
+      "--provenance",
+      provenance,
+    ]);
+    expect(r.code, `stderr: ${r.stderr}\nstdout: ${r.stdout}`).toBe(0);
+    const updated = JSON.parse(readFileSync(provenance, "utf8"));
+    expect(updated.validation_results).toHaveLength(1);
+    expect(updated.validation_results[0]).toMatchObject({
+      artifact_id: "artifact-x",
+      path: artifact,
+      validator_bin: process.execPath,
+      status: "passed",
+      exit_code: 0,
+      stderr: "diagnostic stderr\n",
+    });
+  });
+
+  it("validate-artifact preserves results for different paths with the same artifact id", () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "foundry-validate-many-"));
+    const artifactA = path.join(dir, "a.json");
+    const artifactB = path.join(dir, "b.json");
+    const verify = path.join(dir, "_verify.json");
+    const provenance = path.join(dir, "_provenance.json");
+    writeFileSync(artifactA, "{}\n");
+    writeFileSync(artifactB, "{}\n");
+    writeFileSync(
+      verify,
+      JSON.stringify(
+        {
+          verify_schema_version: 1,
+          entries: [
+            {
+              artifact_id: "artifact-x",
+              direction: "output",
+              schema: "[[schema-x]]",
+              validator_bin: process.execPath,
+              args: ["-e", "process.exit(0)", "{artifact_path}"],
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+    );
+    writeFileSync(
+      provenance,
+      JSON.stringify(
+        {
+          provenance_schema_version: 2,
+          cast_target: "test",
+          mold: { name: "m", path: "content/molds/m/index.md" },
+          refs: [],
+        },
+        null,
+        2,
+      ),
+    );
+
+    for (const artifact of [artifactA, artifactB]) {
+      const r = runTsx(foundryBuild, [
+        "validate-artifact",
+        "artifact-x",
+        artifact,
+        "--verify",
+        verify,
+        "--provenance",
+        provenance,
+      ]);
+      expect(r.code, `stderr: ${r.stderr}\nstdout: ${r.stdout}`).toBe(0);
+    }
+
+    const updated = JSON.parse(readFileSync(provenance, "utf8"));
+    expect(updated.validation_results.map((r: { path: string }) => r.path).sort()).toEqual(
+      [artifactA, artifactB].sort(),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- Add process-based artifact validation via `_verify.json`, `foundry-build validate-artifact`, and `foundry-validate` without requiring validator `--json` output.
- Record validator process evidence in `_provenance.json.validation_results` and preserve/check verify manifests during recasts.
- Move `tests-format` schema metadata to the Foundry wrapper package so `validate-tests-format` participates in `validator_bin` checks.

## Tests
- `npm run test`
- `npm run validate`
- `npm run typecheck`
- `npm run packages-typecheck`

Refs #193