### PR TITLE
docs: Wave 1 — cast-provenance schema note, Mold-vs-Pattern example, annotated cast walkthrough

### DIFF
--- a/content/schemas/cast-provenance.md
+++ b/content/schemas/cast-provenance.md
@@ -1,0 +1,36 @@
+---
+type: schema
+name: cast-provenance
+title: "Cast provenance (_provenance.json, schema v2)"
+upstream: "https://github.com/jmchilton/foundry/blob/main/scripts/lib/schemas/cast-provenance.schema.json"
+tags:
+  - schema
+status: draft
+created: 2026-05-17
+revised: 2026-05-17
+revision: 1
+ai_generated: true
+summary: "_provenance.json contract beside every cast: Mold revision, per-ref deterministic-vs-LLM origin, src/dst hashes, artifact handoff. Schema v2."
+---
+
+Every cast bundle carries a sibling `_provenance.json`: the forensic record of *what* was produced, *from which Mold revision*, *by which method*, and *what each reference's deterministic-vs-LLM provenance looks like*. It is required, but it is **not** part of the skill — consumers read `SKILL.md` and `references/`; maintainers read `_provenance.json`.
+
+**Contract of record.** The authoritative schema is the repo-local JSON Schema at `scripts/lib/schemas/cast-provenance.schema.json` (`provenance_schema_version` is a `const: 2`). It is Foundry-authored — there is no upstream package and no `package_export`; the `upstream` link above points at the in-repo file. The narrative in `docs/COMPILATION_PIPELINE.md` describes *why* the shape is what it is; this note plus the JSON Schema are the *contract*. When the two disagree, the JSON Schema wins.
+
+**Enforcement.** The deterministic verifier `scripts/cast-skill-verify.ts` AJV-validates every committed `_provenance.json` against the schema and additionally rejects any entry still carrying `pending_llm: true` (an unfilled `mode: condense` placeholder). The verifier — not a packaged `validator_bin` — is the enforcement point, which is why this note declares neither `package` nor `validator_bin`.
+
+**Versioning.** `provenance_schema_version` is a hard `const`, currently `2`. A future v3 is a deliberate schema bump: change the `const`, migrate or re-cast existing bundles, and revise this note rather than silently widening v2. Old bundles do not auto-upgrade; `foundry status` surfaces staleness and `foundry cast` regenerates.
+
+## What it records
+
+- **`mold`** — name, source path, `revision`, `content_hash`, and the `commit` the cast was taken from. Drift detection compares the live Mold `index.md` content hash against `mold.content_hash`; a mismatch marks the cast stale.
+- **`refs[]`** — one entry per resolved typed reference, sorted by `(kind, src)` for stable diffs. Each records `mode` (`verbatim` / `condense` / `sidecar`), resolved `src` and bundle `dst`, `src_hash` / `dst_hash` (sha256 at cast time), and **`source`** (`deterministic` vs `llm`). Verbatim copies and sidecars are deterministic; only `mode: condense` refs are LLM-produced.
+- **LLM provenance** — when `source: llm`, the entry must carry `prompt` (origin + identity, optionally hash) so a cast can be reproduced; `model` (name/version) is optional but strongly recommended. `pending_llm: true` marks a condense slot the deterministic phase emitted but the LLM phase has not yet filled — committed provenance with any such entry fails verification.
+- **`artifacts`** — the pipeline handoff contract copied from the Mold's frontmatter: `produces[]` (with producer-owned `schema`) and `consumes[]` (with `inherited_schema` and resolved `producers`), so a harness can wire a prior step's output path to a stable `id`.
+- **`validation_results[]`** — process evidence from artifact-validator CLI runs: `validator_bin`, `status` (`passed` / `failed` / `error`), `exit_code` (authoritative), and captured `stdout` / `stderr` plus their hashes (opaque diagnostics).
+
+## Why it exists
+
+Provenance is the foundation for three things the Foundry promises: **drift detection** (Mold or ref changed since the cast), **reproducibility audits** (which prompt and model produced a condensed reference), and **"why does this cast contain X" forensics** (every `dst` traces back to a Mold ref and a `src` hash). Deterministic assembly is expected to be byte-stable aside from timestamps and `cast_history`; explicit LLM condensation is not guaranteed byte-identical, but `source`, `prompt`, and `model` make each LLM-produced byte reviewable.
+
+The field tables below are generated from the JSON Schema itself; anchors are stable for deep-linking from Mold bodies and design docs.

