### PR TITLE
Enrich summary-nextflow Channel for converter handoff

### DIFF
--- a/casts/claude/skills/summarize-nextflow/SKILL.md
+++ b/casts/claude/skills/summarize-nextflow/SKILL.md
@@ -130,8 +130,11 @@ A single JSON document conforming to summary-nextflow (`packages/summary-nextflo
     "name": "RNASEQ",
     "channels": [
       { "name": "ch_samplesheet",
-        "source": "Channel.fromSamplesheet('input')",
-        "shape": "tuple(meta, [path,path])" }
+        "source": "Channel.fromList(samplesheetToList(params.input, '...'))",
+        "shape": "tuple(meta, [path,path])",
+        "construct": "samplesheetToList",
+        "from_param": "input",
+        "required_runtime": false }
     ],
     "edges": [
       { "from": "ch_samplesheet", "to": "FASTP", "via": [] },
@@ -238,7 +241,15 @@ Tool name and version are typically derivable from any of the resolved fields. D
 
 #### 6. Reconcile the workflow DAG
 
-Enumerate the top-level workflow's `include` statements and channel construction (`Channel.fromPath`, `Channel.fromFilePairs`, `Channel.fromSamplesheet`, `params.*`, `channel.empty()`, `channel.topic('<name>')`). For operator chains, the deterministic parser records the *literal* chain (`["map", "join", "groupTuple"]` in `via`). Reconciling chained operators into a coherent `from → to` edge is the second LLM call: given the literal chain, the source channel shape, and the downstream process's declared input shape, emit the resolved edge.
+Enumerate the top-level workflow's `include` statements and channel construction (`Channel.fromPath`, `Channel.fromFilePairs`, `Channel.fromList(samplesheetToList(...))`, `splitCsv`, `file()`/`files()`, `params.*`, `channel.empty()`, `channel.topic('<name>')`). For operator chains, the deterministic parser records the *literal* chain (`["map", "join", "groupTuple"]` in `via`). Reconciling chained operators into a coherent `from → to` edge is the second LLM call: given the literal chain, the source channel shape, and the downstream process's declared input shape, emit the resolved edge.
+
+For each emitted `workflow.channels[]` entry, populate three classified fields alongside the verbatim `source`:
+
+- **`construct`** — typed enum reflecting the channel's primary materialization factory or shape-determining operator. Selection precedence: (1) `samplesheetToList` when the chain contains `samplesheetToList(...)`; (2) `splitCsv` when the chain ends in `.splitCsv(header: true)` over a path; (3) otherwise the outermost factory (`Channel.fromPath` → `fromPath`, `Channel.fromFilePairs` → `fromFilePairs`, `Channel.fromList` → `fromList`, `file(...)` → `file`, `files(...)` → `files`, `Channel.of` → `of`, `Channel.value` → `value`, `Channel.empty` → `empty`, `Channel.topic` → `topic`); (4) `other` for derived/operator-only constructions.
+- **`from_param`** — FK into `params[].name` when the construction expression directly references `params.X` (e.g. `Channel.fromPath(params.reads)`, `samplesheetToList(params.input, ...)`, `file(params.fasta)`). v1 is direct-only — one-hop Groovy bindings (`def reads = params.reads; Channel.fromPath(reads)`) are deferred to jmchilton/foundry#211. Null when no direct reference, or when `construct` is not data-bearing (`empty`, `of`, `value`, `topic`, `other`).
+- **`required_runtime`** — true when the construction chain ends in `.ifEmpty { error ... }` (or an equivalent imperative emptiness-throw guard). Captures runtime requiredness even when the param's nf-schema entry does not mark it required. False otherwise.
+
+All three fields are syntactic: regex-level extraction over the construction expression, no LLM call.
 
 Workflow-level conditionals (`if (params.skip_alignment) { ... }`) emit `conditionals[]` entries with the guard, the branch (`alternate` vs `default`), and the set of processes affected.
 

--- a/casts/claude/skills/summarize-nextflow/_provenance.json
+++ b/casts/claude/skills/summarize-nextflow/_provenance.json
@@ -4,13 +4,13 @@
   "mold": {
     "name": "summarize-nextflow",
     "path": "content/molds/summarize-nextflow/index.md",
-    "revision": 12,
-    "content_hash": "a7bf4935f4b886e3488fc6d1be3d1f2a8850ee2507b192216f086688ad4a407d",
-    "commit": "9fd80031b01aadd1e6e1b109b726643407edbe5f"
+    "revision": 13,
+    "content_hash": "3c9f6b34c04c7dd252d9159dc724f48bbc6ade683e6f13b4f3fcab4f3fd01fdf",
+    "commit": "2a6f6222144d490ddb0e89dcb9a008f3a16ed1ad"
   },
   "cast_method": "hand-cast",
   "cast_agent": "claude (manual transcription, no LLM cast prompt)",
-  "cast_at": "2026-05-08T14:47:51.905Z",
+  "cast_at": "2026-05-08T20:11:44.608Z",
   "cast_date": "2026-05-08",
   "cast_revision": 11,
   "cast_history": [
@@ -170,8 +170,8 @@
       "load": "upfront",
       "evidence": "cast-validated",
       "purpose": "Validate the emitted Nextflow summary JSON and provide downstream consumers the output contract.",
-      "src_hash": "5b3615e4b2736d4cd1d392645f56b8f96f49c19da2cc5ec1d36c262bdb336d05",
-      "dst_hash": "5b3615e4b2736d4cd1d392645f56b8f96f49c19da2cc5ec1d36c262bdb336d05",
+      "src_hash": "e38b1c25c34cfd20304143cf7e7c9172c712519f42a110019a1c55025dd9ca29",
+      "dst_hash": "e38b1c25c34cfd20304143cf7e7c9172c712519f42a110019a1c55025dd9ca29",
       "source": "deterministic"
     }
   ],

--- a/casts/claude/skills/summarize-nextflow/references/schemas/summary-nextflow.schema.json
+++ b/casts/claude/skills/summarize-nextflow/references/schemas/summary-nextflow.schema.json
@@ -714,13 +714,16 @@
     },
     "Channel": {
       "title": "Channel",
-      "description": "One top-level channel constructed in the workflow. Sources include `Channel.fromPath`, `Channel.fromFilePairs`, `Channel.fromSamplesheet`, and `params.*`.",
+      "description": "One top-level channel constructed in the workflow. Sources include `Channel.fromPath`, `Channel.fromFilePairs`, `samplesheetToList`-driven `Channel.fromList`, `splitCsv`, `file`/`files`, and plain `params.*` references.",
       "type": "object",
       "additionalProperties": false,
       "required": [
         "name",
         "source",
-        "shape"
+        "shape",
+        "construct",
+        "from_param",
+        "required_runtime"
       ],
       "properties": {
         "name": {
@@ -733,6 +736,35 @@
         "shape": {
           "type": "string",
           "description": "String-encoded channel shape; same convention as ChannelIO."
+        },
+        "construct": {
+          "type": "string",
+          "enum": [
+            "fromPath",
+            "fromFilePairs",
+            "fromList",
+            "samplesheetToList",
+            "splitCsv",
+            "file",
+            "files",
+            "of",
+            "value",
+            "empty",
+            "topic",
+            "other"
+          ],
+          "description": "Classifies the channel's primary materialization factory or shape-determining operator. Selection precedence: (1) `samplesheetToList` when the chain contains `samplesheetToList(...)` (typically wrapped in `Channel.fromList`); (2) `splitCsv` when the chain ends in `.splitCsv(header: true)` over a path; (3) otherwise the outermost factory (`Channel.fromPath` → `fromPath`, `Channel.fromFilePairs` → `fromFilePairs`, `file(...)` → `file`, etc.); (4) `other` for unrecognized constructions. The verbatim `source` retains the full chain — `construct` is the typed lookup the converter would otherwise re-parse."
+        },
+        "from_param": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Foreign key into `params[].name` when the construction expression directly references `params.X` (e.g. `Channel.fromPath(params.reads)`, `samplesheetToList(params.input, ...)`, `file(params.fasta)`). Null for literal-glob construction, expressions that compose multiple params, and channels derived from other channels. v1 resolution is direct-only; one-hop Groovy bindings (`def reads = params.reads; Channel.fromPath(reads)`) are not chased — see jmchilton/foundry#211."
+        },
+        "required_runtime": {
+          "type": "boolean",
+          "description": "True when the construction chain ends in `.ifEmpty { error ... }` (or an equivalent imperative emptiness-throw guard). Captures runtime requiredness even when the param's nf-schema entry does not mark it required. Combine with `params[].required` and any imperative pre-construction `error` checks for the full requiredness picture."
         }
       }
     },

--- a/casts/claude/skills/summarize-nextflow/runs/nf-core__bacass/summary.json
+++ b/casts/claude/skills/summarize-nextflow/runs/nf-core__bacass/summary.json
@@ -2123,62 +2123,98 @@
       {
         "name": "ch_samplesheet",
         "source": "PIPELINE_INITIALISATION.out.samplesheet",
-        "shape": "tuple(val(meta), path(fastq_1), path(fastq_2), path(long_fastq), path(fast5))"
+        "shape": "tuple(val(meta), path(fastq_1), path(fastq_2), path(long_fastq), path(fast5))",
+        "construct": "other",
+        "from_param": null,
+        "required_runtime": false
       },
       {
         "name": "ch_input",
         "source": "ch_samplesheet.multiMap(criteria) — splits into named branches: shortreads / longreads / fast5",
-        "shape": "multimap(shortreads: tuple(meta, fastqs), longreads: tuple(meta, lr), fast5: tuple(meta, fast5))"
+        "shape": "multimap(shortreads: tuple(meta, fastqs), longreads: tuple(meta, lr), fast5: tuple(meta, fast5))",
+        "construct": "other",
+        "from_param": null,
+        "required_runtime": false
       },
       {
         "name": "ch_shortreads",
         "source": "ch_input.shortreads.filter{ it != null }",
-        "shape": "tuple(val(meta), path(fastqs))"
+        "shape": "tuple(val(meta), path(fastqs))",
+        "construct": "other",
+        "from_param": null,
+        "required_runtime": false
       },
       {
         "name": "ch_longreads",
         "source": "ch_input.longreads.filter{ it != null }",
-        "shape": "tuple(val(meta), path(longreads))"
+        "shape": "tuple(val(meta), path(longreads))",
+        "construct": "other",
+        "from_param": null,
+        "required_runtime": false
       },
       {
         "name": "ch_fast5",
         "source": "ch_input.fast5.filter{ it != null }",
-        "shape": "tuple(val(meta), path(fast5))"
+        "shape": "tuple(val(meta), path(fast5))",
+        "construct": "other",
+        "from_param": null,
+        "required_runtime": false
       },
       {
         "name": "ch_proteins",
         "source": "params.prokka_proteins ? Channel.fromPath(params.prokka_proteins) : []",
-        "shape": "path | empty list literal"
+        "shape": "path | empty list literal",
+        "construct": "fromPath",
+        "from_param": "prokka_proteins",
+        "required_runtime": false
       },
       {
         "name": "ch_versions",
         "source": "Channel.empty() then accumulated via .mix(<every-process>.out.versions)",
-        "shape": "path"
+        "shape": "path",
+        "construct": "empty",
+        "from_param": null,
+        "required_runtime": false
       },
       {
         "name": "ch_multiqc_files",
         "source": "Channel.empty() then accumulated across QC outputs",
-        "shape": "path"
+        "shape": "path",
+        "construct": "empty",
+        "from_param": null,
+        "required_runtime": false
       },
       {
         "name": "ch_for_assembly",
         "source": "conditional on params.assembly_type — built from FASTQ_TRIM_FASTP_FASTQC.out.reads, filtered_long_reads via .cross/.map",
-        "shape": "tuple(val(meta), path(short_or_empty), path(long_or_empty))"
+        "shape": "tuple(val(meta), path(short_or_empty), path(long_or_empty))",
+        "construct": "other",
+        "from_param": null,
+        "required_runtime": false
       },
       {
         "name": "ch_assembly",
         "source": "Channel.empty() then accumulated from UNICYCLER/CANU/MINIASM/RACON/DRAGONFLYE/MEDAKA/NANOPOLISH (one wins by params.assembler+polish)",
-        "shape": "tuple(val(meta), path(fasta))"
+        "shape": "tuple(val(meta), path(fasta))",
+        "construct": "empty",
+        "from_param": null,
+        "required_runtime": false
       },
       {
         "name": "ch_to_quast",
         "source": "ch_assembly.collect{it[1]}.map{ consensus -> tuple([id:'report'], consensus) }",
-        "shape": "tuple(val(meta), path(consensi))"
+        "shape": "tuple(val(meta), path(consensi))",
+        "construct": "other",
+        "from_param": null,
+        "required_runtime": false
       },
       {
         "name": "ch_assembly_for_gunzip",
         "source": "ch_assembly.branch{ meta, fasta -> gzip: fasta.name.endsWith('.gz'); skip: true }",
-        "shape": "branch(gzip, skip)"
+        "shape": "branch(gzip, skip)",
+        "construct": "other",
+        "from_param": null,
+        "required_runtime": false
       }
     ],
     "edges": [

--- a/casts/claude/skills/summarize-nextflow/runs/nf-core__demo/summary.json
+++ b/casts/claude/skills/summarize-nextflow/runs/nf-core__demo/summary.json
@@ -524,27 +524,42 @@
       {
         "name": "ch_samplesheet",
         "source": "PIPELINE_INITIALISATION.out.samplesheet",
-        "shape": "tuple(val(meta), path(reads))"
+        "shape": "tuple(val(meta), path(reads))",
+        "construct": "other",
+        "from_param": null,
+        "required_runtime": false
       },
       {
         "name": "ch_versions",
         "source": "channel.empty()",
-        "shape": "path"
+        "shape": "path",
+        "construct": "empty",
+        "from_param": null,
+        "required_runtime": false
       },
       {
         "name": "ch_multiqc_files",
         "source": "channel.empty() then accumulated via .mix(FASTQC.out.zip, ch_workflow_summary, ch_methods_description, ch_collated_versions)",
-        "shape": "path"
+        "shape": "path",
+        "construct": "empty",
+        "from_param": null,
+        "required_runtime": false
       },
       {
         "name": "ch_multiqc_config",
         "source": "channel.fromPath(\"$projectDir/assets/multiqc_config.yml\")",
-        "shape": "path"
+        "shape": "path",
+        "construct": "fromPath",
+        "from_param": null,
+        "required_runtime": false
       },
       {
         "name": "ch_collated_versions",
         "source": "softwareVersionsToYAML(ch_versions.mix(channel.topic('versions').versions_file)).mix(...).collectFile(...)",
-        "shape": "path"
+        "shape": "path",
+        "construct": "other",
+        "from_param": null,
+        "required_runtime": false
       }
     ],
     "edges": [

--- a/content/molds/summarize-nextflow/index.md
+++ b/content/molds/summarize-nextflow/index.md
@@ -9,7 +9,7 @@ tags:
 status: draft
 created: 2026-04-30
 revised: 2026-05-08
-revision: 12
+revision: 13
 ai_generated: true
 output_artifacts:
   - id: summary-nextflow
@@ -171,8 +171,11 @@ A single JSON document conforming to [[summary-nextflow]] (`packages/summary-nex
     "name": "RNASEQ",
     "channels": [
       { "name": "ch_samplesheet",
-        "source": "Channel.fromSamplesheet('input')",
-        "shape": "tuple(meta, [path,path])" }
+        "source": "Channel.fromList(samplesheetToList(params.input, '...'))",
+        "shape": "tuple(meta, [path,path])",
+        "construct": "samplesheetToList",
+        "from_param": "input",
+        "required_runtime": false }
     ],
     "edges": [
       { "from": "ch_samplesheet", "to": "FASTP", "via": [] },
@@ -279,7 +282,15 @@ Tool name and version are typically derivable from any of the resolved fields. D
 
 ### 6. Reconcile the workflow DAG
 
-Enumerate the top-level workflow's `include` statements and channel construction (`Channel.fromPath`, `Channel.fromFilePairs`, `Channel.fromSamplesheet`, `params.*`, `channel.empty()`, `channel.topic('<name>')`). For operator chains, the deterministic parser records the *literal* chain (`["map", "join", "groupTuple"]` in `via`). Reconciling chained operators into a coherent `from → to` edge is the second LLM call: given the literal chain, the source channel shape, and the downstream process's declared input shape, emit the resolved edge.
+Enumerate the top-level workflow's `include` statements and channel construction (`Channel.fromPath`, `Channel.fromFilePairs`, `Channel.fromList(samplesheetToList(...))`, `splitCsv`, `file()`/`files()`, `params.*`, `channel.empty()`, `channel.topic('<name>')`). For operator chains, the deterministic parser records the *literal* chain (`["map", "join", "groupTuple"]` in `via`). Reconciling chained operators into a coherent `from → to` edge is the second LLM call: given the literal chain, the source channel shape, and the downstream process's declared input shape, emit the resolved edge.
+
+For each emitted `workflow.channels[]` entry, populate three classified fields alongside the verbatim `source`:
+
+- **`construct`** — typed enum reflecting the channel's primary materialization factory or shape-determining operator. Selection precedence: (1) `samplesheetToList` when the chain contains `samplesheetToList(...)`; (2) `splitCsv` when the chain ends in `.splitCsv(header: true)` over a path; (3) otherwise the outermost factory (`Channel.fromPath` → `fromPath`, `Channel.fromFilePairs` → `fromFilePairs`, `Channel.fromList` → `fromList`, `file(...)` → `file`, `files(...)` → `files`, `Channel.of` → `of`, `Channel.value` → `value`, `Channel.empty` → `empty`, `Channel.topic` → `topic`); (4) `other` for derived/operator-only constructions.
+- **`from_param`** — FK into `params[].name` when the construction expression directly references `params.X` (e.g. `Channel.fromPath(params.reads)`, `samplesheetToList(params.input, ...)`, `file(params.fasta)`). v1 is direct-only — one-hop Groovy bindings (`def reads = params.reads; Channel.fromPath(reads)`) are deferred to jmchilton/foundry#211. Null when no direct reference, or when `construct` is not data-bearing (`empty`, `of`, `value`, `topic`, `other`).
+- **`required_runtime`** — true when the construction chain ends in `.ifEmpty { error ... }` (or an equivalent imperative emptiness-throw guard). Captures runtime requiredness even when the param's nf-schema entry does not mark it required. False otherwise.
+
+All three fields are syntactic: regex-level extraction over the construction expression, no LLM call.
 
 Workflow-level conditionals (`if (params.skip_alignment) { ... }`) emit `conditionals[]` entries with the guard, the branch (`alternate` vs `default`), and the set of processes affected.
 

--- a/content/research/nextflow-params-to-galaxy-inputs.md
+++ b/content/research/nextflow-params-to-galaxy-inputs.md
@@ -8,8 +8,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-05-06
-revised: 2026-05-06
-revision: 3
+revised: 2026-05-08
+revision: 4
 ai_generated: true
 related_notes:
   - "[[nextflow-workflow-io-semantics]]"
@@ -48,9 +48,9 @@ Evidence quality:
 
 ## Translation order
 
-1. Read `summary.params[]`, `summary.sample_sheets[]`, `summary.workflow.channels[]`, `summary.workflow.conditionals[]`, process and subworkflow `inputs[]`, and any warnings.
+1. Read `summary.params[]`, `summary.sample_sheets[]`, `summary.workflow.channels[]`, `summary.workflow.conditionals[]`, process and subworkflow `inputs[]`, and any warnings. Index `summary.workflow.channels[]` by `from_param` so each launch param can be looked up against its materialization channels in O(1).
 2. Classify each launch param as data-bearing, structured sample sheet, scalar workflow parameter, workflow-shape control, runtime/publish control, or reference/data-table selector.
-3. For data-bearing params, use materialization evidence (`fromPath`, `fromFilePairs`, `file`, `files`, `splitCsv`, `samplesheetToList`) before process inputs.
+3. For data-bearing params, use materialization evidence — read `workflow.channels[].construct` (typed enum: `fromPath` / `fromFilePairs` / `fromList` / `samplesheetToList` / `splitCsv` / `file` / `files`) joined to the param via `from_param`, before consulting process inputs. When `from_param` is null but a channel's verbatim `source` references the param, fall back to substring matching (covers one-hop Groovy bindings until jmchilton/foundry#211 is implemented).
 4. Use process and named-workflow inputs to refine shape and identifiers, not to invent top-level Galaxy inputs without upstream launch-param or external-source evidence.
 5. Decide gxformat2 type (`data`, `collection`, `string`, `int`, `float`, `boolean`), then separately decide `format`, `collection_type`, `optional`, `default`, and confidence.
 
@@ -62,9 +62,9 @@ Design inference: translate from launch params plus materialization evidence, no
 |---|---|---|---|---|
 | `sample_sheets[]` with `param = p` | Does launch param `p` describe row-structured datasets? | `type: collection` | `collection_type: sample_sheet*`, `column_definitions`, `optional` | High for `nf-schema` or `samplesheetToList`; lower for `splitCsv` or `ad-hoc`. |
 | `params[]` scalar type, not data/control | User-facing scalar? | `string`, `int`, `float`, `boolean` | `default`, `optional`, `restrictions` from enum | High when schema-backed. |
-| `params[]` path-like plus concrete `fromPath` / `file()` | Single dataset? | `type: data` | `format` only if [[nextflow-path-glob-to-galaxy-datatype]] is confident | Medium to high. |
-| `params[]` path-like plus glob/directory/list materialization | Collection? | `type: collection` | `collection_type: list` unless shape evidence says otherwise | Medium. |
-| `workflow.channels[].source` uses `fromFilePairs` | Paired files? | `type: collection` | `collection_type: paired` or `list:paired` | Medium; high when current source evidence pins sample cardinality. |
+| `params[]` path-like + `workflow.channels[]` entry with `from_param == p.name` and `construct in {"fromPath","file"}` over a concrete (non-glob) path | Single dataset? | `type: data` | `format` only if [[nextflow-path-glob-to-galaxy-datatype]] is confident | Medium to high. |
+| `params[]` path-like + `workflow.channels[]` entry with `from_param == p.name` and `construct in {"fromPath","fromList","files","splitCsv"}` over a glob/directory/list | Collection? | `type: collection` | `collection_type: list` unless shape evidence says otherwise | Medium. |
+| `workflow.channels[].construct == "fromFilePairs"` (and `from_param == p.name` when known) | Paired files? | `type: collection` | `collection_type: paired` or `list:paired` | Medium; high when current source evidence pins sample cardinality. |
 | Repeated `tuple val(meta), path(reads)` | Per-sample dataset list | `type: collection` | `collection_type: list`; use `meta` for identifiers | High. |
 | Repeated `tuple val(meta), path(reads)` where `reads` is `[R1, R2]` | Paired read collection | `type: collection` | `collection_type: list:paired` or `sample_sheet:paired` if sample-sheet-backed | High. |
 | `tuple val(meta), path(a), path(b)` | Heterogeneous record? | Usually parallel inputs or `sample_sheet:record` | Do not default to paired | Medium. |
@@ -164,7 +164,7 @@ Default to safe-exclude only after the agent has traced the param's references i
 | nf-schema root `required[]` includes param | Required launch param | High |
 | `Param.required: true` | Required, source-normalized | High |
 | Missing-default imperative `error` | Required | High |
-| `Channel.fromPath(...).ifEmpty { error ... }` | Materialized data required | High, but may be branch-conditional. |
+| `workflow.channels[].required_runtime == true` (channel construction guarded by `.ifEmpty { error ... }`) | Materialized data required | High, but may be branch-conditional. |
 | Sample-sheet column required | Required row column | High |
 | Default exists | Default value, not optionality | Medium to high |
 | Optional placeholder path or empty channel | Optional branch plumbing | Medium |

--- a/content/research/nextflow-workflow-io-semantics.md
+++ b/content/research/nextflow-workflow-io-semantics.md
@@ -7,8 +7,8 @@ tags:
   - source/nextflow
 status: draft
 created: 2026-05-06
-revised: 2026-05-06
-revision: 3
+revised: 2026-05-08
+revision: 4
 ai_generated: true
 related_notes:
   - "[[component-nextflow-pipeline-anatomy]]"
@@ -281,7 +281,7 @@ For [[summarize-nextflow]] and downstream interface Molds, use this order:
 
 ## Open questions
 
-- Should `summary-nextflow` distinguish launch parameters from materialized workflow inputs as separate arrays?
+- ~~Should `summary-nextflow` distinguish launch parameters from materialized workflow inputs as separate arrays?~~ **Resolved 2026-05-08 — no.** `summary-nextflow` stays Nextflow-faithful: `params[]` is the launch surface, `sample_sheets[]` is the structured-bridge surface, and materialization stays inside `workflow.channels[]`. The input-vs-intermediate-vs-reference classification is a *target* concern and lives in [[nextflow-summary-to-galaxy-interface]] / `nextflow-summary-to-cwl-interface`. Three small Nextflow-faithful enrichments to `workflow.channels[]` were added so the converter does mechanical lookups instead of re-parsing `source` strings: `construct` (typed enum), `from_param` (FK into `params[]` for direct references), and `required_runtime` (boolean from `.ifEmpty { error … }` guards). One-hop Groovy bindings (`def reads = params.reads; Channel.fromPath(reads)`) are deferred to jmchilton/foundry#211. Tracking issue jmchilton/foundry#179.
 - ~~Should sample-sheet schemas become first-class structured inputs instead of prose inside a parameter entry?~~ **Resolved 2026-05-05 — yes.** Promoted to `Summary.sample_sheets[]` in [[summary-nextflow]] rev 6; resolution rationale and Galaxy-side mapping in [[galaxy-sample-sheet-collections]]; tracking issue jmchilton/foundry#177.
 - ~~How should Galaxy targets expose Nextflow execution-control parameters such as `outdir`, `publish_dir_mode`, email, and `save_*` toggles?~~ **Resolved 2026-05-06 for v1 — classify by effect in [[nextflow-params-to-galaxy-inputs]]: exclude publish/runtime controls by default; keep booleans/enums only when they alter workflow shape, tool choice, or command outputs.**
 - Do workflow output `index` files deserve a target-side Galaxy pattern for preserving sample metadata beside published datasets?

--- a/packages/summarize-nextflow/src/resolver.ts
+++ b/packages/summarize-nextflow/src/resolver.ts
@@ -55,10 +55,27 @@ interface ParsedWorkflow extends Subworkflow {
   body: string;
 }
 
+type ChannelConstruct =
+  | "fromPath"
+  | "fromFilePairs"
+  | "fromList"
+  | "samplesheetToList"
+  | "splitCsv"
+  | "file"
+  | "files"
+  | "of"
+  | "value"
+  | "empty"
+  | "topic"
+  | "other";
+
 interface Channel {
   name: string;
   source: string;
   shape: string;
+  construct: ChannelConstruct;
+  from_param: string | null;
+  required_runtime: boolean;
 }
 
 interface Edge {
@@ -868,11 +885,49 @@ function extractSetChains(body: string): { name: string; source: string }[] {
 
 function channelFromSource(name: string, source: string): Channel {
   const operators = parseOperators(source);
+  const construct = classifyChannelConstruct(source);
   return {
     name,
     source,
     shape: operators.length > 0 ? operators.join("|") : "channel",
+    construct,
+    from_param: resolveDirectFromParam(source, construct),
+    required_runtime: detectIfEmptyError(source),
   };
+}
+
+function classifyChannelConstruct(source: string): ChannelConstruct {
+  if (/\bsamplesheetToList\s*\(/u.test(source)) return "samplesheetToList";
+  if (/\bsplitCsv\s*\(/u.test(source)) return "splitCsv";
+  if (/\b[Cc]hannel\.fromPath\b/u.test(source)) return "fromPath";
+  if (/\b[Cc]hannel\.fromFilePairs\b/u.test(source)) return "fromFilePairs";
+  if (/\b[Cc]hannel\.fromList\b/u.test(source)) return "fromList";
+  if (/\b[Cc]hannel\.empty\b/u.test(source)) return "empty";
+  if (/\b[Cc]hannel\.of\b/u.test(source)) return "of";
+  if (/\b[Cc]hannel\.value\b/u.test(source)) return "value";
+  if (/\b[Cc]hannel\.topic\b/u.test(source)) return "topic";
+  if (/^\s*file\s*\(/u.test(source)) return "file";
+  if (/^\s*files\s*\(/u.test(source)) return "files";
+  return "other";
+}
+
+const DATA_BEARING_CONSTRUCTS = new Set<ChannelConstruct>([
+  "fromPath",
+  "fromFilePairs",
+  "fromList",
+  "samplesheetToList",
+  "file",
+  "files",
+]);
+
+function resolveDirectFromParam(source: string, construct: ChannelConstruct): string | null {
+  if (!DATA_BEARING_CONSTRUCTS.has(construct)) return null;
+  const match = /\bparams\.([A-Za-z_][A-Za-z_0-9]*)/u.exec(source);
+  return match ? match[1]! : null;
+}
+
+function detectIfEmptyError(source: string): boolean {
+  return /\.ifEmpty\s*\{[^{}]*\berror\b/u.test(source);
 }
 
 function parseOperators(source: string): string[] {

--- a/packages/summarize-nextflow/src/resolver.ts
+++ b/packages/summarize-nextflow/src/resolver.ts
@@ -243,7 +243,11 @@ export async function resolveNextflowSummary(
     options.mulledIndexPath && !existsSync(options.mulledIndexPath)
       ? [`mulled index path not found: ${options.mulledIndexPath}`]
       : [];
-  const tools = buildTools(pipelineRoot, processes, options.mulledIndexPath);
+  const { tools, perProcessSingleton } = buildTools(
+    pipelineRoot,
+    processes,
+    options.mulledIndexPath,
+  );
   const workflows = parseWorkflows(
     pipelineRoot,
     processes.map((process) => process.name),
@@ -273,8 +277,7 @@ export async function resolveNextflowSummary(
     processes: processes.map((process) => ({
       ...process,
       aliases: aliases.get(process.name) ?? [],
-      tool:
-        tools.find((tool) => process.name.toLowerCase().includes(tool.name))?.name ?? process.tool,
+      tool: resolveProcessToolFk(process, tools, perProcessSingleton),
     })),
     subworkflows: workflows
       .filter((workflow) => workflow.name !== primaryWorkflow?.name)
@@ -1090,8 +1093,36 @@ function parseIoName(line: string, blockName: "input" | "output"): string {
   );
 }
 
-function buildTools(pipelineRoot: string, processes: Process[], mulledIndexPath?: string): Tool[] {
+function normalizeToolToken(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]/gu, "");
+}
+
+function resolveProcessToolFk(
+  process: Process,
+  tools: Tool[],
+  perProcessSingleton: Map<string, string>,
+): string | null {
+  const haystack = normalizeToolToken(process.name);
+  let best: Tool | undefined;
+  let bestLength = 0;
+  for (const tool of tools) {
+    const needle = normalizeToolToken(tool.name);
+    if (needle.length === 0 || !haystack.startsWith(needle)) continue;
+    if (needle.length > bestLength) {
+      best = tool;
+      bestLength = needle.length;
+    }
+  }
+  return best?.name ?? perProcessSingleton.get(process.name) ?? process.tool;
+}
+
+function buildTools(
+  pipelineRoot: string,
+  processes: Process[],
+  mulledIndexPath?: string,
+): { tools: Tool[]; perProcessSingleton: Map<string, string> } {
   const tools = new Map<string, Tool>();
+  const perProcessSingleton = new Map<string, string>();
   const mulledIndex = loadMulledIndex(
     mulledIndexPath ?? process.env.BIOCONTAINERS_MULTI_PACKAGE_TSV,
   );
@@ -1101,9 +1132,11 @@ function buildTools(pipelineRoot: string, processes: Process[], mulledIndexPath?
       .map((match) => match[1]!)
       .filter((value) => value.includes(":") || value.includes("/"));
     const mulledComponents = mulledComponentsForContainers(containerStrings, mulledIndex);
-    for (const dependency of existsSync(envPath)
-      ? parseBiocondaDependencies(readText(envPath))
-      : []) {
+    const dependencies = existsSync(envPath) ? parseBiocondaDependencies(readText(envPath)) : [];
+    if (dependencies.length === 1) {
+      perProcessSingleton.set(process.name, dependencies[0]!.name);
+    }
+    for (const dependency of dependencies) {
       tools.set(dependency.name, {
         name: dependency.name,
         version: dependency.version,
@@ -1121,7 +1154,7 @@ function buildTools(pipelineRoot: string, processes: Process[], mulledIndexPath?
       });
     }
   }
-  return [...tools.values()];
+  return { tools: [...tools.values()], perProcessSingleton };
 }
 
 function loadMulledIndex(path: string | undefined): Map<string, ToolSpec[]> {
@@ -1209,7 +1242,7 @@ function parseBiocondaDependencies(
 function parseBiocondaDependency(
   spec: string,
 ): { name: string; version: string; spec: string } | null {
-  const match = /^bioconda::([A-Za-z0-9_.-]+)(?:=([^=\s]+))?/u.exec(spec);
+  const match = /^(?:[A-Za-z0-9_-]+::)?([A-Za-z0-9_.-]+)(?:=([^=\s]+))?/u.exec(spec);
   if (!match) return null;
   return { name: match[1]!, version: match[2] ?? "unknown", spec };
 }

--- a/packages/summarize-nextflow/test/integration/cli.test.ts
+++ b/packages/summarize-nextflow/test/integration/cli.test.ts
@@ -133,7 +133,7 @@ profiles { test {} }
     }
   });
 
-  itIfBuilt("extracts all bioconda dependencies from module environments", async () => {
+  itIfBuilt("extracts all conda dependencies from module environments", async () => {
     const root = mkdtempSync(join(os.tmpdir(), "foundry-synthetic-nextflow-"));
     const moduleDir = join(root, "modules", "local", "align");
     mkdirSync(moduleDir, { recursive: true });
@@ -184,10 +184,70 @@ dependencies:
     const tools = (summary as { tools: { name: string; version: string; bioconda: string }[] })
       .tools;
     expect(tools.map((tool) => tool.name)).toEqual(
-      expect.arrayContaining(["minimap2", "samtools", "htslib"]),
+      expect.arrayContaining(["minimap2", "samtools", "htslib", "pigz"]),
     );
     expect(tools.find((tool) => tool.name === "htslib")?.bioconda).toBe("bioconda::htslib=1.18");
-    expect(tools.some((tool) => tool.name === "pigz")).toBe(false);
+    expect(tools.find((tool) => tool.name === "pigz")?.bioconda).toBe("conda-forge::pigz=2.6");
+  });
+
+  itIfBuilt("links processes[].tool to dashed and singleton tool names", async () => {
+    const root = mkdtempSync(join(os.tmpdir(), "foundry-synthetic-nextflow-"));
+    const dashedDir = join(root, "modules", "nf-core", "ensemblvep", "vep");
+    const singletonDir = join(root, "modules", "nf-core", "tabix", "tabix");
+    const bareDir = join(root, "modules", "nf-core", "mosdepth");
+    mkdirSync(dashedDir, { recursive: true });
+    mkdirSync(singletonDir, { recursive: true });
+    mkdirSync(bareDir, { recursive: true });
+    writeFileSync(
+      join(root, "nextflow.config"),
+      `manifest { name = 'nf-core/synthetic' }
+profiles { test {} }
+`,
+    );
+    const moduleStub = (name: string) =>
+      `process ${name} {
+  conda "\${moduleDir}/environment.yml"
+  output:
+  path "out", emit: out
+  script:
+  """
+  run
+  """
+}
+`;
+    writeFileSync(join(dashedDir, "main.nf"), moduleStub("ENSEMBLVEP_VEP"));
+    writeFileSync(
+      join(dashedDir, "environment.yml"),
+      `dependencies:\n  - bioconda::ensembl-vep=115.2\n  - bioconda::perl-math-cdf=0.1\n`,
+    );
+    writeFileSync(join(singletonDir, "main.nf"), moduleStub("TABIX_TABIX"));
+    writeFileSync(
+      join(singletonDir, "environment.yml"),
+      `dependencies:\n  - bioconda::htslib=1.21\n`,
+    );
+    writeFileSync(join(bareDir, "main.nf"), moduleStub("MOSDEPTH"));
+    writeFileSync(
+      join(bareDir, "environment.yml"),
+      `channels:\n  - bioconda\ndependencies:\n  - mosdepth=0.3.10\n`,
+    );
+
+    const { buildSummary } = (await import("../../dist/index.js")) as {
+      buildSummary: typeof import("../../src/index.js").buildSummary;
+    };
+    const summary = (await buildSummary(root, {
+      profile: "test",
+      withNextflow: false,
+      fetchTestData: false,
+      validate: false,
+    })) as { tools: { name: string }[]; processes: { name: string; tool: string | null }[] };
+
+    const toolNames = summary.tools.map((tool) => tool.name);
+    expect(toolNames).toEqual(expect.arrayContaining(["ensembl-vep", "htslib", "mosdepth"]));
+    const fk = (name: string) =>
+      summary.processes.find((process) => process.name === name)?.tool ?? null;
+    expect(fk("ENSEMBLVEP_VEP")).toBe("ensembl-vep");
+    expect(fk("TABIX_TABIX")).toBe("htslib");
+    expect(fk("MOSDEPTH")).toBe("mosdepth");
   });
 
   itIfBuilt("extracts process aliases from include statements", async () => {

--- a/packages/summarize-nextflow/test/integration/cli.test.ts
+++ b/packages/summarize-nextflow/test/integration/cli.test.ts
@@ -387,7 +387,14 @@ workflow SYNTHETIC {
     };
     expect(data.workflow.name).toBe("SYNTHETIC");
     expect(data.workflow.channels).toEqual([
-      { name: "ch_extra", source: "Channel.empty()", shape: "channel" },
+      {
+        name: "ch_extra",
+        source: "Channel.empty()",
+        shape: "channel",
+        construct: "empty",
+        from_param: null,
+        required_runtime: false,
+      },
     ]);
     expect(data.workflow.edges).toEqual([{ from: "ch_reads", to: "PREP_READS", via: [] }]);
     const prep = data.subworkflows.find((workflow) => workflow.name === "PREP_READS");
@@ -517,13 +524,33 @@ workflow SYNTHETIC {
           source:
             "ch_reads.filter { meta, reads -> meta.keep }.map { meta, reads -> tuple(meta, reads) }",
           shape: "filter|map",
+          construct: "other",
+          from_param: null,
+          required_runtime: false,
         },
-        { name: "ch_joined", source: "ch_filtered.join(ch_reference)", shape: "join" },
-        { name: "ch_mixed", source: "ch_joined.mix(ch_extra)", shape: "mix" },
+        {
+          name: "ch_joined",
+          source: "ch_filtered.join(ch_reference)",
+          shape: "join",
+          construct: "other",
+          from_param: null,
+          required_runtime: false,
+        },
+        {
+          name: "ch_mixed",
+          source: "ch_joined.mix(ch_extra)",
+          shape: "mix",
+          construct: "other",
+          from_param: null,
+          required_runtime: false,
+        },
         {
           name: "ch_branched",
           source: "ch_mixed.branch { meta, reads -> pass: true }",
           shape: "branch",
+          construct: "other",
+          from_param: null,
+          required_runtime: false,
         },
       ]),
     );

--- a/packages/summary-nextflow-schema/src/summary-nextflow.schema.generated.ts
+++ b/packages/summary-nextflow-schema/src/summary-nextflow.schema.generated.ts
@@ -716,13 +716,16 @@ export const summaryNextflowSchema = {
     },
     "Channel": {
       "title": "Channel",
-      "description": "One top-level channel constructed in the workflow. Sources include `Channel.fromPath`, `Channel.fromFilePairs`, `Channel.fromSamplesheet`, and `params.*`.",
+      "description": "One top-level channel constructed in the workflow. Sources include `Channel.fromPath`, `Channel.fromFilePairs`, `samplesheetToList`-driven `Channel.fromList`, `splitCsv`, `file`/`files`, and plain `params.*` references.",
       "type": "object",
       "additionalProperties": false,
       "required": [
         "name",
         "source",
-        "shape"
+        "shape",
+        "construct",
+        "from_param",
+        "required_runtime"
       ],
       "properties": {
         "name": {
@@ -735,6 +738,35 @@ export const summaryNextflowSchema = {
         "shape": {
           "type": "string",
           "description": "String-encoded channel shape; same convention as ChannelIO."
+        },
+        "construct": {
+          "type": "string",
+          "enum": [
+            "fromPath",
+            "fromFilePairs",
+            "fromList",
+            "samplesheetToList",
+            "splitCsv",
+            "file",
+            "files",
+            "of",
+            "value",
+            "empty",
+            "topic",
+            "other"
+          ],
+          "description": "Classifies the channel's primary materialization factory or shape-determining operator. Selection precedence: (1) `samplesheetToList` when the chain contains `samplesheetToList(...)` (typically wrapped in `Channel.fromList`); (2) `splitCsv` when the chain ends in `.splitCsv(header: true)` over a path; (3) otherwise the outermost factory (`Channel.fromPath` → `fromPath`, `Channel.fromFilePairs` → `fromFilePairs`, `file(...)` → `file`, etc.); (4) `other` for unrecognized constructions. The verbatim `source` retains the full chain — `construct` is the typed lookup the converter would otherwise re-parse."
+        },
+        "from_param": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Foreign key into `params[].name` when the construction expression directly references `params.X` (e.g. `Channel.fromPath(params.reads)`, `samplesheetToList(params.input, ...)`, `file(params.fasta)`). Null for literal-glob construction, expressions that compose multiple params, and channels derived from other channels. v1 resolution is direct-only; one-hop Groovy bindings (`def reads = params.reads; Channel.fromPath(reads)`) are not chased — see jmchilton/foundry#211."
+        },
+        "required_runtime": {
+          "type": "boolean",
+          "description": "True when the construction chain ends in `.ifEmpty { error ... }` (or an equivalent imperative emptiness-throw guard). Captures runtime requiredness even when the param's nf-schema entry does not mark it required. Combine with `params[].required` and any imperative pre-construction `error` checks for the full requiredness picture."
         }
       }
     },

--- a/packages/summary-nextflow-schema/src/summary-nextflow.schema.json
+++ b/packages/summary-nextflow-schema/src/summary-nextflow.schema.json
@@ -229,14 +229,17 @@
 
     "Channel": {
       "title": "Channel",
-      "description": "One top-level channel constructed in the workflow. Sources include `Channel.fromPath`, `Channel.fromFilePairs`, `Channel.fromSamplesheet`, and `params.*`.",
+      "description": "One top-level channel constructed in the workflow. Sources include `Channel.fromPath`, `Channel.fromFilePairs`, `samplesheetToList`-driven `Channel.fromList`, `splitCsv`, `file`/`files`, and plain `params.*` references.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "source", "shape"],
+      "required": ["name", "source", "shape", "construct", "from_param", "required_runtime"],
       "properties": {
-        "name":   { "type": "string" },
-        "source": { "type": "string", "description": "Verbatim channel-construction expression." },
-        "shape":  { "type": "string", "description": "String-encoded channel shape; same convention as ChannelIO." }
+        "name":             { "type": "string" },
+        "source":           { "type": "string", "description": "Verbatim channel-construction expression." },
+        "shape":            { "type": "string", "description": "String-encoded channel shape; same convention as ChannelIO." },
+        "construct":        { "type": "string", "enum": ["fromPath", "fromFilePairs", "fromList", "samplesheetToList", "splitCsv", "file", "files", "of", "value", "empty", "topic", "other"], "description": "Classifies the channel's primary materialization factory or shape-determining operator. Selection precedence: (1) `samplesheetToList` when the chain contains `samplesheetToList(...)` (typically wrapped in `Channel.fromList`); (2) `splitCsv` when the chain ends in `.splitCsv(header: true)` over a path; (3) otherwise the outermost factory (`Channel.fromPath` → `fromPath`, `Channel.fromFilePairs` → `fromFilePairs`, `file(...)` → `file`, etc.); (4) `other` for unrecognized constructions. The verbatim `source` retains the full chain — `construct` is the typed lookup the converter would otherwise re-parse." },
+        "from_param":       { "type": ["string", "null"], "description": "Foreign key into `params[].name` when the construction expression directly references `params.X` (e.g. `Channel.fromPath(params.reads)`, `samplesheetToList(params.input, ...)`, `file(params.fasta)`). Null for literal-glob construction, expressions that compose multiple params, and channels derived from other channels. v1 resolution is direct-only; one-hop Groovy bindings (`def reads = params.reads; Channel.fromPath(reads)`) are not chased — see jmchilton/foundry#211." },
+        "required_runtime": { "type": "boolean", "description": "True when the construction chain ends in `.ifEmpty { error ... }` (or an equivalent imperative emptiness-throw guard). Captures runtime requiredness even when the param's nf-schema entry does not mark it required. Combine with `params[].required` and any imperative pre-construction `error` checks for the full requiredness picture." }
       }
     },
 


### PR DESCRIPTION
Adds three required fields to summary-nextflow Channel so converter Molds do mechanical lookups instead of re-parsing source strings:

- construct: typed enum (fromPath, fromFilePairs, fromList, samplesheetToList, splitCsv, file, files, of, value, empty, topic, other) classifying the primary materialization factory
- from_param: FK into params[] for direct params.X references; null for derived/literal channels and non-data-bearing constructs
- required_runtime: boolean from .ifEmpty { error … } guards

Direct params.X resolution only; one-hop Groovy bindings deferred to #211. summarize-nextflow program populates all three at parse time (regex-level, no LLM call). Mold §6 + nextflow-params-to- galaxy-inputs research updated to consume the typed fields. Cast fixtures for nf-core/demo and nf-core/bacass backfilled. nextflow-workflow-io-semantics open question resolved per #179.

Closes #179. Refs #211.