### PR TITLE
Resolve more processes[].tool FKs in summarize-nextflow

### DIFF
--- a/packages/summarize-nextflow/src/resolver.ts
+++ b/packages/summarize-nextflow/src/resolver.ts
@@ -243,7 +243,11 @@ export async function resolveNextflowSummary(
     options.mulledIndexPath && !existsSync(options.mulledIndexPath)
       ? [`mulled index path not found: ${options.mulledIndexPath}`]
       : [];
-  const tools = buildTools(pipelineRoot, processes, options.mulledIndexPath);
+  const { tools, perProcessSingleton } = buildTools(
+    pipelineRoot,
+    processes,
+    options.mulledIndexPath,
+  );
   const workflows = parseWorkflows(
     pipelineRoot,
     processes.map((process) => process.name),
@@ -273,8 +277,7 @@ export async function resolveNextflowSummary(
     processes: processes.map((process) => ({
       ...process,
       aliases: aliases.get(process.name) ?? [],
-      tool:
-        tools.find((tool) => process.name.toLowerCase().includes(tool.name))?.name ?? process.tool,
+      tool: resolveProcessToolFk(process, tools, perProcessSingleton),
     })),
     subworkflows: workflows
       .filter((workflow) => workflow.name !== primaryWorkflow?.name)
@@ -1090,8 +1093,36 @@ function parseIoName(line: string, blockName: "input" | "output"): string {
   );
 }
 
-function buildTools(pipelineRoot: string, processes: Process[], mulledIndexPath?: string): Tool[] {
+function normalizeToolToken(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]/gu, "");
+}
+
+function resolveProcessToolFk(
+  process: Process,
+  tools: Tool[],
+  perProcessSingleton: Map<string, string>,
+): string | null {
+  const haystack = normalizeToolToken(process.name);
+  let best: Tool | undefined;
+  let bestLength = 0;
+  for (const tool of tools) {
+    const needle = normalizeToolToken(tool.name);
+    if (needle.length === 0 || !haystack.startsWith(needle)) continue;
+    if (needle.length > bestLength) {
+      best = tool;
+      bestLength = needle.length;
+    }
+  }
+  return best?.name ?? perProcessSingleton.get(process.name) ?? process.tool;
+}
+
+function buildTools(
+  pipelineRoot: string,
+  processes: Process[],
+  mulledIndexPath?: string,
+): { tools: Tool[]; perProcessSingleton: Map<string, string> } {
   const tools = new Map<string, Tool>();
+  const perProcessSingleton = new Map<string, string>();
   const mulledIndex = loadMulledIndex(
     mulledIndexPath ?? process.env.BIOCONTAINERS_MULTI_PACKAGE_TSV,
   );
@@ -1101,9 +1132,11 @@ function buildTools(pipelineRoot: string, processes: Process[], mulledIndexPath?
       .map((match) => match[1]!)
       .filter((value) => value.includes(":") || value.includes("/"));
     const mulledComponents = mulledComponentsForContainers(containerStrings, mulledIndex);
-    for (const dependency of existsSync(envPath)
-      ? parseBiocondaDependencies(readText(envPath))
-      : []) {
+    const dependencies = existsSync(envPath) ? parseBiocondaDependencies(readText(envPath)) : [];
+    if (dependencies.length === 1) {
+      perProcessSingleton.set(process.name, dependencies[0]!.name);
+    }
+    for (const dependency of dependencies) {
       tools.set(dependency.name, {
         name: dependency.name,
         version: dependency.version,
@@ -1121,7 +1154,7 @@ function buildTools(pipelineRoot: string, processes: Process[], mulledIndexPath?
       });
     }
   }
-  return [...tools.values()];
+  return { tools: [...tools.values()], perProcessSingleton };
 }
 
 function loadMulledIndex(path: string | undefined): Map<string, ToolSpec[]> {
@@ -1209,7 +1242,7 @@ function parseBiocondaDependencies(
 function parseBiocondaDependency(
   spec: string,
 ): { name: string; version: string; spec: string } | null {
-  const match = /^bioconda::([A-Za-z0-9_.-]+)(?:=([^=\s]+))?/u.exec(spec);
+  const match = /^(?:[A-Za-z0-9_-]+::)?([A-Za-z0-9_.-]+)(?:=([^=\s]+))?/u.exec(spec);
   if (!match) return null;
   return { name: match[1]!, version: match[2] ?? "unknown", spec };
 }

--- a/packages/summarize-nextflow/test/integration/cli.test.ts
+++ b/packages/summarize-nextflow/test/integration/cli.test.ts
@@ -133,7 +133,7 @@ profiles { test {} }
     }
   });
 
-  itIfBuilt("extracts all bioconda dependencies from module environments", async () => {
+  itIfBuilt("extracts all conda dependencies from module environments", async () => {
     const root = mkdtempSync(join(os.tmpdir(), "foundry-synthetic-nextflow-"));
     const moduleDir = join(root, "modules", "local", "align");
     mkdirSync(moduleDir, { recursive: true });
@@ -184,10 +184,70 @@ dependencies:
     const tools = (summary as { tools: { name: string; version: string; bioconda: string }[] })
       .tools;
     expect(tools.map((tool) => tool.name)).toEqual(
-      expect.arrayContaining(["minimap2", "samtools", "htslib"]),
+      expect.arrayContaining(["minimap2", "samtools", "htslib", "pigz"]),
     );
     expect(tools.find((tool) => tool.name === "htslib")?.bioconda).toBe("bioconda::htslib=1.18");
-    expect(tools.some((tool) => tool.name === "pigz")).toBe(false);
+    expect(tools.find((tool) => tool.name === "pigz")?.bioconda).toBe("conda-forge::pigz=2.6");
+  });
+
+  itIfBuilt("links processes[].tool to dashed and singleton tool names", async () => {
+    const root = mkdtempSync(join(os.tmpdir(), "foundry-synthetic-nextflow-"));
+    const dashedDir = join(root, "modules", "nf-core", "ensemblvep", "vep");
+    const singletonDir = join(root, "modules", "nf-core", "tabix", "tabix");
+    const bareDir = join(root, "modules", "nf-core", "mosdepth");
+    mkdirSync(dashedDir, { recursive: true });
+    mkdirSync(singletonDir, { recursive: true });
+    mkdirSync(bareDir, { recursive: true });
+    writeFileSync(
+      join(root, "nextflow.config"),
+      `manifest { name = 'nf-core/synthetic' }
+profiles { test {} }
+`,
+    );
+    const moduleStub = (name: string) =>
+      `process ${name} {
+  conda "\${moduleDir}/environment.yml"
+  output:
+  path "out", emit: out
+  script:
+  """
+  run
+  """
+}
+`;
+    writeFileSync(join(dashedDir, "main.nf"), moduleStub("ENSEMBLVEP_VEP"));
+    writeFileSync(
+      join(dashedDir, "environment.yml"),
+      `dependencies:\n  - bioconda::ensembl-vep=115.2\n  - bioconda::perl-math-cdf=0.1\n`,
+    );
+    writeFileSync(join(singletonDir, "main.nf"), moduleStub("TABIX_TABIX"));
+    writeFileSync(
+      join(singletonDir, "environment.yml"),
+      `dependencies:\n  - bioconda::htslib=1.21\n`,
+    );
+    writeFileSync(join(bareDir, "main.nf"), moduleStub("MOSDEPTH"));
+    writeFileSync(
+      join(bareDir, "environment.yml"),
+      `channels:\n  - bioconda\ndependencies:\n  - mosdepth=0.3.10\n`,
+    );
+
+    const { buildSummary } = (await import("../../dist/index.js")) as {
+      buildSummary: typeof import("../../src/index.js").buildSummary;
+    };
+    const summary = (await buildSummary(root, {
+      profile: "test",
+      withNextflow: false,
+      fetchTestData: false,
+      validate: false,
+    })) as { tools: { name: string }[]; processes: { name: string; tool: string | null }[] };
+
+    const toolNames = summary.tools.map((tool) => tool.name);
+    expect(toolNames).toEqual(expect.arrayContaining(["ensembl-vep", "htslib", "mosdepth"]));
+    const fk = (name: string) =>
+      summary.processes.find((process) => process.name === name)?.tool ?? null;
+    expect(fk("ENSEMBLVEP_VEP")).toBe("ensembl-vep");
+    expect(fk("TABIX_TABIX")).toBe("htslib");
+    expect(fk("MOSDEPTH")).toBe("mosdepth");
   });
 
   itIfBuilt("extracts process aliases from include statements", async () => {


### PR DESCRIPTION
## Summary

Initial pass on jmchilton/foundry#213. Lifts sarek 23/99 nf-core null-tool processes down to 5 (legitimate multi-tool / container-only wrappers) with three resolver changes:

1. **Accept any conda channel prefix** — bare `mosdepth=0.3.10` and `conda-forge::pigz=2.3.4` were silently dropped by the bioconda-only regex. Now `<channel>::<name>=<version>` and bare `<name>=<version>` both parse.
2. **Normalize FK matching + longest-prefix** — strip non-alphanumerics on both sides, longest-prefix match instead of substring. Handles `ENSEMBLVEP_VEP → ensembl-vep`, `GATK4SPARK_* → gatk4-spark` (over `gatk4`), and rejects spurious hits like `CNVKIT_ANTITARGET → tar` and `TABIX_BGZIPTABIX → gzip`.
3. **Singleton fallback** — when a module's `environment.yml` declares exactly one conda dep, that dep is the FK even if the name doesn't share a prefix. Covers `TABIX_TABIX → htslib`, `CAT_CAT → pigz`, `RBT_VCFSPLIT → rust-bio-tools`.

## Sarek before/after

Null `processes[].tool` under `modules/nf-core/`:

- Before: 23 (CAT_CAT, CAT_FASTQ, CONTROLFREEC_*, DEEPVARIANT_RUNDEEPVARIANT, ENSEMBLVEP_*, GAWK, GUNZIP, MOSDEPTH, MSISENSORPRO_*, PARABRICKS_FQ2BAM, RBT_VCFSPLIT, SVDB_MERGE, TABIX_BGZIPTABIX, TABIX_TABIX, UNTAR, UNZIP, YTE)
- After: 5 (CAT_FASTQ, DEEPVARIANT_RUNDEEPVARIANT, GUNZIP, PARABRICKS_FQ2BAM, UNTAR) — all multi-tool wrappers or container-only modules with empty `environment.yml`

## Out of scope

- Container-only modules (DEEPVARIANT, PARABRICKS) — needs container URL parsing to derive a tool name.
- Multi-tool modules (CAT_FASTQ, GUNZIP, UNTAR) — no obvious single FK.
- The eval case suggested in the issue. Worth adding once the container-derivation pass lands.

## Stacking note

Branch is stacked on `summary-nextflow-channel-enrichment` (PR #212) so its tests pass against the new `Channel` schema fields. Will retarget to `main` once #212 merges.

## Test plan

- [x] `pnpm --filter @galaxy-foundry/summarize-nextflow test` — 39/39 pass, includes new test for dashed/singleton/bare-conda FK resolution
- [x] `npx tsx scripts/cast-mold.ts summarize-nextflow --check` — clean
- [x] Manual sarek run confirms 23→5 reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)