### PR TITLE
[codex] wire reference-data classification downstream

### DIFF
--- a/content/molds/nextflow-summary-to-galaxy-data-flow/index.md
+++ b/content/molds/nextflow-summary-to-galaxy-data-flow/index.md
@@ -11,7 +11,7 @@ tags:
 status: draft
 created: 2026-05-05
 revised: 2026-05-10
-revision: 3
+revision: 4
 ai_generated: true
 summary: "Translate a Nextflow summary into a Galaxy data-flow design brief."
 input_artifacts:
@@ -89,6 +89,14 @@ references:
     purpose: "Preserve per-row metadata on the data-flow side: keep sample_sheet column_definitions wired through identifier-keyed steps instead of dropping into parallel parameter inputs, and re-attach metadata after map-over steps that lose it."
     trigger: "When the upstream interface brief carries a sample_sheet[:paired|:paired_or_unpaired|:record] input, or when the Nextflow summary shows tuple(meta, path...) channel shape originating from samplesheetToList or splitCsv(header: true)."
   - kind: research
+    ref: "[[nextflow-reference-data-classification]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Cross-check source-side reference-data classifications before deciding how reference assets and optional rebuild branches flow through the Galaxy data-flow draft."
+    trigger: "When the reference-data or interface brief is silent, low-confidence, or conflicts with source evidence for iGenomes-derived params, coordinated bundles, compute-if-missing branches, multi-DB pick-lists, or cohort-specific assets."
+  - kind: research
     ref: "[[nextflow-to-galaxy-reference-data-mapping]]"
     used_at: runtime
     load: on-demand
@@ -108,6 +116,7 @@ related_notes:
   - "[[summary-nextflow]]"
   - "[[nextflow-summary-to-galaxy-interface]]"
   - "[[nextflow-summary-to-galaxy-template]]"
+  - "[[nextflow-reference-data-classification]]"
   - "[[nextflow-params-to-galaxy-inputs]]"
   - "[[nextflow-path-glob-to-galaxy-datatype]]"
 ---

--- a/content/molds/nextflow-summary-to-galaxy-interface/index.md
+++ b/content/molds/nextflow-summary-to-galaxy-interface/index.md
@@ -11,7 +11,7 @@ tags:
 status: draft
 created: 2026-05-05
 revised: 2026-05-10
-revision: 3
+revision: 4
 ai_generated: true
 summary: "Map a Nextflow summary into a Galaxy workflow interface design brief."
 input_artifacts:
@@ -70,6 +70,14 @@ references:
     purpose: "Pick the right sample_sheet variant and translate nf-schema column metadata into Galaxy column_definitions when the source pipeline uses sample-sheet-shaped inputs."
     trigger: "When the Nextflow summary reports a samplesheetToList materialization, a parameter whose nf-schema entry sets schema: assets/schema_*.json, or a channel built from splitCsv(header: true) over a tabular params input."
   - kind: research
+    ref: "[[nextflow-reference-data-classification]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Cross-check source-side reference-data classifications before translating the reference-data brief into Galaxy workflow inputs."
+    trigger: "When the reference-data brief is silent, low-confidence, or conflicts with source evidence for iGenomes-derived params, coordinated bundles, compute-if-missing branches, multi-DB pick-lists, or cohort-specific assets."
+  - kind: research
     ref: "[[nextflow-to-galaxy-reference-data-mapping]]"
     used_at: runtime
     load: on-demand
@@ -80,6 +88,7 @@ references:
 related_notes:
   - "[[summary-nextflow]]"
   - "[[nextflow-summary-to-galaxy-template]]"
+  - "[[nextflow-reference-data-classification]]"
   - "[[nextflow-params-to-galaxy-inputs]]"
   - "[[nextflow-path-glob-to-galaxy-datatype]]"
 ---

--- a/content/molds/nextflow-summary-to-galaxy-template/index.md
+++ b/content/molds/nextflow-summary-to-galaxy-template/index.md
@@ -11,7 +11,7 @@ tags:
 status: draft
 created: 2026-05-05
 revised: 2026-05-10
