### PR TITLE
template Mold: consume reference-data brief + research

### DIFF
--- a/content/molds/nextflow-summary-to-galaxy-data-flow/index.md
+++ b/content/molds/nextflow-summary-to-galaxy-data-flow/index.md
@@ -107,6 +107,7 @@ references:
 related_notes:
   - "[[summary-nextflow]]"
   - "[[nextflow-summary-to-galaxy-interface]]"
+  - "[[nextflow-summary-to-galaxy-template]]"
   - "[[nextflow-params-to-galaxy-inputs]]"
   - "[[nextflow-path-glob-to-galaxy-datatype]]"
 ---

--- a/content/molds/nextflow-summary-to-galaxy-interface/index.md
+++ b/content/molds/nextflow-summary-to-galaxy-interface/index.md
@@ -79,6 +79,7 @@ references:
     trigger: "When the source pipeline declares iGenomes-derived params (params.genome with getGenomeAttribute), per-asset reference path params (fasta, fasta_fai, dict, bwa_index, dbsnp, known_indels, intervals, pon), or any compute-if-missing index-building branch in the source."
 related_notes:
   - "[[summary-nextflow]]"
+  - "[[nextflow-summary-to-galaxy-template]]"
   - "[[nextflow-params-to-galaxy-inputs]]"
   - "[[nextflow-path-glob-to-galaxy-datatype]]"
 ---

--- a/content/molds/nextflow-summary-to-galaxy-reference-data/index.md
+++ b/content/molds/nextflow-summary-to-galaxy-reference-data/index.md
@@ -48,9 +48,11 @@ references:
 related_notes:
   - "[[summary-nextflow]]"
   - "[[nextflow-to-galaxy-reference-data-mapping]]"
+  - "[[nextflow-summary-to-galaxy-template]]"
 related_molds:
   - "[[nextflow-summary-to-galaxy-interface]]"
   - "[[nextflow-summary-to-galaxy-data-flow]]"
+  - "[[nextflow-summary-to-galaxy-template]]"
 ---
 # nextflow-summary-to-galaxy-reference-data
 

--- a/content/molds/nextflow-summary-to-galaxy-template/index.md
+++ b/content/molds/nextflow-summary-to-galaxy-template/index.md
@@ -11,12 +11,14 @@ tags:
 status: draft
 created: 2026-05-05
 revised: 2026-05-10
-revision: 4
+revision: 5
 ai_generated: true
 summary: "gxformat2 skeleton with per-step TODOs from a Nextflow summary and prior Galaxy design briefs."
 input_artifacts:
   - id: summary-nextflow
     description: "Structured Nextflow pipeline summary emitted by [[summarize-nextflow]]; consulted while emitting placeholder steps."
+  - id: nextflow-galaxy-reference-data
+    description: "Reference-data shape brief from [[nextflow-summary-to-galaxy-reference-data]] that pins per-asset reference inputs, optionality, datatype hints, and rebuild-on-absence behavior the skeleton must honor."
   - id: nextflow-galaxy-interface
     description: "Galaxy interface brief from [[nextflow-summary-to-galaxy-interface]] that pins workflow inputs, outputs, labels."
   - id: nextflow-galaxy-data-flow
@@ -100,16 +102,26 @@ references:
     evidence: corpus-observed
     purpose: "Emit `when:` clauses on the right step type (subworkflow vs tool) and the right output fan-in primitive (`pick_value`, modes `first_non_null` / `first_or_skip` / `the_only_non_null`) when the data-flow brief carries a conditional disposition through to the skeleton."
     trigger: "When the upstream data-flow brief assigns a source conditional to a subworkflow `when:` or inline `when:` shape, or when emitting the merge step for two or more `when:`-gated branches that produce the same logical output."
+  - kind: research
+    ref: "[[nextflow-to-galaxy-reference-data-mapping]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Resolve reference-asset declarations into gxformat2 inputs with the right datatype, optionality, and rebuild-on-absence wiring; cross-check the upstream brief against the datatypes table and v1 posture when the brief is silent or low-confidence on a specific asset."
+    trigger: "When emitting workflow inputs or input-connection wiring for any reference asset flagged in the reference-data brief (FASTA, fai, dict, indexes, dbsnp, known_indels, intervals, PoN, …), or when the source pipeline declares iGenomes-derived params, per-asset reference path params, or any compute-if-missing index-building branch."
 related_notes:
   - "[[summary-nextflow]]"
   - "[[nextflow-summary-to-galaxy-interface]]"
   - "[[nextflow-summary-to-galaxy-data-flow]]"
+  - "[[nextflow-summary-to-galaxy-reference-data]]"
+  - "[[nextflow-to-galaxy-reference-data-mapping]]"
 ---
 # nextflow-summary-to-galaxy-template
 
