### PR TITLE
cli-command: require package+upstream in schema; refresh stale meta-s…

### DIFF
--- a/meta_schema.yml
+++ b/meta_schema.yml
@@ -358,13 +358,13 @@ allOf:
     then:
       required: [title, source, target, source_pattern_kind, implemented_by_patterns]
 
-  # cli-command requires tool + command
+  # cli-command requires tool + command + package/upstream for metadata-backed rendering
   - if:
       properties:
         type: { const: cli-command }
       required: [type]
     then:
-      required: [tool, command]
+      required: [tool, command, package, upstream]
 
   # cli-tool requires tool + install metadata
   - if:

--- a/site/src/lib/cli-registry.ts
+++ b/site/src/lib/cli-registry.ts
@@ -98,7 +98,7 @@ export async function loadCliRegistry(): Promise<Record<string, CliRegistryEntry
         : {}),
     };
   } catch {
-    // Published 1.1.0 lacks the meta subpath; keep raw markdown pages rendering.
+    // Defensive: meta subpath ships from @galaxy-tool-util/cli >=1.2.0; fall back to raw markdown if import fails.
     return {};
   }
 }


### PR DESCRIPTION
…ubpath comment

@galaxy-tool-util/cli 1.4.0 ships ./meta; cross-file validator already enforced package/upstream — promote to schema requireds for earlier error.