--- a/docs/CAST_WALKTHROUGH.md
+++ b/docs/CAST_WALKTHROUGH.md
@@ -1,0 +1,82 @@
+# Cast Walkthrough
+
+`COMPILATION_PIPELINE.md` describes casting abstractly. This page narrates one **real, committed** cast end to end so the abstraction has something concrete behind it: every file in the bundle, where it came from, and how `_provenance.json` lets you prove it.
+
+The subject is **`discover-shed-tool`** (`content/molds/discover-shed-tool/`), cast to the Claude target at `casts/claude/skills/discover-shed-tool/`. It was chosen because its cast is **fully deterministic** — no `mode: condense` references, so no LLM step — which makes the walkthrough stable across rebuilds and lets us talk about provenance without "it depends on the model that day."
+
+This is annotation of an existing artifact, not a synthetic example. Hashes below are abbreviated sha256s shown for shape; the committed bundle carries the full values.
+
+## The bundle
+
+```
+casts/claude/skills/discover-shed-tool/
+├── SKILL.md                                  # deterministic render of the Mold body
+├── _provenance.json                          # the forensic record (schema v2)
+├── _required_tools.json                      # aggregated tool install metadata
+├── _verify.json                              # per-artifact verification contract
+└── references/
+    ├── cli/tool-search.json                  # ← cli-command ref, sidecar
+    ├── cli/tool-versions.json                # ← cli-command ref, sidecar
+    ├── cli/tool-revisions.json               # ← cli-command ref, sidecar
+    ├── notes/component-tool-shed-search.md    # ← research ref, verbatim
+    └── schemas/galaxy-tool-discovery.schema.json  # ← schema ref, verbatim
+```
+
+Nothing in `references/` is freehand. Each file is the destination of exactly one entry in the Mold's `references:` manifest, resolved through casting's per-kind dispatch.
+
+## What came from where
+
+`_provenance.json` `refs[]` is the index. Five entries, three dispatch behaviors:
+
+### cli-command → JSON sidecar (×3)
+
+`[[tool-search]]`, `[[tool-versions]]`, `[[tool-revisions]]` are CLI manual pages under `content/cli/gxwf/`. Cast `mode: sidecar`:
+
+- `src: content/cli/gxwf/tool-search.md` → `dst: references/cli/tool-search.json`
+- `src_hash` ≠ `dst_hash` — and that inequality is the point. The manpage markdown is *transformed* into a structured JSON sidecar (synopsis, flags, exit codes, error shapes), not copied. The hashes differ because the bytes legitimately differ; provenance records both so the transform is auditable.
+- `load: on-demand`, so `SKILL.md` lists them under **Load On Demand** with each ref's `trigger` as the load condition.
+
+### research → verbatim copy (×1)
+
+`[[component-tool-shed-search]]` is a research note. Cast `mode: verbatim`:
+
+- `src: content/research/component-tool-shed-search.md` → `dst: references/notes/component-tool-shed-search.md`
+- `src_hash == dst_hash`. Byte-identical. A verbatim copy's matching hashes are the cheapest possible proof that nothing was paraphrased or silently edited on the way into the bundle.
+
+### schema → verbatim from a package export (×1)
+
+`[[galaxy-tool-discovery]]` is a `type: schema` note whose JSON is owned by a package, not the content tree:
+
+- `src: package://@galaxy-foundry/foundry#galaxyToolDiscoverySchema` → `dst: references/schemas/galaxy-tool-discovery.schema.json`
+- `src_hash == dst_hash` — the named runtime export is imported and serialized verbatim. The `package://` source form (rather than a file path) records *which* package export, so a package bump that changes the schema shows up as a `src_hash` change on re-cast.
+- `evidence: cast-validated` and a `verification:` string ride along — this ref's correctness has been exercised, not just asserted.
+
+Every entry here is `source: deterministic`. There is no `prompt` or `model` block because none was needed; there is no `pending_llm` entry because nothing is awaiting an LLM phase. A `mode: condense` Mold (e.g. `convert-nfcore-module-to-galaxy-tool`) would show `source: llm` entries carrying `prompt` (origin + identity + hash) and `model` — see [[cast-provenance]] for those fields.
+
+## How `SKILL.md` is built
+
+`SKILL.md` is **not** authored in the bundle. It is a deterministic render of `content/molds/discover-shed-tool/index.md`'s body: the `## When To Use`, `## Inputs`, `## Outputs`, `## Required Tools`, `## Load Upfront`, and `## Load On Demand` sections are projected from the Mold's frontmatter (`output_artifacts`, `references[].load`/`trigger`) and procedural body. The rule from `COMPILATION_PIPELINE.md` holds here literally: skill-body changes flow from Mold source changes; the LLM phase (when there is one) may fill condense refs but must not hand-edit `SKILL.md`. `_required_tools.json` aggregates install metadata (here: `gxwf`); `_verify.json` is the per-artifact verification contract — the `validator_bin` + `args` + `schema` a harness or CI runs to validate the artifact this skill produces (`galaxy-tool-pin`). Recorded validation *results* live in `_provenance.json`'s `validation_results[]` — empty here, since `galaxy-tool-pin` is produced at runtime, not at cast time.
+
+## How provenance ties it together
+
+The `mold` block anchors the whole bundle:
+
+```json
+"mold": {
+  "name": "discover-shed-tool",
+  "path": "content/molds/discover-shed-tool/index.md",
+  "revision": 4,
+  "content_hash": "11f14fee…",
+  "commit": "8fed7f9…"
+}
+```
+
+- **Drift detection** compares the live `content/molds/discover-shed-tool/index.md` content hash against `mold.content_hash`. Mismatch ⇒ the cast is stale; `foundry status` flags it, `foundry cast` regenerates it.
+- **Reference drift** is per-ref: if `content/research/component-tool-shed-search.md` changes, its live hash no longer matches the recorded `src_hash`, so the stale reference is identifiable without re-reading the whole bundle.
+- **Forensics**: "why does this bundle contain `references/cli/tool-search.json`?" → the `refs[]` entry whose `dst` is that path, back to `[[tool-search]]` in the Mold manifest, with `purpose` and `trigger` explaining why the Mold pulled it.
+- **Artifact handoff**: `artifacts.produces` records `galaxy-tool-pin` with its producer-owned `schema: [[galaxy-tool-discovery]]`. A downstream Mold that consumes `galaxy-tool-pin` by shared `id` inherits that schema contract — provenance is where a harness reads the wiring.
+- **`cast_history`** keeps the human-readable trail of why this cast was re-taken (here: five entries, schema wiki-link merge → runtime-facing render → marking the discovery schema cast-validated).
+
+## What this proves
+
+For a deterministic cast, re-casting an unchanged Mold with unchanged references reproduces byte-identical `SKILL.md` and `references/` — only cast timestamps and `cast_history` move. That is the reproducibility claim made checkable: not "trust the pipeline," but "here is a compiled skill, and here is exactly how every byte traces back to a Mold revision and a source hash." The per-field contract behind `_provenance.json` is the [[cast-provenance]] schema note.

