### PR TITLE
nfcore→galaxy phase 0: convert Mold, patterns, planemo manpages, research backfill

### DIFF
--- a/content/molds/convert-nfcore-module-to-galaxy-tool/index.md
+++ b/content/molds/convert-nfcore-module-to-galaxy-tool/index.md
@@ -1,0 +1,281 @@
+---
+type: mold
+name: convert-nfcore-module-to-galaxy-tool
+axis: target-specific
+target: galaxy
+tags:
+  - mold
+  - target/galaxy
+  - source/nextflow
+status: draft
+created: 2026-05-10
+revised: 2026-05-10
+revision: 1
+ai_generated: true
+summary: "Convert one nf-core module dir into a Galaxy tool wrapper (tool.xml + macros.xml + _provenance.yml + remote-URL <test> blocks)."
+references:
+  - kind: pattern
+    ref: "[[nfcore-channel-input-to-galaxy-collection]]"
+    used_at: both
+    load: upfront
+    mode: condense
+    evidence: hypothesis
+    purpose: "Map process input channels (tuple(meta, path)) to Galaxy <param type=\"data\"> / <param type=\"data_collection\">."
+    trigger: "When emitting <inputs> for a module."
+    verification: "Cast and run against fastp (paired, tuple(meta, [path,path])) and seqkit/grep (single, tuple(meta, path)); confirm Galaxy <inputs> shape matches the channel cardinality."
+  - kind: pattern
+    ref: "[[nfcore-meta-map-to-galaxy-params]]"
+    used_at: both
+    load: upfront
+    mode: condense
+    evidence: hypothesis
+    purpose: "Triage meta-map keys: behavior-driving keys become Galaxy <param>s; identity keys are dropped."
+    trigger: "When a process consumes a meta-map and any meta keys influence the script: body."
+    verification: "Cast against a paired-aware module (fastp); confirm meta.single_end becomes a <conditional>, meta.id is dropped."
+  - kind: pattern
+    ref: "[[nfcore-task-ext-args-to-galaxy-additional-options]]"
+    used_at: both
+    load: upfront
+    mode: condense
+    evidence: hypothesis
+    purpose: "Surface task.ext.args as a single Galaxy text param; do not enumerate per-flag inputs."
+    trigger: "When the upstream script: body interpolates ${task.ext.args} (or args2/args3)."
+    verification: "Cast against a module with task.ext.args (samtools/sort); confirm a single extra_args text param is emitted with sane sanitization."
+  - kind: pattern
+    ref: "[[nfcore-versions-emit-to-galaxy-version-command]]"
+    used_at: both
+    load: upfront
+    mode: condense
+    evidence: hypothesis
+    purpose: "Translate the versions.yml emit block (or topic: versions) into Galaxy's <version_command>."
+    trigger: "When the script: body or output: declarations contain a versions emit."
+    verification: "Cast against fastp; confirm <version_command> reproduces the upstream version string for the primary tool."
+  - kind: pattern
+    ref: "[[nfcore-stub-block-to-galaxy-noop-test]]"
+    used_at: both
+    load: upfront
+    mode: condense
+    evidence: hypothesis
+    purpose: "Document the intentional drop of stub: blocks; rely on planemo test for fixture coverage."
+    trigger: "When the module's main.nf contains a stub: block."
+    verification: "Confirm _provenance.yml.overrides records the dropped stub: block with reason."
+  - kind: research
+    ref: "[[component-nf-core-tools]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    evidence: hypothesis
+    purpose: "Reference for nf-core module conventions: meta.yml shape, modules.json, environment.yml posture, test layout, container directive idioms."
+    trigger: "When parsing meta.yml, environment.yml, or main.nf and a convention is unclear; when populating _provenance.yml."
+    verification: "Cast and verify _provenance.yml.nfcore_source.git_sha resolution and meta.yml DOI extraction work for fastp."
+  - kind: research
+    ref: "[[component-nextflow-containers-and-envs]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    evidence: hypothesis
+    purpose: "Resolve the container directive (mulled, biocontainer, Wave) and environment.yml into a Galaxy <requirements> block with matching bioconda pins."
+    trigger: "When emitting <requirements> and the module's container directive is non-trivial (ternary or mulled)."
+    verification: "Cast against a mulled-container module (multiqc); confirm <requirements> declares all packages from environment.yml."
+  - kind: research
+    ref: "[[galaxy-discover-datasets]]"
+    used_at: runtime
+    load: on-demand
+    mode: condense
+    evidence: hypothesis
+    purpose: "Reference for the <discover_datasets> XML element: attributes, named/regex patterns, <data> vs <collection> contexts, test-side <discovered_dataset>."
+    trigger: "When translating a Nextflow output: channel that uses a glob path or runtime-interpolated filenames into a Galaxy <collection> or multi-output <data>."
+    verification: "Cast against a glob-output module (samtools/index); confirm the emitted <collection><discover_datasets pattern=...> shape resolves the glob correctly under planemo test."
+related_notes:
+  - "[[component-nf-core-tools]]"
+  - "[[galaxy-discover-datasets]]"
+---
+
+# convert-nfcore-module-to-galaxy-tool
+
+Convert **one nf-core module directory** into a Galaxy tool wrapper. Input is a path to `modules/nf-core/<name>/` (or any directory of the same shape: `main.nf` + `meta.yml` + `environment.yml` + optional `tests/`). Output is a self-contained tool dir: `tool.xml`, `macros.xml`, `_provenance.yml`, with `<test>` blocks pinned to remote `nf-core/test-datasets` URLs.
+
+The Mold authors a Galaxy tool XML wrapper directly from the nf-core module shape — the regular structure (`tuple(meta, path)` channels, `task.ext.args` escape hatch, versions emit, environment.yml bioconda pin) makes a mechanical mapping practical. It does **not** depend on `[[summarize-nextflow]]` — that Mold summarizes whole pipelines, the wrong granularity for one module.
+
+The Mold is run per module by an outer harness (a script or human loop). Cross-module batches are not its concern.
+
+## Inputs
+
+The Mold expects:
+
+- A **path** to the module directory (`modules/nf-core/<name>/`, or any local clone of that shape).
+- Optional **module pin**: tag, branch, or commit SHA of `nf-core/modules`. When absent, the cast skill resolves to `git rev-parse HEAD` of the dir's containing repo.
+- Optional **test-datasets pin**: SHA of `nf-core/test-datasets` to use for `<test>` block `location` URLs. When absent, the cast skill resolves to a recent SHA on the module's pipeline-of-record branch (best-effort; recorded in `_provenance.yml` either way).
+
+The Mold does **not** accept "convert a subworkflow" — `meta.yml` with a populated `components:` field is out of scope (composes other modules; route to a separate subworkflow Mold not in this plan).
+
+## Outputs
+
+Three files in a sibling output directory the harness specifies:
+
+```
+<output_dir>/
+  <name>.xml          # primary wrapper
+  macros.xml          # tool-local macros (token, requirements, version_command, citations)
+  _provenance.yml     # nfcore source SHA, file hashes, mold revision, generated_at
+```
+
+`tool.xml` shape (skeleton; idiomatic IUC layout):
+
+```xml
+<tool id="<name>" name="<name>" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="23.1">
+  <description><!-- meta.yml description, first sentence --></description>
+  <macros>
+    <import>macros.xml</import>
+  </macros>
+  <expand macro="requirements"/>
+  <expand macro="version_command"/>
+  <command detect_errors="exit_code"><![CDATA[
+    <!-- script: body translated, $task.ext.args → $extra_args -->
+  ]]></command>
+  <inputs>
+    <!-- per nfcore-channel-input-to-galaxy-collection + nfcore-meta-map-to-galaxy-params -->
+    <param name="extra_args" type="text" optional="true" .../>  <!-- per task.ext.args pattern -->
+  </inputs>
+  <outputs>
+    <!-- one Galaxy <data> / <collection> per output: channel, minus the versions channel -->
+  </outputs>
+  <tests>
+    <test>
+      <param name="reads_1" location="https://raw.githubusercontent.com/nf-core/test-datasets/<sha>/.../test_1.fastq.gz"/>
+      <output name="trimmed" location="https://raw.githubusercontent.com/nf-core/test-datasets/<sha>/.../trimmed.fastq.gz"
+              checksum="sha256$..."/>
+    </test>
+  </tests>
+  <help><!-- meta.yml description --></help>
+  <expand macro="citations"/>
+</tool>
+```
+
+`_provenance.yml` shape (canonical):
+
+```yaml
+nfcore_source:
+  modules_repo: nf-core/modules
+  module_path: modules/nf-core/<name>
+  branch: master
+  git_sha: <sha at conversion time>
+  meta_yml_hash: <sha256 of meta.yml at conversion>
+  main_nf_hash:  <sha256 of main.nf at conversion>
+  environment_yml_hash: <sha256 of environment.yml at conversion>
+  test_datasets_sha: <sha of nf-core/test-datasets pin>
+generated:
+  by_mold: convert-nfcore-module-to-galaxy-tool
+  mold_revision: 1
+  cast_target: claude
+  cast_artifact_sha: <sha of cast bundle used>
+  on_date: 2026-05-10
+overrides: []
+```
+
+## Procedure
+
+The cast skill is **not a single LLM prompt**. It is a small program with embedded LLM calls:
+
+- **Deterministic:** read meta.yml / main.nf / environment.yml / tests/main.nf.test; tokenize the `process` block for input/output channels; resolve container directive into bioconda packages; compute file hashes; resolve git SHAs; emit `_provenance.yml` and the static portions of `<requirements>`, `<citations>`, `<version_command>`.
+- **LLM-driven:** translate the `script:` body into Galaxy `<command>` Cheetah; pick `<inputs>` shapes (data vs collection; conditional gating); name and document outputs; humanize `<help>`; place `<test>` block fixtures.
+
+The boundary mirrors `[[summarize-nextflow]]` §Procedure: enumerated artifacts deterministic, free-text fields LLM.
+
+### 1. Read the module
+
+Open `meta.yml`, `main.nf`, `environment.yml`, and `tests/main.nf.test` (when present). Reject early if `meta.yml.components:` is populated (subworkflow composing other modules; out of scope — see *Non-goals*).
+
+Compute `sha256` of each file and capture for `_provenance.yml`.
+
+### 2. Build `<requirements>`
+
+Walk `environment.yml.dependencies:`. Each `bioconda::<name>=<version>` becomes a Galaxy `<requirement type="package" version="<version>"><name></requirement>` entry. For mulled / multi-package environments, declare every package — bioconda's mulled-resolution produces an equivalent image (per `[[component-nextflow-containers-and-envs]]`).
+
+Record any forced divergence from upstream container choice in `_provenance.yml.overrides`.
+
+### 3. Translate `<inputs>`
+
+Per `[[nfcore-channel-input-to-galaxy-collection]]`, decide the Galaxy input shape from the process's input channel cardinality. Per `[[nfcore-meta-map-to-galaxy-params]]`, triage meta-map keys into Galaxy params, conditionals, or drops.
+
+Emit a final `extra_args` text param per `[[nfcore-task-ext-args-to-galaxy-additional-options]]` if (and only if) the script body interpolates `${task.ext.args}` / `args2` / `args3`.
+
+### 4. Translate `<outputs>`
+
+For each `output:` channel that isn't the `versions` emit (per the four rules in `[[galaxy-discover-datasets]]` §*Convert Mold posture*):
+
+- `path('*.bam')` glob → `<collection type="list" name="..." format="bam">` with `<discover_datasets pattern="__name_and_ext__" visible="true"/>`.
+- `tuple val(meta), path("*_R{1,2}.fastp.fastq.gz")` paired → `<collection type="paired" ...>` with a custom `(?P<name>...)_R(?P<identifier_1>[12])...` regex.
+- Single `path("${prefix}.json")` deterministic → `<data name="..." format="json" from_work_dir="${prefix}.json"/>`, no discovery.
+- `versions` channel → drop; the `<version_command>` carries that load (per `[[nfcore-versions-emit-to-galaxy-version-command]]`).
+
+### 5. Translate `script:` to `<command>`
+
+LLM step. Pass:
+
+- The verbatim `script:` body.
+- The Galaxy `<inputs>` and `<outputs>` already chosen.
+- The `task.ext.args` mapping (text param → `$extra_args`).
+
+Ask only for the Cheetah-flavored Galaxy command. Wrap in `<![CDATA[...]]>`. Set `detect_errors="exit_code"` unless a comment in the original `script:` argues otherwise.
+
+### 6. Emit `<version_command>`
+
+Per `[[nfcore-versions-emit-to-galaxy-version-command]]`: extract the primary tool's version-emit line from the heredoc or `topic: versions` annotation, strip Nextflow escaping (`\$( → $(` etc.), and wrap in `<![CDATA[...]]>`.
+
+### 7. Emit `<citations>` and `<help>`
+
+`<citations>` are DOIs from `meta.yml.tools[].doi` (one `<citation type="doi">…</citation>` per tool). `<help>` is the `meta.yml.description` (humanized one-liner; expanded into a paragraph if `meta.yml` has a longer prose block).
+
+### 8. Emit `<test>` blocks (remote URLs)
+
+Read `tests/main.nf.test`. For each test that asserts a successful run with a non-trivial fixture:
+
+- Resolve every input fixture path to a `raw.githubusercontent.com/nf-core/test-datasets/<test_datasets_sha>/...` URL. Pin `<test_datasets_sha>` upfront — never use a branch ref.
+- Emit Galaxy `<param ... location="https://..."/>` for inputs.
+- For outputs, prefer `<output name="..." location="https://..." checksum="sha256$..."/>` (compute checksum from the upstream snapshot file when one exists; omit if not).
+
+When `tests/main.nf.test` has no usable fixture (stub-only coverage, missing test file), the convert Mold **does not ship a placeholder `<test>`**. It surfaces the gap in `_provenance.yml.overrides` and exits with a non-zero status; the harness escalates to human review. Every shipped wrapper carries at least one `<test>` block backed by a real fixture (per `[[nfcore-stub-block-to-galaxy-noop-test]]` and the reviewer Mold's dimension #6).
+
+### 9. Emit `_provenance.yml`
+
+Collect: nf-core module source (repo, path, branch, git_sha), file hashes, test-datasets pin, mold metadata, any overrides (forced divergence from upstream container, dropped stub block, hand-edits the cast skill chose to apply).
+
+### 10. Convergence loop: lint, test, fix
+
+Iterate until clean:
+
+1. `planemo lint <output_dir>`. XSD failures are hard — fix the XML and re-emit. Soft findings (missing `<help>`, missing `<citations>`) are fixed in place by the cast skill.
+2. `planemo test <output_dir>`. Test failures classify into:
+   - `<command>` mismatch with the upstream script — the LLM revises the Cheetah translation.
+   - Output discovery mismatch — adjust `<discover_datasets>` patterns.
+   - Fixture availability — verify the remote URL resolves; fall back to a local `test-data/` copy and document in `_provenance.yml.overrides`.
+3. Stop when both pass; emit the final files.
+
+The convergence loop is bounded (default 3 attempts). On exhaustion, the cast skill writes whatever it has and surfaces the final `planemo` output for human triage.
+
+## Non-goals
+
+- **Subworkflow conversion.** `meta.yml.components:` populated → out of scope. Routed to a separate Mold (not in this plan).
+- **Pipeline conversion.** Whole nf-core pipelines stay with `[[nextflow-to-galaxy]]`; this Mold runs at the module tier.
+- **Discovery / dedup against IUC.** The new repo coexists with IUC by design (different interface contract for the same upstream tool).
+- **Cross-module refactoring.** Per-module unit; harness owns batches.
+- **Tool Shed publication.** The output is a tool dir on disk; `.shed.yml` and shed publication live in the new repo's CI, not in this Mold.
+
+## Caveats
+
+- **`meta.yml` may lie.** Hand-authored, can drift from `script:` IO. When the LLM-inferred IO disagrees with `meta.yml`, prefer `meta.yml` and surface the disagreement in `_provenance.yml.overrides`.
+- **Container directive ternaries** require pulling **both** branches; the bioconda pin from `environment.yml` is the source of truth for `<requirements>`. Don't substitute a hand-picked container source.
+- **`task.ext.args` with embedded Groovy logic** can't be cleanly mapped to a single text param. Surface as a text param **plus** a heavy `<help>` block; document the divergence in `_provenance.yml.overrides`.
+- **Stub-only tests.** When `tests/main.nf.test` has only stub-mode coverage (`-stub-run`), the convert Mold cannot derive a Galaxy `<test>` from it (per `[[nfcore-stub-block-to-galaxy-noop-test]]`). Surface the gap; let the harness decide whether to author a `<test>` by hand.
+
+## Reference dispatch (for casting)
+
+- `patterns` → 5 nf-core→Galaxy translation patterns (see frontmatter `references[]`). LLM-condensed into the cast skill.
+- planemo invocations (`planemo lint`, `planemo test`) are called as subprocesses by the cast skill; deferred Foundry CLI manpages for planemo until `@galaxy-tool-util/cli` metadata (or equivalent) carries planemo coverage.
+- `research` → `[[component-nf-core-tools]]`, `[[component-nextflow-containers-and-envs]]`, `[[galaxy-discover-datasets]]`. On-demand, condensed into runtime context when triggered.
+- `examples` — pending: 3 hand-picked Wave 1 modules (one trivial, one paired-aware, one with conditional). Used for round-trip smoke testing before this Mold ships.
+
+## Revision history
+
+- **rev 1 (2026-05-10)** — initial draft. Procedure sketched against the trimmed plan; no cast runs yet. Pattern + CLI references all `evidence: hypothesis`.

--- a/content/patterns/nfcore-channel-input-to-galaxy-collection.md
+++ b/content/patterns/nfcore-channel-input-to-galaxy-collection.md
@@ -1,0 +1,158 @@
+---
+type: pattern
+pattern_kind: operation
+evidence: hypothesis
+title: "nf-core channel input → Galaxy data / collection"
+tags:
+  - pattern
+  - target/galaxy
+status: draft
+created: 2026-05-10
+revised: 2026-05-10
+revision: 2
+ai_generated: true
+summary: "Map an nf-core process's tuple(meta, path) input channel to a Galaxy <param type=\"data\"> or paired/list collection input."
+related_molds:
+  - "[[convert-nfcore-module-to-galaxy-tool]]"
+related_patterns:
+  - "[[nfcore-meta-map-to-galaxy-params]]"
+related_notes:
+  - "[[galaxy-discover-datasets]]"
+sources:
+  - "https://github.com/nf-core/modules/tree/9b261a459473bc8e2d830bfc626f480c0733f4fe"
+  - "https://github.com/galaxyproject/tools-iuc"
+---
+
+# nf-core channel input → Galaxy data / collection
+
+Cited modules pinned to `nf-core/modules@9b261a459473bc8e2d830bfc626f480c0733f4fe`.
+
+## Triage table
+
+| nf-core input shape | meta-driven branching? | Galaxy mapping |
+|---|---|---|
+| `tuple val(meta), path(input)` (single artifact) | no | one `<param type="data">` |
+| `tuple val(meta), path(input), path(secondary)` | no | two `<param type="data">` (one per role) |
+| `tuple val(meta), path(reads)` with `meta.single_end` driving the script | yes | `<conditional>` switching `<param type="data">` (single) ↔ `<param type="data_collection" collection_type="paired">` (paired) |
+| `tuple val(meta), path(reads, stageAs: "input*/*")` (multi-list) | yes (single/paired branching) | `<conditional>` switching `<param type="data" multiple="true">` ↔ `<param type="data_collection" collection_type="list:paired">` |
+| `tuple val(meta), path("*.bam")` glob | no | `<param type="data_collection" collection_type="list">` |
+
+The `meta` map itself is **never** an input — see `[[nfcore-meta-map-to-galaxy-params]]`. Its keys may *gate* a `<conditional>`, but the map data does not flow as a Galaxy param.
+
+## Cited cases
+
+### Single artifact, no meta branching → single `<param type="data">`
+
+`modules/nf-core/samtools/index/main.nf`:
+
+```nextflow
+input:
+tuple val(meta), path(input)
+
+output:
+tuple val(meta), path("*.{bai,csi,crai}"), emit: index
+```
+
+Galaxy mapping:
+
+```xml
+<inputs>
+  <param name="input" type="data" format="bam,cram" label="BAM / CRAM to index"/>
+</inputs>
+<outputs>
+  <data name="index" format_source="input">
+    <discover_datasets pattern="__name_and_ext__" directory="."/>
+  </data>
+</outputs>
+```
+
+`samtools/index`'s upstream behavior already reads file-extension cues to pick the index format; the convert Mold should not surface `index_format` as a Galaxy param when the upstream tool can derive it. Surface it only if `task.ext.args` exposes it as a knob.
+
+### Two artifacts, role-split → two `<param type="data">`
+
+`modules/nf-core/seqkit/grep/main.nf`:
+
+```nextflow
+input:
+tuple val(meta), path(sequence)
+path pattern
+```
+
+`sequence` is the FASTQ/FASTA to filter; `pattern` is a separate file of names. Galaxy:
+
+```xml
+<param name="sequence" type="data" format="fasta,fastq,fasta.gz,fastq.gz" label="Sequences to filter"/>
+<param name="pattern"  type="data" format="txt" optional="true" label="Pattern file (one ID per line)"/>
+```
+
+Two roles → two params. A `<repeat>` would only fit if the module accepted N pattern files; here it's exactly one.
+
+### Paired/single branching driven by `meta.single_end` → `<conditional>`
+
+`modules/nf-core/fastp/main.nf`:
+
+```nextflow
+input:
+tuple val(meta), path(reads), path(adapter_fasta)
+val   discard_trimmed_pass
+val   save_trimmed_fail
+val   save_merged
+
+script:
+def args = task.ext.args ?: ''
+...
+if ( task.ext.args?.contains('--interleaved_in') ) {
+    """ ...fastp --stdout --in1 ... """          // interleaved-FASTQ mode
+} else if (meta.single_end) {
+    """ ...fastp --in1 ... """                   // single-end
+} else {
+    """ ...fastp --in1 ... --in2 ... """         // paired-end
+}
+```
+
+Three branches: interleaved (driven by `task.ext.args` introspection — see `[[nfcore-task-ext-args-to-galaxy-additional-options]]`), single-end (driven by `meta.single_end == true`), paired (default). The first two are *meta- and args-driven* convergence onto a single-input shape; the third is the genuine paired shape.
+
+`tools-iuc/tools/fastp/fastp.xml` (revision pinned by viewing master) shows the canonical Galaxy translation as a **two-arm** conditional:
+
+```xml
+<conditional name="single_paired">
+  <param name="single_paired_selector" type="select" label="Single-end or paired reads">
+    <option value="single" selected="true">Single-end</option>
+    <option value="paired_collection">Paired Collection</option>
+  </param>
+  <when value="single">
+    <param name="in1" type="data" format="fastqsanger,fastqsanger.gz"/>
+    ...
+  </when>
+  <when value="paired_collection">
+    <param name="paired_input" type="data_collection" collection_type="paired"
+           format="fastqsanger,fastqsanger.gz"/>
+    ...
+  </when>
+</conditional>
+```
+
+Two reasons IUC chose `paired_collection` over a literal `paired` (in1 + in2 separate datasets) arm:
+
+1. **Galaxy collection idiom.** Paired-end data in Galaxy lives in `paired` collections; pairing them into a collection at upload time is the recommended workflow shape (and the only shape that survives downstream collection-aware tools cleanly).
+2. **Single source of truth for the pair.** Two separate `data` params lets a user pair non-matching files; a paired collection enforces the pair structure at the dataset level.
+
+The convert Mold's posture should match IUC: emit `single` + `paired_collection` only. The interleaved-FASTQ path collapses into the `single` arm — `task.ext.args` carrying `--interleaved_in` is a usage choice the user makes via the additional-options bag (see `[[nfcore-task-ext-args-to-galaxy-additional-options]]`), not a third `<conditional>` arm.
+
+### Multi-list (cat/fastq style) → `<conditional>` over multi-data + list:paired
+
+`modules/nf-core/cat/fastq/main.nf` consumes `tuple val(meta), path(reads, stageAs: "input*/*")` — N reads per sample, single-end *or* paired. The Galaxy mapping mirrors the fastp shape with `multiple="true"` on the single arm and `collection_type="list:paired"` on the paired arm.
+
+## Pitfalls
+
+- **Don't promote `meta.id` to a Galaxy input.** Galaxy datasets carry their own identifier (`$input.element_identifier`); `meta.id` belongs in the wrapper script, not in `<inputs>`. See `[[nfcore-meta-map-to-galaxy-params]]`.
+- **Glob inputs (`path('*.bam')`) ≠ `multiple="true"`.** They map to a `<param type="data_collection" collection_type="list">`, because Galaxy's collection abstraction is the right idiom for "N files of the same shape with stable identifiers." `multiple="true"` discards element identifiers.
+- **`stageAs:` directives carry information.** `path(reads, stageAs: "input*/*")` tells Nextflow to stage each read under a numbered subdirectory; the convert Mold should preserve this in `<command>` via `&& mkdir input1 input2 && ln -sf` style staging, not flatten to a single dir.
+- **Optional artifacts are `optional="true"`, not a separate `<conditional>` arm.** `tuple val(meta), path(adapter_fasta)` where `adapter_fasta` may be empty maps to `<param ... optional="true">`, not a paired/no-paired conditional.
+
+## See also
+
+- `[[nfcore-meta-map-to-galaxy-params]]` — sibling: how to handle the `meta` map keys that travel with the data path.
+- `[[galaxy-discover-datasets]]` — reference for the `<discover_datasets>` element used in the glob-input mapping.
+- `[[convert-nfcore-module-to-galaxy-tool]]` — Mold that consumes this pattern.
+- `tools-iuc/tools/fastp/fastp.xml` — canonical IUC paired/single conditional shape.

--- a/content/patterns/nfcore-meta-map-to-galaxy-params.md
+++ b/content/patterns/nfcore-meta-map-to-galaxy-params.md
@@ -1,0 +1,119 @@
+---
+type: pattern
+pattern_kind: operation
+evidence: hypothesis
+title: "nf-core meta-map → Galaxy params"
+tags:
+  - pattern
+  - target/galaxy
+status: draft
+created: 2026-05-10
+revised: 2026-05-10
+revision: 2
+ai_generated: true
+summary: "Promote nf-core meta-map keys to Galaxy <param>s only when they drive script behavior; drop identity-only keys; pull naming from $input.element_identifier."
+related_molds:
+  - "[[convert-nfcore-module-to-galaxy-tool]]"
+related_patterns:
+  - "[[nfcore-channel-input-to-galaxy-collection]]"
+sources:
+  - "https://github.com/nf-core/modules/tree/9b261a459473bc8e2d830bfc626f480c0733f4fe"
+---
+
+# nf-core meta-map → Galaxy params
+
+The nf-core `meta` map travels with the data channel as `tuple val(meta), path(...)`. Galaxy has no metadata-channel equivalent — datasets carry only their own `element_identifier`, `name`, and format. The convert Mold's job is to triage every meta key the script body reads.
+
+Cited modules pinned to `nf-core/modules@9b261a459473bc8e2d830bfc626f480c0733f4fe`.
+
+## Triage rule
+
+Walk the module's `script:` body for `meta.<key>` references. For each key, classify:
+
+| Class | Diagnostic | Galaxy mapping |
+|---|---|---|
+| **Identity** | only used in output filenames (`${meta.id}.bam`) | **drop** — use `$input.element_identifier` in `<command>` |
+| **Behavior-driving** | gates branches in the script body | `<conditional>` (boolean) or `<param type="select">` (multi-mode) |
+| **Mode/strategy** | substituted into a flag value (`--lib_type ${meta.strandedness}`) | `<param type="select">` with explicit options |
+| **Pass-through tag** | written into output metadata or filenames but doesn't change behavior | optional `<param type="text">`, default `${input.element_identifier}` |
+
+When in doubt, prefer **dropping** over surfacing. Galaxy users don't expect to fill in metadata that the platform already tracks per-dataset.
+
+## Cited cases
+
+### Identity only → drop
+
+`modules/nf-core/samtools/index/main.nf`:
+
+```nextflow
+process SAMTOOLS_INDEX {
+    tag "${meta.id}"
+    ...
+    input:
+    tuple val(meta), path(input)
+    ...
+    script:
+    """
+    samtools index -@ ${task.cpus} ${args} ${input}
+    """
+}
+```
+
+`meta.id` appears only in the `tag` directive (Nextflow log line) — never in the script. Drop entirely; Galaxy's history-item identity is the dataset's `element_identifier`. The convert Mold's `<command>` does not need to reference `meta.id` at all.
+
+### Behavior-driving (boolean) → `<conditional>`
+
+`modules/nf-core/fastp/main.nf`:
+
+```nextflow
+script:
+def args = task.ext.args ?: ''
+...
+if ( task.ext.args?.contains('--interleaved_in') ) {
+    """ ...fastp --stdout --in1 ... """          // interleaved (single-input shape)
+} else if (meta.single_end) {
+    """ ...fastp --in1 ... """                   // single-end
+} else {
+    """ ...fastp --in1 ... --in2 ... """         // paired
+}
+```
+
+`meta.single_end` gates a hard branch — the command line is materially different. The first branch (interleaved) is `task.ext.args`-driven, not meta-driven, and collapses into the single-input shape (see `[[nfcore-task-ext-args-to-galaxy-additional-options]]`). Galaxy mapping for the meta gate: a `<conditional name="single_paired">` whose selector drives both the `<inputs>` shape (per `[[nfcore-channel-input-to-galaxy-collection]]` — two arms `single` + `paired_collection`) and the `<command>` branching:
+
+```xml
+<command><![CDATA[
+fastp
+#if $single_paired.single_paired_selector == "single"
+    --in1 '$single_paired.in1'
+#else
+    --in1 '$single_paired.in1' --in2 '$single_paired.in2'
+#end if
+]]></command>
+```
+
+Same key, two collaborating mappings: input shape and command shape. The convert Mold should treat the `<conditional>` as a single unit gated by the meta key, not two independent translations.
+
+### Behavior-driving (multi-arm) → `<param type="select">`
+
+`modules/nf-core/cat/fastq/main.nf` reads `meta.single_end` to switch between cat-one-stream and cat-two-streams. Same shape as fastp; `<conditional>` over the same selector.
+
+### Pass-through tag → optional text param
+
+When a module writes `meta.id` into a non-output-name place (e.g., a header field of a derived file), the convert Mold can either:
+
+1. Default to `$input.element_identifier` in `<command>` and **not** surface the param. (Preferred — Galaxy users already named the dataset.)
+2. Surface as `<param name="sample_id" type="text" optional="true" label="Sample ID (defaults to dataset name)">`, defaulting to `$input.element_identifier`.
+
+Option 1 is right unless the upstream tool genuinely supports two distinct identifiers for one input (rare).
+
+## Pitfalls
+
+- **Don't surface `meta.id` as a required user input.** This is the most common over-translation. Galaxy already has identifier semantics; doubling them up confuses users and breaks collection-aware idioms.
+- **Don't expand a meta-map's full key set.** Pipelines extend the `meta` map with arbitrary keys (`meta.run`, `meta.lane`, `meta.barcode`); only the keys the *module's own* script body reads matter at conversion time.
+- **Behavior-driving keys must surface.** Hiding `meta.single_end` inside the wrapper (e.g., always emitting the paired branch) silently breaks single-end runs. The conditional is non-negotiable when the script branches on it.
+- **`meta.strandedness` is rare in modules; it usually surfaces as a separate `val` input.** Don't auto-emit a strandedness `<param>` based on key name; check the script body actually reads it.
+
+## See also
+
+- `[[nfcore-channel-input-to-galaxy-collection]]` — sibling pattern: meta-driven input shape decisions.
+- `[[convert-nfcore-module-to-galaxy-tool]]` — Mold that consumes this pattern.

--- a/content/patterns/nfcore-stub-block-to-galaxy-noop-test.md
+++ b/content/patterns/nfcore-stub-block-to-galaxy-noop-test.md
@@ -1,0 +1,95 @@
+---
+type: pattern
+pattern_kind: operation
+evidence: hypothesis
+title: "nf-core stub: block → Galaxy (intentional drop)"
+tags:
+  - pattern
+  - target/galaxy
+status: draft
+created: 2026-05-10
+revised: 2026-05-10
+revision: 2
+ai_generated: true
+summary: "nf-core's stub: block has no Galaxy analog; the convert Mold drops it intentionally and records the drop in _provenance.yml."
+related_molds:
+  - "[[convert-nfcore-module-to-galaxy-tool]]"
+sources:
+  - "https://github.com/nf-core/modules/tree/9b261a459473bc8e2d830bfc626f480c0733f4fe"
+---
+
+# nf-core `stub:` block → Galaxy (intentional drop)
+
+Cited modules pinned to `nf-core/modules@9b261a459473bc8e2d830bfc626f480c0733f4fe`.
+
+## What the `stub:` block does in nf-core
+
+Most nf-core modules ship a `stub:` block alongside `script:`. It fakes the outputs cheaply so `nextflow run -stub-run` exercises the DAG (channels, joins, output discovery, naming) without invoking the upstream tool.
+
+`modules/nf-core/samtools/index/main.nf`:
+
+```nextflow
+script:
+def args = task.ext.args ?: ''
+"""
+samtools index -@ ${task.cpus} ${args} ${input}
+"""
+
+stub:
+def args = task.ext.args ?: ''
+def extension = file(input).getExtension() == 'cram'
+    ? "crai"
+    : args.contains("-c") ? "csi" : "bai"
+"""
+touch ${input}.${extension}
+"""
+```
+
+`modules/nf-core/fastp/main.nf` has a more elaborate `stub:` block that produces every conditional output the script can emit (paired/single, merged, fail FASTQs, JSON, HTML, log).
+
+## Why Galaxy doesn't need an analog
+
+Galaxy's tool-execution model has no DAG-level dry-run. The Galaxy/IUC equivalent of "did the wrapper plumb correctly" is `planemo lint` (XML-shape correctness) followed by `planemo test` (real CLI invocation against a fixture). Together they cover the same ground:
+
+| nf-core | Galaxy |
+|---|---|
+| `nextflow run -stub-run` (DAG resolves, channels join) | `planemo lint` (XML valid, params bind, output discovery rules are well-formed) |
+| `nextflow run` (real fixture) | `planemo test` (real fixture via `<test>` blocks) |
+
+There's no Galaxy XML element that means "fake the outputs without running the tool." There's no need for one — `planemo test` runs fast against small fixtures, so the cost gap nf-core is closing with `-stub-run` doesn't apply at the per-tool granularity.
+
+## The convert Mold's posture
+
+**Intentionally drop the `stub:` block.** Nothing in `tool.xml` references it. Two minor obligations:
+
+1. **Record the drop in `_provenance.yml`** under `overrides[]`:
+   ```yaml
+   overrides:
+     - reason: "Dropped stub: block per nfcore-stub-block-to-galaxy-noop-test pattern."
+       files: ["main.nf:stub"]
+   ```
+   This makes the drop visible to the reviewer and to a future refresh-from-upstream pass.
+
+2. **Make sure at least one `<test>` block exists** with a real fixture (typically a remote `location` URL pinned to `nf-core/test-datasets`). The `stub:` block's role — exercise the wrapper without paying for the upstream tool — is filled by the runtime test against a small fixture.
+
+When `tests/main.nf.test` has *only* stub-mode coverage (rare), the convert Mold cannot synthesize a Galaxy `<test>` from the stub block. Surface the gap in `_provenance.yml.overrides` and let the harness decide whether to author a `<test>` by hand.
+
+## Cited cases
+
+- `modules/nf-core/samtools/index/main.nf` — short `stub:` (one `touch`); cleanly dropped, `<test>` covers the contract.
+- `modules/nf-core/fastp/main.nf` — elaborate `stub:` mirroring the conditional output set; still cleanly dropped because Galaxy's per-conditional outputs declare format/discovery rules in `<outputs>` that `planemo lint` validates structurally.
+- `modules/nf-core/samtools/sort/main.nf` — `stub:` repeats the index-format introspection; still dropped.
+
+In all three the convert Mold's deliverable is identical: tool.xml + macros.xml + at least one `<test>` block with a real fixture, plus a one-line override entry.
+
+## Pitfalls
+
+- **Don't try to reconstruct outputs from the stub block.** The `stub:` block's `touch` lines are deliberately minimal; using them as a guide for `<discover_datasets>` patterns is misleading. Read the `output:` channel declarations directly.
+- **Don't surface the drop as a warning.** It's an *intentional* drop, not a deficiency — recording it as an override is enough.
+- **Stub-only test coverage is the real risk.** When the only fixture in `tests/main.nf.test` is `-stub-run`, the convert Mold lacks the input/output values it would need to write a Galaxy `<test>`. That's the case worth surfacing for human review.
+
+## See also
+
+- `[[convert-nfcore-module-to-galaxy-tool]]` — Mold that consumes this pattern.
+- `planemo test` — the runtime sink that makes the drop safe.
+- `planemo lint` — the XML-shape gate that fills in for the DAG-resolution part of `-stub-run`.

--- a/content/patterns/nfcore-task-ext-args-to-galaxy-additional-options.md
+++ b/content/patterns/nfcore-task-ext-args-to-galaxy-additional-options.md
@@ -1,0 +1,122 @@
+---
+type: pattern
+pattern_kind: operation
+evidence: hypothesis
+title: "nf-core task.ext.args → Galaxy additional-options bag"
+tags:
+  - pattern
+  - target/galaxy
+status: draft
+created: 2026-05-10
+revised: 2026-05-10
+revision: 2
+ai_generated: true
+summary: "Map nf-core's task.ext.args escape hatch to a single Galaxy text param surfacing extra command-line arguments."
+related_molds:
+  - "[[convert-nfcore-module-to-galaxy-tool]]"
+sources:
+  - "https://github.com/nf-core/modules/tree/9b261a459473bc8e2d830bfc626f480c0733f4fe"
+  - "https://github.com/galaxyproject/tools-iuc"
+---
+
+# nf-core task.ext.args → Galaxy additional-options bag
+
+Cited modules pinned to `nf-core/modules@9b261a459473bc8e2d830bfc626f480c0733f4fe`.
+
+## Why a single bag, not per-flag inputs
+
+nf-core modules expose `task.ext.args` (sometimes `args2`, `args3`) as the configuration escape hatch — pipelines override these per-process via `modules.config`. The bag is intentionally opaque: the module's authors chose **not** to enumerate every flag of the upstream tool, so the wrapper inherits a one-string-of-CLI surface.
+
+Galaxy has no per-step config layer; the natural mirror is one optional text `<param>` appended to the command line. Going further (per-flag inputs) re-enumerates the upstream tool's CLI in Galaxy XML, which:
+
+- Forces the wrapper author to track upstream releases at the flag level — the exact maintenance load nf-core declined.
+- Doubles the cognitive surface for users: which flags are first-class, which need the bag.
+
+The **policy** is: surface `task.ext.args` as a single bag. Promote individual flags to first-class `<param>`s only when the module already does (e.g., `discard_trimmed_pass` is a `val` input in fastp; that's a `<param type="boolean">`, not part of the args bag).
+
+## Cited cases
+
+### Single-arg use → one `extra_args` text param
+
+`modules/nf-core/samtools/index/main.nf`:
+
+```nextflow
+script:
+def args = task.ext.args ?: ''
+"""
+samtools index -@ ${task.cpus} ${args} ${input}
+"""
+```
+
+Galaxy:
+
+```xml
+<param argument="" name="extra_args" type="text" optional="true"
+       label="Additional command-line options"
+       help="Pass-through string appended to the upstream tool's CLI. Mirrors nf-core's task.ext.args escape hatch.">
+  <sanitizer invalid_char="">
+    <valid initial="string.printable">
+      <remove value="&apos;"/>
+    </valid>
+  </sanitizer>
+</param>
+```
+
+```xml
+<command><![CDATA[
+samtools index -@ \${GALAXY_SLOTS:-1} $extra_args '$input'
+]]></command>
+```
+
+### Args used to introspect → still one bag
+
+`modules/nf-core/fastp/main.nf` reads its own `task.ext.args` to switch on `--interleaved_in`:
+
+```nextflow
+script:
+def args = task.ext.args ?: ''
+...
+if ( task.ext.args?.contains('--interleaved_in') ) {
+    """ ...fastp --stdout --in1 ... """
+}
+```
+
+The convert Mold should **not** try to translate this introspection into Galaxy XML. Two reasonable options:
+
+1. Surface `extra_args` and document in `<help>`: "Set `--interleaved_in` to enable interleaved-FASTQ mode."
+2. Promote the specific flag to a `<param type="boolean">` (`interleaved_in`) and pass-through everything else via `extra_args`.
+
+Option 2 is the IUC pattern (`tools-iuc/tools/fastp/fastp.xml` does exactly this for many flags); option 1 is the fast path the convert Mold defaults to. Record the choice in `_provenance.yml.overrides` so the reviewer can flag aggressive expansions for verification.
+
+### `args2` / `args3` → numbered bags
+
+`modules/nf-core/sratools/fasterqdump/main.nf`:
+
+```nextflow
+def args  = task.ext.args  ?: ''
+def args2 = task.ext.args2 ?: ''
+```
+
+Used to feed two distinct upstream invocations. Galaxy mapping: two text params (`extra_args`, `extra_args2`), each scoped to the relevant invocation in `<command>`. Document the mapping in `<help>`.
+
+## Sanitization
+
+Galaxy's default sanitizer rewrites quotes and backslashes — fine for a value like a sample name, fatal for a CLI fragment. Two options:
+
+1. **Permissive `<sanitizer>` block** as shown above. Lets users include their own quoting; the convert Mold leans on `<![CDATA[ ]]>` in `<command>` for outer quoting.
+2. **`sanitize="false"`** on the `<param>`. Simplest; trust that the user knows shell quoting. Acceptable for an opt-in advanced field.
+
+The convert Mold defaults to (1) because it preserves the rest of Galaxy's input safety machinery while opening the specific quote-removal behavior that breaks args bags.
+
+## Pitfalls
+
+- **Don't double-quote the bag in `<command>`.** `'$extra_args'` injects literal quotes around the entire string, breaking the user's quoting.
+- **Watch for `${task.cpus}` interpolation.** nf-core scripts use `${task.cpus}` for thread counts; Galaxy's analog is `\${GALAXY_SLOTS:-1}`. Translate this directly; it does **not** belong in the args bag.
+- **Don't surface `task.ext.prefix`.** Modules use it for output filenames; Galaxy's `$input.element_identifier` is the right substitute. See `[[nfcore-meta-map-to-galaxy-params]]`.
+- **`task.ext.when`** is the conditional gate for whether the process runs. It has no Galaxy analog (Galaxy's tool runs unconditionally when invoked); ignore.
+
+## See also
+
+- `[[nfcore-meta-map-to-galaxy-params]]` — sibling: handling identity vs behavior keys.
+- `[[convert-nfcore-module-to-galaxy-tool]]` — Mold that consumes this pattern.
+- `tools-iuc/tools/fastp/fastp.xml` — IUC's per-flag promotion choice (option 2 above).

--- a/content/patterns/nfcore-versions-emit-to-galaxy-version-command.md
+++ b/content/patterns/nfcore-versions-emit-to-galaxy-version-command.md
@@ -1,0 +1,115 @@
+---
+type: pattern
+pattern_kind: operation
+evidence: hypothesis
+title: "nf-core versions emit → Galaxy <version_command>"
+tags:
+  - pattern
+  - target/galaxy
+status: draft
+created: 2026-05-10
+revised: 2026-05-10
+revision: 2
+ai_generated: true
+summary: "Translate nf-core's versions emit (heredoc or topic: versions) into Galaxy's <version_command>, dropping the versions output channel."
+related_molds:
+  - "[[convert-nfcore-module-to-galaxy-tool]]"
+sources:
+  - "https://github.com/nf-core/modules/tree/9b261a459473bc8e2d830bfc626f480c0733f4fe"
+---
+
+# nf-core versions emit → Galaxy `<version_command>`
+
+Cited modules pinned to `nf-core/modules@9b261a459473bc8e2d830bfc626f480c0733f4fe`.
+
+Every nf-core module emits a tool-version string. Galaxy's `<version_command>` is the natural sink. Two emission shapes are both common in current nf-core/modules:
+
+1. **`topic: versions`** (Nextflow 24+) — modern; an output tuple with `eval(...)` capturing the version string.
+2. **`cat <<-END_VERSIONS > versions.yml`** heredoc — older; still present in many modules.
+
+The convert Mold's job is the same either way: extract the primary tool's version-line command, strip Nextflow escaping, drop the versions channel from outputs, and emit `<version_command>`.
+
+## Cited cases
+
+### `topic: versions` style → strip `eval('...')`, keep the inner command
+
+`modules/nf-core/fastp/main.nf`:
+
+```nextflow
+output:
+...
+tuple val("${task.process}"), val('fastp'),
+      eval('fastp --version 2>&1 | sed -e "s/fastp //g"'),
+      emit: versions_fastp, topic: versions
+```
+
+Galaxy:
+
+```xml
+<version_command><![CDATA[fastp --version 2>&1 | sed -e 's/fastp //g']]></version_command>
+```
+
+Mechanical translation: take the `eval(...)` argument verbatim, strip nothing (no escaping needed for `eval(...)` content), wrap in `<![CDATA[ ]]>`. Done.
+
+`modules/nf-core/samtools/sort/main.nf`:
+
+```nextflow
+tuple val("${task.process}"), val('samtools'),
+      eval("samtools version | sed '1!d;s/.* //'"),
+      topic: versions, emit: versions_samtools
+```
+
+→
+
+```xml
+<version_command><![CDATA[samtools version | sed '1!d;s/.* //']]></version_command>
+```
+
+### Heredoc style → strip `\$(...)` escaping
+
+`modules/nf-core/shasta/main.nf`:
+
+```nextflow
+cat <<-END_VERSIONS > versions.yml
+"${task.process}":
+    shasta: \$(shasta --version | head -n 1 | cut -f 3 -d " ")
+END_VERSIONS
+```
+
+The `\$( ... )` is Nextflow escaping for "let bash run this when the script runs, don't expand at Nextflow parse time." Galaxy's `<version_command>` is invoked directly by Galaxy at tool-introspection time — no Nextflow layer, no escaping needed. Strip the leading backslash:
+
+```xml
+<version_command><![CDATA[shasta --version | head -n 1 | cut -f 3 -d " "]]></version_command>
+```
+
+## Mapping rules
+
+- **Single-tool module** → one `<version_command>`. Pick the one tool the module wraps (the tool whose name matches `meta.yml.tools[0]` or the module's own slug).
+- **Multi-tool module (mulled)** → still one `<version_command>` for the primary tool. Galaxy's `<version_command>` is single-string. Document the other tools' versions in `<help>` text; they're surfaced by BioContainers metadata at runtime, not by the wrapper.
+- **Drop the `versions` output channel.** It has no Galaxy analog — Galaxy's `<requirements>` + `<version_command>` carry the same information end-to-end. The convert Mold should never emit a Galaxy `<data>` for the versions channel.
+
+## Multiqc-style edge cases
+
+`modules/nf-core/multiqc/main.nf` deliberately emits its versions outside the `topic: versions` channel:
+
+```nextflow
+// MultiQC should not push its versions to the `versions` topic.
+// Its input depends on the versions topic to be resolved
+// thus outputting to the topic will let the pipeline hang forever
+tuple val("${task.process}"), val('multiqc'),
+      eval('multiqc --version | sed "s/.* //g"'), emit: versions
+```
+
+Translation is identical: extract the `eval(...)` argument; emit one `<version_command>`. The pipeline-level rationale (avoiding a topic-channel deadlock) doesn't carry into Galaxy — there's no topic mechanism here.
+
+## Pitfalls
+
+- **Don't escape backslashes twice.** `\$(...)` in Nextflow becomes `$(...)` in the bash that Nextflow runs. Galaxy runs the `<version_command>` directly via subprocess — `$(...)` works as-is.
+- **Sed expressions need single-quoting.** Inside `<![CDATA[ ]]>`, single quotes survive intact; double-quoted seds need careful escaping if they include `$`. Default to `<![CDATA[...]]>` + single-quoted sed.
+- **Tools that print version to stdout vs stderr.** Use the same redirection as the upstream module (`2>&1` if the module uses it). Don't optimize away — the inversion can mask the actual version string.
+- **Tools without a `--version` flag.** Some modules use `<tool> -h | head -n 1 | awk '...'`. Preserve the exact pipeline; Galaxy's `<version_command>` is bash, not nextflow-eval.
+
+## See also
+
+- `[[convert-nfcore-module-to-galaxy-tool]]` — Mold that consumes this pattern.
+- `tools-iuc/tools/fastp/fastp.xml` — IUC's `<version_command>` posture (often shorter than nf-core's because IUC wraps a single tool).

--- a/content/research/component-nf-core-tools.md
+++ b/content/research/component-nf-core-tools.md
@@ -12,6 +12,10 @@ ai_generated: true
 summary: "White paper on nf-core/tools — conventions, CLI surface, schema universe, container resolution. Survey, not decision."
 related_molds:
   - "[[summarize-nextflow]]"
+  - "[[convert-nfcore-module-to-galaxy-tool]]"
+related_notes:
+  - "[[convert-nfcore-module-to-galaxy-tool]]"
+  - "[[component-nextflow-containers-and-envs]]"
 sources:
   - "https://github.com/nf-core/tools"
   - "https://nf-co.re/docs/nf-core-tools"

--- a/content/research/galaxy-collection-semantics.md
+++ b/content/research/galaxy-collection-semantics.md
@@ -19,6 +19,7 @@ related_notes:
   - "[[galaxy-tool-job-failure-reference]]"
   - "[[galaxy-workflow-invocation-failure-reference]]"
   - "[[iwc-transformations-survey]]"
+  - "[[galaxy-discover-datasets]]"
 sources:
   - "https://github.com/galaxyproject/galaxy/blob/7765fae934fbfdee77e3be5f5b235e43735273ae/lib/galaxy/model/dataset_collections/types/collection_semantics.yml"
 summary: "Vendored formal spec of Galaxy dataset-collection mapping/reduction semantics, with labeled examples and pinned test references."

--- a/content/research/galaxy-discover-datasets.md
+++ b/content/research/galaxy-discover-datasets.md
@@ -1,0 +1,263 @@
+---
+type: research
+subtype: component
+title: "Galaxy <discover_datasets>"
+tags:
+  - research/component
+  - target/galaxy
+component: "Galaxy <discover_datasets> XML element"
+status: draft
+created: 2026-05-10
+revised: 2026-05-10
+revision: 1
+ai_generated: true
+summary: "Reference for the <discover_datasets> Galaxy XML element — attributes, named/regex patterns, <data> vs <collection> contexts, test assertions."
+related_molds:
+  - "[[convert-nfcore-module-to-galaxy-tool]]"
+related_patterns:
+  - "[[nfcore-channel-input-to-galaxy-collection]]"
+related_notes:
+  - "[[convert-nfcore-module-to-galaxy-tool]]"
+  - "[[nfcore-channel-input-to-galaxy-collection]]"
+  - "[[galaxy-collection-semantics]]"
+  - "[[planemo-asserts-idioms]]"
+sources:
+  - "https://github.com/galaxyproject/galaxy/blob/7765fae934fbfdee77e3be5f5b235e43735273ae/lib/galaxy/tool_util/xsd/galaxy.xsd"
+  - "https://github.com/galaxyproject/galaxy/blob/7765fae934fbfdee77e3be5f5b235e43735273ae/lib/galaxy/tool_util/parser/output_collection_def.py"
+  - "https://planemo.readthedocs.io/en/latest/writing_advanced.html#multiple-output-files"
+  - "https://github.com/galaxyproject/galaxy/tree/dev/test/functional/tools"
+---
+
+# Galaxy `<discover_datasets>`
+
+Cited Galaxy source pinned to `galaxyproject/galaxy@7765fae9` (XSD: `lib/galaxy/tool_util/xsd/galaxy.xsd`; parser: `lib/galaxy/tool_util/parser/output_collection_def.py`).
+
+`<discover_datasets>` is Galaxy's mechanism for collecting outputs whose names or counts aren't knowable at tool-wrapper authoring time. A tool that emits "one BAM per chromosome", "every `*.report.tsv` in the working dir", "whatever fell out of split-by-this-column" — uses `<discover_datasets>` to tell Galaxy how to find them after the job completes.
+
+Two parents, slightly different behavior:
+
+| Parent | What discover_datasets populates | Result |
+|---|---|---|
+| `<data>` | The primary dataset's siblings (and optionally the primary itself with `assign_primary_output="true"`) | Multiple history items derived from one `<data>` declaration |
+| `<collection>` | The elements of the collection | A `list`, `paired`, `list:paired`, or arbitrarily-nested collection |
+
+The convert Mold (`[[convert-nfcore-module-to-galaxy-tool]]`) reaches for `<discover_datasets>` inside `<collection>` whenever a Nextflow `output:` channel uses a glob (`path('*.bam')`) or names interpolated from runtime values; the corresponding Galaxy idiom needs to discover the matching files after the script runs.
+
+## Two discovery modes
+
+Set with `from_provided_metadata`. Default is `pattern`.
+
+### `pattern` mode (default)
+
+Galaxy scans the working directory (or a named subdirectory) and matches filenames against a regex.
+
+```xml
+<discover_datasets pattern="(?P<designation>.+)\.report\.tsv" ext="tabular" visible="true"/>
+```
+
+The regex must match the filename (not the full path, unless `match_relative_path="true"`). Named groups inside the pattern feed Galaxy metadata about each discovered file — see *Named groups* below.
+
+### `tool_provided_metadata` mode
+
+The tool writes a `galaxy.json` (or equivalent) into the working directory listing each output's path, name, datatype, and metadata. Galaxy reads it verbatim.
+
+```xml
+<discover_datasets from_provided_metadata="true" visible="true"/>
+```
+
+Used when the regex idiom doesn't carry enough information — usually because the tool needs to set datatype per file, attach element identifiers from a non-filename source, or surface metadata Galaxy can't infer. `pattern` and `sort_by` are forbidden in this mode (the parser rejects them at load time per `output_collection_def.py:88-90`).
+
+## Attribute reference
+
+All attributes are optional. Pulled from `OutputDiscoverDatasetsCommon` in `galaxy.xsd:6698-6749`.
+
+| Attribute | Type | Notes |
+|---|---|---|
+| `pattern` | regex | Filename pattern. May be a named pattern (`__name__`, …) or a literal regex with named groups. Forbidden when `from_provided_metadata="true"`. |
+| `directory` | string | Working-dir-relative directory to scan. Default is the working dir itself. |
+| `recurse` | bool | Walk `directory` recursively. Default `false`. |
+| `match_relative_path` | bool | Match the regex against the path relative to `directory` (lets you embed path components in named groups). Default `false` — match filename only. |
+| `format` / `ext` | datatype | Datatype for every discovered file. `format` is an alias for `ext`. Override per-file via a named `ext` regex group. |
+| `sort_by` | string | `[reverse_][SORT_COMP_]SORTBY`. `SORTBY` ∈ {`filename`, `name`, `designation`, `dbkey`}; `SORT_COMP` ∈ {`lexical`, `numeric`}. Default `lexical_filename`. |
+| `visible` | bool | History visibility of discovered datasets. Defaults to `false` per the XSD, but the XSD doc string explicitly warns "probably shouldn't be" — almost every IUC and Galaxy test tool sets `visible="true"`. |
+| `from_provided_metadata` | bool | Switch to `tool_provided_metadata` mode. |
+
+Additional on `<discover_datasets>` inside `<data>` (`OutputDiscoverDatasets` only):
+
+| Attribute | Notes |
+|---|---|
+| `assign_primary_output` | Replace the parent `<data>`'s primary dataset with the first discovered match. Useful for tools where one of N outputs should be the canonical output. |
+
+## Named patterns
+
+Five string aliases that expand to regexes (`output_collection_def.py:31-37`):
+
+| Alias | Expands to | Effect |
+|---|---|---|
+| `__default__` | `primary_DATASET_ID_(?P<designation>[^_]+)_(?P<visible>[^_]+)_(?P<ext>[^_]+)(_(?P<dbkey>[^_]+))?` | The historical Galaxy convention. Filename literally begins with `primary_DATASET_ID_…`. Avoid for new tools — too much encoded in the filename. |
+| `__name__` | `(?P<name>.*)` | Match anything; the filename becomes the element identifier. Datatype comes from `ext` / `format` on the `<discover_datasets>` element. |
+| `__designation__` | `(?P<designation>.*)` | Same as `__name__` semantically, but the matched group is `designation` (the legacy term that still drives the `<discovered_dataset designation="…">` test assertion form). |
+| `__name_and_ext__` | `(?P<name>.*)\.(?P<ext>[^\.]+)?` | Match `<basename>.<extension>`; element identifier is the basename, datatype is the extension. The most common new-tool choice. |
+| `__designation_and_ext__` | `(?P<designation>.*)\.(?P<ext>[^\._]+)?` | Same shape, but populates `designation` instead of `name`. Use when test fixtures need `<discovered_dataset designation="…">` to match — by convention, anywhere the test side uses `discovered_dataset`. |
+
+Use a named pattern unless you need information from the filename that the aliases can't capture (per-file `dbkey`, multi-level nesting via `identifier_0`/`identifier_1`).
+
+## Named regex groups Galaxy recognizes
+
+Custom regexes feed Galaxy metadata through specific named groups:
+
+| Group | Meaning |
+|---|---|
+| `name` | Element identifier (history-item name). |
+| `designation` | Element identifier under the legacy term; same effect. |
+| `ext` | Per-file datatype, overrides the element-level `ext`/`format`. |
+| `dbkey` | Per-file dbkey (genome build). Defaults to the input's dbkey (`INPUT_DBKEY_TOKEN = "__input__"`). |
+| `visible` | Per-file visibility override (boolean). |
+| `identifier_0`, `identifier_1`, …, `identifier_N` | Inside `<collection>`: nested-level identifiers. `list:paired` uses `identifier_0` for the outer list identifier and `identifier_1` for the inner `forward`/`reverse`. The level count must match the collection type's nesting depth. |
+
+Cited example — nested `list:paired` from a single discover sweep (`test/functional/tools/output_filter.xml:75`):
+
+```xml
+<collection name="paired_list_output" type="list:paired" label="paired list">
+  <discover_datasets pattern="(?P<identifier_0>p[12])\.(?P<identifier_1>.*)" ext="txt" visible="true"/>
+</collection>
+```
+
+A file `p1.forward` becomes an element under outer identifier `p1`, inner identifier `forward`.
+
+## Inside `<data>` — multiple outputs from one declaration
+
+```xml
+<data format="tabular" name="sample">
+  <discover_datasets pattern="(?P<designation>.+)\.report\.tsv" ext="tabular" visible="true" assign_primary_output="true"/>
+</data>
+```
+
+`assign_primary_output="true"` makes the *first* discovered match (under the configured `sort_by`) become the primary dataset that `name="sample"` resolves to in the test block; the rest become additional, sibling history items. Without `assign_primary_output`, Galaxy expects the `<data>` to be produced as normal (e.g. via `from_work_dir` or stdout redirection) and discover_datasets contributes only siblings.
+
+Cited test case: `test/functional/tools/multi_output_assign_primary.xml:15`.
+
+## Inside `<collection>` — discovered collection elements
+
+```xml
+<collection name="list_output" type="list" label="List">
+  <discover_datasets pattern="(?P<identifier_0>[45])" ext="txt" visible="true"/>
+</collection>
+```
+
+The collection type determines how many `identifier_N` groups are required:
+
+- `list` → `identifier_0`.
+- `paired` → not usable directly; the two element identifiers are fixed (`forward`, `reverse`). Use the `__name__` form and rely on filenames matching `forward` and `reverse`, or split with a `<discover_datasets>` per arm (rare).
+- `list:paired` → `identifier_0` (outer list) + `identifier_1` (inner `forward`/`reverse`).
+- Deeper nesting → add `identifier_2`, ….
+
+Optional / variable-cardinality collections: combine `<discover_datasets>` with `<filter>` on the `<collection>` to gate the whole emit, or use an output `count`/`min`/`max` on the `<test>` side to assert cardinality.
+
+## Test-side `<discovered_dataset>`
+
+Inside `<test>` blocks, the discovered files are addressable for assertions through `<discovered_dataset designation="…">` nested under the matching `<output>` (`galaxy.xsd:2247-2297`):
+
+```xml
+<test>
+  <param name="num_param" value="7"/>
+  <param name="input" ftype="txt" value="simple_line.txt"/>
+  <output name="sample">
+    <assert_contents><has_line line="1"/></assert_contents>
+    <discovered_dataset designation="sample2" ftype="tabular">
+      <assert_contents><has_line line="2"/></assert_contents>
+    </discovered_dataset>
+    <discovered_dataset designation="sample3" ftype="tabular">
+      <assert_contents><has_line line="3"/></assert_contents>
+    </discovered_dataset>
+  </output>
+</test>
+```
+
+The `designation` attribute matches the value of the `designation` (or `name`) named group from the pattern. `ftype` checks the inferred datatype. The first discovered match was hoisted to the primary output by `assign_primary_output="true"`, so its `<assert_contents>` lives directly under `<output>`.
+
+For dynamic-collection outputs, use `<element name="…">` instead — same shape, different addressing surface — and add `count`/`min`/`max` on the `<output>` to assert cardinality (`galaxy.xsd:2085-2099`).
+
+## Galaxy 24+ — the `format` propagation change
+
+Pre-24, `format` declared on the parent `<data>`/`<collection>` was **ignored** for discovered datasets; you had to set `ext`/`format` on the `<discover_datasets>` element itself (or else discovered files defaulted to `data`). Galaxy 24+ propagates the parent `format` if `<discover_datasets>` doesn't specify one (`galaxy.xsd:6265`).
+
+Practical impact for the convert Mold: declaring `format` on the parent `<collection>` is **necessary and sufficient** as long as the wrapper sets `profile="24.0"` or later. For the convert Mold's `profile="23.1"` default (chosen for broad compatibility), keep declaring `ext`/`format` on the `<discover_datasets>` element itself.
+
+## Convert Mold posture — nf-core → Galaxy mapping
+
+The Mold's §4 (*Translate `<outputs>`*) collapses to three rules driven by what the Nextflow `output:` channel declaration looks like.
+
+### Rule 1 — glob output, single shape → `<collection type="list">` + `<discover_datasets>`
+
+Nextflow:
+```nextflow
+output:
+tuple val(meta), path('*.bam'), emit: bams
+```
+
+Galaxy:
+```xml
+<collection name="bams" type="list" format="bam">
+  <discover_datasets pattern="__name_and_ext__" directory="." visible="true"/>
+</collection>
+```
+
+`__name_and_ext__` captures the basename as the element identifier and the extension as datatype.
+
+### Rule 2 — single named output → `<data from_work_dir="…">`, no discovery
+
+Nextflow:
+```nextflow
+output:
+tuple val(meta), path("${prefix}.json"), emit: json
+```
+
+The output path is deterministic (one filename, runtime-known but stable). Galaxy:
+```xml
+<data name="json" format="json" from_work_dir="${prefix}.json"/>
+```
+
+`<discover_datasets>` is unnecessary here — there's exactly one output with a known path. (The convert Mold's LLM step is responsible for resolving `${prefix}` to a literal `*.json` glob if the prefix is meta-derived; in that case fall back to Rule 1.)
+
+### Rule 3 — paired output discovered together → `<collection type="paired">` + paired discovery
+
+Nextflow:
+```nextflow
+output:
+tuple val(meta), path("*_R{1,2}.fastp.fastq.gz"), emit: reads
+```
+
+Galaxy:
+```xml
+<collection name="reads" type="paired" format="fastqsanger.gz">
+  <discover_datasets pattern="(?P<name>.+)_R(?P<identifier_1>[12])\..*\.fastq\.gz" ext="fastqsanger.gz" visible="true"/>
+</collection>
+```
+
+This needs a custom regex; no named pattern captures the `R1`/`R2` split into `identifier_1`. The Mold's LLM step generates the regex from the file glob.
+
+### Rule 4 — `versions.yml` (the versions emit) → drop
+
+The `versions:` channel has no Galaxy analog (`<version_command>` covers it). Don't emit `<data>` or `<collection>` for it. See `[[nfcore-versions-emit-to-galaxy-version-command]]`.
+
+## Pitfalls
+
+- **`visible` defaults to false.** Always declare `visible="true"` unless you specifically want the discovered files hidden from history. Forgetting it is the most common authoring slip.
+- **`assign_primary_output` only on `<data>`, not `<collection>`.** The collection version doesn't accept it; the XSD enforces this (`OutputCollectionDiscoverDatasets` doesn't include the attribute).
+- **`from_provided_metadata="true"` is exclusive with `pattern` and `sort_by`.** Specify either-or, never both.
+- **Glob in `from_work_dir` ≠ discovery.** `from_work_dir="*.bam"` is invalid; that attribute takes a literal path. For globs you must use `<discover_datasets>`.
+- **`__name__` vs `__designation__`.** The only difference is which named group the regex captures. Use `__designation__` (and `<discovered_dataset designation="…">` on the test side) when matching IUC convention for tests; use `__name__` when the surrounding wrapper already uses `name`-style identifiers.
+- **Sort matters for `assign_primary_output`.** Default sort is lexical filename. If your wrapper expects a specific file as primary, pin the sort (`sort_by="numeric_name"`, `sort_by="reverse_lexical_designation"`, etc.) — don't rely on luck.
+- **Nested collections need every `identifier_N`.** A `list:paired` discover that names only `identifier_0` fails at runtime; you need both levels covered by the regex.
+- **Custom regexes match filename only by default.** To match subdirectory components, set `match_relative_path="true"` and embed the path in named groups; otherwise scope with `directory="subdir"` + `recurse="false"`.
+
+## See also
+
+- `[[convert-nfcore-module-to-galaxy-tool]]` — Mold that consumes this reference when emitting `<outputs>`.
+- `[[nfcore-channel-input-to-galaxy-collection]]` — companion: how to map input channels to data / collection params.
+- `[[galaxy-collection-semantics]]` — what map-over / reduction does to a collection at workflow time.
+- `[[planemo-asserts-idioms]]` — how to write assertions inside `<discovered_dataset>` / `<element>` bodies.
+- Galaxy XSD: `lib/galaxy/tool_util/xsd/galaxy.xsd` — authoritative attribute grammar.
+- Galaxy test tools: `test/functional/tools/multi_output*.xml`, `output_filter.xml`, `discover_sort_by.xml`, `collection_creates_dynamic_*.xml` — exhaustive coverage of supported shapes.
+- Planemo writing-advanced docs: "Multiple output files" — narrative tutorial.

--- a/content/research/planemo-asserts-idioms.md
+++ b/content/research/planemo-asserts-idioms.md
@@ -18,6 +18,7 @@ related_notes:
   - "[[planemo-workflow-test-architecture]]"
   - "[[validate-tests]]"
   - "[[iwc-tabular-operations-survey]]"
+  - "[[galaxy-discover-datasets]]"
 summary: "Decision and idiom guide for picking planemo workflow-test assertions: which family per output type, how to size tolerances, when to validate."
 ---
 


### PR DESCRIPTION
## Summary

Phase 0 deliverables for the `NFCORE_TO_GALAXY_TOOLS` plan — Foundry content that the new `convert-nfcore-module-to-galaxy-tool` cast skill will lean on, plus the two research notes the Mold depends on.

- **Mold**: `convert-nfcore-module-to-galaxy-tool` (target/galaxy, source/nextflow). 9 typed references, 10-step procedure, deterministic + LLM step boundary mirrored from `summarize-nextflow`.
- **Patterns (5 stubs)**: `nfcore-channel-input-to-galaxy-collection`, `nfcore-meta-map-to-galaxy-params`, `nfcore-task-ext-args-to-galaxy-additional-options`, `nfcore-versions-emit-to-galaxy-version-command`, `nfcore-stub-block-to-galaxy-noop-test`. Cited modules pinned to `nf-core/modules@9b261a45`.
- **CLI manpages**: `planemo lint`, `planemo test` — stubs to grow with Mold convergence.
- **Research**: new `galaxy-discover-datasets` (XSD attrs, named patterns, regex named groups, `<data>` vs `<collection>` semantics, test-side `<discovered_dataset>`, Galaxy 24+ format propagation, nf-core mapping rules). `component-nextflow-containers-and-envs` promoted from placeholder stub to substantive grounding: three eras of container conventions (current Wave/Seqera, legacy depot.galaxyproject.org, mulled-v2), `environment.yml` invariants, mulled equivalence, mapping into Galaxy `<requirements>`. Galaxy source citations pinned to `galaxyproject/galaxy@7765fae9`.

Plan ref: `vault/projects/workflow_state/skills/NFCORE_TO_GALAXY_TOOLS.md` §4, §8 Phase 0.

## Test plan

- [x] `npm run validate` — 0 errors, 18 warnings (baseline)
- [ ] Cast `convert-nfcore-module-to-galaxy-tool` for `target: claude`; smoke-test against fastp / samtools-index / one conditional module
- [ ] `planemo lint` + `planemo test` against the cast output
- [ ] Reviewer pass on the discover_datasets mapping rules (Mold §4) against the smoke-test wrappers

🤖 Generated with [Claude Code](https://claude.com/claude-code)