-Read the original Nextflow source artifact, the `summary-nextflow.json` summary, the Nextflow-to-Galaxy interface brief, and the Nextflow-to-Galaxy data-flow brief. Emit a gxformat2 skeleton with workflow inputs, workflow outputs, placeholder steps, rough connections, and TODO slots for later implementation Molds.
+Read the original Nextflow source artifact, the `summary-nextflow.json` summary, the Nextflow-to-Galaxy reference-data brief, the Nextflow-to-Galaxy interface brief, and the Nextflow-to-Galaxy data-flow brief. Emit a gxformat2 skeleton with workflow inputs, workflow outputs, placeholder steps, rough connections, and TODO slots for later implementation Molds.
 
-The interface and data-flow briefs guide the skeleton, but they do not replace source evidence. Treat the prior-step index as the working context: Nextflow source, source summary, interface brief, data-flow brief, and any open questions carried forward.
+The reference-data, interface, and data-flow briefs guide the skeleton, but they do not replace source evidence. Treat the prior-step index as the working context: Nextflow source, source summary, reference-data brief, interface brief, data-flow brief, and any open questions carried forward.
 
 Topology is this Mold's job to settle. The output must be concrete gxformat2: workflow inputs with their final collection shapes and formats, workflow outputs, the step set, the producer→consumer edge graph, branches, and `when:` guards are all decided here. The upstream interface and data-flow briefs guide those decisions, but if they hedge or leave a topology choice open, this Mold makes the call from source evidence, IWC exemplars, and pattern pages — never emit a topology `TODO`. What is deferred to per-step authoring is strictly wrapper-tier: `tool_id`, `tool_version`, `tool_shed_repository`, `tool_state`, and the wrapper-determined port names that surface in `in:` / `out:` / `outputSource`. Capture deferred intent in the `_plan_*` family (`_plan_state`, `_plan_context`, `_plan_in`, `_plan_out`) so the per-step Mold has the source evidence and constraints it needs.
 

--- a/content/research/nextflow-to-galaxy-reference-data-mapping.md
+++ b/content/research/nextflow-to-galaxy-reference-data-mapping.md
@@ -16,6 +16,7 @@ related_notes:
   - "[[nextflow-path-glob-to-galaxy-datatype]]"
   - "[[summary-nextflow]]"
   - "[[nextflow-summary-to-galaxy-reference-data]]"
+  - "[[nextflow-summary-to-galaxy-template]]"
   - "[[galaxy-sample-sheet-collections]]"
   - "[[galaxy-datatypes-conf]]"
 related_molds:
@@ -23,6 +24,7 @@ related_molds:
   - "[[nextflow-summary-to-galaxy-reference-data]]"
   - "[[nextflow-summary-to-galaxy-interface]]"
   - "[[nextflow-summary-to-galaxy-data-flow]]"
+  - "[[nextflow-summary-to-galaxy-template]]"
 sources:
   - "https://nf-co.re/docs/usage/reference_genomes"
   - "https://github.com/nf-core/sarek/blob/master/conf/igenomes.config"

--- a/content/schemas/summary-nextflow.md
+++ b/content/schemas/summary-nextflow.md
@@ -23,6 +23,7 @@ related_notes:
   - "[[nextflow-summary-to-galaxy-reference-data]]"
   - "[[nextflow-summary-to-galaxy-interface]]"
   - "[[nextflow-summary-to-galaxy-data-flow]]"
+  - "[[nextflow-summary-to-galaxy-template]]"
   - "[[nextflow-summary-to-cwl-interface]]"
   - "[[nextflow-summary-to-cwl-data-flow]]"
   - "[[author-galaxy-tool-wrapper]]"


### PR DESCRIPTION
## Summary

Wires `nextflow-summary-to-galaxy-template` to consume the new reference-data outputs, matching the interface and data-flow Molds.

- Adds `nextflow-galaxy-reference-data` to `input_artifacts` — the brief from `nextflow-summary-to-galaxy-reference-data` carries per-asset reference inputs, optionality, datatype hints, and rebuild-on-absence behavior the skeleton must honor.
- Adds `[[nextflow-to-galaxy-reference-data-mapping]]` as `kind: research`, `load: on-demand`. Trigger fires when the template emits workflow inputs or input-connection wiring for reference assets (FASTA, indexes, dict, dbsnp/known_indels, intervals, PoN, …) or when the source pipeline shows iGenomes-derived params or compute-if-missing branches.
- Body updated to list the reference-data brief in the working-context narrative.
- Backlinks updated on the new Mold + research note's `related_notes`/`related_molds`.

The interface and data-flow Molds were wired in #224. This PR closes the loop so the template doesn't re-derive (or contradict) the reference-data decisions the new Mold owns.

## Test plan
- [x] `npm run validate` — 0 errors; warnings unchanged at 113

🤖 Generated with [Claude Code](https://claude.com/claude-code)