--- a/docs/COMPILATION_PIPELINE.md
+++ b/docs/COMPILATION_PIPELINE.md
@@ -114,7 +114,7 @@ casts/web/<mold-name>/
 
 For **generic**: single self-contained markdown unless a richer consumer appears.
 
-`_provenance.json` is required for every cast. The contract is `scripts/lib/schemas/cast-provenance.schema.json` (schema version 2). Shape:
+`_provenance.json` is required for every cast. The contract of record is the [[cast-provenance]] schema note (rendered field-by-field from `scripts/lib/schemas/cast-provenance.schema.json`, schema version 2); the JSON below is an illustrative sketch, not the authority. Shape:
 
 ```json
 {
@@ -173,7 +173,7 @@ For **generic**: single self-contained markdown unless a richer consumer appears
 
 `refs[]` is sorted by `(kind, src)` for stable diffs. Each entry's `source` field records whether the dst was produced deterministically or by an LLM step. `artifacts` records the runtime handoff contract after producer inheritance. While a condense ref is awaiting LLM output, the entry carries `pending_llm: true` and the deterministic verifier rejects committed provenance with any unfilled entry.
 
-Provenance is the foundation for drift detection, reproducibility audits, and "why does this cast contain X" forensics.
+Provenance is the foundation for drift detection, reproducibility audits, and "why does this cast contain X" forensics. See [[cast-provenance]] for the per-field contract and stable anchors.
 
 ## Schema artifacts in casts
 

--- a/docs/MOLDS.md
+++ b/docs/MOLDS.md
@@ -116,6 +116,18 @@ Excluded from the inventory by design. Naming them keeps the boundary visible.
 
 **Wrapping a CLI is *not* a Mold disqualifier.** `discover-shed-tool`, `validate-galaxy-step`, `validate-galaxy-workflow`, and `run-workflow-test` all wrap CLIs and are Molds. The criterion is whether there is procedural content worth casting (when to run, how to interpret, when to loop back), not whether the underlying mechanism is a CLI.
 
+### Worked example: `compare-against-iwc-exemplar`
+
+A case that genuinely could have gone the other way. "Compare the design against the IWC corpus" sounds like *knowledge*: the corpus-first principle is already reference content (`CORPUS_INGESTION.md`, the IWC-grounding research notes). One plausible shape was a pattern page describing the corpus-first idiom, referenced by the template Mold — no separate Mold.
+
+It landed as an **action Mold** (`content/molds/compare-against-iwc-exemplar/`) because the deciding criterion from the rule above resolves the same way it does for the CLI wrappers — there is procedural content worth casting:
+
+- **When to run** — after the interface/data-flow (or combined paper) briefs, before the `*-summary-to-galaxy-template` Mold, so corpus divergence is caught before per-step authoring effort is spent.
+- **How to interpret** — rank candidates by the feature hierarchy (domain intent → input topology → tool families → DAG motifs), not by superficial similarity.
+- **What it hands off** — a structural-diff artifact (`iwc-comparison-notes`) the downstream template Mold consumes by shared `id`.
+
+The corpus-first *principle* it rests on stays reference content; the *act* of locating the nearest exemplar, ranking it, and gating the template step is procedure. Idiom that a Mold can simply cite is reference; a repeatable decision-and-handoff is a Mold. Same test, applied to a candidate where the answer was not obvious up front.
+
 ## Counts and reuse
 
 - 33 current candidate Molds total in `content/molds/` (Galaxy validation split into step/workflow Molds; interface/data-flow design is source-target specific; `find-test-data` included; corpus Mold renamed/reframed as `compare-against-iwc-exemplar`; `discover-shed-tool` graduated from "Not Molds"; whole-CLI catalogs are reference content, not Molds).

--- a/site/src/components/SchemaBody.astro
+++ b/site/src/components/SchemaBody.astro
@@ -44,45 +44,56 @@ function renderType(prop: any): string {
   return prop.type ?? 'any';
 }
 
+function viewFromNode(id: string, node: any): DefView | null {
+  if (!node || typeof node !== 'object') return null;
+  const required = Array.isArray(node.required) ? node.required : [];
+  const defProps = (node.properties ?? {}) as Record<string, any>;
+  const props: Property[] = Object.entries(defProps).map(([propName, propNode]) => ({
+    name: propName,
+    type: renderType(propNode),
+    description: (propNode as any)?.description,
+    required: required.includes(propName),
+    default: (propNode as any)?.default,
+    constValue: (propNode as any)?.const,
+  }));
+  // Sort: required first, then alphabetical by name (but keep `that` discriminator first if present).
+  props.sort((a, b) => {
+    if (a.name === 'that') return -1;
+    if (b.name === 'that') return 1;
+    if (a.required !== b.required) return a.required ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
+  return { id, title: node.title ?? id, description: node.description, properties: props, required };
+}
+
 function buildDefViews(schema: Record<string, unknown> | undefined): DefView[] {
   if (!schema) return [];
-  const defs = (schema['$defs'] as Record<string, any>) ?? {};
+  // Support both draft 2019+ ($defs) and draft-07 (definitions).
+  const defs = {
+    ...((schema['$defs'] as Record<string, any>) ?? {}),
+    ...((schema['definitions'] as Record<string, any>) ?? {}),
+  };
   const views: DefView[] = [];
   for (const [defName, defNode] of Object.entries(defs)) {
-    if (!defNode || typeof defNode !== 'object') continue;
-    const required = Array.isArray(defNode.required) ? defNode.required : [];
-    const props: Property[] = [];
-    const defProps = (defNode.properties ?? {}) as Record<string, any>;
-    for (const [propName, propNode] of Object.entries(defProps)) {
-      props.push({
-        name: propName,
-        type: renderType(propNode),
-        description: propNode?.description,
-        required: required.includes(propName),
-        default: propNode?.default,
-        constValue: propNode?.const,
-      });
-    }
-    // Sort: required first, then alphabetical by name (but keep `that` discriminator first if present).
-    props.sort((a, b) => {
-      if (a.name === 'that') return -1;
-      if (b.name === 'that') return 1;
-      if (a.required !== b.required) return a.required ? -1 : 1;
-      return a.name.localeCompare(b.name);
-    });
-    views.push({
-      id: defName,
-      title: defNode.title ?? defName,
-      description: defNode.description,
-      properties: props,
-      required,
-    });
+    const v = viewFromNode(defName, defNode);
+    if (v) views.push(v);
   }
   views.sort((a, b) => a.id.localeCompare(b.id));
   return views;
 }
 
+// Object-root schemas (e.g. cast-provenance, summary-cwl) carry their main
+// shape in top-level `properties`; surface that as a stable `#root` section
+// ahead of the definitions. $ref-only or array roots contribute nothing.
+function buildRootView(schema: Record<string, unknown> | undefined): DefView | null {
+  const s = schema as any;
+  if (!s?.properties || Object.keys(s.properties).length === 0) return null;
+  return viewFromNode('root', s);
+}
+
 const defViews = reg ? buildDefViews(reg.schema) : [];
