### PR TITLE
[codex] Fix module Planemo refs and eval

### DIFF
--- a/content/cli/planemo/planemo-lint.md
+++ b/content/cli/planemo/planemo-lint.md
@@ -54,16 +54,18 @@ planemo lint [OPTIONS] TOOL_PATH
 
 <!-- Hand-edited. Preserved across `tsx scripts/sync-planemo-cli.ts`. -->
 
-_Describe stdout/stderr shape, exit-code contract, and any JSON-report flags here._
+Console output is human-oriented; use the process exit status as the pass/fail gate.
 
 ## Examples
 
 <!-- Hand-edited. Preserved across `tsx scripts/sync-planemo-cli.ts`. -->
 
-_Add canonical invocations here._
+```sh
+planemo lint <tool_dir>
+```
 
 ## Gotchas
 
 <!-- Hand-edited. Preserved across `tsx scripts/sync-planemo-cli.ts`. -->
 
-_Document non-obvious behavior and common failure modes here._
+No Foundry-specific gotchas recorded yet.

--- a/content/cli/planemo/planemo-test.md
+++ b/content/cli/planemo/planemo-test.md
@@ -127,16 +127,18 @@ planemo test [OPTIONS] TOOL_PATH
 
 <!-- Hand-edited. Preserved across `tsx scripts/sync-planemo-cli.ts`. -->
 
-_Describe stdout/stderr shape, exit-code contract, and any JSON-report flags here._
+Use `--test_output_json <path>` for machine-readable results; stdout and stderr are human-oriented.
 
 ## Examples
 
 <!-- Hand-edited. Preserved across `tsx scripts/sync-planemo-cli.ts`. -->
 
-_Add canonical invocations here._
+```sh
+planemo test <tool_dir> --test_output_json <tool_dir>/_planemo_test_report.json
+```
 
 ## Gotchas
 
 <!-- Hand-edited. Preserved across `tsx scripts/sync-planemo-cli.ts`. -->
 
-_Document non-obvious behavior and common failure modes here._
+No Foundry-specific gotchas recorded yet.

--- a/content/molds/convert-nfcore-module-to-galaxy-tool/eval.md
+++ b/content/molds/convert-nfcore-module-to-galaxy-tool/eval.md
@@ -1,0 +1,13 @@
+# convert-nfcore-module-to-galaxy-tool eval
+
+## Case: generated wrapper readiness
+
+- check: deterministic
+- fixture: cast output for one nf-core module directory with `main.nf`, `meta.yml`, `environment.yml`, and at least one usable nf-test fixture.
+- expectation: generated tool directory contains a complete Galaxy wrapper, local macros, provenance, requirements, inputs, outputs, help, citations when source metadata provides them, and at least one runnable test; `planemo lint` and `planemo test --test_output_json` either pass or produce structured artifacts ready for focused repair.
+
+## Case: module fidelity review
+
+- check: llm-judged
+- fixture: same module source and generated Galaxy tool directory.
+- expectation: wrapper command, parameters, requirements, output declarations, test fixtures, and recorded provenance look faithful to the underlying Nextflow module. Any intentional divergence, unresolved mapping, or missing fixture is visible rather than silently papered over.

--- a/content/molds/convert-nfcore-module-to-galaxy-tool/index.md
+++ b/content/molds/convert-nfcore-module-to-galaxy-tool/index.md
@@ -99,7 +99,7 @@ references:
     ref: "[[planemo-lint]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: sidecar
     evidence: hypothesis
     purpose: "Reference for `planemo lint` flags and output classification; first gate in the convergence loop."
     trigger: "Step 10.1 — after every <command>/<inputs>/<outputs> emission."
@@ -108,7 +108,7 @@ references:
     ref: "[[planemo-test]]"
     used_at: runtime
     load: on-demand
-    mode: condense
+    mode: sidecar
     evidence: hypothesis
     purpose: "Reference for `planemo test --test_output_json` invocation, exit codes, and the JSON report path."
     trigger: "Step 10.2 — after lint clears."


### PR DESCRIPTION
## Summary

- Switch the convert-nfcore module Mold's Planemo command references from invalid `condense` mode to the current CLI command sidecar mode.
- Replace placeholder Planemo `lint`/`test` manual sections with minimal factual notes and examples.
- Add a small initial `eval.md` for the convert Mold focused on wrapper readiness and module fidelity.

## Why

The convert Mold could not pass the deterministic cast check because `cli-command` references are currently emitted as structured sidecars, not condensed text. The Planemo command pages also still carried placeholder preserved sections, and the Mold lacked an eval file.

## Validation

- `npm run validate` passes with 0 errors; existing repository warnings remain.
- `npm run cast -- convert-nfcore-module-to-galaxy-tool --target=claude --check` now reports 0 errors. It still reports expected drift for not-yet-generated cast outputs.
- `npm run check:planemo-cli` was attempted but could not run because pinned `planemo` is not installed on PATH in this checkout.