-revision: 5
+revision: 6
 ai_generated: true
 summary: "gxformat2 skeleton with per-step TODOs from a Nextflow summary and prior Galaxy design briefs."
 input_artifacts:
@@ -103,6 +103,14 @@ references:
     purpose: "Emit `when:` clauses on the right step type (subworkflow vs tool) and the right output fan-in primitive (`pick_value`, modes `first_non_null` / `first_or_skip` / `the_only_non_null`) when the data-flow brief carries a conditional disposition through to the skeleton."
     trigger: "When the upstream data-flow brief assigns a source conditional to a subworkflow `when:` or inline `when:` shape, or when emitting the merge step for two or more `when:`-gated branches that produce the same logical output."
   - kind: research
+    ref: "[[nextflow-reference-data-classification]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Cross-check source-side reference-data classifications before committing reference assets, optional inputs, and rebuild behavior into the gxformat2 skeleton."
+    trigger: "When emitting workflow inputs or input-connection wiring for reference assets and the reference-data brief is silent, low-confidence, or conflicts with source evidence for iGenomes-derived params, coordinated bundles, compute-if-missing branches, multi-DB pick-lists, or cohort-specific assets."
+  - kind: research
     ref: "[[nextflow-to-galaxy-reference-data-mapping]]"
     used_at: runtime
     load: on-demand
@@ -115,6 +123,7 @@ related_notes:
   - "[[nextflow-summary-to-galaxy-interface]]"
   - "[[nextflow-summary-to-galaxy-data-flow]]"
   - "[[nextflow-summary-to-galaxy-reference-data]]"
+  - "[[nextflow-reference-data-classification]]"
   - "[[nextflow-to-galaxy-reference-data-mapping]]"
 ---
 # nextflow-summary-to-galaxy-template

--- a/content/research/nextflow-reference-data-classification.md
+++ b/content/research/nextflow-reference-data-classification.md
@@ -8,15 +8,21 @@ tags:
 status: draft
 created: 2026-05-10
 revised: 2026-05-10
-revision: 1
+revision: 2
 ai_generated: true
 related_notes:
   - "[[summary-nextflow]]"
   - "[[nextflow-to-galaxy-reference-data-mapping]]"
   - "[[nextflow-summary-to-galaxy-reference-data]]"
+  - "[[nextflow-summary-to-galaxy-interface]]"
+  - "[[nextflow-summary-to-galaxy-data-flow]]"
+  - "[[nextflow-summary-to-galaxy-template]]"
 related_molds:
   - "[[summarize-nextflow]]"
   - "[[nextflow-summary-to-galaxy-reference-data]]"
+  - "[[nextflow-summary-to-galaxy-interface]]"
+  - "[[nextflow-summary-to-galaxy-data-flow]]"
+  - "[[nextflow-summary-to-galaxy-template]]"
 sources:
   - "https://nf-co.re/docs/usage/reference_genomes"
   - "https://github.com/nf-core/sarek/blob/master/conf/igenomes.config"


### PR DESCRIPTION
## Summary

Adds `[[nextflow-reference-data-classification]]` as an on-demand research reference for the downstream Nextflow-to-Galaxy Molds that may need to cross-check source-side reference-data evidence after the mapping/classification split in #227.

- Wires the classification note into `nextflow-summary-to-galaxy-interface`
- Wires the classification note into `nextflow-summary-to-galaxy-data-flow`
- Wires the classification note into `nextflow-summary-to-galaxy-template`
- Reciprocates backlinks from the classification research note

## Why

The Galaxy-side mapping note now depends on a separate source-side classification note. These downstream Molds normally consume the reference-data brief, but when that brief is silent, low-confidence, or conflicts with source evidence, their cast artifacts should package the source-side classification guidance as well.

## Validation

- `npm run validate` — 0 errors, 123 warnings (baseline)