+const rootView = reg ? buildRootView(reg.schema) : null;
+const allViews = rootView ? [rootView, ...defViews] : defViews;
 const root = reg?.schema as any;
 const rootDescription = root?.description as string | undefined;
 const rootTitle = root?.title as string | undefined;
@@ -111,17 +122,17 @@ const rootTitle = root?.title as string | undefined;
     {rootTitle && <h2 class="not-prose text-lg font-semibold mb-2">{rootTitle}</h2>}
     {rootDescription && <p class="not-prose text-sm text-(--color-text-secondary) m-0">{rootDescription}</p>}
     <div class="mt-3 text-xs text-(--color-text-secondary)">
-      {defViews.length} definitions. Anchor links per definition (e.g. <code>#has_text_model</code>) are stable.
+      {allViews.length} sections. Anchor links per section (e.g. <code>#root</code>) are stable.
     </div>
   </section>
 )}
 
-{reg && defViews.length > 0 && (
+{reg && allViews.length > 0 && (
   <nav class="mb-8 p-3 rounded-lg border border-(--color-border) text-xs">
     <details>
-      <summary class="cursor-pointer font-semibold text-sm">All definitions ({defViews.length})</summary>
+      <summary class="cursor-pointer font-semibold text-sm">All sections ({allViews.length})</summary>
       <ul class="not-prose mt-2 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-1 list-none p-0">
-        {defViews.map(d => (
+        {allViews.map(d => (
           <li><a href={`#${d.id}`} class="text-(--color-link) hover:underline font-mono text-xs">{d.id}</a></li>
         ))}
       </ul>
@@ -130,7 +141,7 @@ const rootTitle = root?.title as string | undefined;
 )}
 
 <div class="space-y-6">
-  {defViews.map(d => (
+  {allViews.map(d => (
     <section id={d.id} class="not-prose p-4 rounded-lg border border-(--color-border) scroll-mt-20">
       <header class="flex flex-wrap items-baseline gap-2 mb-2">
         <h3 class="text-base font-semibold m-0">

--- a/site/src/lib/design-docs.ts
+++ b/site/src/lib/design-docs.ts
@@ -42,6 +42,13 @@ export const DESIGN_DOCS: DesignDoc[] = [
     category: 'foundation',
   },
   {
+    slug: 'cast-walkthrough',
+    title: 'Cast Walkthrough',
+    source: 'CAST_WALKTHROUGH.md',
+    summary: 'One real committed cast (discover-shed-tool) annotated end to end: every bundle file traced back through per-kind dispatch and _provenance.json.',
+    category: 'foundation',
+  },
+  {
     slug: 'corpus',
     title: 'Corpus Integration',
     source: 'CORPUS_INGESTION.md',

--- a/site/src/lib/schema-registry.ts
+++ b/site/src/lib/schema-registry.ts
@@ -1,12 +1,14 @@
 // Registry of JSON Schemas, keyed by note `name` field.
-// All schemas come from two packages: producer-co-located
+// Most schemas come from two packages: producer-co-located
 // (@galaxy-foundry/summarize-nextflow) or foundry-bundled
-// (@galaxy-foundry/foundry).
+// (@galaxy-foundry/foundry). `cast-provenance` is Foundry-authored and
+// repo-local — its contract lives in scripts/lib/schemas/, not a package.
 
 import galaxyToolDiscoverySchema from '../../../packages/foundry/src/schemas/galaxy-tool-discovery/galaxy-tool-discovery.schema.json';
 import galaxyToolSummarySchema from '../../../packages/foundry/src/schemas/galaxy-tool-summary/galaxy-tool-summary.schema.json';
 import summaryCwlSchema from '../../../packages/foundry/src/schemas/summary-cwl/summary-cwl.schema.json';
 import testsFormatSchema from '../../../packages/foundry/src/schemas/tests-format/tests.schema.json';
+import castProvenanceSchema from '../../../scripts/lib/schemas/cast-provenance.schema.json';
 import foundryPkg from '../../../packages/foundry/package.json';
 import summaryNextflowSchema from '../../../packages/summarize-nextflow/src/schema/summary-nextflow.schema.json';
 import summarizeNextflowPkg from '../../../packages/summarize-nextflow/package.json';
@@ -38,6 +40,10 @@ export const schemaRegistry: Record<string, SchemaEntry> = {
   },
   'galaxy-tool-summary': {
     schema: galaxyToolSummarySchema as unknown as Record<string, unknown>,
+    version: foundryVersion,
+  },
+  'cast-provenance': {
+    schema: castProvenanceSchema as unknown as Record<string, unknown>,
     version: foundryVersion,
   },
 };


### PR DESCRIPTION
> **Posted by Claude (AI assistant) on jmchilton's behalf** — drafted/opened by Claude Code, not authored personally.

Wave 1 documentation work — three open issues, three commits, doc-only changes plus the minimal site wiring to render the new schema note.

## What's here

**#252 — `_provenance.json` v2 as a renderable schema note** (`24123f9`)
`content/schemas/cast-provenance.md` is the contract-of-record note for `_provenance.json`. It is Foundry-authored: no upstream package, no `package_export`. The contract lives at repo-local `scripts/lib/schemas/cast-provenance.schema.json` and is enforced by the deterministic verifier `scripts/cast-skill-verify.ts`, not a packaged `validator_bin` — the note says so explicitly and declares neither `package` nor `validator_bin`.
Scope decision: `SchemaBody.astro` previously rendered only draft-2019 `$defs`. Extended additively to also render draft-07 `definitions` and synthesize a stable `#root` section from top-level `properties`. This is the principled fix (vs. contorting a verifier-critical schema to fit the renderer). Side effect: `summary-cwl` now also surfaces its previously-hidden top-level properties — an improvement, not a regression; `tests-format` and `$ref`-only schemas are unchanged. `schema-registry.ts` gains the repo-local import; `COMPILATION_PIPELINE.md` now names `[[cast-provenance]]` the contract of record.

**#250 — worked Mold-vs-Pattern boundary example** (`aa4f361`)
A tight subsection in `MOLDS.md` using the real `compare-against-iwc-exemplar` Mold — a genuine borderline case (could have been a corpus-first pattern page) — with the deciding criterion made explicit, reusing the existing "Not Molds" framing. Claims verified against the live Mold: artifact `iwc-comparison-notes` is consumed by the three `*-summary-to-galaxy-template` Molds by shared `id`.

**#249 — annotated end-to-end cast walkthrough** (`f0ca430`)
`docs/CAST_WALKTHROUGH.md` narrates the committed, fully-deterministic `discover-shed-tool` cast end to end: bundle tree, every `references/` file traced through per-kind dispatch (cli-command→sidecar with src≠dst, research→verbatim with src==dst, schema→verbatim from a `package://` export), deterministic `SKILL.md` render, and how `_provenance.json` powers drift detection / forensics / artifact handoff. Registered in `design-docs.ts`. Every claim was checked byte-for-byte against the real bundle (`mold` block, 5 `refs[]`, hash equalities, `cast_history`, `artifacts.produces`).

## Polish applied during review

The walkthrough originally described `_verify.json` as "the verifier's recorded result / recorded pass." That is wrong: `_verify.json` is the per-artifact verification *contract* (`validator_bin` + `args` + `schema`) that `foundry-build validate-artifact` runs; recorded validation *results* live in `_provenance.json`'s `validation_results[]`. Corrected in both the bundle-tree comment and the prose (folded into the #249 commit since the branch was unpushed). The correction strengthens the cross-link to the new `[[cast-provenance]]` note.

## Verification

`npm run validate` → 0 errors / 153 warnings (= origin/main baseline, zero new) · `npm run test` → 100/100 · `npm run typecheck` → clean · `astro check` → 0/0/0 (59 files). Cast bundles unchanged (no regeneration needed — doc + render-only).

## Cross-cutting follow-up (out of scope, flagged not fixed)

Design docs render `[[wiki-links]]` literally — the marked path only rewrites `](X.md)` for design docs, with no wiki-link resolution. Pre-existing (`COMPILATION_PIPELINE.md` already has a literal `[[galaxy-collection-semantics]]`); the new `[[cast-provenance]]` cross-links inherit this. Candidate follow-up: a small marked/remark extension resolving `[[..]]` in design docs to site routes (analogous to the existing content-side `remark-wiki-links`). Surfaced per the plan's "flag cross-cutting issues" intent; deliberately not in Wave 1 scope.

Closes #249, #250, #252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
