### PR TITLE
cwl→galaxy: 5-step test-drive on ga4gh-challenge + salmon-rnaseq

### DIFF
--- a/.claude/commands/test-drive.md
+++ b/.claude/commands/test-drive.md
@@ -80,6 +80,11 @@ For each Mold the run exercised:
 - For cases tagged `bucket: schema`, run the deterministic check (e.g. `validate-summary-nextflow`) where applicable.
 - For cases tagged `bucket: utility` / `llm-judged`, score by inspection.
 
+In addition to Mold specific eval.md instructions, evaluate
+each skill run at a high-level. Does the Mold output seem appropriate for the job being done. Evaluate what research
+was used, whether it was useful, and what research was missing. Exposing gaps in research (missing/incorrect research within a document or missing documents) is an
+an important aspect of the evaluation step.
+
 Report eval results in a table; don't paper over misses. Misses are the point of the run.
 
 ## 6. Capture refinements
@@ -123,6 +128,9 @@ If the run surfaced concrete bugs in the Mold implementations or schemas (not ju
 - Summarize what changed on disk (run-dir contents + any refinement journal entries).
 - List the open questions in one place; concise, sacrifice grammar for brevity.
 - Suggest a follow-up: "run the next phase," "open issues for X / Y," "promote refinement entry → real schema change," "re-run after `/reload-plugins`."
+
+Follow-ups should most likely reflect generalizations of
+the lessons learned.
 
 ## Notes on emulation vs runtime invocation
 

--- a/casts/claude/skills/_emulated-runs/ga4gh-challenge-cwl-galaxy-5step/cwl-galaxy-data-flow.md
+++ b/casts/claude/skills/_emulated-runs/ga4gh-challenge-cwl-galaxy-5step/cwl-galaxy-data-flow.md
@@ -1,0 +1,79 @@
+# Galaxy data-flow brief — biowardrobe_chipseq_se
+
+Source: `summary-cwl.json` + `cwl-galaxy-interface.md`.
+Confidence: high for topology, medium for Directory + conditional-output mapping.
+
+## Abstract topology
+
+Linear ChIP-seq pipeline, single-end, with one trivial 3-step nested workflow inlined and one conditional step:
+
+```
+fastq_file → extract_fastq → bowtie_aligner → samtools_sort_index → samtools_rmdup → samtools_sort_index_after_rmdup → bam_to_bigwig.{bam_to_bedgraph → sort_bedgraph → sorted_bedgraph_to_bigwig} → bigwig
+                                              ↘ macs2_callpeak (+ optional control_bam) → island_intersect → iaintersect_result
+                                                                  ↘ average_tag_density → atdp_result
+                                                                  ↘ get_stat
+                          ↘ fastx_quality_stats → fastx_statistics
+```
+
+Edge count (workflow + nested): ~30 from `summary-cwl.graph.edges`. No scatter, no `linkMerge`, no `pickValue`. One `null`-flowing edge to a non-null sink.
+
+## Galaxy collection semantics
+
+None required. All step inputs are scalars (single `File`, scalar parameters). No CWL arrays, records, or scatter in this workflow.
+
+- **`indices_folder` (Directory).** Not a collection — treat as a single reference-data dataset. Recommended Galaxy translation: cached `bowtie_indices` data table (see interface brief, open question #1). If that's not viable, request a composite `bowtie_index` datatype. Do **not** translate to a collection of files.
+- **`control_bam` (optional File).** Galaxy optional `data` input. The downstream `macs2_callpeak` step needs a connect-or-don't connection; Galaxy supports optional dataset inputs natively in gxformat2.
+
+## Conditional/expression pressure
+
+1. `macs2_callpeak/peak_xls_file` is `(null|File)` but is wired to `get_stat/peak_xls_file: File`. cwltool flagged this in validation. **Galaxy translation decision:** mark `get_stat` as a step whose input may be empty. gxformat2 does not have CWL `when:`. Options:
+   - (a) accept that `get_stat` produces an empty/failed dataset when no peaks are called; downstream output `get_stat_log` is already typed `File?` in CWL, so this is consistent.
+   - (b) make the `get_stat` step contingent on `broad_peak`/`narrow_peak` selection. Galaxy lacks native step skipping; would require splitting the workflow into broad/narrow sibling workflows. Out of scope for this fixture — defer.
+   - Recommend (a). Surface as an `eval`-time test case (run with and without producing peaks).
+2. The CWL workflow has `InlineJavascriptRequirement` at the top level. Spot-checks of step inputs show only literal sources and a couple of `default` integers — no expression-driven control flow at the workflow boundary. **No translation pressure at the gxformat2 level**; expressions inside individual CommandLineTools become wrapper-level concerns.
+3. The nested `#bam-bedgraph-bigwig.cwl` subworkflow uses `StepInputExpressionRequirement` for value derivations inside its three steps. Translate the subworkflow as three sibling Galaxy steps; the value-derivation pressure surfaces as per-step wrapper concerns (output naming, format), not workflow wiring.
+
+## Placeholder transformations
+
+| Edge | CWL marker | Galaxy translation |
+| --- | --- | --- |
+| `bowtie_aligner/output` → `samtools_sort_index/sort_input` | direct | direct dataset connection |
+| `samtools_sort_index/bam_bai_pair` → `samtools_rmdup/bam_file` | direct | direct (Galaxy carries BAI as composite) |
+| `samtools_rmdup/rmdup_output` → `samtools_sort_index_after_rmdup/sort_input` | direct | direct |
+| `samtools_sort_index_after_rmdup/bam_bai_pair` → `bam_to_bigwig/bam_file` | direct (was nested-workflow input) | inline as three steps; direct connection |
+| `macs2_callpeak/peak_xls_file (null\|File)` → `get_stat/peak_xls_file (File)` | type-narrowing | accept and let Galaxy fail the step on empty input; document in tests |
+| 14 scalar parameter inputs → corresponding step parameter inputs | direct | direct |
+
+## Unresolved Galaxy tool needs
+
+Twelve CommandLineTools to map to Galaxy tools (Tool Shed lookups owned by the discover-or-author branch downstream):
+
+- `bowtie-alignreads.cwl` (bowtie v1.2.0) — bowtie1 ChIP-seq alignment.
+- `samtools-sort-index.cwl` (samtools v1.4) — used twice (before + after rmdup).
+- `samtools-rmdup.cwl` (samtools v1.4).
+- `bedtools-genomecov.cwl` (bedtools v2.26.0).
+- `linux-sort.cwl` (`sort`) — coreutils, likely Tool Shed `text_processing` family.
+- `ucsc-bedgraphtobigwig.cwl` (UCSC userApps v358) — well-known wrapper exists.
+- `macs2-callpeak-biowardrobe-only.cwl` (custom MACS2 wrapper) — **likely needs author-galaxy-tool-wrapper**; the upstream `python run.py macs2 callpeak` invocation is biowardrobe-specific.
+- `iaintersect.cwl` (biowardrobe iaintersect) — **biowardrobe-specific**; expect to author.
+- `atdp.cwl` (biowardrobe atdp average tag density) — **biowardrobe-specific**; expect to author.
+- `extract-fastq.cwl` — likely a thin extract/concat shim; consider replacing with `Concatenate datasets` or skipping if input is already FASTQ.
+- `fastx-quality-stats.cwl` (fastx_toolkit v0.0.14) — Tool Shed wrapper exists.
+- `python-get-stat-chipseq.cwl` — biowardrobe stat-collector; **expect to author**.
+
+Counting: 6 likely Tool Shed hits, 5 likely-author, 1 ambiguous (`extract-fastq`).
+
+## Confidence
+
+High for topology and direct edges. Medium for:
+
+- Directory→Galaxy mapping (interface concern, but it ripples here).
+- Conditional `get_stat` step (no Galaxy native `when:`).
+- Whether biowardrobe-flavored MACS2/atdp/iaintersect tools have IUC equivalents (deferred to discover-shed-tool).
+
+## Open questions
+
+1. Inline the nested workflow as three steps vs author a Galaxy sub-workflow? Recommend inline.
+2. Drop `extract_fastq` step entirely if Galaxy datasets are always pre-extracted?
+3. How to handle the null→File edge: accept downstream failure vs sibling-workflow split?
+4. Are biowardrobe-* tools available in Tool Shed under different names? Discover phase will answer.

--- a/casts/claude/skills/_emulated-runs/ga4gh-challenge-cwl-galaxy-5step/cwl-galaxy-interface.md
+++ b/casts/claude/skills/_emulated-runs/ga4gh-challenge-cwl-galaxy-5step/cwl-galaxy-interface.md
@@ -1,0 +1,50 @@
+# Galaxy interface brief — biowardrobe_chipseq_se
+
+Source: `biowardrobe_chipseq_se.cwl` (GA4GH challenge entry, Barski-Lab).
+Provenance: summary-cwl @ `summary-cwl.json` (cwlVersion v1.0, 11 steps, 12 tools, 1 nested workflow).
+Confidence: medium-high — single fastq input, no scatter, no `when:`/`pickValue`, single-end only.
+
+## Workflow inputs (Galaxy-facing)
+
+| Galaxy label | Galaxy shape | CWL source | Notes |
+| --- | --- | --- | --- |
+| `fastq_file` | dataset (datatype `fastqsanger` from EDAM 1930) | `fastq_file` (File) | Required. SE reads. |
+| `bowtie_indices` | (review) Directory | `indices_folder` (Directory) | **Open question.** Galaxy has no first-class Directory input. Options: (a) ship indices as a Galaxy `bowtie_base_index` data-table reference (preferred per IWC ChIP-seq convention); (b) expose as a `data_collection` of index files + a `prefix` parameter; (c) require pre-built `.bowtie_indices` composite datatype. Recommend (a). |
+| `control_bam` | optional dataset (datatype `bam`) | `control_file` (File?) | Optional control for MACS2. Map to a Galaxy optional `data` input. |
+| `annotation_file` | dataset (datatype `tabular`) | `annotation_file` (File, EDAM 3475) | Tab-separated annotation used by `iaintersect`. |
+| `chrom_length` | dataset (datatype `len`) | `chrom_length` (File, EDAM 2330) | Chromosome sizes for `bedGraphToBigWig`. |
+| `genome_size` | parameter (text, restricted) | `genome_size` (string) | Help: `hs, mm, ce, dm, or a number e.g. 2.7e9`. |
+| `broad_peak` | parameter (boolean) | `broad_peak` (boolean) | MACS2 broad-peak toggle. |
+| `exp_fragment_size` | parameter (integer, default 150) | `exp_fragment_size` (int?) | |
+| `force_fragment_size` | parameter (boolean, default false) | `force_fragment_size` (boolean?) | |
+| `clip_3p_end` | parameter (integer, default 0) | `clip_3p_end` (int?) | |
+| `clip_5p_end` | parameter (integer, default 0) | `clip_5p_end` (int?) | |
+| `remove_duplicates` | parameter (boolean, default false) | `remove_duplicates` (boolean?) | Drives `samtools rmdup`. |
+| `threads` | parameter (integer, default 2) | `threads` (int?) | Per-step parallelism. Usually a runtime/admin concern in Galaxy — consider hiding. |
+
+## Workflow outputs (Galaxy-facing)
+
+Promote the following as **public** workflow outputs (downstream-consumable):
+
+- `bigwig` — BigWig signal (EDAM 3006) → datatype `bigwig`.
+- `bambai_pair` — sorted, deduplicated BAM+BAI → Galaxy `bam` (BAI auto-attached via composite or sibling collection).
+- `macs2_narrow_peaks` / `macs2_broad_peaks` / `macs2_gapped_peak` / `macs2_peak_summits` — peak files. Optional; exposed because they are downstream-consumable.
+- `iaintersect_result` — annotated peaks table (`tabular`).
+- `atdp_result` — average tag density table (`tabular`).
+- `fastx_statistics` — FASTQ QC stats (`tabular`).
+
+Promote the following as **checkpoint** outputs (review-only, not downstream-consumed):
+
+- `bowtie_log`, `samtools_rmdup_log`, `macs2_log`, `macs2_fragment_stat`, `atdp_log`, `iaintersect_log`, `get_stat_log`, `macs2_moder_r`, `macs2_called_peaks`.
+
+## Open questions
+
+1. **Directory → Galaxy.** `indices_folder` is the highest-friction mapping. The IWC ChIP-seq exemplars use a `bowtie2_indices` cached reference data table; this workflow is bowtie1. Confirm a `bowtie_indices` data table exists (or accept index tarball as a composite type).
+2. **Optional File output flowing into a non-null sink.** `macs2_callpeak/peak_xls_file` is `(null|File)` but feeds `get_stat/peak_xls_file: File`. cwltool flagged this. Galaxy translation must either gate the `get_stat` step on `broad_peak=false`/MACS2 success, or accept that `get_stat` only runs when peaks are present. Surface as conditional-step decision in the data-flow brief.
+3. **Nested workflow `#bam-bedgraph-bigwig.cwl`.** Three-step subworkflow (bedtools genomecov → sort → bedGraphToBigWig). Recommend inlining as three Galaxy steps rather than authoring a Galaxy sub-workflow — Galaxy sub-workflows exist but are an unnecessary boundary for this fixture.
+4. **`threads` parameter exposure.** CWL exposes thread count as a workflow input. Galaxy convention buries this in tool configuration. Recommend dropping from the public interface.
+5. **Datatype for `chrom_length`.** Listed as EDAM 2330 (plain text) but Galaxy has `len` and `tabular` candidates; `len` is the bedGraphToBigWig-canonical type.
+
+## Confidence
+
+Medium-high. The workflow is small (one main + one trivial subworkflow), single-end, no expression-driven control flow, no scatter, and inputs map cleanly except for the Directory case. Datatype choices need IWC ChIP-seq cross-check (step 4).

--- a/casts/claude/skills/_emulated-runs/ga4gh-challenge-cwl-galaxy-5step/extract.mjs
+++ b/casts/claude/skills/_emulated-runs/ga4gh-challenge-cwl-galaxy-5step/extract.mjs
@@ -1,0 +1,200 @@
+import fs from "fs";
+
+const data = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+const ENTRY = "workflow-fixtures/cwl/Barski-Lab__ga4gh_challenge/biowardrobe_chipseq_se.cwl";
+const NORM = "normalized/biowardrobe_chipseq_se.packed.json";
+
+const strip = (s) => typeof s === "string" ? s.replace(/^#main\//, "").replace(/^#/, "") : s;
+const sfList = (sf) => (Array.isArray(sf) ? sf : (sf ? [sf] : [])).map((x) => typeof x === "string" ? x : (x.pattern || JSON.stringify(x)));
+
+const main = data.$graph.find((g) => g.id === "#main");
+const tools = data.$graph.filter((g) => g.class === "CommandLineTool");
+const subs = data.$graph.filter((g) => g.class === "Workflow" && g.id !== "#main");
+
+const reqsOf = (item) => {
+  const all = (item.requirements || []).concat(item.hints || []);
+  return all.map((r) => {
+    const docker = r.class === "DockerRequirement" ? (r.dockerPull || null) : null;
+    return {
+      class: r.class || "Unknown",
+      docker_pull: docker,
+      docker_image_id: r.dockerImageId || null,
+      packages: r.class === "SoftwareRequirement" ? (r.packages || []).map((p) => ({ package: p.package, version: p.version || [], specs: p.specs || [] })) : [],
+      raw: r,
+    };
+  });
+};
+
+const typeStr = (t) => {
+  if (typeof t === "string") return t;
+  if (Array.isArray(t)) return t.map(typeStr).join(" | ");
+  if (t && typeof t === "object") return t.type || JSON.stringify(t);
+  return String(t);
+};
+
+const isOptional = (t) => Array.isArray(t) && t.includes("null");
+
+const workflow_inputs = main.inputs.map((i) => ({
+  id: strip(i.id),
+  label: i.label || strip(i.id),
+  type: typeStr(i.type),
+  optional: isOptional(i.type),
+  default: i.default ?? null,
+  doc: i.doc || null,
+  format: i.format || null,
+  secondary_files: sfList(i.secondaryFiles),
+}));
+
+const workflow_outputs = main.outputs.map((o) => ({
+  id: strip(o.id),
+  label: o.label || strip(o.id),
+  type: typeStr(o.type),
+  output_source: Array.isArray(o.outputSource) ? o.outputSource.map(strip) : [strip(o.outputSource)],
+  doc: o.doc || null,
+  format: o.format || null,
+  secondary_files: sfList(o.secondaryFiles),
+}));
+
+const classOfRun = (runId) => {
+  const found = data.$graph.find((g) => g.id === runId);
+  return found ? found.class : "Unknown";
+};
+
+const steps = main.steps.map((s) => {
+  const runId = s.run;
+  return {
+    id: strip(s.id),
+    run: strip(runId),
+    run_class: classOfRun(runId),
+    label: s.label || null,
+    doc: s.doc || null,
+    in: s.in.map((i) => ({
+      id: strip(i.id),
+      source: i.source ? (Array.isArray(i.source) ? i.source.map(strip) : [strip(i.source)]) : [],
+      default: i.default ?? null,
+      value_from: i.valueFrom || null,
+      link_merge: i.linkMerge || null,
+      pick_value: i.pickValue || null,
+    })),
+    out: (s.out || []).map((o) => typeof o === "string" ? strip(o).split("/").pop() : strip(o.id).split("/").pop()),
+    scatter: s.scatter ? (Array.isArray(s.scatter) ? s.scatter.map(strip) : [strip(s.scatter)]) : [],
+    scatter_method: s.scatterMethod || null,
+    when: s.when || null,
+    requirements: reqsOf(s),
+    hints: [],
+  };
+});
+
+const bindingOf = (b) => b ? ({
+  position: b.position ?? null,
+  prefix: b.prefix || null,
+  glob: null,
+  value_from: b.valueFrom || null,
+}) : null;
+
+const outBindingOf = (b) => b ? ({
+  position: null,
+  prefix: null,
+  glob: Array.isArray(b.glob) ? b.glob.join(",") : (b.glob || null),
+  value_from: b.outputEval || null,
+}) : null;
+
+const cmdTools = tools.map((t) => ({
+  id: strip(t.id),
+  label: t.label || null,
+  base_command: Array.isArray(t.baseCommand) ? t.baseCommand : (t.baseCommand ? [t.baseCommand] : []),
+  arguments: (t.arguments || []).map((a) => typeof a === "string" ? a : JSON.stringify(a)),
+  inputs: (t.inputs || []).map((i) => ({
+    id: strip(i.id).split("/").pop(),
+    type: typeStr(i.type),
+    input_binding: bindingOf(i.inputBinding),
+    doc: i.doc || null,
+    format: i.format || null,
+    secondary_files: sfList(i.secondaryFiles),
+  })),
+  outputs: (t.outputs || []).map((o) => ({
+    id: strip(o.id).split("/").pop(),
+    type: typeStr(o.type),
+    output_binding: outBindingOf(o.outputBinding),
+    doc: o.doc || null,
+    format: o.format || null,
+    secondary_files: sfList(o.secondaryFiles),
+  })),
+  requirements: reqsOf(t),
+  hints: [],
+}));
+
+const subWorkflows = subs.map((sw) => ({
+  id: strip(sw.id),
+  label: sw.label || null,
+  base_command: [],
+  arguments: [],
+  inputs: (sw.inputs || []).map((i) => ({ id: strip(i.id).split("/").pop(), type: typeStr(i.type), input_binding: null, doc: i.doc || null, format: i.format || null, secondary_files: [] })),
+  outputs: (sw.outputs || []).map((o) => ({ id: strip(o.id).split("/").pop(), type: typeStr(o.type), output_binding: null, doc: o.doc || null, format: o.format || null, secondary_files: [] })),
+  requirements: reqsOf(sw),
+  hints: [{ class: "_NestedWorkflow", docker_pull: null, docker_image_id: null, packages: [], raw: { steps: sw.steps.map((s) => ({ id: strip(s.id), run: strip(s.run) })) } }],
+}));
+
+const nodes = [];
+const edges = [];
+for (const i of workflow_inputs) nodes.push({ id: i.id, kind: "workflow-input", label: i.label });
+for (const o of workflow_outputs) nodes.push({ id: o.id, kind: "workflow-output", label: o.label });
+for (const s of steps) nodes.push({ id: s.id, kind: "step", label: s.id });
+
+for (const s of steps) {
+  for (const sin of s.in) {
+    for (const src of sin.source) {
+      edges.push({ from: src, to: `${s.id}/${sin.id.split("/").pop()}`, via: sin.value_from ? ["valueFrom"] : [] });
+    }
+  }
+}
+for (const o of workflow_outputs) {
+  for (const src of o.output_source) edges.push({ from: src, to: o.id, via: [] });
+}
+
+const summary = {
+  summary_version: "1",
+  source: {
+    ecosystem: "cwl",
+    workflow: "biowardrobe_chipseq_se",
+    url: "https://github.com/Barski-Lab/ga4gh_challenge/blob/f28d47bd0911e5e7210c4dc83f75653a1e0297c9/biowardrobe_chipseq_se.cwl",
+    version: "f28d47bd0911e5e7210c4dc83f75653a1e0297c9",
+    license: null,
+    slug: "biowardrobe-chipseq-se",
+    cwl_version: "v1.0",
+    entrypoint: "biowardrobe_chipseq_se.cwl",
+  },
+  documents: {
+    entrypoint: ENTRY,
+    normalized_path: NORM,
+    validation: {
+      command: "cwltool --validate biowardrobe_chipseq_se.cwl",
+      status: "valid",
+      diagnostics: [
+        "warning biowardrobe_chipseq_se.cwl:341:9 — macs2_callpeak/peak_xls_file (null|File) may be incompatible with downstream sink input_filename (File)",
+      ],
+    },
+  },
+  workflow_inputs,
+  workflow_outputs,
+  steps,
+  tools: [...cmdTools, ...subWorkflows],
+  graph: { nodes, edges },
+  tests: [
+    {
+      name: "biowardrobe_chipseq_se",
+      job_path: "biowardrobe_chipseq_se.yaml",
+      expected_outputs: [],
+      provenance: "sibling-yaml: biowardrobe_chipseq_se.yaml job file in repo; no asserted expected outputs",
+    },
+  ],
+  warnings: [
+    { code: "expression.javascript", message: "InlineJavascriptRequirement is active; expressions are preserved, not executed.", path: "requirements" },
+    { code: "ref.directory", message: "indices_folder is a CWL Directory input; downstream Galaxy translation must choose between directory-capable wrappers, explicit files, or collections.", path: "workflow_inputs/indices_folder" },
+    { code: "nested.workflow", message: "Nested workflow #bam-bedgraph-bigwig.cwl in step bam_to_bigwig is preserved as a step target; downstream may need expansion.", path: "steps/bam_to_bigwig" },
+    { code: "type.compat", message: "macs2_callpeak/peak_xls_file is (null|File) but is fed to a sink expecting File; downstream needs null-handling.", path: "steps/macs2_callpeak" },
+  ],
+};
+
+fs.writeFileSync(process.argv[3], JSON.stringify(summary, null, 2));
+console.log("wrote", process.argv[3], "size", fs.statSync(process.argv[3]).size);

--- a/casts/claude/skills/_emulated-runs/ga4gh-challenge-cwl-galaxy-5step/galaxy-workflow-draft.gxwf.yml
+++ b/casts/claude/skills/_emulated-runs/ga4gh-challenge-cwl-galaxy-5step/galaxy-workflow-draft.gxwf.yml
@@ -1,0 +1,339 @@
+class: GalaxyWorkflow
+label: "ChIP-seq SE (biowardrobe) — CWL→Galaxy draft"
+doc: |
+  Draft gxformat2 skeleton derived from Barski-Lab/ga4gh_challenge biowardrobe_chipseq_se.cwl
+  (cwlVersion v1.0, SHA f28d47b). Topology and edges are settled here; tool_ids and tool_state
+  are TODO and deferred to the per-step authoring Molds. Per IWC comparison notes, a faithful
+  conversion is the first-pass intent; IWC-alignment alternatives are recorded in _plan_context.
+
+inputs:
+  - id: fastq_file
+    type: data
+    optional: false
+    doc: "Single-end ChIP-seq FASTQ reads."
+    _plan_context: |
+      Source CWL: workflow_input fastq_file (File, format EDAM 1930).
+      Datatype: fastqsanger.
+      IWC-alignment note: IWC chipseq-sr uses a list collection. Faithful-to-source keeps a
+      single dataset; consider revising to `type: collection / collection_type: list` if the
+      consumer wants batch use.
+
+  - id: bowtie_indices
+    type: data
+    optional: false
+    doc: "Bowtie1 reference indices. CWL source is a Directory; in Galaxy expect a cached reference data table or a composite bowtie_index dataset."
+    _plan_context: |
+      Source CWL: workflow_input indices_folder (Directory).
+      Galaxy translation candidates:
+        (a) Replace with `type: string` + `restrictOnConnections: true`, resolved via a
+            bowtie_indices data table (IWC chipseq-sr pattern, but for bowtie2 — verify a
+            bowtie1 table exists).
+        (b) Composite datatype `bowtie_base_index`.
+      Keep as opaque `data` for the skeleton; the per-step authoring Mold will pick (a) or (b).
+
+  - id: control_bam
+    type: data
+    optional: true
+    doc: "Optional control BAM for MACS2."
+    _plan_context: "CWL source: control_file (File?, format EDAM 2572). Datatype: bam."
+
+  - id: annotation_file
+    type: data
+    optional: false
+    doc: "Tab-separated annotation for iaintersect."
+    _plan_context: "CWL source: annotation_file (File, format EDAM 3475). Datatype: tabular."
+
+  - id: chrom_length
+    type: data
+    optional: false
+    doc: "Chromosome sizes file for bedGraphToBigWig."
+    _plan_context: "CWL source: chrom_length (File, format EDAM 2330). Datatype: len (canonical for bedGraphToBigWig)."
+
+  - id: genome_size
+    type: string
+    optional: false
+    doc: "MACS2 effective genome size. e.g. hs, mm, ce, dm, or a number like 2.7e9."
+
+  - id: broad_peak
+    type: boolean
+    optional: false
+    doc: "Set to call broad peaks via MACS2 --broad."
+
+  - id: exp_fragment_size
+    type: int
+    optional: true
+    default: 150
+    doc: "Expected fragment size for MACS2."
+
+  - id: force_fragment_size
+    type: boolean
+    optional: true
+    default: false
+    doc: "Force MACS2 to use exp_fragment_size."
+
+  - id: clip_3p_end
+    type: int
+    optional: true
+    default: 0
+    doc: "Bases to clip from 3' end."
+
+  - id: clip_5p_end
+    type: int
+    optional: true
+    default: 0
+    doc: "Bases to clip from 5' end."
+
+  - id: remove_duplicates
+    type: boolean
+    optional: true
+    default: false
+    doc: "Run samtools rmdup."
+
+outputs:
+  - id: bigwig
+    outputSource: sorted_bedgraph_to_bigwig/TODO_bigwig
+  - id: bambai_pair
+    outputSource: samtools_sort_index_after_rmdup/TODO_bam_bai
+  - id: macs2_narrow_peaks
+    outputSource: macs2_callpeak/TODO_narrow_peaks
+  - id: macs2_broad_peaks
+    outputSource: macs2_callpeak/TODO_broad_peaks
+  - id: macs2_peak_summits
+    outputSource: macs2_callpeak/TODO_peak_summits
+  - id: macs2_gapped_peak
+    outputSource: macs2_callpeak/TODO_gapped_peak
+  - id: macs2_called_peaks
+    outputSource: macs2_callpeak/TODO_peak_xls
+  - id: macs2_fragment_stat
+    outputSource: macs2_callpeak/TODO_macs2_stat
+  - id: macs2_log
+    outputSource: macs2_callpeak/TODO_log
+  - id: iaintersect_result
+    outputSource: island_intersect/TODO_result
+  - id: iaintersect_log
+    outputSource: island_intersect/TODO_log
+  - id: atdp_result
+    outputSource: average_tag_density/TODO_result
+  - id: atdp_log
+    outputSource: average_tag_density/TODO_log
+  - id: fastx_statistics
+    outputSource: fastx_quality_stats/TODO_statistics
+  - id: bowtie_log
+    outputSource: bowtie_aligner/TODO_log
+  - id: samtools_rmdup_log
+    outputSource: samtools_rmdup/TODO_log
+  - id: get_stat_log
+    outputSource: get_stat/TODO_log
+
+steps:
+  - id: extract_fastq
+    label: "Extract FASTQ"
+    tool_id: TODO
+    tool_version: TODO
+    in:
+      TODO_input: fastq_file
+    out:
+      - id: TODO_fastq
+    _plan_state: "Concat/extract step from CWL; consider dropping if Galaxy datasets are pre-extracted."
+    _plan_context: |
+      Source CWL: extract-fastq.cwl, baseCommand: ["bash","-c"], docker: biowardrobe2/scidap:v0.0.3.
+      Likely replace with: built-in identity, or `Concatenate datasets` if multi-file input.
+
+  - id: fastx_quality_stats
+    label: "FASTQ quality statistics"
+    tool_id: TODO
+    tool_version: TODO
+    in:
+      TODO_input: extract_fastq/TODO_fastq
+    out:
+      - id: TODO_statistics
+    _plan_state: "fastx_toolkit quality stats on extracted FASTQ."
+    _plan_context: |
+      Source CWL: fastx-quality-stats.cwl, baseCommand: ["fastx_quality_stats"],
+      docker: biowardrobe2/fastx_toolkit:v0.0.14.
+      Tool Shed candidate: devteam/fastx_toolkit / fastx_quality_stats.
+      IWC-alignment alt: replace with fastp (IWC chipseq-sr idiom) which both trims and reports.
+
+  - id: bowtie_aligner
+    label: "Bowtie1 SE alignment"
+    tool_id: TODO
+    tool_version: TODO
+    in:
+      TODO_reads: extract_fastq/TODO_fastq
+      TODO_indices: bowtie_indices
+      TODO_clip_3p: clip_3p_end
+      TODO_clip_5p: clip_5p_end
+    out:
+      - id: TODO_sam
+      - id: TODO_log
+    _plan_state: "Bowtie1 SE alignment; clip_3p_end / clip_5p_end from workflow inputs."
+    _plan_context: |
+      Source CWL: bowtie-alignreads.cwl, baseCommand: ["bowtie"],
+      docker: biowardrobe2/bowtie:v1.2.0.
+      Tool Shed candidate: devteam/bowtie_wrappers (bowtie1) or alternative.
+      IWC-alignment alt: bowtie2 (devteam/bowtie2/2.5.4+galaxy0) — diverges from source.
+
+  - id: samtools_sort_index
+    label: "Sort + index BAM (pre-rmdup)"
+    tool_id: TODO
+    tool_version: TODO
+    in:
+      TODO_input: bowtie_aligner/TODO_sam
+    out:
+      - id: TODO_bam_bai
+    _plan_state: "samtools sort+index after bowtie alignment."
+    _plan_context: |
+      Source CWL: samtools-sort-index.cwl, docker: biowardrobe2/samtools:v1.4.
+      Tool Shed candidate: devteam/samtools_sort.
+
+  - id: samtools_rmdup
+    label: "samtools rmdup"
+    tool_id: TODO
+    tool_version: TODO
+    in:
+      TODO_input: samtools_sort_index/TODO_bam_bai
+      TODO_remove: remove_duplicates
+    out:
+      - id: TODO_bam
+      - id: TODO_log
+    _plan_state: |
+      Step always runs in this draft to keep topology static. The CWL source treats rmdup as
+      always-on with a remove_duplicates boolean threaded into the tool; if Galaxy convention
+      prefers a conditional, defer to per-step Mold or split into sibling workflows.
+    _plan_context: "Source CWL: samtools-rmdup.cwl, docker: biowardrobe2/samtools:v1.4."
+
+  - id: samtools_sort_index_after_rmdup
+    label: "Sort + index BAM (post-rmdup)"
+    tool_id: TODO
+    tool_version: TODO
+    in:
+      TODO_input: samtools_rmdup/TODO_bam
+    out:
+      - id: TODO_bam_bai
+    _plan_state: "Second samtools sort+index pass after rmdup."
+    _plan_context: "Same wrapper as samtools_sort_index step."
+
+  # --- nested workflow #bam-bedgraph-bigwig.cwl inlined as three steps ---
+
+  - id: bam_to_bedgraph
+    label: "bedtools genomecov → bedGraph"
+    tool_id: TODO
+    tool_version: TODO
+    in:
+      TODO_input: samtools_sort_index_after_rmdup/TODO_bam_bai
+      TODO_chrom_length: chrom_length
+    out:
+      - id: TODO_bedgraph
+    _plan_state: "bedtools genomecov, bedgraph output. Inlined from CWL nested workflow #bam-bedgraph-bigwig.cwl."
+    _plan_context: |
+      Source CWL: bedtools-genomecov.cwl, baseCommand: ["bedtools","genomecov"],
+      docker: biowardrobe2/bedtools2:v2.26.0.
+      Tool Shed candidate: iuc/bedtools / bedtools_genomecoveragebed.
+
+  - id: sort_bedgraph
+    label: "Sort bedGraph"
+    tool_id: TODO
+    tool_version: TODO
+    in:
+      TODO_input: bam_to_bedgraph/TODO_bedgraph
+    out:
+      - id: TODO_sorted_bedgraph
+    _plan_state: "GNU sort on bedgraph (chr, start). Inlined from nested CWL workflow."
+    _plan_context: |
+      Source CWL: linux-sort.cwl, baseCommand: ["sort"], docker: biowardrobe2/scidap:v0.0.2.
+      Tool Shed candidate: bgruening/text_processing / tp_sort.
+
+  - id: sorted_bedgraph_to_bigwig
+    label: "bedGraph → BigWig"
+    tool_id: TODO
+    tool_version: TODO
+    in:
+      TODO_input: sort_bedgraph/TODO_sorted_bedgraph
+      TODO_chrom_length: chrom_length
+    out:
+      - id: TODO_bigwig
+    _plan_state: "UCSC bedGraphToBigWig. Inlined from nested CWL workflow."
+    _plan_context: |
+      Source CWL: ucsc-bedgraphtobigwig.cwl, baseCommand: ["bedGraphToBigWig"],
+      docker: biowardrobe2/ucscuserapps:v358.
+      Tool Shed candidate: Galaxy built-in wig_to_bigWig or iuc/ucsc_bedgraphtobigwig.
+
+  # --- end nested-workflow inlining ---
+
+  - id: macs2_callpeak
+    label: "MACS2 callpeak"
+    tool_id: TODO
+    tool_version: TODO
+    in:
+      TODO_treatment: samtools_sort_index_after_rmdup/TODO_bam_bai
+      TODO_control: control_bam
+      TODO_genome_size: genome_size
+      TODO_broad: broad_peak
+      TODO_exp_fragment_size: exp_fragment_size
+      TODO_force_fragment_size: force_fragment_size
+    out:
+      - id: TODO_narrow_peaks
+      - id: TODO_broad_peaks
+      - id: TODO_peak_summits
+      - id: TODO_gapped_peak
+      - id: TODO_peak_xls
+      - id: TODO_macs2_stat
+      - id: TODO_log
+      - id: TODO_moder_r
+    _plan_state: "MACS2 callpeak; broad/narrow toggled by broad_peak input."
+    _plan_context: |
+      Source CWL: macs2-callpeak-biowardrobe-only.cwl, baseCommand: ["python","run.py","macs2 callpeak"],
+      docker: biowardrobe2/macs2:v2.1.1.
+      Tool Shed candidate: iuc/macs2 / macs2_callpeak/2.2.9.1+galaxy0 (IWC chipseq-sr pin).
+      Warning carried from summary-cwl: peak_xls_file is (null|File) but downstream get_stat
+      expects File. Accept downstream-may-fail or split workflows for broad/narrow.
+
+  - id: island_intersect
+    label: "iaintersect: annotate peaks"
+    tool_id: TODO
+    tool_version: TODO
+    in:
+      TODO_peaks: macs2_callpeak/TODO_peak_xls
+      TODO_annotation: annotation_file
+    out:
+      - id: TODO_result
+      - id: TODO_log
+    _plan_state: "Biowardrobe iaintersect; annotates MACS2 peaks against tab-separated annotation."
+    _plan_context: |
+      Source CWL: iaintersect.cwl, baseCommand: ["iaintersect"],
+      docker: biowardrobe2/iaintersect:v0.0.2.
+      No likely Tool Shed equivalent — expect to author via author-galaxy-tool-wrapper.
+
+  - id: average_tag_density
+    label: "Average tag density (atdp)"
+    tool_id: TODO
+    tool_version: TODO
+    in:
+      TODO_bam: samtools_sort_index_after_rmdup/TODO_bam_bai
+      TODO_annotation: annotation_file
+    out:
+      - id: TODO_result
+      - id: TODO_log
+    _plan_state: "Biowardrobe atdp; produces per-region tag density."
+    _plan_context: |
+      Source CWL: atdp.cwl, baseCommand: ["bash","-c"], docker: biowardrobe2/atdp:v0.0.1.
+      No likely Tool Shed equivalent — expect to author.
+
+  - id: get_stat
+    label: "Aggregate ChIP-seq stats"
+    tool_id: TODO
+    tool_version: TODO
+    in:
+      TODO_bowtie_log: bowtie_aligner/TODO_log
+      TODO_rmdup_log: samtools_rmdup/TODO_log
+      TODO_peak_xls: macs2_callpeak/TODO_peak_xls
+    out:
+      - id: TODO_log
+    _plan_state: |
+      Biowardrobe python-get-stat-chipseq. Note: source CWL types TODO_peak_xls as (null|File)
+      flowing into File; expect step to fail or produce empty output when peaks are not called.
+      Tested-without-peaks behavior must be a workflow-test case.
+    _plan_context: |
+      Source CWL: python-get-stat-chipseq.cwl, baseCommand: ["python","-c"],
+      docker: biowardrobe2/scidap:v0.0.2.
+      IWC-alignment alt: replace with MultiQC (IWC chipseq-sr idiom).

--- a/casts/claude/skills/_emulated-runs/ga4gh-challenge-cwl-galaxy-5step/iwc-comparison-notes.md
+++ b/casts/claude/skills/_emulated-runs/ga4gh-challenge-cwl-galaxy-5step/iwc-comparison-notes.md
@@ -1,0 +1,66 @@
+# IWC exemplar comparison — biowardrobe_chipseq_se
+
+Briefs compared: `cwl-galaxy-interface.md` + `cwl-galaxy-data-flow.md`.
+Corpus: `~/projects/repositories/workflow-fixtures/iwc-format2/` (galaxyproject/iwc, format2).
+
+## Nearest exemplar(s)
+
+- **Primary:** [[chipseq-sr]] at `epigenetics/chipseq-sr/chipseq-sr.gxwf.yml`. Confidence: **medium-high**.
+- **Sibling for reference:** [[chipseq-pe]] at `epigenetics/chipseq-pe/chipseq-pe.gxwf.yml`. Not selected (PE; brief is SE).
+- **Adjacent:** [[consensus-peaks-chip-sr]] at `epigenetics/consensus-peaks/consensus-peaks-chip-sr.gxwf.yml`. Downstream multi-sample peak consensus; out of scope for a single-sample pipeline.
+
+`chipseq-sr` is the closest IWC analog: same domain (ChIP-seq), same input topology (single-end FASTQ), same primary tool families (aligner → BAM filter → MACS2 → bigwig → MultiQC). Marked medium-high (not high) because the aligner and several downstream tools differ.
+
+## Feature-hierarchy diff (brief → IWC `chipseq-sr`)
+
+| Feature | Brief proposal | IWC chipseq-sr | Verdict |
+| --- | --- | --- | --- |
+| **Domain** | ChIP-seq, single-end | ChIP-seq, single-end | match |
+| **Input topology** | single `fastq_file` dataset | **`collection: list` of FASTQs** | **diverge — IWC uses a list collection** |
+| **Reference input** | `indices_folder` (Directory) → cached `bowtie_indices` table | `Reference genome` (string, `restrictOnConnections: true`) — Galaxy reference-data table | match in spirit; IWC uses a `string` reference-name input, not a Directory |
+| **Aligner** | bowtie1 (`bowtie-alignreads`) | **bowtie2** (`devteam/bowtie2`) | diverge — version/tool family |
+| **QC pre-align** | `fastx_quality_stats` (legacy) | `fastp` (adapter + quality) | diverge — IWC adapter trim, brief only emits stats |
+| **Duplicate removal** | `samtools rmdup` (optional, `remove_duplicates` toggle) | not present in chipseq-sr | diverge — brief has it; IWC chipseq-sr does not |
+| **BAM filter** | none | `filter MAPQ30` (samtool_filter2) | diverge — IWC adds MAPQ filter |
+| **Peak caller** | MACS2 callpeak (biowardrobe wrapper) | MACS2 callpeak (`iuc/macs2_callpeak/2.2.9.1+galaxy0`) | match (different wrapper) |
+| **Control sample** | optional `control_bam` File? | not modeled in chipseq-sr | diverge — IWC chipseq-sr is no-control; **chipseq-pe** also no-control. IWC pattern is per-workflow not per-input. |
+| **Coverage track** | `bedtools genomecov → sort → bedGraphToBigWig` (nested 3-step subworkflow) | `Bigwig from MACS2` (single `wig_to_bigWig` step on MACS2 output) | **diverge — different recipe**; IWC uses MACS2's bigwig output |
+| **Peak annotation** | `iaintersect` (biowardrobe) → tabular | not present | diverge |
+| **Tag-density profile** | `atdp` (biowardrobe) → tabular | not present | diverge |
+| **Stat collector** | `python-get-stat-chipseq` (biowardrobe) → log | `summary of MACS2` (text_processing/tp_grep_tool) + MultiQC | diverge — IWC uses MultiQC for aggregate stats |
+| **Test fixture topology** | sibling `biowardrobe_chipseq_se.yaml` job file; no asserted outputs | gxformat2 `-tests.yml` with asserted outputs | diverge — brief has no tests yet |
+
+## Routing findings
+
+**Template/data-flow issues (for `cwl-summary-to-galaxy-template`):**
+
+1. **Reconsider input topology.** IWC ChIP-seq workflows take a `collection: list` of FASTQs, not a single dataset. Even for a single-sample run, this is the IWC idiom — it makes batch use trivial without rewriting. Recommend revising the interface brief to a `list` collection input.
+2. **Reference input shape.** IWC ChIP-seq uses a `string` reference-genome name with `restrictOnConnections: true`, resolved at runtime against Galaxy's cached `bowtie2_indices` data table. This is closer to the right Galaxy-native shape than "Directory input" or "data table on the back end." Recommend revising open question #1 in the interface brief.
+3. **Inline subworkflow, but consider replacing with MACS2 bigwig.** The 3-step bedtools→sort→bedGraphToBigWig recipe is not the IWC idiom for ChIP-seq coverage. IWC uses MACS2's own bigwig output. If fidelity-to-source is required, keep the 3-step recipe; if reaching for an IWC-shaped output, replace.
+4. **Add MultiQC.** IWC ChIP-seq workflows end with a MultiQC step aggregating fastp/bowtie/MACS2 logs into an HTML report. The brief proposes a custom biowardrobe `get_stat` step instead. Recommend adding MultiQC as a Galaxy-idiom additive, alongside or instead of `get_stat`.
+5. **MAPQ filter.** IWC adds an explicit `samtool_filter2 MAPQ30` step; the CWL workflow does not. Decide: faithful-to-source (skip) vs IWC-aligned (add). Recommend faithful-to-source for the conversion fidelity test, with the MAPQ filter as a noted enrichment.
+
+**Pattern issues:**
+
+- The CWL-Directory → Galaxy-reference-table pattern (open question #1) is recurring. Worth surfacing as a candidate pattern page: "CWL Directory inputs for index bundles → Galaxy reference-data tables." (Out of scope for this run, raised as future work.)
+
+**Tool-step issues (for downstream discover-shed-tool):**
+
+- Likely Tool Shed hits: `iuc/macs2`, `devteam/bowtie` (1.x?) or `devteam/bowtie2`, `devteam/samtools_*`, `iuc/bedtools`, `wig_to_bigWig` (built-in), `iuc/fastp`.
+- Likely-author: `biowardrobe` flavored `atdp`, `iaintersect`, `python-get-stat-chipseq`, `extract-fastq`, and the `macs2-callpeak-biowardrobe-only` wrapper.
+- The IWC ChIP-seq workflows do not include analogs of `atdp` or `iaintersect`. If conversion fidelity matters, expect to author. If IWC-alignment is more important, drop them.
+
+**Test issues:**
+
+- IWC ChIP-seq carries a `-tests.yml` next to each workflow with asserted outputs. The fixture has a sibling `biowardrobe_chipseq_se.yaml` job file but no asserted outputs. Defer to `cwl-test-to-galaxy-test-plan`.
+
+## Confidence
+
+Medium-high on the exemplar choice (correct domain + topology), medium on the structural diff (5 substantive divergences listed). The biowardrobe-specific downstream stats (atdp, iaintersect, get_stat) have no IWC analog — that's the largest source of uncertainty about whether to translate faithfully or substitute the IWC idiom.
+
+## Open questions
+
+1. Conversion fidelity vs IWC-alignment tradeoff. Recommend documenting both intents at the template stage and letting the user pick.
+2. Should the brief revise to `collection: list` SE input before template authoring? Recommend yes.
+3. Bowtie1 vs bowtie2 — keep faithful or upgrade? Faithful for first pass.
+4. Add MultiQC as an idiomatic Galaxy add-on, or leave the workflow biowardrobe-shaped? Recommend add.

--- a/casts/claude/skills/_emulated-runs/ga4gh-challenge-cwl-galaxy-5step/normalized/biowardrobe_chipseq_se.packed.json
+++ b/casts/claude/skills/_emulated-runs/ga4gh-challenge-cwl-galaxy-5step/normalized/biowardrobe_chipseq_se.packed.json
@@ -1,0 +1,3752 @@
+{
+    "$graph": [
+        {
+            "class": "Workflow",
+            "requirements": [
+                {
+                    "class": "SubworkflowFeatureRequirement"
+                },
+                {
+                    "class": "ScatterFeatureRequirement"
+                },
+                {
+                    "class": "StepInputExpressionRequirement"
+                },
+                {
+                    "class": "InlineJavascriptRequirement"
+                },
+                {
+                    "class": "MultipleInputFeatureRequirement"
+                }
+            ],
+            "inputs": [
+                {
+                    "type": "File",
+                    "label": "Annotation file",
+                    "format": "http://edamontology.org/format_3475",
+                    "doc": "Tab-separated input annotation file",
+                    "id": "#main/annotation_file"
+                },
+                {
+                    "type": "boolean",
+                    "label": "Callpeak broad",
+                    "doc": "Set to call broad peak for MACS2",
+                    "id": "#main/broad_peak"
+                },
+                {
+                    "type": "File",
+                    "label": "Chromosome length file",
+                    "format": "http://edamontology.org/format_2330",
+                    "doc": "Chromosome length file",
+                    "id": "#main/chrom_length"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "default": 0,
+                    "label": "Clip from 3p end",
+                    "doc": "Number of bases to clip from the 3p end",
+                    "id": "#main/clip_3p_end"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "default": 0,
+                    "label": "Clip from 5p end",
+                    "doc": "Number of bases to clip from the 5p end",
+                    "id": "#main/clip_5p_end"
+                },
+                {
+                    "type": [
+                        "null",
+                        "File"
+                    ],
+                    "default": null,
+                    "label": "Control BAM file",
+                    "format": "http://edamontology.org/format_2572",
+                    "doc": "Control BAM file file for MACS2 peak calling",
+                    "id": "#main/control_file"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "default": 150,
+                    "label": "Expected fragment size",
+                    "doc": "Expected fragment size for MACS2",
+                    "id": "#main/exp_fragment_size"
+                },
+                {
+                    "type": "File",
+                    "label": "FASTQ input file",
+                    "format": "http://edamontology.org/format_1930",
+                    "doc": "Reads data in a FASTQ format, received after single end sequencing",
+                    "id": "#main/fastq_file"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "default": false,
+                    "label": "Force fragment size",
+                    "doc": "Force MACS2 to use exp_fragment_size",
+                    "id": "#main/force_fragment_size"
+                },
+                {
+                    "type": "string",
+                    "label": "Effective genome size",
+                    "doc": "MACS2 effective genome size: hs, mm, ce, dm or number, for example 2.7e9",
+                    "id": "#main/genome_size"
+                },
+                {
+                    "type": "Directory",
+                    "label": "BOWTIE indices folder",
+                    "doc": "Path to BOWTIE generated indices folder",
+                    "id": "#main/indices_folder"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "default": false,
+                    "label": "Remove duplicates",
+                    "doc": "Calls samtools rmdup to remove duplicates from sortesd BAM file",
+                    "id": "#main/remove_duplicates"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "default": 2,
+                    "doc": "Number of threads for those steps that support multithreading",
+                    "label": "Number of threads",
+                    "id": "#main/threads"
+                }
+            ],
+            "steps": [
+                {
+                    "run": "#atdp.cwl",
+                    "in": [
+                        {
+                            "source": "#main/annotation_file",
+                            "id": "#main/average_tag_density/annotation_filename"
+                        },
+                        {
+                            "default": 200,
+                            "id": "#main/average_tag_density/avd_heat_window_bp"
+                        },
+                        {
+                            "default": 50,
+                            "id": "#main/average_tag_density/avd_smooth_bp"
+                        },
+                        {
+                            "default": 5000,
+                            "id": "#main/average_tag_density/avd_window_bp"
+                        },
+                        {
+                            "default": "chrX chrY",
+                            "id": "#main/average_tag_density/double_chr"
+                        },
+                        {
+                            "source": "#main/macs2_callpeak/macs2_fragments_calculated",
+                            "id": "#main/average_tag_density/fragmentsize_bp"
+                        },
+                        {
+                            "default": "chrM",
+                            "id": "#main/average_tag_density/ignore_chr"
+                        },
+                        {
+                            "source": "#main/samtools_sort_index_after_rmdup/bam_bai_pair",
+                            "id": "#main/average_tag_density/input_file"
+                        },
+                        {
+                            "source": "#main/get_stat/mapped_reads",
+                            "id": "#main/average_tag_density/mapped_reads"
+                        }
+                    ],
+                    "out": [
+                        "#main/average_tag_density/result_file",
+                        "#main/average_tag_density/log_file"
+                    ],
+                    "id": "#main/average_tag_density"
+                },
+                {
+                    "run": "#bam-bedgraph-bigwig.cwl",
+                    "in": [
+                        {
+                            "source": "#main/samtools_sort_index_after_rmdup/bam_bai_pair",
+                            "id": "#main/bam_to_bigwig/bam_file"
+                        },
+                        {
+                            "source": "#main/chrom_length",
+                            "id": "#main/bam_to_bigwig/chrom_length_file"
+                        },
+                        {
+                            "source": "#main/macs2_callpeak/macs2_fragments_calculated",
+                            "id": "#main/bam_to_bigwig/fragment_size"
+                        },
+                        {
+                            "source": "#main/get_stat/mapped_reads",
+                            "id": "#main/bam_to_bigwig/mapped_reads_number"
+                        }
+                    ],
+                    "out": [
+                        "#main/bam_to_bigwig/bigwig_file"
+                    ],
+                    "id": "#main/bam_to_bigwig"
+                },
+                {
+                    "run": "#bowtie-alignreads.cwl",
+                    "in": [
+                        {
+                            "default": true,
+                            "id": "#main/bowtie_aligner/best"
+                        },
+                        {
+                            "source": "#main/clip_3p_end",
+                            "id": "#main/bowtie_aligner/clip_3p_end"
+                        },
+                        {
+                            "source": "#main/clip_5p_end",
+                            "id": "#main/bowtie_aligner/clip_5p_end"
+                        },
+                        {
+                            "source": "#main/indices_folder",
+                            "id": "#main/bowtie_aligner/indices_folder"
+                        },
+                        {
+                            "default": 1,
+                            "id": "#main/bowtie_aligner/m"
+                        },
+                        {
+                            "default": true,
+                            "id": "#main/bowtie_aligner/q"
+                        },
+                        {
+                            "default": true,
+                            "id": "#main/bowtie_aligner/sam"
+                        },
+                        {
+                            "default": true,
+                            "id": "#main/bowtie_aligner/strata"
+                        },
+                        {
+                            "source": "#main/threads",
+                            "id": "#main/bowtie_aligner/threads"
+                        },
+                        {
+                            "source": "#main/extract_fastq/fastq_file",
+                            "id": "#main/bowtie_aligner/upstream_filelist"
+                        },
+                        {
+                            "default": 3,
+                            "id": "#main/bowtie_aligner/v"
+                        }
+                    ],
+                    "out": [
+                        "#main/bowtie_aligner/sam_file",
+                        "#main/bowtie_aligner/log_file"
+                    ],
+                    "id": "#main/bowtie_aligner"
+                },
+                {
+                    "run": "#extract-fastq.cwl",
+                    "in": [
+                        {
+                            "source": "#main/fastq_file",
+                            "id": "#main/extract_fastq/compressed_file"
+                        }
+                    ],
+                    "out": [
+                        "#main/extract_fastq/fastq_file"
+                    ],
+                    "id": "#main/extract_fastq"
+                },
+                {
+                    "run": "#fastx-quality-stats.cwl",
+                    "in": [
+                        {
+                            "source": "#main/extract_fastq/fastq_file",
+                            "id": "#main/fastx_quality_stats/input_file"
+                        }
+                    ],
+                    "out": [
+                        "#main/fastx_quality_stats/statistics_file"
+                    ],
+                    "id": "#main/fastx_quality_stats"
+                },
+                {
+                    "run": "#python-get-stat-chipseq.cwl",
+                    "in": [
+                        {
+                            "source": "#main/bowtie_aligner/log_file",
+                            "id": "#main/get_stat/bowtie_log"
+                        },
+                        {
+                            "source": "#main/samtools_rmdup/rmdup_log",
+                            "id": "#main/get_stat/rmdup_log"
+                        }
+                    ],
+                    "out": [
+                        "#main/get_stat/output_file",
+                        "#main/get_stat/mapped_reads"
+                    ],
+                    "id": "#main/get_stat"
+                },
+                {
+                    "run": "#iaintersect.cwl",
+                    "in": [
+                        {
+                            "source": "#main/annotation_file",
+                            "id": "#main/island_intersect/annotation_filename"
+                        },
+                        {
+                            "source": "#main/macs2_callpeak/peak_xls_file",
+                            "id": "#main/island_intersect/input_filename"
+                        },
+                        {
+                            "default": 1000,
+                            "id": "#main/island_intersect/promoter_bp"
+                        }
+                    ],
+                    "out": [
+                        "#main/island_intersect/result_file",
+                        "#main/island_intersect/log_file"
+                    ],
+                    "id": "#main/island_intersect"
+                },
+                {
+                    "run": "#macs2-callpeak-biowardrobe-only.cwl",
+                    "in": [
+                        {
+                            "source": "#main/broad_peak",
+                            "id": "#main/macs2_callpeak/broad"
+                        },
+                        {
+                            "default": 10000,
+                            "id": "#main/macs2_callpeak/buffer_size"
+                        },
+                        {
+                            "source": "#main/exp_fragment_size",
+                            "id": "#main/macs2_callpeak/bw"
+                        },
+                        {
+                            "source": "#main/broad_peak",
+                            "valueFrom": "$(!self)",
+                            "id": "#main/macs2_callpeak/call_summits"
+                        },
+                        {
+                            "source": "#main/control_file",
+                            "id": "#main/macs2_callpeak/control_file"
+                        },
+                        {
+                            "source": "#main/exp_fragment_size",
+                            "id": "#main/macs2_callpeak/extsize"
+                        },
+                        {
+                            "default": "BAM",
+                            "id": "#main/macs2_callpeak/format_mode"
+                        },
+                        {
+                            "source": "#main/genome_size",
+                            "id": "#main/macs2_callpeak/genome_size"
+                        },
+                        {
+                            "default": "auto",
+                            "id": "#main/macs2_callpeak/keep_dup"
+                        },
+                        {
+                            "default": "4 40",
+                            "id": "#main/macs2_callpeak/mfold"
+                        },
+                        {
+                            "source": "#main/control_file",
+                            "valueFrom": "$(!self)",
+                            "id": "#main/macs2_callpeak/nolambda"
+                        },
+                        {
+                            "source": "#main/force_fragment_size",
+                            "id": "#main/macs2_callpeak/nomodel"
+                        },
+                        {
+                            "default": 0.05,
+                            "id": "#main/macs2_callpeak/q_value"
+                        },
+                        {
+                            "source": "#main/samtools_sort_index_after_rmdup/bam_bai_pair",
+                            "id": "#main/macs2_callpeak/treatment_file"
+                        },
+                        {
+                            "default": 3,
+                            "id": "#main/macs2_callpeak/verbose"
+                        }
+                    ],
+                    "out": [
+                        "#main/macs2_callpeak/peak_xls_file",
+                        "#main/macs2_callpeak/narrow_peak_file",
+                        "#main/macs2_callpeak/peak_summits_file",
+                        "#main/macs2_callpeak/broad_peak_file",
+                        "#main/macs2_callpeak/moder_r_file",
+                        "#main/macs2_callpeak/gapped_peak_file",
+                        "#main/macs2_callpeak/treat_pileup_bdg_file",
+                        "#main/macs2_callpeak/control_lambda_bdg_file",
+                        "#main/macs2_callpeak/macs_log",
+                        "#main/macs2_callpeak/macs2_stat_file",
+                        "#main/macs2_callpeak/macs2_fragments_calculated"
+                    ],
+                    "id": "#main/macs2_callpeak"
+                },
+                {
+                    "run": "#samtools-rmdup.cwl",
+                    "in": [
+                        {
+                            "source": "#main/samtools_sort_index/bam_bai_pair",
+                            "id": "#main/samtools_rmdup/bam_file"
+                        },
+                        {
+                            "default": true,
+                            "id": "#main/samtools_rmdup/single_end"
+                        },
+                        {
+                            "source": "#main/remove_duplicates",
+                            "id": "#main/samtools_rmdup/trigger"
+                        }
+                    ],
+                    "out": [
+                        "#main/samtools_rmdup/rmdup_output",
+                        "#main/samtools_rmdup/rmdup_log"
+                    ],
+                    "id": "#main/samtools_rmdup"
+                },
+                {
+                    "run": "#samtools-sort-index.cwl",
+                    "in": [
+                        {
+                            "source": "#main/bowtie_aligner/sam_file",
+                            "id": "#main/samtools_sort_index/sort_input"
+                        },
+                        {
+                            "source": "#main/threads",
+                            "id": "#main/samtools_sort_index/threads"
+                        }
+                    ],
+                    "out": [
+                        "#main/samtools_sort_index/bam_bai_pair"
+                    ],
+                    "id": "#main/samtools_sort_index"
+                },
+                {
+                    "run": "#samtools-sort-index.cwl",
+                    "in": [
+                        {
+                            "source": "#main/samtools_rmdup/rmdup_output",
+                            "id": "#main/samtools_sort_index_after_rmdup/sort_input"
+                        },
+                        {
+                            "source": "#main/threads",
+                            "id": "#main/samtools_sort_index_after_rmdup/threads"
+                        },
+                        {
+                            "source": "#main/remove_duplicates",
+                            "id": "#main/samtools_sort_index_after_rmdup/trigger"
+                        }
+                    ],
+                    "out": [
+                        "#main/samtools_sort_index_after_rmdup/bam_bai_pair"
+                    ],
+                    "id": "#main/samtools_sort_index_after_rmdup"
+                }
+            ],
+            "doc": "The workflow is used to run CHIP-Seq basic analysis with single-end input FASTQ file.\nIn outputs it returns coordinate sorted BAM file alongside with index BAI file, quality\nstatistics of the input FASTQ file, reads coverage in a form of bigWig file, peaks calling\ndata in a form of narrowPeak or broadPeak files.\n",
+            "id": "#main",
+            "http://schema.org/name": "biowardrobe_chipseq_se",
+            "http://schema.org/downloadUrl": "https://raw.githubusercontent.com/Barski-lab/ga4gh_challenge/master/biowardrobe_chipseq_se.cwl",
+            "http://schema.org/codeRepository": "https://github.com/Barski-lab/ga4gh_challenge",
+            "http://schema.org/license": "http://www.apache.org/licenses/LICENSE-2.0",
+            "http://schema.org/isPartOf": {
+                "class": "http://schema.org/CreativeWork",
+                "http://schema.org/name": "Common Workflow Language",
+                "http://schema.org/url": "http://commonwl.org/"
+            },
+            "http://schema.org/creator": [
+                {
+                    "class": "http://schema.org/Organization",
+                    "http://schema.org/legalName": "Cincinnati Children's Hospital Medical Center",
+                    "http://schema.org/location": [
+                        {
+                            "class": "http://schema.org/PostalAddress",
+                            "http://schema.org/addressCountry": "USA",
+                            "http://schema.org/addressLocality": "Cincinnati",
+                            "http://schema.org/addressRegion": "OH",
+                            "http://schema.org/postalCode": "45229",
+                            "http://schema.org/streetAddress": "3333 Burnet Ave",
+                            "http://schema.org/telephone": "+1(513)636-4200"
+                        }
+                    ],
+                    "http://schema.org/logo": "https://www.cincinnatichildrens.org/-/media/cincinnati%20childrens/global%20shared/childrens-logo-new.png",
+                    "http://schema.org/department": [
+                        {
+                            "class": "http://schema.org/Organization",
+                            "http://schema.org/legalName": "Allergy and Immunology",
+                            "http://schema.org/department": [
+                                {
+                                    "class": "http://schema.org/Organization",
+                                    "http://schema.org/legalName": "Barski Research Lab",
+                                    "http://schema.org/member": [
+                                        {
+                                            "class": "http://schema.org/Person",
+                                            "http://schema.org/name": "Michael Kotliar",
+                                            "http://schema.org/email": "mailto:misha.kotliar@gmail.com",
+                                            "http://schema.org/sameAs": [
+                                                {
+                                                    "id": "#0000-0002-6486-3898"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "http://schema.org/about": "The workflow is a CWL version of a Python pipeline from BioWardrobe (Kartashov and Barski, 2015).\nIt starts by extracting input FASTQ file (in case it was compressed). Next step runs BowTie\n(Langmead et al., 2009) to perform alignment to a reference genome, resulting in an unsorted SAM file.\nThe SAM file is then sorted and indexed with samtools (Li et al., 2009) to obtain a BAM file and a BAI index.\nNext MACS2 (Zhang et al., 2008) is used to call peaks and to estimate fragment size. In the last few steps,\nthe coverage by estimated fragments is calculated from the BAM file and is reported in bigWig format. The pipeline\nalso reports statistics, such as read quality, peak number and base frequency, and other troubleshooting information\nusing tools such as fastx-toolkit and bamtools.",
+            "outputs": [
+                {
+                    "type": "File",
+                    "label": "ATDP log",
+                    "format": "http://edamontology.org/format_3475",
+                    "doc": "Average Tag Density generated log",
+                    "outputSource": "#main/average_tag_density/log_file",
+                    "id": "#main/atdp_log"
+                },
+                {
+                    "type": "File",
+                    "label": "ATDP results",
+                    "format": "http://edamontology.org/format_3475",
+                    "doc": "Average Tag Density generated results",
+                    "outputSource": "#main/average_tag_density/result_file",
+                    "id": "#main/atdp_result"
+                },
+                {
+                    "type": "File",
+                    "format": "http://edamontology.org/format_2572",
+                    "label": "Coordinate sorted BAM alignment file (+index BAI)",
+                    "doc": "Coordinate sorted BAM file and BAI index file",
+                    "outputSource": "#main/samtools_sort_index_after_rmdup/bam_bai_pair",
+                    "id": "#main/bambai_pair"
+                },
+                {
+                    "type": "File",
+                    "format": "http://edamontology.org/format_3006",
+                    "label": "BigWig file",
+                    "doc": "Generated BigWig file",
+                    "outputSource": "#main/bam_to_bigwig/bigwig_file",
+                    "id": "#main/bigwig"
+                },
+                {
+                    "type": "File",
+                    "label": "BOWTIE alignment log",
+                    "format": "http://edamontology.org/format_2330",
+                    "doc": "BOWTIE generated alignment log",
+                    "outputSource": "#main/bowtie_aligner/log_file",
+                    "id": "#main/bowtie_log"
+                },
+                {
+                    "type": "File",
+                    "label": "FASTQ statistics",
+                    "format": "http://edamontology.org/format_2330",
+                    "doc": "fastx_quality_stats generated FASTQ file quality statistics file",
+                    "outputSource": "#main/fastx_quality_stats/statistics_file",
+                    "id": "#main/fastx_statistics"
+                },
+                {
+                    "type": [
+                        "null",
+                        "File"
+                    ],
+                    "label": "Bowtie & Samtools Rmdup combined log",
+                    "format": "http://edamontology.org/format_2330",
+                    "doc": "Processed and combined Bowtie aligner and Samtools rmdup log",
+                    "outputSource": "#main/get_stat/output_file",
+                    "id": "#main/get_stat_log"
+                },
+                {
+                    "type": "File",
+                    "label": "Island intersect log",
+                    "format": "http://edamontology.org/format_3475",
+                    "doc": "Iaintersect generated log",
+                    "outputSource": "#main/island_intersect/log_file",
+                    "id": "#main/iaintersect_log"
+                },
+                {
+                    "type": "File",
+                    "label": "Island intersect results",
+                    "format": "http://edamontology.org/format_3475",
+                    "doc": "Iaintersect generated results",
+                    "outputSource": "#main/island_intersect/result_file",
+                    "id": "#main/iaintersect_result"
+                },
+                {
+                    "type": [
+                        "null",
+                        "File"
+                    ],
+                    "label": "Broad peaks",
+                    "format": "http://edamontology.org/format_3614",
+                    "doc": "Contains the peak locations together with peak summit, pvalue and qvalue",
+                    "outputSource": "#main/macs2_callpeak/broad_peak_file",
+                    "id": "#main/macs2_broad_peaks"
+                },
+                {
+                    "type": [
+                        "null",
+                        "File"
+                    ],
+                    "label": "Called peaks",
+                    "format": "http://edamontology.org/format_3468",
+                    "doc": "XLS file to include information about called peaks",
+                    "outputSource": "#main/macs2_callpeak/peak_xls_file",
+                    "id": "#main/macs2_called_peaks"
+                },
+                {
+                    "type": [
+                        "null",
+                        "File"
+                    ],
+                    "label": "FRAGMENT, FRAGMENTE, ISLANDS",
+                    "format": "http://edamontology.org/format_2330",
+                    "doc": "fragment, calculated fragment, islands count from MACS2 results",
+                    "outputSource": "#main/macs2_callpeak/macs2_stat_file",
+                    "id": "#main/macs2_fragment_stat"
+                },
+                {
+                    "type": [
+                        "null",
+                        "File"
+                    ],
+                    "label": "Gapped peak",
+                    "format": "http://edamontology.org/format_3586",
+                    "doc": "Contains both the broad region and narrow peaks",
+                    "outputSource": "#main/macs2_callpeak/gapped_peak_file",
+                    "id": "#main/macs2_gapped_peak"
+                },
+                {
+                    "type": [
+                        "null",
+                        "File"
+                    ],
+                    "label": "MACS2 log",
+                    "format": "http://edamontology.org/format_2330",
+                    "doc": "MACS2 output log",
+                    "outputSource": "#main/macs2_callpeak/macs_log",
+                    "id": "#main/macs2_log"
+                },
+                {
+                    "type": [
+                        "null",
+                        "File"
+                    ],
+                    "label": "MACS2 generated R script",
+                    "format": "http://edamontology.org/format_2330",
+                    "doc": "R script to produce a PDF image about the model based on your data",
+                    "outputSource": "#main/macs2_callpeak/moder_r_file",
+                    "id": "#main/macs2_moder_r"
+                },
+                {
+                    "type": [
+                        "null",
+                        "File"
+                    ],
+                    "label": "Narrow peaks",
+                    "format": "http://edamontology.org/format_3613",
+                    "doc": "Contains the peak locations together with peak summit, pvalue and qvalue",
+                    "outputSource": "#main/macs2_callpeak/narrow_peak_file",
+                    "id": "#main/macs2_narrow_peaks"
+                },
+                {
+                    "type": [
+                        "null",
+                        "File"
+                    ],
+                    "label": "Peak summits",
+                    "format": "http://edamontology.org/format_3003",
+                    "doc": "Contains the peak summits locations for every peaks",
+                    "outputSource": "#main/macs2_callpeak/peak_summits_file",
+                    "id": "#main/macs2_peak_summits"
+                },
+                {
+                    "type": "File",
+                    "label": "Remove duplicates log",
+                    "format": "http://edamontology.org/format_2330",
+                    "doc": "Samtools rmdup generated log",
+                    "outputSource": "#main/samtools_rmdup/rmdup_log",
+                    "id": "#main/samtools_rmdup_log"
+                }
+            ]
+        },
+        {
+            "class": "Workflow",
+            "requirements": [
+                {
+                    "class": "StepInputExpressionRequirement"
+                },
+                {
+                    "class": "InlineJavascriptRequirement"
+                }
+            ],
+            "inputs": [
+                {
+                    "type": "File",
+                    "label": "Input BAM file",
+                    "doc": "Input BAM file, sorted by coordinates",
+                    "id": "#bam-bedgraph-bigwig.cwl/bam_file"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "label": "bedGraph output filename",
+                    "doc": "Output filename for generated bedGraph",
+                    "id": "#bam-bedgraph-bigwig.cwl/bedgraph_filename"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "label": "bigWig output filename",
+                    "doc": "Output filename for generated bigWig",
+                    "id": "#bam-bedgraph-bigwig.cwl/bigwig_filename"
+                },
+                {
+                    "type": "File",
+                    "label": "Chromosome length file",
+                    "doc": "Tab delimited chromosome length file: <chromName><TAB><chromSize>",
+                    "id": "#bam-bedgraph-bigwig.cwl/chrom_length_file"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "label": "Enable dUTP",
+                    "doc": "Change strand af the mate read, so both reads come from the same strand",
+                    "id": "#bam-bedgraph-bigwig.cwl/dutp"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "label": "Fixed fragment size",
+                    "doc": "Set fixed fragment size for genome coverage calculation",
+                    "id": "#bam-bedgraph-bigwig.cwl/fragment_size"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "label": "Mapped reads number",
+                    "doc": "Parameter to calculate scale as 1000000/mapped_reads_number. Ignored by bedtools-genomecov.cwl in\nbam_to_bedgraph step if scale is provided\n",
+                    "id": "#bam-bedgraph-bigwig.cwl/mapped_reads_number"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "label": "Enable paired-end genome coverage calculation",
+                    "doc": "Enable paired-end genome coverage calculation",
+                    "id": "#bam-bedgraph-bigwig.cwl/pairchip"
+                },
+                {
+                    "type": [
+                        "null",
+                        "float"
+                    ],
+                    "label": "Genome coverage scaling coefficient",
+                    "doc": "Coefficient to scale the genome coverage by a constant factor",
+                    "id": "#bam-bedgraph-bigwig.cwl/scale"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "label": "Split reads by 'N' and 'D'",
+                    "doc": "Calculate genome coverage for each part of the splitted by 'N' and 'D' read",
+                    "id": "#bam-bedgraph-bigwig.cwl/split"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "label": "Enable strand specific genome coverage calculation",
+                    "doc": "Calculate genome coverage of intervals from a specific strand",
+                    "id": "#bam-bedgraph-bigwig.cwl/strand"
+                }
+            ],
+            "outputs": [
+                {
+                    "type": "File",
+                    "outputSource": "#bam-bedgraph-bigwig.cwl/sort_bedgraph/sorted_file",
+                    "label": "bedGraph output file",
+                    "doc": "bedGraph output file",
+                    "id": "#bam-bedgraph-bigwig.cwl/bedgraph_file"
+                },
+                {
+                    "type": "File",
+                    "outputSource": "#bam-bedgraph-bigwig.cwl/sorted_bedgraph_to_bigwig/bigwig_file",
+                    "label": "bigWig output file",
+                    "doc": "bigWig output file",
+                    "id": "#bam-bedgraph-bigwig.cwl/bigwig_file"
+                }
+            ],
+            "steps": [
+                {
+                    "run": "#bedtools-genomecov.cwl",
+                    "in": [
+                        {
+                            "default": "-bg",
+                            "id": "#bam-bedgraph-bigwig.cwl/bam_to_bedgraph/depth"
+                        },
+                        {
+                            "source": "#bam-bedgraph-bigwig.cwl/dutp",
+                            "id": "#bam-bedgraph-bigwig.cwl/bam_to_bedgraph/du"
+                        },
+                        {
+                            "source": "#bam-bedgraph-bigwig.cwl/fragment_size",
+                            "id": "#bam-bedgraph-bigwig.cwl/bam_to_bedgraph/fragment_size"
+                        },
+                        {
+                            "source": "#bam-bedgraph-bigwig.cwl/bam_file",
+                            "id": "#bam-bedgraph-bigwig.cwl/bam_to_bedgraph/input_file"
+                        },
+                        {
+                            "source": "#bam-bedgraph-bigwig.cwl/mapped_reads_number",
+                            "id": "#bam-bedgraph-bigwig.cwl/bam_to_bedgraph/mapped_reads_number"
+                        },
+                        {
+                            "source": "#bam-bedgraph-bigwig.cwl/bedgraph_filename",
+                            "id": "#bam-bedgraph-bigwig.cwl/bam_to_bedgraph/output_filename"
+                        },
+                        {
+                            "source": "#bam-bedgraph-bigwig.cwl/pairchip",
+                            "id": "#bam-bedgraph-bigwig.cwl/bam_to_bedgraph/pairchip"
+                        },
+                        {
+                            "source": "#bam-bedgraph-bigwig.cwl/scale",
+                            "id": "#bam-bedgraph-bigwig.cwl/bam_to_bedgraph/scale"
+                        },
+                        {
+                            "source": "#bam-bedgraph-bigwig.cwl/split",
+                            "default": true,
+                            "id": "#bam-bedgraph-bigwig.cwl/bam_to_bedgraph/split"
+                        },
+                        {
+                            "source": "#bam-bedgraph-bigwig.cwl/strand",
+                            "id": "#bam-bedgraph-bigwig.cwl/bam_to_bedgraph/strand"
+                        }
+                    ],
+                    "out": [
+                        "#bam-bedgraph-bigwig.cwl/bam_to_bedgraph/genome_coverage_file"
+                    ],
+                    "id": "#bam-bedgraph-bigwig.cwl/bam_to_bedgraph"
+                },
+                {
+                    "run": "#linux-sort.cwl",
+                    "in": [
+                        {
+                            "default": [
+                                "1,1",
+                                "2,2n"
+                            ],
+                            "id": "#bam-bedgraph-bigwig.cwl/sort_bedgraph/key"
+                        },
+                        {
+                            "source": "#bam-bedgraph-bigwig.cwl/bam_to_bedgraph/genome_coverage_file",
+                            "id": "#bam-bedgraph-bigwig.cwl/sort_bedgraph/unsorted_file"
+                        }
+                    ],
+                    "out": [
+                        "#bam-bedgraph-bigwig.cwl/sort_bedgraph/sorted_file"
+                    ],
+                    "id": "#bam-bedgraph-bigwig.cwl/sort_bedgraph"
+                },
+                {
+                    "run": "#ucsc-bedgraphtobigwig.cwl",
+                    "in": [
+                        {
+                            "source": "#bam-bedgraph-bigwig.cwl/sort_bedgraph/sorted_file",
+                            "id": "#bam-bedgraph-bigwig.cwl/sorted_bedgraph_to_bigwig/bedgraph_file"
+                        },
+                        {
+                            "source": "#bam-bedgraph-bigwig.cwl/chrom_length_file",
+                            "id": "#bam-bedgraph-bigwig.cwl/sorted_bedgraph_to_bigwig/chrom_length_file"
+                        },
+                        {
+                            "source": "#bam-bedgraph-bigwig.cwl/bigwig_filename",
+                            "id": "#bam-bedgraph-bigwig.cwl/sorted_bedgraph_to_bigwig/output_filename"
+                        }
+                    ],
+                    "out": [
+                        "#bam-bedgraph-bigwig.cwl/sorted_bedgraph_to_bigwig/bigwig_file"
+                    ],
+                    "id": "#bam-bedgraph-bigwig.cwl/sorted_bedgraph_to_bigwig"
+                }
+            ],
+            "id": "#bam-bedgraph-bigwig.cwl"
+        },
+        {
+            "class": "CommandLineTool",
+            "requirements": [
+                {
+                    "class": "InlineJavascriptRequirement",
+                    "expressionLib": [
+                        "var default_output_filename = function(ext) { let root = inputs.input_file.basename.split('.').slice(0,-1).join('.'); return (root == \"\")?inputs.input_file.basename+ext:root+ext; };"
+                    ]
+                },
+                {
+                    "class": "InitialWorkDirRequirement",
+                    "listing": "${\n  return  [\n            {\n              \"entry\": inputs.annotation_filename,\n              \"entryname\": inputs.annotation_filename.basename,\n              \"writable\": true\n            }\n          ]\n}\n"
+                }
+            ],
+            "hints": [
+                {
+                    "class": "DockerRequirement",
+                    "dockerPull": "biowardrobe2/atdp:v0.0.1"
+                }
+            ],
+            "inputs": [
+                {
+                    "type": [
+                        "File"
+                    ],
+                    "inputBinding": {
+                        "position": 3,
+                        "prefix": "--a=",
+                        "separate": false
+                    },
+                    "doc": "Annotation file, tsv\n",
+                    "id": "#atdp.cwl/annotation_filename"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 11,
+                        "prefix": "--avd_heat_window=",
+                        "separate": false
+                    },
+                    "doc": "Average tag density window for heatmap\n",
+                    "id": "#atdp.cwl/avd_heat_window_bp"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 8,
+                        "prefix": "--avd_smooth=",
+                        "separate": false
+                    },
+                    "doc": "Average smooth window (odd), int [0]\n",
+                    "id": "#atdp.cwl/avd_smooth_bp"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 7,
+                        "prefix": "--avd_window=",
+                        "separate": false
+                    },
+                    "doc": "Average tag density window, int [5000]\n",
+                    "id": "#atdp.cwl/avd_window_bp"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "inputBinding": {
+                        "position": 10,
+                        "prefix": "--sam_twicechr=",
+                        "separate": false
+                    },
+                    "doc": "The chromosomes to be doubled, string\n",
+                    "id": "#atdp.cwl/double_chr"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 6,
+                        "prefix": "--f=",
+                        "separate": false
+                    },
+                    "doc": "Fragmentsize, int [150]\n",
+                    "id": "#atdp.cwl/fragmentsize_bp"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "inputBinding": {
+                        "position": 9,
+                        "prefix": "--sam_ignorechr=",
+                        "separate": false
+                    },
+                    "doc": "The chromosomes to be ignored, string\n",
+                    "id": "#atdp.cwl/ignore_chr"
+                },
+                {
+                    "type": [
+                        "null",
+                        "File"
+                    ],
+                    "inputBinding": {
+                        "position": 13,
+                        "prefix": "--index=",
+                        "separate": false
+                    },
+                    "doc": "Index file\n",
+                    "id": "#atdp.cwl/index_file"
+                },
+                {
+                    "type": [
+                        "File"
+                    ],
+                    "inputBinding": {
+                        "position": 2,
+                        "prefix": "--in=",
+                        "separate": false
+                    },
+                    "doc": "Input indexed BAM file (optionally +BAI index file in secondaryFiles)\n",
+                    "id": "#atdp.cwl/input_file"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "inputBinding": {
+                        "position": 5,
+                        "prefix": "--log=",
+                        "separate": false,
+                        "valueFrom": "${\n    if (self == \"\"){\n      return default_output_filename('_atdp.log');\n    } else {\n      return self;\n    }\n}\n"
+                    },
+                    "default": "",
+                    "doc": "Log filename\n",
+                    "id": "#atdp.cwl/log_filename"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 12,
+                        "prefix": "--m=",
+                        "separate": false
+                    },
+                    "doc": "Mapped reads number\n",
+                    "id": "#atdp.cwl/mapped_reads"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "inputBinding": {
+                        "position": 4,
+                        "prefix": "--out=",
+                        "separate": false,
+                        "valueFrom": "${\n    if (self == \"\"){\n      return default_output_filename('_atdp.tsv');\n    } else {\n      return self;\n    }\n}\n"
+                    },
+                    "default": "",
+                    "doc": "Base output file name, tsv\n",
+                    "id": "#atdp.cwl/output_filename"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "default": "#!/bin/bash\nset -- \"$0\" \"$@\"\necho \"Original arguments:\"\nfor i in \"$@\";\n    do echo $i;\ndone;\nset -- \"$1\" --a=$(basename \"${2:4}\") \"${@:3}\"\necho Updated arguments:\nfor i in \"$@\";\n    do echo $i;\ndone;\nrefgene-sort -i \"${2:4}\" -o \"${2:4}\" -s \"ORDER BY chrom, strand, CASE strand WHEN '+' THEN txStart WHEN '-' THEN txEnd END\"\natdp \"$@\"\n",
+                    "inputBinding": {
+                        "position": 1
+                    },
+                    "doc": "Bash function to run samtools sort with all input parameters or skip it if trigger is false\n",
+                    "id": "#atdp.cwl/script"
+                }
+            ],
+            "outputs": [
+                {
+                    "type": "File",
+                    "outputBinding": {
+                        "glob": "${\n  if (inputs.log_filename == \"\"){\n    return default_output_filename('_atdp.log');\n  } else {\n    return inputs.log_filename;\n  }\n}\n"
+                    },
+                    "id": "#atdp.cwl/log_file"
+                },
+                {
+                    "type": "File",
+                    "outputBinding": {
+                        "glob": "${\n  if (inputs.output_filename == \"\"){\n    return default_output_filename('_atdp.tsv');\n  } else {\n    return inputs.output_filename;\n  }\n}\n"
+                    },
+                    "id": "#atdp.cwl/result_file"
+                }
+            ],
+            "baseCommand": [
+                "bash",
+                "-c"
+            ],
+            "id": "#atdp.cwl"
+        },
+        {
+            "class": "CommandLineTool",
+            "requirements": [
+                {
+                    "class": "InlineJavascriptRequirement",
+                    "expressionLib": [
+                        "var default_output_filename = function() { let ext = (inputs.depth == \"-bg\" || inputs.depth == \"-bga\")?\".bedGraph\":\".tab\"; return inputs.input_file.location.split('/').slice(-1)[0].split('.').slice(0,-1).join('.') + ext; };"
+                    ]
+                }
+            ],
+            "hints": [
+                {
+                    "class": "DockerRequirement",
+                    "dockerPull": "biowardrobe2/bedtools2:v2.26.0"
+                }
+            ],
+            "inputs": [
+                {
+                    "type": [
+                        "null",
+                        "File"
+                    ],
+                    "inputBinding": {
+                        "position": 17,
+                        "prefix": "-g"
+                    },
+                    "doc": "Input genome file. Needed only when -i flag. The genome file is tab delimited <chromName><TAB><chromSize>\n",
+                    "id": "#bedtools-genomecov.cwl/chrom_length_file"
+                },
+                {
+                    "type": [
+                        "null",
+                        {
+                            "type": "enum",
+                            "name": "#bedtools-genomecov.cwl/depth/depth",
+                            "symbols": [
+                                "#bedtools-genomecov.cwl/depth/depth/-bg",
+                                "#bedtools-genomecov.cwl/depth/depth/-bga",
+                                "#bedtools-genomecov.cwl/depth/depth/-d",
+                                "#bedtools-genomecov.cwl/depth/depth/-dz"
+                            ]
+                        }
+                    ],
+                    "inputBinding": {
+                        "position": 5
+                    },
+                    "doc": "Report the depth type. By default, bedtools genomecov will compute a histogram of coverage\nfor the genome file provided (intputs.chrom_length_file)\n",
+                    "id": "#bedtools-genomecov.cwl/depth"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 11,
+                        "prefix": "-du"
+                    },
+                    "doc": "Change strand af the mate read (so both reads from the same strand) useful for strand specific.\nWorks for BAM files only\n",
+                    "id": "#bedtools-genomecov.cwl/du"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 12,
+                        "prefix": "-fs"
+                    },
+                    "doc": "Set fixed fragment size\n",
+                    "id": "#bedtools-genomecov.cwl/fragment_size"
+                },
+                {
+                    "type": "File",
+                    "inputBinding": {
+                        "position": 16,
+                        "valueFrom": "${\n  var prefix = ((/.*\\.bam$/i).test(inputs.input_file.path))?'-ibam':'-i';\n  return [prefix, inputs.input_file.path];\n}\n"
+                    },
+                    "doc": "The input file can be in BAM format (Note: BAM must be sorted by position) or <bed/gff/vcf>.\nPrefix is selected on the base of input file extension\n",
+                    "id": "#bedtools-genomecov.cwl/input_file"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 15,
+                        "prefix": "-3"
+                    },
+                    "doc": "Calculate coverage of 3\" positions (instead of entire interval)\n",
+                    "id": "#bedtools-genomecov.cwl/m3"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 14,
+                        "prefix": "-5"
+                    },
+                    "doc": "Calculate coverage of 5\" positions (instead of entire interval)\n",
+                    "id": "#bedtools-genomecov.cwl/m5"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 7,
+                        "prefix": "-scale",
+                        "valueFrom": "${\n  if (inputs.scale){\n    return null;\n  } else if (inputs.mapped_reads_number) {\n    return 1000000/inputs.mapped_reads_number;\n  } else {\n    return null;\n  }\n}\n"
+                    },
+                    "doc": "Optional parameter to calculate scale as 1000000/mapped_reads_number if inputs.scale is not provided\n",
+                    "id": "#bedtools-genomecov.cwl/mapped_reads_number"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 13,
+                        "prefix": "-max"
+                    },
+                    "doc": "Combine all positions with a depth >= max into\na single bin in the histogram. Irrelevant\nfor -d and -bedGraph\n- (INTEGER)\n",
+                    "id": "#bedtools-genomecov.cwl/max"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "doc": "Name for generated output file\n",
+                    "id": "#bedtools-genomecov.cwl/output_filename"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 10,
+                        "prefix": "-pc"
+                    },
+                    "doc": "pair-end chip seq experiment\n",
+                    "id": "#bedtools-genomecov.cwl/pairchip"
+                },
+                {
+                    "type": [
+                        "null",
+                        "float"
+                    ],
+                    "inputBinding": {
+                        "position": 6,
+                        "prefix": "-scale"
+                    },
+                    "doc": "Scale the coverage by a constant factor.\nEach coverage value is multiplied by this factor before being reported.\nUseful for normalizing coverage by, e.g., reads per million (RPM).\n- Default is 1.0; i.e., unscaled.\n- (FLOAT)\n",
+                    "id": "#bedtools-genomecov.cwl/scale"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 8,
+                        "prefix": "-split"
+                    },
+                    "doc": "treat \"split\" BAM or BED12 entries as distinct BED intervals.\nwhen computing coverage.\nFor BAM files, this uses the CIGAR \"N\" and \"D\" operations\nto infer the blocks for computing coverage.\nFor BED12 files, this uses the BlockCount, BlockStarts, and BlockEnds\nfields (i.e., columns 10,11,12).\n",
+                    "id": "#bedtools-genomecov.cwl/split"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "inputBinding": {
+                        "position": 9,
+                        "prefix": "-strand"
+                    },
+                    "doc": "Calculate coverage of intervals from a specific strand.\nWith BED files, requires at least 6 columns (strand is column 6).\n- (STRING): can be + or -\n",
+                    "id": "#bedtools-genomecov.cwl/strand"
+                }
+            ],
+            "outputs": [
+                {
+                    "type": "File",
+                    "outputBinding": {
+                        "glob": "${\n  if (inputs.output_filename == null){\n    return default_output_filename();\n  } else {\n    return inputs.output_filename;\n  }\n}\n"
+                    },
+                    "doc": "Generated genome coverage output file\n",
+                    "id": "#bedtools-genomecov.cwl/genome_coverage_file"
+                }
+            ],
+            "stdout": "${\n  if (inputs.output_filename == null){\n    return default_output_filename();\n  } else {\n    return inputs.output_filename;\n  }\n}\n",
+            "baseCommand": [
+                "bedtools",
+                "genomecov"
+            ],
+            "id": "#bedtools-genomecov.cwl"
+        },
+        {
+            "class": "CommandLineTool",
+            "requirements": [
+                {
+                    "class": "ShellCommandRequirement"
+                },
+                {
+                    "class": "InlineJavascriptRequirement",
+                    "expressionLib": [
+                        "var default_output_filename = function(ext) { if (inputs.output_filename != \"\" && !ext){ return inputs.output_filename; } ext = ext || \".sam\"; let root = \"\"; if (inputs.output_filename != \"\"){ root = inputs.output_filename.split('.').slice(0,-1).join('.'); return (root == \"\")?inputs.output_filename+ext:root+ext; } else if (Array.isArray(inputs.upstream_filelist) && inputs.upstream_filelist.length > 0){ root = inputs.upstream_filelist[0].basename.split('.').slice(0,-1).join('.'); return (root == \"\")?inputs.upstream_filelist[0].basename+ext:root+ext; } else if (inputs.upstream_filelist != null){ root = inputs.upstream_filelist.basename.split('.').slice(0,-1).join('.'); return (root == \"\")?inputs.upstream_filelist.basename+ext:root+ext; } else if (Array.isArray(inputs.downstream_filelist) && inputs.downstream_filelist.length > 0){ root = inputs.downstream_filelist[0].basename.split('.').slice(0,-1).join('.'); return (root == \"\")?inputs.downstream_filelist[0].basename+ext:root+ext; } else if (inputs.downstream_filelist != null){ root = inputs.downstream_filelist.basename.split('.').slice(0,-1).join('.'); return (root == \"\")?inputs.downstream_filelist.basename+ext:root+ext; } else if (Array.isArray(inputs.crossbow_filelist) && inputs.crossbow_filelist.length > 0){ root = inputs.crossbow_filelist[0].basename.split('.').slice(0,-1).join('.'); return (root == \"\")?inputs.crossbow_filelist[0].basename+ext:root+ext; } else if (inputs.crossbow_filelist != null){ root = inputs.crossbow_filelist.basename.split('.').slice(0,-1).join('.'); return (root == \"\")?inputs.crossbow_filelist.basename+ext:root+ext; } else { return null; } };"
+                    ]
+                }
+            ],
+            "hints": [
+                {
+                    "class": "DockerRequirement",
+                    "dockerPull": "biowardrobe2/bowtie:v1.2.0"
+                }
+            ],
+            "inputs": [
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "-B"
+                    },
+                    "doc": "--offbase <int> leftmost ref offset = <int> in bowtie output (default: 0)\n",
+                    "id": "#bowtie-alignreads.cwl/B"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "-C"
+                    },
+                    "doc": "reads and index are in colorspace\n",
+                    "id": "#bowtie-alignreads.cwl/C"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "-I"
+                    },
+                    "doc": "--minins <int>  minimum insert size for paired-end alignment (default: 0)\n",
+                    "id": "#bowtie-alignreads.cwl/I"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "-M"
+                    },
+                    "doc": "<int> like -m, but reports 1 random hit (MAPQ=0)\n",
+                    "id": "#bowtie-alignreads.cwl/M"
+                },
+                {
+                    "type": [
+                        "null",
+                        "File"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "-Q"
+                    },
+                    "doc": "QV file(s) corresponding to CSFASTA inputs; use with -f -C\n",
+                    "id": "#bowtie-alignreads.cwl/Q"
+                },
+                {
+                    "type": [
+                        "null",
+                        "File"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--Q1"
+                    },
+                    "doc": "--Q1/--Q2 <file>   same as -Q, but for mate files 1 and 2 respectively\n",
+                    "id": "#bowtie-alignreads.cwl/Q1"
+                },
+                {
+                    "type": [
+                        "null",
+                        "File"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--Q2"
+                    },
+                    "doc": "--Q1/--Q2 <file>   same as -Q, but for mate files 1 and 2 respectively\n",
+                    "id": "#bowtie-alignreads.cwl/Q2"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "-X"
+                    },
+                    "doc": "--maxins <int>  maximum insert size for paired-end alignment (default: 250)\n",
+                    "id": "#bowtie-alignreads.cwl/X"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "-a"
+                    },
+                    "doc": "--all           report all alignments per read (much slower than low -k)\n",
+                    "id": "#bowtie-alignreads.cwl/a"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--al"
+                    },
+                    "doc": "<fname>       write aligned reads/pairs to file(s) <fname>\n",
+                    "id": "#bowtie-alignreads.cwl/al"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--best"
+                    },
+                    "doc": "hits guaranteed best stratum; ties broken by quality\n",
+                    "id": "#bowtie-alignreads.cwl/best"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "-c"
+                    },
+                    "doc": "query sequences given on cmd line (as <mates>, <singles>)\n",
+                    "id": "#bowtie-alignreads.cwl/c"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--chunkmbs"
+                    },
+                    "doc": "<int>   max megabytes of RAM for best-first search frames (def: 64)\n",
+                    "id": "#bowtie-alignreads.cwl/chunkmbs"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "-3"
+                    },
+                    "doc": "--trim3 <int>   trim <int> bases from 3' (right) end of reads\n",
+                    "id": "#bowtie-alignreads.cwl/clip_3p_end"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "-5"
+                    },
+                    "doc": "--trim5 <int>   trim <int> bases from 5' (left) end of reads\n",
+                    "id": "#bowtie-alignreads.cwl/clip_5p_end"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--col-cqual"
+                    },
+                    "doc": "print original colorspace quals, not decoded quals\n",
+                    "id": "#bowtie-alignreads.cwl/col_cqual"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--col-cseq"
+                    },
+                    "doc": "print aligned colorspace seqs as colors, not decoded bases\n",
+                    "id": "#bowtie-alignreads.cwl/col_cseq"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--col-keepends"
+                    },
+                    "doc": "keep nucleotides at extreme ends of decoded alignment\n",
+                    "id": "#bowtie-alignreads.cwl/col_keepends"
+                },
+                {
+                    "type": [
+                        "null",
+                        "File",
+                        {
+                            "type": "array",
+                            "items": "File"
+                        }
+                    ],
+                    "inputBinding": {
+                        "itemSeparator": ",",
+                        "position": 86,
+                        "prefix": "-12"
+                    },
+                    "doc": "Comma-separated list of files containing Crossbow-style reads.\nCan be a mixture of paired and unpaired.  Specify \"-\"for stdin.\n",
+                    "id": "#bowtie-alignreads.cwl/crossbow_filelist"
+                },
+                {
+                    "type": [
+                        "null",
+                        "File",
+                        {
+                            "type": "array",
+                            "items": "File"
+                        }
+                    ],
+                    "inputBinding": {
+                        "itemSeparator": ",",
+                        "position": 85
+                    },
+                    "doc": "Comma-separated list of files containing downstream mates (or the\nsequences themselves if -c is set) paired with mates in <m1>\n",
+                    "id": "#bowtie-alignreads.cwl/downstream_filelist"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "-e"
+                    },
+                    "doc": "--maqerr <int>  max sum of mismatch quals across alignment for -n (def: 70)\n",
+                    "id": "#bowtie-alignreads.cwl/e"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "-f"
+                    },
+                    "doc": "query input files are (multi-)FASTA .fa/.mfa\n",
+                    "id": "#bowtie-alignreads.cwl/f"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--ff"
+                    },
+                    "doc": "--fr/--rf/--ff     -1, -2 mates align fw/rev, rev/fw, fw/fw (default: --fr)\n",
+                    "id": "#bowtie-alignreads.cwl/ff"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--fr"
+                    },
+                    "doc": "--fr/--rf/--ff     -1, -2 mates align fw/rev, rev/fw, fw/fw (default: --fr)\n",
+                    "id": "#bowtie-alignreads.cwl/fr"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--fullref"
+                    },
+                    "doc": "write entire ref name (default: only up to 1st space)\n",
+                    "id": "#bowtie-alignreads.cwl/fullref"
+                },
+                {
+                    "type": "Directory",
+                    "inputBinding": {
+                        "position": 81,
+                        "valueFrom": "${\n    for (var i = 0; i < self.listing.length; i++) {\n        if (self.listing[i].path.split('.').slice(-3).join('.') == 'rev.1.ebwt' ||\n            self.listing[i].path.split('.').slice(-3).join('.') == 'rev.1.ebwtl'){\n          return self.listing[i].path.split('.').slice(0,-3).join('.');\n        }\n    }\n    return null;\n}\n"
+                    },
+                    "doc": "Folder with Bowtie indices\n",
+                    "id": "#bowtie-alignreads.cwl/indices_folder"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--integer-quals"
+                    },
+                    "doc": "qualities are given as space-separated integers (not ASCII)\n",
+                    "id": "#bowtie-alignreads.cwl/integer_quals"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "-k"
+                    },
+                    "doc": "<int>           report up to <int> good alignments per read (default: 1)\n",
+                    "id": "#bowtie-alignreads.cwl/k"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "-l"
+                    },
+                    "doc": "--seedlen <int> seed length for -n (default: 28)\n",
+                    "id": "#bowtie-alignreads.cwl/l"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--large-index"
+                    },
+                    "doc": "force usage of a 'large' index, even if a small one is present\n",
+                    "id": "#bowtie-alignreads.cwl/large_index"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "-m"
+                    },
+                    "doc": "<int>           suppress all alignments if > <int> exist (def: no limit)\n",
+                    "id": "#bowtie-alignreads.cwl/m"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--mapq"
+                    },
+                    "doc": "<int>       default mapping quality (MAPQ) to print for SAM alignments\n",
+                    "id": "#bowtie-alignreads.cwl/mapq"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--max"
+                    },
+                    "doc": "<fname>      write reads/pairs over -m limit to file(s) <fname>\n",
+                    "id": "#bowtie-alignreads.cwl/max"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--maxbts"
+                    },
+                    "doc": "<int>     max # backtracks for -n 2/3 (default: 125, 800 for --best)\n",
+                    "id": "#bowtie-alignreads.cwl/maxbts"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--mm"
+                    },
+                    "doc": "use memory-mapped I/O for index; many 'bowtie's can share\n",
+                    "id": "#bowtie-alignreads.cwl/mm"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "-n"
+                    },
+                    "doc": "--seedmms <int> max mismatches in seed (can be 0-3, default: -n 2)\n",
+                    "id": "#bowtie-alignreads.cwl/n"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--nofw"
+                    },
+                    "doc": "--norc      do not align to forward/reverse-complement reference strand\n",
+                    "id": "#bowtie-alignreads.cwl/nofw"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--nomaqround"
+                    },
+                    "doc": "disable Maq-like quality rounding for -n (nearest 10 <= 30)\n",
+                    "id": "#bowtie-alignreads.cwl/nomaqround"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "-o"
+                    },
+                    "doc": "--offrate <int> override offrate of index; must be >= index's offrate\n",
+                    "id": "#bowtie-alignreads.cwl/o"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "inputBinding": {
+                        "position": 90,
+                        "valueFrom": "$(default_output_filename())"
+                    },
+                    "default": "",
+                    "doc": "Generates default output filename on the base of upstream_filelist/downstream_filelist files\n",
+                    "id": "#bowtie-alignreads.cwl/output_filename"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--pairtries"
+                    },
+                    "doc": "<int>  max # attempts to find mate for anchor hit (default: 100)\n",
+                    "id": "#bowtie-alignreads.cwl/pairtries"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--phred33-quals"
+                    },
+                    "doc": "input quals are Phred+33 (default)\n",
+                    "id": "#bowtie-alignreads.cwl/phred33_quals"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--phred64-quals"
+                    },
+                    "doc": "input quals are Phred+64 (same as --solexa1.3-quals)\n",
+                    "id": "#bowtie-alignreads.cwl/phred64_quals"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "-q"
+                    },
+                    "doc": "query input files are FASTQ .fq/.fastq (default)\n",
+                    "id": "#bowtie-alignreads.cwl/q"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--quiet"
+                    },
+                    "doc": "print nothing but the alignments\n",
+                    "id": "#bowtie-alignreads.cwl/quiet"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "-r"
+                    },
+                    "doc": "query input files are raw one-sequence-per-line\n",
+                    "id": "#bowtie-alignreads.cwl/r"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--reads-per-batch"
+                    },
+                    "doc": "# of reads to read from input file at once (default: 16)\n",
+                    "id": "#bowtie-alignreads.cwl/reads_per_batch"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--refidx"
+                    },
+                    "doc": "refer to ref. seqs by 0-based index rather than name\n",
+                    "id": "#bowtie-alignreads.cwl/refidx"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--refout"
+                    },
+                    "doc": "write alignments to files refXXXXX.map, 1 map per reference\n",
+                    "id": "#bowtie-alignreads.cwl/refout"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--rf"
+                    },
+                    "doc": "--fr/--rf/--ff     -1, -2 mates align fw/rev, rev/fw, fw/fw (default: --fr)\n",
+                    "id": "#bowtie-alignreads.cwl/rf"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "-s"
+                    },
+                    "doc": "--skip <int>    skip the first <int> reads/pairs in the input\n",
+                    "id": "#bowtie-alignreads.cwl/s"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "-S"
+                    },
+                    "doc": "--sam write hits in SAM format\n",
+                    "id": "#bowtie-alignreads.cwl/sam"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--sam-RG"
+                    },
+                    "doc": "<text>    add <text> (usually \"lab=value\") to @RG line of SAM header\n",
+                    "id": "#bowtie-alignreads.cwl/sam_RG"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--sam-nohead"
+                    },
+                    "doc": "supppress header lines (starting with @) for SAM output\n",
+                    "id": "#bowtie-alignreads.cwl/sam_nohead"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--sam-nosq"
+                    },
+                    "doc": "supppress @SQ header lines for SAM output\n",
+                    "id": "#bowtie-alignreads.cwl/sam_nosq"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--seed"
+                    },
+                    "doc": "<int>       seed for random number generator\n",
+                    "id": "#bowtie-alignreads.cwl/seed"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--shmem"
+                    },
+                    "doc": "use shared mem for index\n",
+                    "id": "#bowtie-alignreads.cwl/shmem"
+                },
+                {
+                    "type": [
+                        "null",
+                        "float"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--snpfrac"
+                    },
+                    "doc": "<dec>    approx. fraction of SNP bases (e.g. 0.001); sets --snpphred\n",
+                    "id": "#bowtie-alignreads.cwl/snpfrac"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--snpphred"
+                    },
+                    "doc": "<int>   Phred penalty for SNP when decoding colorspace (def: 30)\n",
+                    "id": "#bowtie-alignreads.cwl/snpphred"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--solexa1.3-quals"
+                    },
+                    "doc": "input quals are from GA Pipeline ver. >= 1.3\n",
+                    "id": "#bowtie-alignreads.cwl/solexa1.3_quals"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--solexa-quals"
+                    },
+                    "doc": "input quals are from GA Pipeline ver. < 1.3\n",
+                    "id": "#bowtie-alignreads.cwl/solexa_quals"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--strata"
+                    },
+                    "doc": "hits in sub-optimal strata aren't reported (requires --best)\n",
+                    "id": "#bowtie-alignreads.cwl/strata"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--suppress"
+                    },
+                    "doc": "<cols>  suppresses given columns (comma-delim'ed) in default output\n",
+                    "id": "#bowtie-alignreads.cwl/suppress"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "-t"
+                    },
+                    "doc": "--time          print wall-clock time taken by search phases\n",
+                    "id": "#bowtie-alignreads.cwl/t"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "-p"
+                    },
+                    "doc": "--threads <int> number of alignment threads to launch (default: 1)\n",
+                    "id": "#bowtie-alignreads.cwl/threads"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "-u"
+                    },
+                    "doc": "--qupto <int>   stop after first <int> reads/pairs (excl. skipped reads)\n",
+                    "id": "#bowtie-alignreads.cwl/u"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--un"
+                    },
+                    "doc": "<fname>       write unaligned reads/pairs to file(s) <fname>\n",
+                    "id": "#bowtie-alignreads.cwl/un"
+                },
+                {
+                    "type": [
+                        "null",
+                        "File",
+                        {
+                            "type": "array",
+                            "items": "File"
+                        }
+                    ],
+                    "inputBinding": {
+                        "itemSeparator": ",",
+                        "position": 83
+                    },
+                    "doc": "Comma-separated list of files containing upstream mates (or the\nsequences themselves, if -c is set) paired with mates in <m2>\n",
+                    "id": "#bowtie-alignreads.cwl/upstream_filelist"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "-v"
+                    },
+                    "doc": "report end-to-end hits w/ <=v mismatches; ignore qualities\n",
+                    "id": "#bowtie-alignreads.cwl/v"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--verbose"
+                    },
+                    "doc": "verbose output (for debugging)\n",
+                    "id": "#bowtie-alignreads.cwl/verbose"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "-y"
+                    },
+                    "doc": "--tryhard try hard to find valid alignments, at the expense of speed\n",
+                    "id": "#bowtie-alignreads.cwl/y"
+                }
+            ],
+            "outputs": [
+                {
+                    "type": [
+                        "null",
+                        "File"
+                    ],
+                    "outputBinding": {
+                        "glob": "$(inputs.al)"
+                    },
+                    "id": "#bowtie-alignreads.cwl/aligned_file"
+                },
+                {
+                    "type": "File",
+                    "outputBinding": {
+                        "glob": "$(default_output_filename(\".bw\"))"
+                    },
+                    "id": "#bowtie-alignreads.cwl/log_file"
+                },
+                {
+                    "type": "int",
+                    "outputBinding": {
+                        "loadContents": true,
+                        "glob": "$(default_output_filename(\".bw\"))",
+                        "outputEval": "${\n  let mappedRegex = /alignment\\:.*/;\n  return parseInt(self[0].contents.match(mappedRegex)[0].split(\" \")[1]);\n}\n"
+                    },
+                    "id": "#bowtie-alignreads.cwl/mapped_reads_number"
+                },
+                {
+                    "type": [
+                        "null",
+                        "File"
+                    ],
+                    "outputBinding": {
+                        "glob": "$(inputs.max)"
+                    },
+                    "id": "#bowtie-alignreads.cwl/multimapped_file"
+                },
+                {
+                    "type": [
+                        "null",
+                        {
+                            "type": "array",
+                            "items": "File"
+                        }
+                    ],
+                    "outputBinding": {
+                        "glob": "*ref*.map*"
+                    },
+                    "id": "#bowtie-alignreads.cwl/refout_file"
+                },
+                {
+                    "type": [
+                        "null",
+                        "File"
+                    ],
+                    "outputBinding": {
+                        "glob": "$(default_output_filename())"
+                    },
+                    "id": "#bowtie-alignreads.cwl/sam_file"
+                },
+                {
+                    "type": "int",
+                    "outputBinding": {
+                        "loadContents": true,
+                        "glob": "$(default_output_filename(\".bw\"))",
+                        "outputEval": "${\n  let totalRegex = /processed\\:.*/;\n  return parseInt(self[0].contents.match(totalRegex)[0].split(\" \")[1]);\n}\n"
+                    },
+                    "id": "#bowtie-alignreads.cwl/total_reads_number"
+                },
+                {
+                    "type": [
+                        "null",
+                        "File"
+                    ],
+                    "outputBinding": {
+                        "glob": "$(inputs.un)"
+                    },
+                    "id": "#bowtie-alignreads.cwl/unaligned_file"
+                },
+                {
+                    "type": "int",
+                    "outputBinding": {
+                        "loadContents": true,
+                        "glob": "$(default_output_filename(\".bw\"))",
+                        "outputEval": "${\n  let unmappedRegex = /align\\:.*/;\n  return parseInt(self[0].contents.match(unmappedRegex)[0].split(\" \")[1]);\n}\n"
+                    },
+                    "id": "#bowtie-alignreads.cwl/unmapped_reads_number"
+                }
+            ],
+            "baseCommand": [
+                "bowtie"
+            ],
+            "arguments": [
+                {
+                    "valueFrom": "${\n  if (inputs.upstream_filelist && inputs.downstream_filelist){\n    return \"-1\";\n  }\n  return null;\n}\n",
+                    "position": 82
+                },
+                {
+                    "valueFrom": "${\n  if (inputs.upstream_filelist && inputs.downstream_filelist){\n    return \"-2\";\n  }\n  return null;\n}\n",
+                    "position": 84
+                },
+                {
+                    "valueFrom": "${\n  return ' 2> ' + default_output_filename(\".bw\");\n}\n",
+                    "position": 100000,
+                    "shellQuote": false
+                }
+            ],
+            "id": "#bowtie-alignreads.cwl"
+        },
+        {
+            "class": "CommandLineTool",
+            "requirements": [
+                {
+                    "class": "ShellCommandRequirement"
+                }
+            ],
+            "hints": [
+                {
+                    "class": "DockerRequirement",
+                    "dockerPull": "biowardrobe2/scidap:v0.0.3"
+                }
+            ],
+            "inputs": [
+                {
+                    "type": "File",
+                    "inputBinding": {
+                        "position": 6
+                    },
+                    "doc": "Compressed or uncompressed FASTQ file\n",
+                    "id": "#extract-fastq.cwl/compressed_file"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "inputBinding": {
+                        "position": 7
+                    },
+                    "default": ".fastq",
+                    "doc": "Default extension for the extracted file\n",
+                    "id": "#extract-fastq.cwl/output_file_ext"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "default": "#!/bin/bash\nshopt -s nocaseglob\n\nFILE=$0\nDEFAULT_EXT=$1\n\nEXT_LIST=( \".fastq\" \".fq\" )\n\nBASENAME=$(basename \"$FILE\")\nROOT_NAME=\"${BASENAME%.*}\"\n\nfor ITEM in $EXT_LIST; do\n  if [[ $ROOT_NAME == *$ITEM ]]; then\n    DEFAULT_EXT=\"\"\n  fi\ndone\n\nT=`file -b \"${FILE}\" | awk '{print $1}'`\ncase \"${T}\" in\n  \"bzip2\"|\"gzip\"|\"Zip\")\n    7z e -so \"${FILE}\" > \"${ROOT_NAME}${DEFAULT_EXT}\"\n    ;;\n  \"ASCII\")\n    cp \"${FILE}\" \"${ROOT_NAME}${DEFAULT_EXT}\" || true\n    ;;\n  *)\n    echo \"Error: file type unknown\"\n    exit 1\nesac\n",
+                    "inputBinding": {
+                        "position": 5
+                    },
+                    "doc": "Bash script to extract compressed FASTQ file\n",
+                    "id": "#extract-fastq.cwl/script"
+                }
+            ],
+            "outputs": [
+                {
+                    "type": "File",
+                    "outputBinding": {
+                        "glob": "*"
+                    },
+                    "id": "#extract-fastq.cwl/fastq_file"
+                }
+            ],
+            "baseCommand": [
+                "bash",
+                "-c"
+            ],
+            "id": "#extract-fastq.cwl"
+        },
+        {
+            "class": "CommandLineTool",
+            "requirements": [
+                {
+                    "class": "InlineJavascriptRequirement",
+                    "expressionLib": [
+                        "var default_output_filename = function() { return inputs.input_file.location.split('/').slice(-1)[0].split('.').slice(0,-1).join('.') + \".fastxstat\" };"
+                    ]
+                }
+            ],
+            "hints": [
+                {
+                    "class": "DockerRequirement",
+                    "dockerPull": "biowardrobe2/fastx_toolkit:v0.0.14"
+                }
+            ],
+            "inputs": [
+                {
+                    "type": "File",
+                    "inputBinding": {
+                        "position": 10,
+                        "prefix": "-i"
+                    },
+                    "doc": "FASTA/Q input file. If FASTA file is given, only nucleotides distribution is calculated (there's no quality info)\n",
+                    "id": "#fastx-quality-stats.cwl/input_file"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 5,
+                        "prefix": "-N"
+                    },
+                    "doc": "New output format (with more information per nucleotide/cycle).\ncycle (previously called 'column') = cycle number\nmax-count\nFor each nucleotide in the cycle (ALL/A/C/G/T/N):\n    count   = number of bases found in this column.\n    min     = Lowest quality score value found in this column.\n    max     = Highest quality score value found in this column.\n    sum     = Sum of quality score values for this column.\n    mean    = Mean quality score value for this column.\n    Q1\t= 1st quartile quality score.\n    med\t= Median quality score.\n    Q3\t= 3rd quartile quality score.\n    IQR\t= Inter-Quartile range (Q3-Q1).\n    lW\t= 'Left-Whisker' value (for boxplotting).\n    rW\t= 'Right-Whisker' value (for boxplotting).\n",
+                    "id": "#fastx-quality-stats.cwl/new_output_format"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "inputBinding": {
+                        "position": 11,
+                        "prefix": "-o",
+                        "valueFrom": "${\n    if (self == \"\"){\n      return default_output_filename();\n    } else {\n      return self;\n    }\n}\n"
+                    },
+                    "default": "",
+                    "doc": "Output file to store generated statistics. If not provided - return from default_output_filename function\n",
+                    "id": "#fastx-quality-stats.cwl/output_filename"
+                }
+            ],
+            "outputs": [
+                {
+                    "type": "File",
+                    "outputBinding": {
+                        "glob": "${\n    if (inputs.output_filename == \"\"){\n      return default_output_filename();\n    } else {\n      return inputs.output_filename;\n    }\n}\n"
+                    },
+                    "doc": "Generated statistics file",
+                    "id": "#fastx-quality-stats.cwl/statistics_file"
+                }
+            ],
+            "baseCommand": [
+                "fastx_quality_stats"
+            ],
+            "id": "#fastx-quality-stats.cwl"
+        },
+        {
+            "class": "CommandLineTool",
+            "requirements": [
+                {
+                    "class": "InlineJavascriptRequirement",
+                    "expressionLib": [
+                        "var default_output_filename = function(ext) { let root = inputs.input_filename.basename.split('.').slice(0,-1).join('.'); return (root == \"\")?inputs.input_filename.basename+ext:root+ext; };"
+                    ]
+                }
+            ],
+            "hints": [
+                {
+                    "class": "DockerRequirement",
+                    "dockerPull": "biowardrobe2/iaintersect:v0.0.2"
+                }
+            ],
+            "inputs": [
+                {
+                    "type": [
+                        "File"
+                    ],
+                    "inputBinding": {
+                        "position": 2,
+                        "prefix": "--a=",
+                        "separate": false
+                    },
+                    "doc": "Annotation file, tsv\n",
+                    "id": "#iaintersect.cwl/annotation_filename"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "inputBinding": {
+                        "position": 7,
+                        "prefix": "--sam_ignorechr=",
+                        "separate": false
+                    },
+                    "doc": "The chromosome to be ignored, string\n",
+                    "id": "#iaintersect.cwl/ignore_chr"
+                },
+                {
+                    "type": [
+                        "File"
+                    ],
+                    "inputBinding": {
+                        "position": 1,
+                        "prefix": "--in=",
+                        "separate": false
+                    },
+                    "doc": "Input filename with MACS2 peak calling results, tsv\n",
+                    "id": "#iaintersect.cwl/input_filename"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "inputBinding": {
+                        "position": 4,
+                        "prefix": "--log=",
+                        "separate": false,
+                        "valueFrom": "${\n    if (self == \"\"){\n      return default_output_filename('_iaintersect.log');\n    } else {\n      return self;\n    }\n}\n"
+                    },
+                    "default": "",
+                    "doc": "Log filename\n",
+                    "id": "#iaintersect.cwl/log_filename"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "inputBinding": {
+                        "position": 3,
+                        "prefix": "--out=",
+                        "separate": false,
+                        "valueFrom": "${\n    if (self == \"\"){\n      return default_output_filename('_iaintersect.tsv');\n    } else {\n      return self;\n    }\n}\n"
+                    },
+                    "default": "",
+                    "doc": "Base output file name, tsv\n",
+                    "id": "#iaintersect.cwl/output_filename"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 5,
+                        "prefix": "--promoter=",
+                        "separate": false
+                    },
+                    "doc": "Promoter region around TSS, base pairs\n",
+                    "id": "#iaintersect.cwl/promoter_bp"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 6,
+                        "prefix": "--upstream=",
+                        "separate": false
+                    },
+                    "doc": "Upstream region before promoter, base pairs\n",
+                    "id": "#iaintersect.cwl/upstream_bp"
+                }
+            ],
+            "outputs": [
+                {
+                    "type": "File",
+                    "outputBinding": {
+                        "glob": "${\n  if (inputs.log_filename == \"\"){\n    return default_output_filename('_iaintersect.log');\n  } else {\n    return inputs.log_filename;\n  }\n}\n"
+                    },
+                    "id": "#iaintersect.cwl/log_file"
+                },
+                {
+                    "type": "File",
+                    "outputBinding": {
+                        "glob": "${\n  if (inputs.output_filename == \"\"){\n    return default_output_filename('_iaintersect.tsv');\n  } else {\n    return inputs.output_filename;\n  }\n}\n"
+                    },
+                    "id": "#iaintersect.cwl/result_file"
+                }
+            ],
+            "baseCommand": [
+                "iaintersect"
+            ],
+            "id": "#iaintersect.cwl"
+        },
+        {
+            "class": "CommandLineTool",
+            "requirements": [
+                {
+                    "class": "InlineJavascriptRequirement",
+                    "expressionLib": [
+                        "var default_output_filename = function() { return inputs.unsorted_file.location.split('/').slice(-1)[0]; };"
+                    ]
+                }
+            ],
+            "hints": [
+                {
+                    "class": "DockerRequirement",
+                    "dockerPull": "biowardrobe2/scidap:v0.0.2"
+                }
+            ],
+            "inputs": [
+                {
+                    "type": {
+                        "type": "array",
+                        "items": "string",
+                        "inputBinding": {
+                            "prefix": "-k"
+                        }
+                    },
+                    "inputBinding": {
+                        "position": 1
+                    },
+                    "doc": "-k, --key=POS1[,POS2]\nstart a key at POS1, end it at POS2 (origin 1)\n",
+                    "id": "#linux-sort.cwl/key"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "doc": "Name for generated output file\n",
+                    "id": "#linux-sort.cwl/output_filename"
+                },
+                {
+                    "type": "File",
+                    "inputBinding": {
+                        "position": 4
+                    },
+                    "id": "#linux-sort.cwl/unsorted_file"
+                }
+            ],
+            "outputs": [
+                {
+                    "type": "File",
+                    "outputBinding": {
+                        "glob": "${\n  if (inputs.output_filename == null){\n    return default_output_filename();\n  } else {\n    return inputs.output_filename;\n  }\n}\n"
+                    },
+                    "doc": "Sorted file\n",
+                    "id": "#linux-sort.cwl/sorted_file"
+                }
+            ],
+            "stdout": "${\n  if (inputs.output_filename == null){\n    return default_output_filename();\n  } else {\n    return inputs.output_filename;\n  }\n}\n",
+            "baseCommand": [
+                "sort"
+            ],
+            "id": "#linux-sort.cwl"
+        },
+        {
+            "class": "CommandLineTool",
+            "requirements": [
+                {
+                    "class": "ShellCommandRequirement"
+                },
+                {
+                    "class": "InlineJavascriptRequirement",
+                    "expressionLib": [
+                        "var default_output_filename = function(sufix) { sufix = sufix || \"_macs\"; if (Object.prototype.toString.call(inputs.treatment_file) === '[object Array]'){ let basename = inputs.treatment_file[0].basename; let root = basename.split('.').slice(0,-1).join('.'); return (root == \"\")?basename+sufix:root+sufix; } else { let basename = inputs.treatment_file.basename; let root = basename.split('.').slice(0,-1).join('.'); return (root == \"\")?basename+sufix:root+sufix; } }"
+                    ]
+                },
+                {
+                    "class": "InitialWorkDirRequirement",
+                    "listing": [
+                        {
+                            "entryname": "run.py",
+                            "entry": "#!/usr/bin/env python\nimport subprocess\nimport sys\nimport argparse\nimport re\n\ndef arg_parser():\n    \"\"\"Returns argument parser. used only to get -n and --extsize values\"\"\"\n    parser = argparse.ArgumentParser(description='MACS2 Biowardrobe parser')\n    parser.add_argument(\"-n\", help=\"MACS2 string name of the experiment\")\n    parser.add_argument(\"--extsize\", help=\"MACS2 arbitrary extension size in bp\")\n    return parser\n\ndef get_info (name):\n    fragments, islands = 0, 0\n    with open(name+'_peaks.xls', 'r') as infile:\n        for line in infile:\n            if re.match('^# d = ', line):\n                fragments = int(line.split('d = ')[1])\n                continue\n            if re.match('^#', line):\n                continue\n            if line.strip() != \"\":\n                islands = islands + 1\n    islands = islands - 1\n    return fragments, islands\n\nargs, _ = arg_parser().parse_known_args()\nargv=' '.join(sys.argv[1:])\n\nextsize=args.extsize\nname=args.n\n\nruntime_error=False\ncalculated_fragment_size=0\nexpected_fragment_size=0\nisland_count=0\n\ntry:\n    subprocess.check_output(argv, shell=True)\nexcept subprocess.CalledProcessError as e:\n    if '--nomodel' in argv:\n        print \"MACS2 critical error: \", str(e)\n        sys.exit(1) # stop the whole workflow\n    print \"MACS2 will be rerun to fix not critical error: \", str(e)\n    runtime_error=True\n    expected_fragment_size=extsize\nelse:\n    calculated_fragment_size,island_count=get_info(name)\n    expected_fragment_size=calculated_fragment_size\n\nif runtime_error or (calculated_fragment_size < 80 and ('--nomodel' not in argv)):\n    try:\n        subprocess.check_output(argv+' --nomodel', shell=True)\n    except subprocess.CalledProcessError as e:\n        print \"MACS2 forced error: \", str(e)\n        sys.exit(1) # stop the whole workflow\n    else:\n        calculated_fragment_size,island_count=get_info(name)\n\nwith open(name.replace('_macs','')+'_fragment_stat.tsv', 'w') as output_file:\n    output_file.write(' '.join([str(calculated_fragment_size),str(expected_fragment_size),str(island_count)]))\n"
+                        }
+                    ]
+                }
+            ],
+            "hints": [
+                {
+                    "class": "DockerRequirement",
+                    "dockerPull": "biowardrobe2/macs2:v2.1.1"
+                }
+            ],
+            "inputs": [
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 17,
+                        "prefix": "--bdg"
+                    },
+                    "doc": "If this flag is on, MACS will store the fragment pileup, control lambda, -log10pvalue and -log10qvalue scores in bedGraph files.\nThe bedGraph files will be stored in current directory named NAME+\u2019_treat_pileup.bdg\u2019 for treatment data, NAME+\u2019_control_lambda.bdg\u2019\nfor local lambda values from control, NAME+\u2019_treat_pvalue.bdg\u2019 for Poisson pvalue scores (in -log10(pvalue) form),\nand NAME+\u2019_treat_qvalue.bdg\u2019 for q-value scores from\nBenjamini\u2013Hochberg\u2013Yekutieli procedure <http://en.wikipedia.org/wiki/False_discovery_rate#Dependent_tests>\nDEFAULT: False\n",
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/bdg"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 36,
+                        "prefix": "--broad"
+                    },
+                    "doc": "If set, MACS will try to call broad peaks by linking nearby highly enriched\nregions. The linking region is controlled by another cutoff through --linking-cutoff.\nThe maximum linking region length is 4 times of d from MACS.\nDEFAULT: False\n",
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/broad"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 37,
+                        "prefix": "--broad-cutoff"
+                    },
+                    "doc": "Cutoff for broad region. This option is not available\nunless --broad is set. If -p is set, this is a pvalue\ncutoff, otherwise, it's a qvalue cutoff.\nDEFAULT: 0.1\n",
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/broad_cutoff"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 16,
+                        "prefix": "--buffer-size"
+                    },
+                    "doc": "Buffer size for incrementally increasing internal\narray size to store reads alignment information. In\nmost cases, you don't have to change this parameter.\nHowever, if there are large number of\nchromosomes/contigs/scaffolds in your alignment, it's\nrecommended to specify a smaller buffer size in order\nto decrease memory usage (but it will take longer time\nto read alignment files). Minimum memory requested for\nreading an alignment file is about # of CHROMOSOME *\nBUFFER_SIZE * 2 Bytes.\nDEFAULT: 100000\n",
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/buffer_size"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 21,
+                        "prefix": "--bw"
+                    },
+                    "doc": "Band width for picking regions to compute  fragment  size.  This\nvalue is only used while building the shifting model\nDEFAULT: 300\n",
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/bw"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 39,
+                        "prefix": "--call-summits"
+                    },
+                    "doc": "If set, MACS will use a more sophisticated signal processing approach to\nfind subpeak summits in each enriched peak region.\nDEFAULT: False\n",
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/call_summits"
+                },
+                {
+                    "type": [
+                        "null",
+                        "File",
+                        {
+                            "type": "array",
+                            "items": "File"
+                        }
+                    ],
+                    "inputBinding": {
+                        "position": 12,
+                        "prefix": "-c"
+                    },
+                    "doc": "The control or mock data file. Please follow the same direction as for -t/\u2013treatment.\n",
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/control_file"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 38,
+                        "prefix": "--cutoff-analysis"
+                    },
+                    "doc": "While set, MACS2 will analyze number or total length of peaks that can be\ncalled by different p-value cutoff then output a summary table to help user\ndecide a better cutoff. The table will be saved in NAME_cutoff_analysis.txt\nfile. Note, minlen and maxgap may affect the results. WARNING: May take ~30\nfolds longer time to finish.\nDEFAULT: False\n",
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/cutoff_analysis"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 31,
+                        "prefix": "--down-sample"
+                    },
+                    "doc": "When set, random sampling method will scale down the bigger sample. By default,\nMACS uses linear scaling. Warning: This option will make your result unstable\nand irreproducible since each time, random reads would be selected. Consider\nto use ''randsample'' script instead. <not implmented>If used together with\n--SPMR, 1 million unique reads will be randomly picked.</not implemented> Caution:\ndue to the implementation, the final number of selected reads may not be as\nyou expected!\nDEFAULT: False\n",
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/down_sample"
+                },
+                {
+                    "type": "int",
+                    "inputBinding": {
+                        "position": 26,
+                        "prefix": "--extsize"
+                    },
+                    "doc": "The arbitrary extension size in bp. When nomodel is  true, MACS will use\nthis value as fragment size to  extend each read towards 3'' end, then pile\nthem up.  It''s exactly twice the number of obsolete SHIFTSIZE.  In previous\nlanguage, each read is moved 5''->3''  direction to middle of fragment by 1/2\nd, then  extended to both direction with 1/2 d. This is  equivalent to say each\nread is extended towards 5''->3''  into a d size fragment.EXTSIZE\nand  SHIFT can be combined when necessary. Check SHIFT  option.\nDEFAULT: 200\n",
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/extsize"
+                },
+                {
+                    "type": [
+                        "null",
+                        "float"
+                    ],
+                    "inputBinding": {
+                        "position": 40,
+                        "prefix": "--fe-cutoff"
+                    },
+                    "doc": "When set, the value will be used to filter out peaks\nwith low fold-enrichment. Note, MACS2 use 1.0 as\npseudocount while calculating fold-enrichment.\nDEFAULT: 1.0\n",
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/fe_cutoff"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 23,
+                        "prefix": "--fix-bimodal"
+                    },
+                    "doc": "Whether turn on the auto pair model process. If set, when MACS failed to\nbuild paired model, it will use the nomodel settings, the --exsize parameter\nto extend each tags towards 3'' direction. Not to use this automate fixation\nis a default behavior now.\nDEFAULT: False\n",
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/fix_bimodal"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "inputBinding": {
+                        "position": 13,
+                        "prefix": "-f"
+                    },
+                    "doc": "{AUTO,BAM,SAM,BED,ELAND,ELANDMULTI,ELANDEXPORT,BOWTIE,BAMPE}, --format\n{AUTO,BAM,SAM,BED,ELAND,ELANDMULTI,ELANDEXPORT,BOWTIE,BAMPE} Format of tag file,\n\"AUTO\", \"BED\" or \"ELAND\" or \"ELANDMULTI\" or \"ELANDEXPORT\" or \"SAM\" or \"BAM\"\nor \"BOWTIE\" or \"BAMPE\". The default AUTO option will let MACS decide which format\nthe file is. Note that MACS can''t detect \"BAMPE\" or \"BEDPE\" format with \"AUTO\",\nand you have to implicitly specify the format for \"BAMPE\" and \"BEDPE\".\nDEFAULT: AUTO\n",
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/format_mode"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "inputBinding": {
+                        "position": 14,
+                        "prefix": "-g"
+                    },
+                    "doc": "It\u2019s the mappable genome size or effective genome size which is defined as the genome size which can be sequenced.\nBecause of the repetitive features on the chromsomes, the actual mappable genome size will be smaller than the\noriginal size, about 90% or 70% of the genome size. The default hs \u2013 2.7e9 is recommended for UCSC human hg18\nassembly. Here are all precompiled parameters for effective genome size:\n  hs:\t2.7e9\n  mm:\t1.87e9\n  ce:\t9e7\n  dm:\t1.2e8\nDEFAULT: hs\n",
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/genome_size"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "inputBinding": {
+                        "position": 15,
+                        "prefix": "--keep-dup"
+                    },
+                    "doc": "It controls the MACS behavior towards duplicate tags\nat the exact same location -- the same coordination\nand the same strand. The 'auto' option makes MACS\ncalculate the maximum tags at the exact same location\nbased on binomal distribution using 1e-5 as pvalue\ncutoff; and the 'all' option keeps every tags. If an\ninteger is given, at most this number of tags will be\nkept at the same location. The default is to keep one\ntag at the same location.\nDEFAULT: 1\n",
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/keep_dup"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 35,
+                        "prefix": "--llocal"
+                    },
+                    "doc": "The large nearby region in basepairs to calculate\ndynamic lambda. This is used to capture the surround\nbias. If you set this to 0, MACS will skip llocal\nlambda calculation. *Note* that MACS will always\nperform a d-size local lambda calculation. The final\nlocal bias should be the maximum of the lambda value\nfrom d, slocal, and llocal size windows.\nDEFAULT: 10000.\n",
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/llocal"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "inputBinding": {
+                        "position": 22,
+                        "prefix": "-m"
+                    },
+                    "doc": "Select the regions within MFOLD range of high-\nconfidence enrichment ratio against background to\nbuild model. Fold-enrichment in regions must be lower\nthan upper limit, and higher than the lower limit. Use\nas \"-m 10 30\"\nDEFAULT: 5 50\n",
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/mfold"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 33,
+                        "prefix": "--nolambda"
+                    },
+                    "doc": "If True, MACS will use fixed background lambda as local lambda for every\npeak region. Normally, MACS calculates a dynamic local lambda to reflect the\nlocal bias due to potential chromatin structure.\nDEFAULT: False\n",
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/nolambda"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 24,
+                        "prefix": "--nomodel"
+                    },
+                    "doc": "Whether or not to build the shifting model. If True,  MACS will not build\nmodel. by default it means  shifting size = 100, try to set extsize to change it.\nDEFAULT: False\n",
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/nomodel"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "inputBinding": {
+                        "position": 999,
+                        "prefix": "-n",
+                        "valueFrom": "${\n    if (self == \"\"){\n      return default_output_filename();\n    } else {\n      return self;\n    }\n}\n"
+                    },
+                    "default": "",
+                    "doc": "The name string of the experiment. MACS will use this string NAME to create output files like \u2018NAME_peaks.xls\u2019,\n\u2018NAME_negative_peaks.xls\u2019, \u2018NAME_peaks.bed\u2019 , \u2018NAME_summits.bed\u2019, \u2018NAME_model.r\u2019 and so on.\nSo please avoid any confliction between these filenames and your existing files.\nDEFAULT: generated on the base of the treatment input\n",
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/output_prefix"
+                },
+                {
+                    "type": [
+                        "null",
+                        "float"
+                    ],
+                    "inputBinding": {
+                        "position": 28,
+                        "prefix": "-p"
+                    },
+                    "doc": "Pvalue cutoff for peak detection. DEFAULT: not set.  -q, and -p are mutually\nexclusive. If pvalue cutoff is set, qvalue will not be calculated and reported\nas -1  in the final .xls file.\nDEFAULT: null\n",
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/p_value"
+                },
+                {
+                    "type": [
+                        "null",
+                        "float"
+                    ],
+                    "inputBinding": {
+                        "position": 27,
+                        "prefix": "-q"
+                    },
+                    "doc": "Minimum FDR (q-value) cutoff for peak detection. -q, and\n-p are mutually exclusive.\nDEFAULT: 0.05\n",
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/q_value"
+                },
+                {
+                    "type": [
+                        "null",
+                        "float"
+                    ],
+                    "inputBinding": {
+                        "position": 30,
+                        "prefix": "--ratio"
+                    },
+                    "doc": "When set, use a custom scaling ratio of ChIP/control\n(e.g. calculated using NCIS) for linear scaling.\nDEFAULT: null\n",
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/ratio"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 32,
+                        "prefix": "--seed"
+                    },
+                    "doc": "Set the random seed while down sampling data. Must be\na non-negative integer in order to be effective.\nDEFAULT: null\n",
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/seed"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 25,
+                        "prefix": "--shift"
+                    },
+                    "doc": "(NOT the legacy --shiftsize option!) The arbitrary shift in bp. Use discretion\nwhile setting it other than default value. When NOMODEL is set, MACS will use\nthis value to move cutting ends (5'') towards 5''->3'' direction then apply\nEXTSIZE to extend them to fragments. When this value is negative, ends will\nbe moved toward 3''->5'' direction. Recommended to keep it as default 0 for\nChIP-Seq datasets, or -1 * half of EXTSIZE together with EXTSIZE option for\ndetecting enriched cutting loci such as certain DNAseI-Seq datasets. Note, you\ncan''t set values other than 0 if format is BAMPE for paired-end data.\nDEFAULT: 0\n",
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/shift"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 34,
+                        "prefix": "--slocal"
+                    },
+                    "doc": "The small nearby region in basepairs to calculate\ndynamic lambda. This is used to capture the bias near\nthe peak summit region. Invalid if there is no control\ndata. If you set this to 0, MACS will skip slocal\nlambda calculation. *Note* that MACS will always\nperform a d-size local lambda calculation. The final\nlocal bias should be the maximum of the lambda value\nfrom d, slocal, and llocal size windows.\nDEFAULT: 1000\n",
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/slocal"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 19,
+                        "prefix": "--SPMR"
+                    },
+                    "doc": "If True, MACS will save signal per million reads for fragment pileup profiles.\nRequire --bdg to be set.\nDEFAULT: False\n",
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/spmr"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 29,
+                        "prefix": "--to-large"
+                    },
+                    "doc": "When set, scale the small sample up to the bigger sample. By default, the\nbigger dataset will be scaled down towards the smaller dataset, which will lead\nto smaller p/qvalues and more specific results. Keep in mind that scaling down\nwill bring down background noise more.\nDEFAULT: False\n",
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/to_large"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 18,
+                        "prefix": "--trackline"
+                    },
+                    "doc": "Tells MACS to include trackline with bedGraph files. To include this trackline\nwhile displaying bedGraph at UCSC genome browser, can show name and description\nof the file as well. Require -B to be set.\nDEFAULT: False\n",
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/trackline"
+                },
+                {
+                    "type": [
+                        "File",
+                        {
+                            "type": "array",
+                            "items": "File"
+                        }
+                    ],
+                    "inputBinding": {
+                        "position": 10,
+                        "prefix": "-t"
+                    },
+                    "doc": "This is the only REQUIRED parameter for MACS. File can be in any supported format specified by \u2013format option.\nCheck \u2013format for detail. If you have more than one alignment files, you can specify them as `-t A B C`.\nMACS will pool up all these files together.\n",
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/treatment_file"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 20,
+                        "prefix": "--tsize"
+                    },
+                    "doc": "Tag size. This will overide the auto detected tag size.\nDEFAULT: False\n",
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/tsize"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 41,
+                        "prefix": "--verbose"
+                    },
+                    "doc": "Log level\n",
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/verbose"
+                }
+            ],
+            "outputs": [
+                {
+                    "type": [
+                        "null",
+                        "File"
+                    ],
+                    "outputBinding": {
+                        "glob": "${ if (inputs.output_prefix == \"\"){ return default_output_filename('_macs_peaks.broadPeak'); } else { return inputs.output_prefix + '_peaks.broadPeak'; } }"
+                    },
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/broad_peak_file"
+                },
+                {
+                    "type": [
+                        "null",
+                        "File"
+                    ],
+                    "outputBinding": {
+                        "glob": "${ if (inputs.output_prefix == \"\"){ return default_output_filename('_macs_control_lambda.bdg'); } else { return inputs.output_prefix + '_control_lambda.bdg'; } }"
+                    },
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/control_lambda_bdg_file"
+                },
+                {
+                    "type": [
+                        "null",
+                        "File"
+                    ],
+                    "outputBinding": {
+                        "glob": "${ if (inputs.output_prefix == \"\"){ return default_output_filename('_macs_peaks.gappedPeak'); } else { return inputs.output_prefix + '_peaks.gappedPeak'; } }"
+                    },
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/gapped_peak_file"
+                },
+                {
+                    "type": "int",
+                    "outputBinding": {
+                        "loadContents": true,
+                        "glob": "${\n    if (inputs.output_prefix == \"\"){\n      return default_output_filename('_fragment_stat.tsv');\n    } else {\n      return inputs.output_prefix + '_fragment_stat.tsv';\n    }\n}\n",
+                        "outputEval": "$(parseInt(self[0].contents.split(' ')[0]))"
+                    },
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/macs2_fragments_calculated"
+                },
+                {
+                    "type": "int",
+                    "outputBinding": {
+                        "loadContents": true,
+                        "glob": "${\n    if (inputs.output_prefix == \"\"){\n      return default_output_filename('_fragment_stat.tsv');\n    } else {\n      return inputs.output_prefix + '_fragment_stat.tsv';\n    }\n}\n",
+                        "outputEval": "$(parseInt(self[0].contents.split(' ')[1]))"
+                    },
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/macs2_fragments_expected"
+                },
+                {
+                    "type": "int",
+                    "outputBinding": {
+                        "loadContents": true,
+                        "glob": "${\n    if (inputs.output_prefix == \"\"){\n      return default_output_filename('_fragment_stat.tsv');\n    } else {\n      return inputs.output_prefix + '_fragment_stat.tsv';\n    }\n}\n",
+                        "outputEval": "$(parseInt(self[0].contents.split(' ')[2]))"
+                    },
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/macs2_islands"
+                },
+                {
+                    "type": "File",
+                    "outputBinding": {
+                        "glob": "${\n    if (inputs.output_prefix == \"\"){\n      return default_output_filename('_fragment_stat.tsv');\n    } else {\n      return inputs.output_prefix + '_fragment_stat.tsv';\n    }\n}\n"
+                    },
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/macs2_stat_file"
+                },
+                {
+                    "type": [
+                        "null",
+                        "File"
+                    ],
+                    "outputBinding": {
+                        "glob": "${\n    if (inputs.output_prefix == \"\"){\n      return default_output_filename('_macs.log');\n    } else {\n      return inputs.output_prefix + '.log';\n    }\n}\n"
+                    },
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/macs_log"
+                },
+                {
+                    "type": [
+                        "null",
+                        "File"
+                    ],
+                    "outputBinding": {
+                        "glob": "${ if (inputs.output_prefix == \"\"){ return default_output_filename('_macs_model.r'); } else { return inputs.output_prefix + '_model.r'; } }"
+                    },
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/moder_r_file"
+                },
+                {
+                    "type": [
+                        "null",
+                        "File"
+                    ],
+                    "outputBinding": {
+                        "glob": "${ if (inputs.output_prefix == \"\"){ return default_output_filename('_macs_peaks.narrowPeak'); } else { return inputs.output_prefix + '_peaks.narrowPeak'; } }"
+                    },
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/narrow_peak_file"
+                },
+                {
+                    "type": [
+                        "null",
+                        "File"
+                    ],
+                    "outputBinding": {
+                        "glob": "${ if (inputs.output_prefix == \"\"){ return default_output_filename('_macs_summits.bed'); } else { return inputs.output_prefix + '_summits.bed'; } }"
+                    },
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/peak_summits_file"
+                },
+                {
+                    "type": [
+                        "null",
+                        "File"
+                    ],
+                    "outputBinding": {
+                        "glob": "${ if (inputs.output_prefix == \"\"){ return default_output_filename('_macs_peaks.xls'); } else { return inputs.output_prefix + '_peaks.xls'; } }"
+                    },
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/peak_xls_file"
+                },
+                {
+                    "type": [
+                        "null",
+                        "File"
+                    ],
+                    "outputBinding": {
+                        "glob": "${ if (inputs.output_prefix == \"\"){ return default_output_filename('_macs_treat_pileup.bdg'); } else { return inputs.output_prefix + '_treat_pileup.bdg'; } }"
+                    },
+                    "id": "#macs2-callpeak-biowardrobe-only.cwl/treat_pileup_bdg_file"
+                }
+            ],
+            "baseCommand": [
+                "python",
+                "run.py",
+                "macs2 callpeak"
+            ],
+            "arguments": [
+                {
+                    "valueFrom": "${ if (inputs.output_prefix == \"\"){ return ' 2> ' + default_output_filename('_macs.log'); } else { return ' 2> ' + inputs.output_prefix + '.log'; } }",
+                    "position": 100000,
+                    "shellQuote": true
+                }
+            ],
+            "id": "#macs2-callpeak-biowardrobe-only.cwl"
+        },
+        {
+            "class": "CommandLineTool",
+            "requirements": [
+                {
+                    "class": "ShellCommandRequirement"
+                },
+                {
+                    "class": "InlineJavascriptRequirement",
+                    "expressionLib": [
+                        "var get_output_filename = function() { if (inputs.output_filename == null){ let root = inputs.bowtie_log.basename.split('.').slice(0,-1).join('.'); let ext = \".stat\"; return (root == \"\")?inputs.bowtie_log.basename+ext:root+ext; } else { return inputs.output_filename; } };"
+                    ]
+                }
+            ],
+            "hints": [
+                {
+                    "class": "DockerRequirement",
+                    "dockerPull": "biowardrobe2/scidap:v0.0.2"
+                }
+            ],
+            "inputs": [
+                {
+                    "type": "File",
+                    "inputBinding": {
+                        "position": 6
+                    },
+                    "doc": "Log file from Bowtie\n",
+                    "id": "#python-get-stat-chipseq.cwl/bowtie_log"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "doc": "Name for generated output file\n",
+                    "id": "#python-get-stat-chipseq.cwl/output_filename"
+                },
+                {
+                    "type": "File",
+                    "inputBinding": {
+                        "position": 7
+                    },
+                    "doc": "Log file from samtools rmdup\n",
+                    "id": "#python-get-stat-chipseq.cwl/rmdup_log"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "default": "#!/usr/bin/env python\nimport sys, re\nTOTAL, ALIGNED, SUPRESSED, USED = 100, 80, 0, 0\nwith open(sys.argv[1], 'r') as bowtie_log:\n  for line in bowtie_log:\n    if 'processed:' in line:\n      TOTAL = int(line.split('processed:')[1])\n    if 'alignment:' in line:\n      ALIGNED = int(line.split('alignment:')[1].split()[0])\n    if 'due to -m:' in line:\n      SUPRESSED = int(line.split('due to -m:')[1].split()[0])\nUSED = ALIGNED\nwith open(sys.argv[2], 'r') as rmdup_log:\n  for line in rmdup_log:\n    if '/' in line and 'Skip' not in line:\n      splt = line.split('/')\n      USED = int((splt[1].split('='))[0].strip()) - int((splt[0].split(']'))[1].strip())\nprint TOTAL, ALIGNED, SUPRESSED, USED\n",
+                    "inputBinding": {
+                        "position": 5
+                    },
+                    "doc": "Python script to get TOTAL, ALIGNED, SUPRESSED, USED values from log files\n",
+                    "id": "#python-get-stat-chipseq.cwl/script"
+                }
+            ],
+            "outputs": [
+                {
+                    "type": "int",
+                    "outputBinding": {
+                        "loadContents": true,
+                        "glob": "$(get_output_filename())",
+                        "outputEval": "$(parseInt(self[0].contents.split(' ')[1]))"
+                    },
+                    "id": "#python-get-stat-chipseq.cwl/mapped_reads"
+                },
+                {
+                    "type": "File",
+                    "outputBinding": {
+                        "glob": "$(get_output_filename())"
+                    },
+                    "id": "#python-get-stat-chipseq.cwl/output_file"
+                },
+                {
+                    "type": "int",
+                    "outputBinding": {
+                        "loadContents": true,
+                        "glob": "$(get_output_filename())",
+                        "outputEval": "$(parseInt(self[0].contents.split(' ')[2]))"
+                    },
+                    "id": "#python-get-stat-chipseq.cwl/supressed_reads"
+                },
+                {
+                    "type": "int",
+                    "outputBinding": {
+                        "loadContents": true,
+                        "glob": "$(get_output_filename())",
+                        "outputEval": "$(parseInt(self[0].contents.split(' ')[0]))"
+                    },
+                    "id": "#python-get-stat-chipseq.cwl/total_reads"
+                },
+                {
+                    "type": "int",
+                    "outputBinding": {
+                        "loadContents": true,
+                        "glob": "$(get_output_filename())",
+                        "outputEval": "$(parseInt(self[0].contents.split(' ')[3]))"
+                    },
+                    "id": "#python-get-stat-chipseq.cwl/used_reads"
+                }
+            ],
+            "baseCommand": [
+                "python",
+                "-c"
+            ],
+            "arguments": [
+                {
+                    "valueFrom": "$(\" > \" + get_output_filename())",
+                    "position": 100000,
+                    "shellQuote": false
+                }
+            ],
+            "id": "#python-get-stat-chipseq.cwl"
+        },
+        {
+            "class": "CommandLineTool",
+            "requirements": [
+                {
+                    "class": "ShellCommandRequirement"
+                },
+                {
+                    "class": "InlineJavascriptRequirement",
+                    "expressionLib": [
+                        "var default_output_filename = function() { return inputs.bam_file.location.split('/').slice(-1)[0]; };"
+                    ]
+                },
+                {
+                    "class": "InitialWorkDirRequirement",
+                    "listing": "${\n  return  [\n            {\n              \"entry\": inputs.bam_file,\n              \"entryname\": \"input_file_backup\",\n              \"writable\": true\n            }\n          ]\n}\n"
+                }
+            ],
+            "hints": [
+                {
+                    "class": "DockerRequirement",
+                    "dockerPull": "biowardrobe2/samtools:v1.4"
+                }
+            ],
+            "inputs": [
+                {
+                    "type": "File",
+                    "inputBinding": {
+                        "position": 10
+                    },
+                    "doc": "Input sorted bam file (index file is optional)\n",
+                    "id": "#samtools-rmdup.cwl/bam_file"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "default": "#!/bin/bash\nif [ \"$0\" = \"true\" ]\nthen\n  samtools rmdup \"${@:1}\"\nelse\n  echo \"Skip samtools rmdup \" ${@:1}\n  mv ${@: -2}\nfi\n",
+                    "inputBinding": {
+                        "position": 1
+                    },
+                    "doc": "Bash function to run samtools rmdup with all input parameters or skip it if trigger is false\n",
+                    "id": "#samtools-rmdup.cwl/bash_script"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 4,
+                        "prefix": "-S"
+                    },
+                    "doc": "treat PE reads as SE in rmdup (force -s)\n",
+                    "id": "#samtools-rmdup.cwl/force_single_end"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "inputBinding": {
+                        "position": 11,
+                        "valueFrom": "${\n    if (self == \"\" || inputs.trigger == false){\n      return default_output_filename();\n    } else {\n      return self;\n    }\n}\n"
+                    },
+                    "default": "",
+                    "doc": "Writes the output bam file to output_filename if set,\notherwise generates output_filename on the base of bam_file\n",
+                    "id": "#samtools-rmdup.cwl/output_filename"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 3,
+                        "prefix": "-s"
+                    },
+                    "doc": "rmdup for SE reads\n",
+                    "id": "#samtools-rmdup.cwl/single_end"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "default": true,
+                    "inputBinding": {
+                        "position": 2,
+                        "valueFrom": "${ return self ? \"true\" : \"false\" }\n"
+                    },
+                    "doc": "If true - run samtools rmdup, if false - return bam_file, previously staged into output directory and optional index file\nUse valueFrom to return string instead of boolean, because if return boolean False, argument is not printed\n",
+                    "id": "#samtools-rmdup.cwl/trigger"
+                }
+            ],
+            "outputs": [
+                {
+                    "type": "File",
+                    "outputBinding": {
+                        "glob": "${\n  if (inputs.output_filename == \"\" || inputs.trigger == false){\n    return default_output_filename().split('.').slice(0,-1).join('.') + '.rmdup';\n  } else {\n    return inputs.output_filename.split('.').slice(0,-1).join('.') + '.rmdup';\n  }\n}\n"
+                    },
+                    "id": "#samtools-rmdup.cwl/rmdup_log"
+                },
+                {
+                    "type": "File",
+                    "outputBinding": {
+                        "glob": "${\n    if (inputs.output_filename == \"\" || inputs.trigger == false){\n      return default_output_filename();\n    } else {\n      return inputs.output_filename;\n    }\n}\n"
+                    },
+                    "secondaryFiles": "${\n    if (inputs.bam_file.secondaryFiles && inputs.trigger == false){\n      return inputs.bam_file.secondaryFiles;\n    } else {\n      return \"null\";\n    }\n  }\n",
+                    "doc": "File with removed duplicates or bam_file with optional secondaryFiles",
+                    "id": "#samtools-rmdup.cwl/rmdup_output"
+                }
+            ],
+            "baseCommand": [
+                "bash",
+                "-c"
+            ],
+            "arguments": [
+                {
+                    "valueFrom": "${\n  if (inputs.output_filename == \"\" || inputs.trigger == false){\n    return \" > \" + default_output_filename().split('.').slice(0,-1).join('.') + \".rmdup 2>&1\";\n  } else {\n    return \" > \" + inputs.output_filename.split('.').slice(0,-1).join('.') + \".rmdup 2>&1\";\n  }\n}\n",
+                    "position": 100000,
+                    "shellQuote": false
+                }
+            ],
+            "id": "#samtools-rmdup.cwl"
+        },
+        {
+            "class": "CommandLineTool",
+            "requirements": [
+                {
+                    "class": "ShellCommandRequirement"
+                },
+                {
+                    "class": "InitialWorkDirRequirement",
+                    "listing": "${\n  return  [\n            {\n              \"entry\": inputs.sort_input,\n              \"entryname\": inputs.sort_input.basename,\n              \"writable\": true\n            }\n          ]\n}\n"
+                },
+                {
+                    "class": "InlineJavascriptRequirement",
+                    "expressionLib": [
+                        "var ext = function() { if (inputs.csi && !inputs.bai){ return '.csi'; } else { return '.bai'; } };",
+                        "var default_bam = function() { if (inputs.trigger == true){ return inputs.sort_input.location.split('/').slice(-1)[0].split('.').slice(0,-1).join('.')+\".bam\"; } else { return inputs.sort_input.location.split('/').slice(-1)[0]; } };"
+                    ]
+                }
+            ],
+            "hints": [
+                {
+                    "class": "DockerRequirement",
+                    "dockerPull": "biowardrobe2/samtools:v1.4"
+                }
+            ],
+            "inputs": [
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "doc": "Generate BAI-format index for BAM files [default]. If input isn't cram.\n",
+                    "id": "#samtools-sort-index.cwl/bai"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "default": "#!/bin/bash\nif [ \"$0\" = \"true\" ]\nthen\n  echo \"Run: samtools index \" ${@:1}\n  samtools index \"${@:1}\"\nelse\n  echo \"Skip samtools index \" ${@:1}\nfi\n",
+                    "inputBinding": {
+                        "position": 20
+                    },
+                    "doc": "Bash function to run samtools index with all input parameters or skip it if trigger is false\n",
+                    "id": "#samtools-sort-index.cwl/bash_script_index"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "default": "#!/bin/bash\nif [ \"$0\" = \"true\" ]\nthen\n  echo \"Run: samtools sort \" ${@:1}\n  samtools sort \"${@:1}\"\nelse\n  echo \"Skip samtools sort \" ${@:1}\nfi\n",
+                    "inputBinding": {
+                        "position": 5
+                    },
+                    "doc": "Bash function to run samtools sort with all input parameters or skip it if trigger is false\n",
+                    "id": "#samtools-sort-index.cwl/bash_script_sort"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "doc": "Generate CSI-format index for BAM files. If input isn't cram.\n",
+                    "id": "#samtools-sort-index.cwl/csi"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 24,
+                        "prefix": "-m"
+                    },
+                    "doc": "Set minimum interval size for CSI indices to 2^INT [14]\n",
+                    "id": "#samtools-sort-index.cwl/csi_interval"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "position": 11,
+                        "prefix": "-l"
+                    },
+                    "doc": "SORT: desired compression level for the final output file, ranging from 0 (uncompressed)\nor 1 (fastest but minimal compression) to 9 (best compression but slowest to write),\nsimilarly to gzip(1)'s compression level setting.\nIf -l is not used, the default compression level will apply.\n",
+                    "id": "#samtools-sort-index.cwl/sort_compression_level"
+                },
+                {
+                    "type": "File",
+                    "inputBinding": {
+                        "position": 16
+                    },
+                    "doc": "Input only in.sam|in.bam|in.cram. Optionally could be supplemented with index file in secondaryFiles\n",
+                    "id": "#samtools-sort-index.cwl/sort_input"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "inputBinding": {
+                        "position": 12,
+                        "prefix": "-o",
+                        "valueFrom": "${\n    if (self == \"\" || inputs.trigger == false){\n      return default_bam();\n    } else {\n      return self;\n    }\n}\n"
+                    },
+                    "default": "",
+                    "doc": "Write the final sorted output to FILE. Only out.bam|out.cram.\nIf output file extension is set to SAM, tool will fail on the index step\n",
+                    "id": "#samtools-sort-index.cwl/sort_output_filename"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "doc": "Set number of sorting and compression threads [1] (Only for sorting)\n",
+                    "id": "#samtools-sort-index.cwl/threads"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "default": true,
+                    "doc": "If true - run samtools, if false - return sort_input and optional index file in secondaryFiles, previously staged\ninto output directory.\n",
+                    "id": "#samtools-sort-index.cwl/trigger"
+                }
+            ],
+            "outputs": [
+                {
+                    "type": "File",
+                    "outputBinding": {
+                        "glob": "${\n    if (inputs.sort_output_filename == \"\" || inputs.trigger == false){\n      return default_bam();\n    } else {\n      return inputs.sort_output_filename;\n    }\n}\n"
+                    },
+                    "secondaryFiles": "${ if (inputs.trigger == true){ return self.basename + ext(); } else { return inputs.sort_input.secondaryFiles?inputs.sort_input.secondaryFiles:\"null\"; } }",
+                    "id": "#samtools-sort-index.cwl/bam_bai_pair"
+                }
+            ],
+            "baseCommand": [
+                "bash",
+                "-c"
+            ],
+            "arguments": [
+                {
+                    "valueFrom": "${ return inputs.trigger ? \"true\" : \"false\" }\n",
+                    "position": 6
+                },
+                {
+                    "valueFrom": "bam",
+                    "position": 13,
+                    "prefix": "-O"
+                },
+                {
+                    "valueFrom": "$(inputs.threads?inputs.threads:1)",
+                    "position": 15,
+                    "prefix": "-@"
+                },
+                {
+                    "valueFrom": ";",
+                    "position": 17,
+                    "shellQuote": false
+                },
+                {
+                    "valueFrom": "bash",
+                    "position": 18
+                },
+                {
+                    "valueFrom": "-c",
+                    "position": 19
+                },
+                {
+                    "valueFrom": "${ return inputs.trigger ? \"true\" : \"false\" }\n",
+                    "position": 21
+                },
+                {
+                    "valueFrom": "$(inputs.bai?'-b':inputs.csi?'-c':[])",
+                    "position": 23
+                },
+                {
+                    "valueFrom": "$(inputs.threads?inputs.threads:1)",
+                    "position": 25,
+                    "prefix": "-@"
+                },
+                {
+                    "valueFrom": "${\n    if (inputs.sort_output_filename == \"\" || inputs.trigger == false){\n      return default_bam();\n    } else {\n      return inputs.sort_output_filename;\n    }\n}\n",
+                    "position": 26
+                },
+                {
+                    "valueFrom": "${\n    if (inputs.sort_output_filename == \"\" || inputs.trigger == false){\n      return default_bam() + ext();\n    } else {\n      return inputs.sort_output_filename + ext();\n    }\n}\n",
+                    "position": 27
+                }
+            ],
+            "id": "#samtools-sort-index.cwl"
+        },
+        {
+            "class": "CommandLineTool",
+            "requirements": [
+                {
+                    "class": "InlineJavascriptRequirement",
+                    "expressionLib": [
+                        "var default_output_filename = function() { let basename = inputs.bedgraph_file.location.split('/').slice(-1)[0]; let root = basename.split('.').slice(0,-1).join('.'); let ext = \".bigWig\"; return (root == \"\")?basename+ext:root+ext; };"
+                    ]
+                }
+            ],
+            "hints": [
+                {
+                    "class": "DockerRequirement",
+                    "dockerPull": "biowardrobe2/ucscuserapps:v358"
+                }
+            ],
+            "inputs": [
+                {
+                    "type": "File",
+                    "inputBinding": {
+                        "position": 10
+                    },
+                    "doc": "Four column bedGraph file: <chrom> <start> <end> <value>\n",
+                    "id": "#ucsc-bedgraphtobigwig.cwl/bedgraph_file"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "separate": false,
+                        "position": 7,
+                        "prefix": "-blockSize="
+                    },
+                    "doc": "Number of items to bundle in r-tree.  Default 256\n",
+                    "id": "#ucsc-bedgraphtobigwig.cwl/block_size"
+                },
+                {
+                    "type": "File",
+                    "inputBinding": {
+                        "position": 11
+                    },
+                    "doc": "Two-column chromosome length file: <chromosome name> <size in bases>\n",
+                    "id": "#ucsc-bedgraphtobigwig.cwl/chrom_length_file"
+                },
+                {
+                    "type": [
+                        "null",
+                        "int"
+                    ],
+                    "inputBinding": {
+                        "separate": false,
+                        "position": 6,
+                        "prefix": "-itemsPerSlot="
+                    },
+                    "doc": "Number of data points bundled at lowest level. Default 1024\n",
+                    "id": "#ucsc-bedgraphtobigwig.cwl/items_per_slot"
+                },
+                {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "inputBinding": {
+                        "position": 12,
+                        "valueFrom": "${\n    if (self == \"\"){\n      return default_output_filename();\n    } else {\n      return self;\n    }\n}\n"
+                    },
+                    "default": "",
+                    "doc": "If set, writes the output bigWig file to output_filename,\notherwise generates filename from default_output_filename()\n",
+                    "id": "#ucsc-bedgraphtobigwig.cwl/output_filename"
+                },
+                {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "inputBinding": {
+                        "position": 5,
+                        "prefix": "-unc"
+                    },
+                    "doc": "Disable compression\n",
+                    "id": "#ucsc-bedgraphtobigwig.cwl/unc"
+                }
+            ],
+            "outputs": [
+                {
+                    "type": "File",
+                    "outputBinding": {
+                        "glob": "${\n    if (inputs.output_filename == \"\"){\n      return default_output_filename();\n    } else {\n      return inputs.output_filename;\n    }\n}\n"
+                    },
+                    "id": "#ucsc-bedgraphtobigwig.cwl/bigwig_file"
+                }
+            ],
+            "baseCommand": [
+                "bedGraphToBigWig"
+            ],
+            "id": "#ucsc-bedgraphtobigwig.cwl"
+        }
+    ],
+    "cwlVersion": "v1.0",
+    "$schemas": [
+        "http://schema.org/docs/schema_org_rdfa.html"
+    ],
+    "$namespaces": {
+        "s": "http://schema.org/"
+    }
+}

--- a/casts/claude/skills/_emulated-runs/ga4gh-challenge-cwl-galaxy-5step/normalized/main_steps.json
+++ b/casts/claude/skills/_emulated-runs/ga4gh-challenge-cwl-galaxy-5step/normalized/main_steps.json
@@ -1,0 +1,367 @@
+[
+  {
+    "id": "average_tag_density",
+    "run": "atdp.cwl",
+    "in": [
+      {
+        "id": "average_tag_density/annotation_filename",
+        "source": "annotation_file",
+        "valueFrom": null
+      },
+      {
+        "id": "average_tag_density/avd_heat_window_bp",
+        "valueFrom": null
+      },
+      {
+        "id": "average_tag_density/avd_smooth_bp",
+        "valueFrom": null
+      },
+      {
+        "id": "average_tag_density/avd_window_bp",
+        "valueFrom": null
+      },
+      {
+        "id": "average_tag_density/double_chr",
+        "valueFrom": null
+      },
+      {
+        "id": "average_tag_density/fragmentsize_bp",
+        "source": "macs2_callpeak/macs2_fragments_calculated",
+        "valueFrom": null
+      },
+      {
+        "id": "average_tag_density/ignore_chr",
+        "valueFrom": null
+      },
+      {
+        "id": "average_tag_density/input_file",
+        "source": "samtools_sort_index_after_rmdup/bam_bai_pair",
+        "valueFrom": null
+      },
+      {
+        "id": "average_tag_density/mapped_reads",
+        "source": "get_stat/mapped_reads",
+        "valueFrom": null
+      }
+    ],
+    "out": [
+      "average_tag_density/result_file",
+      "average_tag_density/log_file"
+    ]
+  },
+  {
+    "id": "bam_to_bigwig",
+    "run": "bam-bedgraph-bigwig.cwl",
+    "in": [
+      {
+        "id": "bam_to_bigwig/bam_file",
+        "source": "samtools_sort_index_after_rmdup/bam_bai_pair",
+        "valueFrom": null
+      },
+      {
+        "id": "bam_to_bigwig/chrom_length_file",
+        "source": "chrom_length",
+        "valueFrom": null
+      },
+      {
+        "id": "bam_to_bigwig/fragment_size",
+        "source": "macs2_callpeak/macs2_fragments_calculated",
+        "valueFrom": null
+      },
+      {
+        "id": "bam_to_bigwig/mapped_reads_number",
+        "source": "get_stat/mapped_reads",
+        "valueFrom": null
+      }
+    ],
+    "out": [
+      "bam_to_bigwig/bigwig_file"
+    ]
+  },
+  {
+    "id": "bowtie_aligner",
+    "run": "bowtie-alignreads.cwl",
+    "in": [
+      {
+        "id": "bowtie_aligner/best",
+        "valueFrom": null
+      },
+      {
+        "id": "bowtie_aligner/clip_3p_end",
+        "source": "clip_3p_end",
+        "valueFrom": null
+      },
+      {
+        "id": "bowtie_aligner/clip_5p_end",
+        "source": "clip_5p_end",
+        "valueFrom": null
+      },
+      {
+        "id": "bowtie_aligner/indices_folder",
+        "source": "indices_folder",
+        "valueFrom": null
+      },
+      {
+        "id": "bowtie_aligner/m",
+        "valueFrom": null
+      },
+      {
+        "id": "bowtie_aligner/q",
+        "valueFrom": null
+      },
+      {
+        "id": "bowtie_aligner/sam",
+        "valueFrom": null
+      },
+      {
+        "id": "bowtie_aligner/strata",
+        "valueFrom": null
+      },
+      {
+        "id": "bowtie_aligner/threads",
+        "source": "threads",
+        "valueFrom": null
+      },
+      {
+        "id": "bowtie_aligner/upstream_filelist",
+        "source": "extract_fastq/fastq_file",
+        "valueFrom": null
+      },
+      {
+        "id": "bowtie_aligner/v",
+        "valueFrom": null
+      }
+    ],
+    "out": [
+      "bowtie_aligner/sam_file",
+      "bowtie_aligner/log_file"
+    ]
+  },
+  {
+    "id": "extract_fastq",
+    "run": "extract-fastq.cwl",
+    "in": [
+      {
+        "id": "extract_fastq/compressed_file",
+        "source": "fastq_file",
+        "valueFrom": null
+      }
+    ],
+    "out": [
+      "extract_fastq/fastq_file"
+    ]
+  },
+  {
+    "id": "fastx_quality_stats",
+    "run": "fastx-quality-stats.cwl",
+    "in": [
+      {
+        "id": "fastx_quality_stats/input_file",
+        "source": "extract_fastq/fastq_file",
+        "valueFrom": null
+      }
+    ],
+    "out": [
+      "fastx_quality_stats/statistics_file"
+    ]
+  },
+  {
+    "id": "get_stat",
+    "run": "python-get-stat-chipseq.cwl",
+    "in": [
+      {
+        "id": "get_stat/bowtie_log",
+        "source": "bowtie_aligner/log_file",
+        "valueFrom": null
+      },
+      {
+        "id": "get_stat/rmdup_log",
+        "source": "samtools_rmdup/rmdup_log",
+        "valueFrom": null
+      }
+    ],
+    "out": [
+      "get_stat/output_file",
+      "get_stat/mapped_reads"
+    ]
+  },
+  {
+    "id": "island_intersect",
+    "run": "iaintersect.cwl",
+    "in": [
+      {
+        "id": "island_intersect/annotation_filename",
+        "source": "annotation_file",
+        "valueFrom": null
+      },
+      {
+        "id": "island_intersect/input_filename",
+        "source": "macs2_callpeak/peak_xls_file",
+        "valueFrom": null
+      },
+      {
+        "id": "island_intersect/promoter_bp",
+        "valueFrom": null
+      }
+    ],
+    "out": [
+      "island_intersect/result_file",
+      "island_intersect/log_file"
+    ]
+  },
+  {
+    "id": "macs2_callpeak",
+    "run": "macs2-callpeak-biowardrobe-only.cwl",
+    "in": [
+      {
+        "id": "macs2_callpeak/broad",
+        "source": "broad_peak",
+        "valueFrom": null
+      },
+      {
+        "id": "macs2_callpeak/buffer_size",
+        "valueFrom": null
+      },
+      {
+        "id": "macs2_callpeak/bw",
+        "source": "exp_fragment_size",
+        "valueFrom": null
+      },
+      {
+        "id": "macs2_callpeak/call_summits",
+        "source": "broad_peak",
+        "valueFrom": "$(!self)"
+      },
+      {
+        "id": "macs2_callpeak/control_file",
+        "source": "control_file",
+        "valueFrom": null
+      },
+      {
+        "id": "macs2_callpeak/extsize",
+        "source": "exp_fragment_size",
+        "valueFrom": null
+      },
+      {
+        "id": "macs2_callpeak/format_mode",
+        "valueFrom": null
+      },
+      {
+        "id": "macs2_callpeak/genome_size",
+        "source": "genome_size",
+        "valueFrom": null
+      },
+      {
+        "id": "macs2_callpeak/keep_dup",
+        "valueFrom": null
+      },
+      {
+        "id": "macs2_callpeak/mfold",
+        "valueFrom": null
+      },
+      {
+        "id": "macs2_callpeak/nolambda",
+        "source": "control_file",
+        "valueFrom": "$(!self)"
+      },
+      {
+        "id": "macs2_callpeak/nomodel",
+        "source": "force_fragment_size",
+        "valueFrom": null
+      },
+      {
+        "id": "macs2_callpeak/q_value",
+        "valueFrom": null
+      },
+      {
+        "id": "macs2_callpeak/treatment_file",
+        "source": "samtools_sort_index_after_rmdup/bam_bai_pair",
+        "valueFrom": null
+      },
+      {
+        "id": "macs2_callpeak/verbose",
+        "valueFrom": null
+      }
+    ],
+    "out": [
+      "macs2_callpeak/peak_xls_file",
+      "macs2_callpeak/narrow_peak_file",
+      "macs2_callpeak/peak_summits_file",
+      "macs2_callpeak/broad_peak_file",
+      "macs2_callpeak/moder_r_file",
+      "macs2_callpeak/gapped_peak_file",
+      "macs2_callpeak/treat_pileup_bdg_file",
+      "macs2_callpeak/control_lambda_bdg_file",
+      "macs2_callpeak/macs_log",
+      "macs2_callpeak/macs2_stat_file",
+      "macs2_callpeak/macs2_fragments_calculated"
+    ]
+  },
+  {
+    "id": "samtools_rmdup",
+    "run": "samtools-rmdup.cwl",
+    "in": [
+      {
+        "id": "samtools_rmdup/bam_file",
+        "source": "samtools_sort_index/bam_bai_pair",
+        "valueFrom": null
+      },
+      {
+        "id": "samtools_rmdup/single_end",
+        "valueFrom": null
+      },
+      {
+        "id": "samtools_rmdup/trigger",
+        "source": "remove_duplicates",
+        "valueFrom": null
+      }
+    ],
+    "out": [
+      "samtools_rmdup/rmdup_output",
+      "samtools_rmdup/rmdup_log"
+    ]
+  },
+  {
+    "id": "samtools_sort_index",
+    "run": "samtools-sort-index.cwl",
+    "in": [
+      {
+        "id": "samtools_sort_index/sort_input",
+        "source": "bowtie_aligner/sam_file",
+        "valueFrom": null
+      },
+      {
+        "id": "samtools_sort_index/threads",
+        "source": "threads",
+        "valueFrom": null
+      }
+    ],
+    "out": [
+      "samtools_sort_index/bam_bai_pair"
+    ]
+  },
+  {
+    "id": "samtools_sort_index_after_rmdup",
+    "run": "samtools-sort-index.cwl",
+    "in": [
+      {
+        "id": "samtools_sort_index_after_rmdup/sort_input",
+        "source": "samtools_rmdup/rmdup_output",
+        "valueFrom": null
+      },
+      {
+        "id": "samtools_sort_index_after_rmdup/threads",
+        "source": "threads",
+        "valueFrom": null
+      },
+      {
+        "id": "samtools_sort_index_after_rmdup/trigger",
+        "source": "remove_duplicates",
+        "valueFrom": null
+      }
+    ],
+    "out": [
+      "samtools_sort_index_after_rmdup/bam_bai_pair"
+    ]
+  }
+]

--- a/casts/claude/skills/_emulated-runs/ga4gh-challenge-cwl-galaxy-5step/run-summary.md
+++ b/casts/claude/skills/_emulated-runs/ga4gh-challenge-cwl-galaxy-5step/run-summary.md
@@ -1,0 +1,117 @@
+# Run summary — ga4gh-challenge-cwl-galaxy-5step
+
+## Scenario
+
+Test-drive phases 1–5 of `content/pipelines/cwl-to-galaxy.md` against
+`workflow-fixtures/cwl/Barski-Lab__ga4gh_challenge/biowardrobe_chipseq_se.cwl`
+(SHA `f28d47b`, cwlVersion `v1.0`, 1 main workflow + 1 nested workflow + 12 CommandLineTools).
+
+## Molds exercised
+
+| # | Mold | Mode | Output |
+| --- | --- | --- | --- |
+| 1 | `summarize-cwl` | emulation + `cwltool --validate` + `cwltool --pack` + extract.mjs + `foundry validate-summary-cwl` | `summary-cwl.json` (160 KB, valid) |
+| 2 | `cwl-summary-to-galaxy-interface` | emulation | `cwl-galaxy-interface.md` |
+| 3 | `cwl-summary-to-galaxy-data-flow` | emulation | `cwl-galaxy-data-flow.md` |
+| 4 | `compare-against-iwc-exemplar` | emulation against local `iwc-format2/epigenetics/` | `iwc-comparison-notes.md` |
+| 5 | `cwl-summary-to-galaxy-template` | emulation + `gxwf validate --no-tool-state` | `galaxy-workflow-draft.gxwf.yml` (structural validation OK) |
+
+## Inputs consumed
+
+- `workflow-fixtures/cwl/Barski-Lab__ga4gh_challenge/biowardrobe_chipseq_se.cwl` @ `f28d47b`.
+- `~/projects/repositories/workflow-fixtures/iwc-format2/epigenetics/chipseq-sr/chipseq-sr.gxwf.yml` (IWC mirror; step 4).
+
+## Outputs produced (all under run dir)
+
+- `normalized/biowardrobe_chipseq_se.packed.json` (cwltool --pack output, since `cwl-normalizer` was broken — see process notes)
+- `summary-cwl.json` (valid against `summary-cwl` schema)
+- `extract.mjs` (one-off extractor script)
+- `cwl-galaxy-interface.md`
+- `cwl-galaxy-data-flow.md`
+- `iwc-comparison-notes.md`
+- `galaxy-workflow-draft.gxwf.yml`
+
+## Eval results
+
+### summarize-cwl
+
+| Case | Verdict | Note |
+| --- | --- | --- |
+| user-guide simple validates | N/A | run targeted ga4gh fixture, not user_guide |
+| scatter recorded | N/A | source has no scatter |
+| nested workflow preserved | ✅ | `#bam-bedgraph-bigwig.cwl` retained as a `tools[]` entry with a `_NestedWorkflow` hint; `steps[].run_class` would be `Workflow` for the corresponding step (translated to `Workflow` because the run target's class is `Workflow`). |
+| conditional `when:` | N/A | source has no `when:` |
+| cross-document refs resolve | ✅ | All 12 tools + 1 nested workflow appear in `tools[]`; no unresolved `run:` strings |
+| step input shape fields survive | ✅ | `steps[].in[]` carries `source`, `default`, `value_from`, `link_merge`, `pick_value` (mostly null for this fixture but shape present) |
+| **high-level** | ⚠ | Output validates against schema and is faithful. Concern: I produced this with a one-off `extract.mjs` (not the Mold), because no CLI implementation of `summarize-cwl` exists yet. The CLI claim in `SKILL.md` ("Required Tools: cwl-normalizer, cwltool, foundry") implies the LLM does the extraction at runtime — workable, but for a 14-doc workflow the schema is large enough that a CLI implementation is plainly the right path. |
+
+### cwl-summary-to-galaxy-interface
+
+| Case | Verdict | Note |
+| --- | --- | --- |
+| secondaryFiles flagged | N/A | source has no `secondaryFiles` |
+| outputs testable | ✅ | 18 stable output labels named; the `null|File`-flowing macs2 outputs are flagged |
+| downstream Mold can consume | ✅ | data-flow brief consumed it without re-deriving from CWL |
+| **high-level** | ✅ | The brief consciously surfaces the Directory→Galaxy mapping as an open question rather than picking blindly. Good fit. |
+
+### cwl-summary-to-galaxy-data-flow
+
+| Case | Verdict | Note |
+| --- | --- | --- |
+| secondaryFiles plumbing | N/A | source has no `secondaryFiles` |
+| no invented Tool Shed IDs | ✅ | placeholders only; one IUC candidate named in the IWC-comparison step, not in the data-flow brief |
+| pickValue not silently dropped | N/A | no pickValue |
+| ExpressionTool surfaced | N/A | no ExpressionTool |
+| template Mold can consume | ✅ | step 5 used the brief directly |
+| **high-level** | ✅ | The fixture has very little translation pressure (no scatter, no when, no pickValue, no expressions at workflow boundary). The brief stayed lighter than nextflow-to-galaxy peers, as the SKILL.md said to. |
+
+### compare-against-iwc-exemplar
+
+| Case | Verdict | Note |
+| --- | --- | --- |
+| nf-core/rnaseq exemplar | N/A | this run is CWL, not nf-core |
+| viralrecon | N/A | as above |
+| mag | N/A | as above |
+| no acceptable exemplar | N/A | exemplar found |
+| IWC clone reuse | ✅ | used existing `~/projects/repositories/workflow-fixtures/iwc-format2/` mirror; no clone needed |
+| **high-level** | ⚠ | Found nearest IWC exemplar at medium-high confidence (`chipseq-sr`) and surfaced 6 actionable diffs. Concern: every eval-defined case is nf-core-flavored; **the Mold has zero CWL-flavored cases in `eval.md`**. This run is unscored by the existing eval. Refinement candidate. |
+
+### cwl-summary-to-galaxy-template
+
+| Case | Verdict | Note |
+| --- | --- | --- |
+| draft is a stub, not runnable | ✅ | 12 `tool_id: TODO`, 12 `tool_version: TODO`, all step inputs/outputs use `TODO_*` placeholders, but topology is fully wired |
+| preserves prior decisions | ✅ | 18 named outputs match interface brief; the Directory open question is carried into `_plan_context` |
+| TODO placeholders actionable | ✅ | Each `_plan_context` names source `baseCommand`, DockerRequirement, Tool Shed candidate (or "expect to author") |
+| collection inputs gxformat2-shaped | ✅ | Non-TODO surfaces parse: `gxwf validate --no-tool-state` reports `Structural validation: OK` |
+| outputs labeled | ✅ | 18 outputs named per the interface brief |
+| IWC findings traceable | ✅ | IWC-alignment alternatives written into `_plan_context` so the per-step Mold can see them, not silently applied |
+| **high-level** | ✅ | Draft structurally validates. The `_plan_context` payload is heavy but useful — it carries the Docker URIs, baseCommands, and Tool Shed candidates the per-step authoring Mold will need. |
+
+## Refinement entries written
+
+- `content/molds/summarize-cwl/refinements/2026-05-11-ga4gh-challenge-cwl-galaxy-5step.md` — `decision: open-question`
+- `content/molds/compare-against-iwc-exemplar/refinements/2026-05-11-ga4gh-challenge-cwl-galaxy-5step.md` — `decision: eval-add`
+
+## Process observations
+
+1. **Cast drift on 4 of 5 Molds.** `npm run cast --check` reported drift; reconciled deterministically (no `pending_llm` follow-up needed). Drift caused by upstream changes to `content/research/galaxy-collection-semantics.md` and the `summaryCwlSchema` package export. After re-cast, `summarize-cwl` verify reports `error: _provenance.json: /refs/1/kind must be equal to one of the allowed values` for its CLI refs; the other 3 Molds verify clean. Worth investigating separately — not blocking emulation.
+2. **Build was required.** `npm run cast` failed initially with `Cannot find package '@galaxy-foundry/foundry'` — had to run `pnpm --filter @galaxy-foundry/foundry build` before `npm run packages-build` could succeed. The `make validate` / `make test` happy path is fine, but the cast pipeline assumes packages are already built.
+3. **`cwl-normalizer` is broken on current cwl-utils.** Calling `uvx --from cwl-utils cwl-normalizer` errors on `ruamel.yaml.round_trip_load` (removed in newer ruamel). Fell back to `cwltool --pack` for normalization. The `summarize-cwl` SKILL.md names `cwl-normalizer` as a required tool — should either pin an older `cwl-utils` or document the `cwltool --pack` fallback.
+4. **No `summarize-cwl` CLI.** The Mold's SKILL.md procedure assumes the LLM reads packed CWL and emits `summary-cwl.json` itself. For this 14-document workflow, I wrote a one-off `extract.mjs` to do the structural extraction deterministically; the LLM filled in the warnings/source-record metadata. This is workable for emulation but suggests a `foundry summarize-cwl` companion to `foundry summarize-nextflow` would pay for itself.
+
+## Cross-cutting open questions
+
+1. CWL Directory → Galaxy reference-data-table is recurring; pattern page candidate.
+2. Conditional steps in source CWL (null/File flowing to non-null sink) have no clean gxformat2 expression; current draft accepts downstream-failure semantics. Sibling-workflow split is the only fidelity-preserving alternative.
+3. `compare-against-iwc-exemplar` eval has no CWL-source-shaped case.
+4. `summarize-cwl` evidence-extraction step is missing a CLI counterpart to `summarize-nextflow`.
+5. Cast verify error on `summarize-cwl` provenance (`refs[1].kind` enum violation) needs investigation independent of this run.
+
+## Follow-ups
+
+- Continue the pipeline past phase 5: `discover-or-author` loop on the 12 tools (6 likely-IUC, 5 expect-author, 1 ambiguous). The draft's `_plan_context` is already shaped for that work.
+- Open an issue / refinement for the missing CLI implementation of `summarize-cwl`.
+- Open an issue for the `cwl-normalizer` breakage; either pin cwl-utils or update the SKILL.md to permit `cwltool --pack` as the normalization fallback.
+- Open an issue for cast verify error on `summarize-cwl` (`/refs/1/kind`).
+- Open an issue (or refinement) to add CWL-source eval cases to `compare-against-iwc-exemplar`.

--- a/casts/claude/skills/_emulated-runs/ga4gh-challenge-cwl-galaxy-5step/summary-cwl.json
+++ b/casts/claude/skills/_emulated-runs/ga4gh-challenge-cwl-galaxy-5step/summary-cwl.json
@@ -1,0 +1,5011 @@
+{
+  "summary_version": "1",
+  "source": {
+    "ecosystem": "cwl",
+    "workflow": "biowardrobe_chipseq_se",
+    "url": "https://github.com/Barski-Lab/ga4gh_challenge/blob/f28d47bd0911e5e7210c4dc83f75653a1e0297c9/biowardrobe_chipseq_se.cwl",
+    "version": "f28d47bd0911e5e7210c4dc83f75653a1e0297c9",
+    "license": null,
+    "slug": "biowardrobe-chipseq-se",
+    "cwl_version": "v1.0",
+    "entrypoint": "biowardrobe_chipseq_se.cwl"
+  },
+  "documents": {
+    "entrypoint": "workflow-fixtures/cwl/Barski-Lab__ga4gh_challenge/biowardrobe_chipseq_se.cwl",
+    "normalized_path": "normalized/biowardrobe_chipseq_se.packed.json",
+    "validation": {
+      "command": "cwltool --validate biowardrobe_chipseq_se.cwl",
+      "status": "valid",
+      "diagnostics": [
+        "warning biowardrobe_chipseq_se.cwl:341:9 — macs2_callpeak/peak_xls_file (null|File) may be incompatible with downstream sink input_filename (File)"
+      ]
+    }
+  },
+  "workflow_inputs": [
+    {
+      "id": "annotation_file",
+      "label": "Annotation file",
+      "type": "File",
+      "optional": false,
+      "default": null,
+      "doc": "Tab-separated input annotation file",
+      "format": "http://edamontology.org/format_3475",
+      "secondary_files": []
+    },
+    {
+      "id": "broad_peak",
+      "label": "Callpeak broad",
+      "type": "boolean",
+      "optional": false,
+      "default": null,
+      "doc": "Set to call broad peak for MACS2",
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "chrom_length",
+      "label": "Chromosome length file",
+      "type": "File",
+      "optional": false,
+      "default": null,
+      "doc": "Chromosome length file",
+      "format": "http://edamontology.org/format_2330",
+      "secondary_files": []
+    },
+    {
+      "id": "clip_3p_end",
+      "label": "Clip from 3p end",
+      "type": "null | int",
+      "optional": true,
+      "default": 0,
+      "doc": "Number of bases to clip from the 3p end",
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "clip_5p_end",
+      "label": "Clip from 5p end",
+      "type": "null | int",
+      "optional": true,
+      "default": 0,
+      "doc": "Number of bases to clip from the 5p end",
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "control_file",
+      "label": "Control BAM file",
+      "type": "null | File",
+      "optional": true,
+      "default": null,
+      "doc": "Control BAM file file for MACS2 peak calling",
+      "format": "http://edamontology.org/format_2572",
+      "secondary_files": []
+    },
+    {
+      "id": "exp_fragment_size",
+      "label": "Expected fragment size",
+      "type": "null | int",
+      "optional": true,
+      "default": 150,
+      "doc": "Expected fragment size for MACS2",
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "fastq_file",
+      "label": "FASTQ input file",
+      "type": "File",
+      "optional": false,
+      "default": null,
+      "doc": "Reads data in a FASTQ format, received after single end sequencing",
+      "format": "http://edamontology.org/format_1930",
+      "secondary_files": []
+    },
+    {
+      "id": "force_fragment_size",
+      "label": "Force fragment size",
+      "type": "null | boolean",
+      "optional": true,
+      "default": false,
+      "doc": "Force MACS2 to use exp_fragment_size",
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "genome_size",
+      "label": "Effective genome size",
+      "type": "string",
+      "optional": false,
+      "default": null,
+      "doc": "MACS2 effective genome size: hs, mm, ce, dm or number, for example 2.7e9",
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "indices_folder",
+      "label": "BOWTIE indices folder",
+      "type": "Directory",
+      "optional": false,
+      "default": null,
+      "doc": "Path to BOWTIE generated indices folder",
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "remove_duplicates",
+      "label": "Remove duplicates",
+      "type": "null | boolean",
+      "optional": true,
+      "default": false,
+      "doc": "Calls samtools rmdup to remove duplicates from sortesd BAM file",
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "threads",
+      "label": "Number of threads",
+      "type": "null | int",
+      "optional": true,
+      "default": 2,
+      "doc": "Number of threads for those steps that support multithreading",
+      "format": null,
+      "secondary_files": []
+    }
+  ],
+  "workflow_outputs": [
+    {
+      "id": "atdp_log",
+      "label": "ATDP log",
+      "type": "File",
+      "output_source": [
+        "average_tag_density/log_file"
+      ],
+      "doc": "Average Tag Density generated log",
+      "format": "http://edamontology.org/format_3475",
+      "secondary_files": []
+    },
+    {
+      "id": "atdp_result",
+      "label": "ATDP results",
+      "type": "File",
+      "output_source": [
+        "average_tag_density/result_file"
+      ],
+      "doc": "Average Tag Density generated results",
+      "format": "http://edamontology.org/format_3475",
+      "secondary_files": []
+    },
+    {
+      "id": "bambai_pair",
+      "label": "Coordinate sorted BAM alignment file (+index BAI)",
+      "type": "File",
+      "output_source": [
+        "samtools_sort_index_after_rmdup/bam_bai_pair"
+      ],
+      "doc": "Coordinate sorted BAM file and BAI index file",
+      "format": "http://edamontology.org/format_2572",
+      "secondary_files": []
+    },
+    {
+      "id": "bigwig",
+      "label": "BigWig file",
+      "type": "File",
+      "output_source": [
+        "bam_to_bigwig/bigwig_file"
+      ],
+      "doc": "Generated BigWig file",
+      "format": "http://edamontology.org/format_3006",
+      "secondary_files": []
+    },
+    {
+      "id": "bowtie_log",
+      "label": "BOWTIE alignment log",
+      "type": "File",
+      "output_source": [
+        "bowtie_aligner/log_file"
+      ],
+      "doc": "BOWTIE generated alignment log",
+      "format": "http://edamontology.org/format_2330",
+      "secondary_files": []
+    },
+    {
+      "id": "fastx_statistics",
+      "label": "FASTQ statistics",
+      "type": "File",
+      "output_source": [
+        "fastx_quality_stats/statistics_file"
+      ],
+      "doc": "fastx_quality_stats generated FASTQ file quality statistics file",
+      "format": "http://edamontology.org/format_2330",
+      "secondary_files": []
+    },
+    {
+      "id": "get_stat_log",
+      "label": "Bowtie & Samtools Rmdup combined log",
+      "type": "null | File",
+      "output_source": [
+        "get_stat/output_file"
+      ],
+      "doc": "Processed and combined Bowtie aligner and Samtools rmdup log",
+      "format": "http://edamontology.org/format_2330",
+      "secondary_files": []
+    },
+    {
+      "id": "iaintersect_log",
+      "label": "Island intersect log",
+      "type": "File",
+      "output_source": [
+        "island_intersect/log_file"
+      ],
+      "doc": "Iaintersect generated log",
+      "format": "http://edamontology.org/format_3475",
+      "secondary_files": []
+    },
+    {
+      "id": "iaintersect_result",
+      "label": "Island intersect results",
+      "type": "File",
+      "output_source": [
+        "island_intersect/result_file"
+      ],
+      "doc": "Iaintersect generated results",
+      "format": "http://edamontology.org/format_3475",
+      "secondary_files": []
+    },
+    {
+      "id": "macs2_broad_peaks",
+      "label": "Broad peaks",
+      "type": "null | File",
+      "output_source": [
+        "macs2_callpeak/broad_peak_file"
+      ],
+      "doc": "Contains the peak locations together with peak summit, pvalue and qvalue",
+      "format": "http://edamontology.org/format_3614",
+      "secondary_files": []
+    },
+    {
+      "id": "macs2_called_peaks",
+      "label": "Called peaks",
+      "type": "null | File",
+      "output_source": [
+        "macs2_callpeak/peak_xls_file"
+      ],
+      "doc": "XLS file to include information about called peaks",
+      "format": "http://edamontology.org/format_3468",
+      "secondary_files": []
+    },
+    {
+      "id": "macs2_fragment_stat",
+      "label": "FRAGMENT, FRAGMENTE, ISLANDS",
+      "type": "null | File",
+      "output_source": [
+        "macs2_callpeak/macs2_stat_file"
+      ],
+      "doc": "fragment, calculated fragment, islands count from MACS2 results",
+      "format": "http://edamontology.org/format_2330",
+      "secondary_files": []
+    },
+    {
+      "id": "macs2_gapped_peak",
+      "label": "Gapped peak",
+      "type": "null | File",
+      "output_source": [
+        "macs2_callpeak/gapped_peak_file"
+      ],
+      "doc": "Contains both the broad region and narrow peaks",
+      "format": "http://edamontology.org/format_3586",
+      "secondary_files": []
+    },
+    {
+      "id": "macs2_log",
+      "label": "MACS2 log",
+      "type": "null | File",
+      "output_source": [
+        "macs2_callpeak/macs_log"
+      ],
+      "doc": "MACS2 output log",
+      "format": "http://edamontology.org/format_2330",
+      "secondary_files": []
+    },
+    {
+      "id": "macs2_moder_r",
+      "label": "MACS2 generated R script",
+      "type": "null | File",
+      "output_source": [
+        "macs2_callpeak/moder_r_file"
+      ],
+      "doc": "R script to produce a PDF image about the model based on your data",
+      "format": "http://edamontology.org/format_2330",
+      "secondary_files": []
+    },
+    {
+      "id": "macs2_narrow_peaks",
+      "label": "Narrow peaks",
+      "type": "null | File",
+      "output_source": [
+        "macs2_callpeak/narrow_peak_file"
+      ],
+      "doc": "Contains the peak locations together with peak summit, pvalue and qvalue",
+      "format": "http://edamontology.org/format_3613",
+      "secondary_files": []
+    },
+    {
+      "id": "macs2_peak_summits",
+      "label": "Peak summits",
+      "type": "null | File",
+      "output_source": [
+        "macs2_callpeak/peak_summits_file"
+      ],
+      "doc": "Contains the peak summits locations for every peaks",
+      "format": "http://edamontology.org/format_3003",
+      "secondary_files": []
+    },
+    {
+      "id": "samtools_rmdup_log",
+      "label": "Remove duplicates log",
+      "type": "File",
+      "output_source": [
+        "samtools_rmdup/rmdup_log"
+      ],
+      "doc": "Samtools rmdup generated log",
+      "format": "http://edamontology.org/format_2330",
+      "secondary_files": []
+    }
+  ],
+  "steps": [
+    {
+      "id": "average_tag_density",
+      "run": "atdp.cwl",
+      "run_class": "CommandLineTool",
+      "label": null,
+      "doc": null,
+      "in": [
+        {
+          "id": "average_tag_density/annotation_filename",
+          "source": [
+            "annotation_file"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "average_tag_density/avd_heat_window_bp",
+          "source": [],
+          "default": 200,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "average_tag_density/avd_smooth_bp",
+          "source": [],
+          "default": 50,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "average_tag_density/avd_window_bp",
+          "source": [],
+          "default": 5000,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "average_tag_density/double_chr",
+          "source": [],
+          "default": "chrX chrY",
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "average_tag_density/fragmentsize_bp",
+          "source": [
+            "macs2_callpeak/macs2_fragments_calculated"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "average_tag_density/ignore_chr",
+          "source": [],
+          "default": "chrM",
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "average_tag_density/input_file",
+          "source": [
+            "samtools_sort_index_after_rmdup/bam_bai_pair"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "average_tag_density/mapped_reads",
+          "source": [
+            "get_stat/mapped_reads"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        }
+      ],
+      "out": [
+        "result_file",
+        "log_file"
+      ],
+      "scatter": [],
+      "scatter_method": null,
+      "when": null,
+      "requirements": [],
+      "hints": []
+    },
+    {
+      "id": "bam_to_bigwig",
+      "run": "bam-bedgraph-bigwig.cwl",
+      "run_class": "Workflow",
+      "label": null,
+      "doc": null,
+      "in": [
+        {
+          "id": "bam_to_bigwig/bam_file",
+          "source": [
+            "samtools_sort_index_after_rmdup/bam_bai_pair"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "bam_to_bigwig/chrom_length_file",
+          "source": [
+            "chrom_length"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "bam_to_bigwig/fragment_size",
+          "source": [
+            "macs2_callpeak/macs2_fragments_calculated"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "bam_to_bigwig/mapped_reads_number",
+          "source": [
+            "get_stat/mapped_reads"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        }
+      ],
+      "out": [
+        "bigwig_file"
+      ],
+      "scatter": [],
+      "scatter_method": null,
+      "when": null,
+      "requirements": [],
+      "hints": []
+    },
+    {
+      "id": "bowtie_aligner",
+      "run": "bowtie-alignreads.cwl",
+      "run_class": "CommandLineTool",
+      "label": null,
+      "doc": null,
+      "in": [
+        {
+          "id": "bowtie_aligner/best",
+          "source": [],
+          "default": true,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "bowtie_aligner/clip_3p_end",
+          "source": [
+            "clip_3p_end"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "bowtie_aligner/clip_5p_end",
+          "source": [
+            "clip_5p_end"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "bowtie_aligner/indices_folder",
+          "source": [
+            "indices_folder"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "bowtie_aligner/m",
+          "source": [],
+          "default": 1,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "bowtie_aligner/q",
+          "source": [],
+          "default": true,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "bowtie_aligner/sam",
+          "source": [],
+          "default": true,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "bowtie_aligner/strata",
+          "source": [],
+          "default": true,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "bowtie_aligner/threads",
+          "source": [
+            "threads"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "bowtie_aligner/upstream_filelist",
+          "source": [
+            "extract_fastq/fastq_file"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "bowtie_aligner/v",
+          "source": [],
+          "default": 3,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        }
+      ],
+      "out": [
+        "sam_file",
+        "log_file"
+      ],
+      "scatter": [],
+      "scatter_method": null,
+      "when": null,
+      "requirements": [],
+      "hints": []
+    },
+    {
+      "id": "extract_fastq",
+      "run": "extract-fastq.cwl",
+      "run_class": "CommandLineTool",
+      "label": null,
+      "doc": null,
+      "in": [
+        {
+          "id": "extract_fastq/compressed_file",
+          "source": [
+            "fastq_file"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        }
+      ],
+      "out": [
+        "fastq_file"
+      ],
+      "scatter": [],
+      "scatter_method": null,
+      "when": null,
+      "requirements": [],
+      "hints": []
+    },
+    {
+      "id": "fastx_quality_stats",
+      "run": "fastx-quality-stats.cwl",
+      "run_class": "CommandLineTool",
+      "label": null,
+      "doc": null,
+      "in": [
+        {
+          "id": "fastx_quality_stats/input_file",
+          "source": [
+            "extract_fastq/fastq_file"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        }
+      ],
+      "out": [
+        "statistics_file"
+      ],
+      "scatter": [],
+      "scatter_method": null,
+      "when": null,
+      "requirements": [],
+      "hints": []
+    },
+    {
+      "id": "get_stat",
+      "run": "python-get-stat-chipseq.cwl",
+      "run_class": "CommandLineTool",
+      "label": null,
+      "doc": null,
+      "in": [
+        {
+          "id": "get_stat/bowtie_log",
+          "source": [
+            "bowtie_aligner/log_file"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "get_stat/rmdup_log",
+          "source": [
+            "samtools_rmdup/rmdup_log"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        }
+      ],
+      "out": [
+        "output_file",
+        "mapped_reads"
+      ],
+      "scatter": [],
+      "scatter_method": null,
+      "when": null,
+      "requirements": [],
+      "hints": []
+    },
+    {
+      "id": "island_intersect",
+      "run": "iaintersect.cwl",
+      "run_class": "CommandLineTool",
+      "label": null,
+      "doc": null,
+      "in": [
+        {
+          "id": "island_intersect/annotation_filename",
+          "source": [
+            "annotation_file"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "island_intersect/input_filename",
+          "source": [
+            "macs2_callpeak/peak_xls_file"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "island_intersect/promoter_bp",
+          "source": [],
+          "default": 1000,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        }
+      ],
+      "out": [
+        "result_file",
+        "log_file"
+      ],
+      "scatter": [],
+      "scatter_method": null,
+      "when": null,
+      "requirements": [],
+      "hints": []
+    },
+    {
+      "id": "macs2_callpeak",
+      "run": "macs2-callpeak-biowardrobe-only.cwl",
+      "run_class": "CommandLineTool",
+      "label": null,
+      "doc": null,
+      "in": [
+        {
+          "id": "macs2_callpeak/broad",
+          "source": [
+            "broad_peak"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "macs2_callpeak/buffer_size",
+          "source": [],
+          "default": 10000,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "macs2_callpeak/bw",
+          "source": [
+            "exp_fragment_size"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "macs2_callpeak/call_summits",
+          "source": [
+            "broad_peak"
+          ],
+          "default": null,
+          "value_from": "$(!self)",
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "macs2_callpeak/control_file",
+          "source": [
+            "control_file"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "macs2_callpeak/extsize",
+          "source": [
+            "exp_fragment_size"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "macs2_callpeak/format_mode",
+          "source": [],
+          "default": "BAM",
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "macs2_callpeak/genome_size",
+          "source": [
+            "genome_size"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "macs2_callpeak/keep_dup",
+          "source": [],
+          "default": "auto",
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "macs2_callpeak/mfold",
+          "source": [],
+          "default": "4 40",
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "macs2_callpeak/nolambda",
+          "source": [
+            "control_file"
+          ],
+          "default": null,
+          "value_from": "$(!self)",
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "macs2_callpeak/nomodel",
+          "source": [
+            "force_fragment_size"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "macs2_callpeak/q_value",
+          "source": [],
+          "default": 0.05,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "macs2_callpeak/treatment_file",
+          "source": [
+            "samtools_sort_index_after_rmdup/bam_bai_pair"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "macs2_callpeak/verbose",
+          "source": [],
+          "default": 3,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        }
+      ],
+      "out": [
+        "peak_xls_file",
+        "narrow_peak_file",
+        "peak_summits_file",
+        "broad_peak_file",
+        "moder_r_file",
+        "gapped_peak_file",
+        "treat_pileup_bdg_file",
+        "control_lambda_bdg_file",
+        "macs_log",
+        "macs2_stat_file",
+        "macs2_fragments_calculated"
+      ],
+      "scatter": [],
+      "scatter_method": null,
+      "when": null,
+      "requirements": [],
+      "hints": []
+    },
+    {
+      "id": "samtools_rmdup",
+      "run": "samtools-rmdup.cwl",
+      "run_class": "CommandLineTool",
+      "label": null,
+      "doc": null,
+      "in": [
+        {
+          "id": "samtools_rmdup/bam_file",
+          "source": [
+            "samtools_sort_index/bam_bai_pair"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "samtools_rmdup/single_end",
+          "source": [],
+          "default": true,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "samtools_rmdup/trigger",
+          "source": [
+            "remove_duplicates"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        }
+      ],
+      "out": [
+        "rmdup_output",
+        "rmdup_log"
+      ],
+      "scatter": [],
+      "scatter_method": null,
+      "when": null,
+      "requirements": [],
+      "hints": []
+    },
+    {
+      "id": "samtools_sort_index",
+      "run": "samtools-sort-index.cwl",
+      "run_class": "CommandLineTool",
+      "label": null,
+      "doc": null,
+      "in": [
+        {
+          "id": "samtools_sort_index/sort_input",
+          "source": [
+            "bowtie_aligner/sam_file"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "samtools_sort_index/threads",
+          "source": [
+            "threads"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        }
+      ],
+      "out": [
+        "bam_bai_pair"
+      ],
+      "scatter": [],
+      "scatter_method": null,
+      "when": null,
+      "requirements": [],
+      "hints": []
+    },
+    {
+      "id": "samtools_sort_index_after_rmdup",
+      "run": "samtools-sort-index.cwl",
+      "run_class": "CommandLineTool",
+      "label": null,
+      "doc": null,
+      "in": [
+        {
+          "id": "samtools_sort_index_after_rmdup/sort_input",
+          "source": [
+            "samtools_rmdup/rmdup_output"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "samtools_sort_index_after_rmdup/threads",
+          "source": [
+            "threads"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "samtools_sort_index_after_rmdup/trigger",
+          "source": [
+            "remove_duplicates"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        }
+      ],
+      "out": [
+        "bam_bai_pair"
+      ],
+      "scatter": [],
+      "scatter_method": null,
+      "when": null,
+      "requirements": [],
+      "hints": []
+    }
+  ],
+  "tools": [
+    {
+      "id": "atdp.cwl",
+      "label": null,
+      "base_command": [
+        "bash",
+        "-c"
+      ],
+      "arguments": [],
+      "inputs": [
+        {
+          "id": "annotation_filename",
+          "type": "File",
+          "input_binding": {
+            "position": 3,
+            "prefix": "--a=",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Annotation file, tsv\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "avd_heat_window_bp",
+          "type": "null | int",
+          "input_binding": {
+            "position": 11,
+            "prefix": "--avd_heat_window=",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Average tag density window for heatmap\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "avd_smooth_bp",
+          "type": "null | int",
+          "input_binding": {
+            "position": 8,
+            "prefix": "--avd_smooth=",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Average smooth window (odd), int [0]\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "avd_window_bp",
+          "type": "null | int",
+          "input_binding": {
+            "position": 7,
+            "prefix": "--avd_window=",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Average tag density window, int [5000]\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "double_chr",
+          "type": "null | string",
+          "input_binding": {
+            "position": 10,
+            "prefix": "--sam_twicechr=",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "The chromosomes to be doubled, string\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "fragmentsize_bp",
+          "type": "null | int",
+          "input_binding": {
+            "position": 6,
+            "prefix": "--f=",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Fragmentsize, int [150]\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "ignore_chr",
+          "type": "null | string",
+          "input_binding": {
+            "position": 9,
+            "prefix": "--sam_ignorechr=",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "The chromosomes to be ignored, string\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "index_file",
+          "type": "null | File",
+          "input_binding": {
+            "position": 13,
+            "prefix": "--index=",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Index file\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "input_file",
+          "type": "File",
+          "input_binding": {
+            "position": 2,
+            "prefix": "--in=",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Input indexed BAM file (optionally +BAI index file in secondaryFiles)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "log_filename",
+          "type": "null | string",
+          "input_binding": {
+            "position": 5,
+            "prefix": "--log=",
+            "glob": null,
+            "value_from": "${\n    if (self == \"\"){\n      return default_output_filename('_atdp.log');\n    } else {\n      return self;\n    }\n}\n"
+          },
+          "doc": "Log filename\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "mapped_reads",
+          "type": "null | int",
+          "input_binding": {
+            "position": 12,
+            "prefix": "--m=",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Mapped reads number\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "output_filename",
+          "type": "null | string",
+          "input_binding": {
+            "position": 4,
+            "prefix": "--out=",
+            "glob": null,
+            "value_from": "${\n    if (self == \"\"){\n      return default_output_filename('_atdp.tsv');\n    } else {\n      return self;\n    }\n}\n"
+          },
+          "doc": "Base output file name, tsv\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "script",
+          "type": "null | string",
+          "input_binding": {
+            "position": 1,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Bash function to run samtools sort with all input parameters or skip it if trigger is false\n",
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "outputs": [
+        {
+          "id": "log_file",
+          "type": "File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "${\n  if (inputs.log_filename == \"\"){\n    return default_output_filename('_atdp.log');\n  } else {\n    return inputs.log_filename;\n  }\n}\n",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "result_file",
+          "type": "File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "${\n  if (inputs.output_filename == \"\"){\n    return default_output_filename('_atdp.tsv');\n  } else {\n    return inputs.output_filename;\n  }\n}\n",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "requirements": [
+        {
+          "class": "InlineJavascriptRequirement",
+          "docker_pull": null,
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "InlineJavascriptRequirement",
+            "expressionLib": [
+              "var default_output_filename = function(ext) { let root = inputs.input_file.basename.split('.').slice(0,-1).join('.'); return (root == \"\")?inputs.input_file.basename+ext:root+ext; };"
+            ]
+          }
+        },
+        {
+          "class": "InitialWorkDirRequirement",
+          "docker_pull": null,
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "InitialWorkDirRequirement",
+            "listing": "${\n  return  [\n            {\n              \"entry\": inputs.annotation_filename,\n              \"entryname\": inputs.annotation_filename.basename,\n              \"writable\": true\n            }\n          ]\n}\n"
+          }
+        },
+        {
+          "class": "DockerRequirement",
+          "docker_pull": "biowardrobe2/atdp:v0.0.1",
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "DockerRequirement",
+            "dockerPull": "biowardrobe2/atdp:v0.0.1"
+          }
+        }
+      ],
+      "hints": []
+    },
+    {
+      "id": "bedtools-genomecov.cwl",
+      "label": null,
+      "base_command": [
+        "bedtools",
+        "genomecov"
+      ],
+      "arguments": [],
+      "inputs": [
+        {
+          "id": "chrom_length_file",
+          "type": "null | File",
+          "input_binding": {
+            "position": 17,
+            "prefix": "-g",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Input genome file. Needed only when -i flag. The genome file is tab delimited <chromName><TAB><chromSize>\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "depth",
+          "type": "null | enum",
+          "input_binding": {
+            "position": 5,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Report the depth type. By default, bedtools genomecov will compute a histogram of coverage\nfor the genome file provided (intputs.chrom_length_file)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "du",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 11,
+            "prefix": "-du",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Change strand af the mate read (so both reads from the same strand) useful for strand specific.\nWorks for BAM files only\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "fragment_size",
+          "type": "null | int",
+          "input_binding": {
+            "position": 12,
+            "prefix": "-fs",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Set fixed fragment size\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "input_file",
+          "type": "File",
+          "input_binding": {
+            "position": 16,
+            "prefix": null,
+            "glob": null,
+            "value_from": "${\n  var prefix = ((/.*\\.bam$/i).test(inputs.input_file.path))?'-ibam':'-i';\n  return [prefix, inputs.input_file.path];\n}\n"
+          },
+          "doc": "The input file can be in BAM format (Note: BAM must be sorted by position) or <bed/gff/vcf>.\nPrefix is selected on the base of input file extension\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "m3",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 15,
+            "prefix": "-3",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Calculate coverage of 3\" positions (instead of entire interval)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "m5",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 14,
+            "prefix": "-5",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Calculate coverage of 5\" positions (instead of entire interval)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "mapped_reads_number",
+          "type": "null | int",
+          "input_binding": {
+            "position": 7,
+            "prefix": "-scale",
+            "glob": null,
+            "value_from": "${\n  if (inputs.scale){\n    return null;\n  } else if (inputs.mapped_reads_number) {\n    return 1000000/inputs.mapped_reads_number;\n  } else {\n    return null;\n  }\n}\n"
+          },
+          "doc": "Optional parameter to calculate scale as 1000000/mapped_reads_number if inputs.scale is not provided\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "max",
+          "type": "null | int",
+          "input_binding": {
+            "position": 13,
+            "prefix": "-max",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Combine all positions with a depth >= max into\na single bin in the histogram. Irrelevant\nfor -d and -bedGraph\n- (INTEGER)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "output_filename",
+          "type": "null | string",
+          "input_binding": null,
+          "doc": "Name for generated output file\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "pairchip",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 10,
+            "prefix": "-pc",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "pair-end chip seq experiment\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "scale",
+          "type": "null | float",
+          "input_binding": {
+            "position": 6,
+            "prefix": "-scale",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Scale the coverage by a constant factor.\nEach coverage value is multiplied by this factor before being reported.\nUseful for normalizing coverage by, e.g., reads per million (RPM).\n- Default is 1.0; i.e., unscaled.\n- (FLOAT)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "split",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 8,
+            "prefix": "-split",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "treat \"split\" BAM or BED12 entries as distinct BED intervals.\nwhen computing coverage.\nFor BAM files, this uses the CIGAR \"N\" and \"D\" operations\nto infer the blocks for computing coverage.\nFor BED12 files, this uses the BlockCount, BlockStarts, and BlockEnds\nfields (i.e., columns 10,11,12).\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "strand",
+          "type": "null | string",
+          "input_binding": {
+            "position": 9,
+            "prefix": "-strand",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Calculate coverage of intervals from a specific strand.\nWith BED files, requires at least 6 columns (strand is column 6).\n- (STRING): can be + or -\n",
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "outputs": [
+        {
+          "id": "genome_coverage_file",
+          "type": "File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "${\n  if (inputs.output_filename == null){\n    return default_output_filename();\n  } else {\n    return inputs.output_filename;\n  }\n}\n",
+            "value_from": null
+          },
+          "doc": "Generated genome coverage output file\n",
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "requirements": [
+        {
+          "class": "InlineJavascriptRequirement",
+          "docker_pull": null,
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "InlineJavascriptRequirement",
+            "expressionLib": [
+              "var default_output_filename = function() { let ext = (inputs.depth == \"-bg\" || inputs.depth == \"-bga\")?\".bedGraph\":\".tab\"; return inputs.input_file.location.split('/').slice(-1)[0].split('.').slice(0,-1).join('.') + ext; };"
+            ]
+          }
+        },
+        {
+          "class": "DockerRequirement",
+          "docker_pull": "biowardrobe2/bedtools2:v2.26.0",
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "DockerRequirement",
+            "dockerPull": "biowardrobe2/bedtools2:v2.26.0"
+          }
+        }
+      ],
+      "hints": []
+    },
+    {
+      "id": "bowtie-alignreads.cwl",
+      "label": null,
+      "base_command": [
+        "bowtie"
+      ],
+      "arguments": [
+        "{\"valueFrom\":\"${\\n  if (inputs.upstream_filelist && inputs.downstream_filelist){\\n    return \\\"-1\\\";\\n  }\\n  return null;\\n}\\n\",\"position\":82}",
+        "{\"valueFrom\":\"${\\n  if (inputs.upstream_filelist && inputs.downstream_filelist){\\n    return \\\"-2\\\";\\n  }\\n  return null;\\n}\\n\",\"position\":84}",
+        "{\"valueFrom\":\"${\\n  return ' 2> ' + default_output_filename(\\\".bw\\\");\\n}\\n\",\"position\":100000,\"shellQuote\":false}"
+      ],
+      "inputs": [
+        {
+          "id": "B",
+          "type": "null | int",
+          "input_binding": {
+            "position": 1,
+            "prefix": "-B",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "--offbase <int> leftmost ref offset = <int> in bowtie output (default: 0)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "C",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 1,
+            "prefix": "-C",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "reads and index are in colorspace\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "I",
+          "type": "null | int",
+          "input_binding": {
+            "position": 1,
+            "prefix": "-I",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "--minins <int>  minimum insert size for paired-end alignment (default: 0)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "M",
+          "type": "null | int",
+          "input_binding": {
+            "position": 1,
+            "prefix": "-M",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "<int> like -m, but reports 1 random hit (MAPQ=0)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "Q",
+          "type": "null | File",
+          "input_binding": {
+            "position": 1,
+            "prefix": "-Q",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "QV file(s) corresponding to CSFASTA inputs; use with -f -C\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "Q1",
+          "type": "null | File",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--Q1",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "--Q1/--Q2 <file>   same as -Q, but for mate files 1 and 2 respectively\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "Q2",
+          "type": "null | File",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--Q2",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "--Q1/--Q2 <file>   same as -Q, but for mate files 1 and 2 respectively\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "X",
+          "type": "null | int",
+          "input_binding": {
+            "position": 1,
+            "prefix": "-X",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "--maxins <int>  maximum insert size for paired-end alignment (default: 250)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "a",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 1,
+            "prefix": "-a",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "--all           report all alignments per read (much slower than low -k)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "al",
+          "type": "null | string",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--al",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "<fname>       write aligned reads/pairs to file(s) <fname>\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "best",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--best",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "hits guaranteed best stratum; ties broken by quality\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "c",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 1,
+            "prefix": "-c",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "query sequences given on cmd line (as <mates>, <singles>)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "chunkmbs",
+          "type": "null | int",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--chunkmbs",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "<int>   max megabytes of RAM for best-first search frames (def: 64)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "clip_3p_end",
+          "type": "null | int",
+          "input_binding": {
+            "position": 1,
+            "prefix": "-3",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "--trim3 <int>   trim <int> bases from 3' (right) end of reads\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "clip_5p_end",
+          "type": "null | int",
+          "input_binding": {
+            "position": 1,
+            "prefix": "-5",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "--trim5 <int>   trim <int> bases from 5' (left) end of reads\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "col_cqual",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--col-cqual",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "print original colorspace quals, not decoded quals\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "col_cseq",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--col-cseq",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "print aligned colorspace seqs as colors, not decoded bases\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "col_keepends",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--col-keepends",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "keep nucleotides at extreme ends of decoded alignment\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "crossbow_filelist",
+          "type": "null | File | array",
+          "input_binding": {
+            "position": 86,
+            "prefix": "-12",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Comma-separated list of files containing Crossbow-style reads.\nCan be a mixture of paired and unpaired.  Specify \"-\"for stdin.\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "downstream_filelist",
+          "type": "null | File | array",
+          "input_binding": {
+            "position": 85,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Comma-separated list of files containing downstream mates (or the\nsequences themselves if -c is set) paired with mates in <m1>\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "e",
+          "type": "null | int",
+          "input_binding": {
+            "position": 1,
+            "prefix": "-e",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "--maqerr <int>  max sum of mismatch quals across alignment for -n (def: 70)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "f",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 1,
+            "prefix": "-f",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "query input files are (multi-)FASTA .fa/.mfa\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "ff",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--ff",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "--fr/--rf/--ff     -1, -2 mates align fw/rev, rev/fw, fw/fw (default: --fr)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "fr",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--fr",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "--fr/--rf/--ff     -1, -2 mates align fw/rev, rev/fw, fw/fw (default: --fr)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "fullref",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--fullref",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "write entire ref name (default: only up to 1st space)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "indices_folder",
+          "type": "Directory",
+          "input_binding": {
+            "position": 81,
+            "prefix": null,
+            "glob": null,
+            "value_from": "${\n    for (var i = 0; i < self.listing.length; i++) {\n        if (self.listing[i].path.split('.').slice(-3).join('.') == 'rev.1.ebwt' ||\n            self.listing[i].path.split('.').slice(-3).join('.') == 'rev.1.ebwtl'){\n          return self.listing[i].path.split('.').slice(0,-3).join('.');\n        }\n    }\n    return null;\n}\n"
+          },
+          "doc": "Folder with Bowtie indices\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "integer_quals",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--integer-quals",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "qualities are given as space-separated integers (not ASCII)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "k",
+          "type": "null | int",
+          "input_binding": {
+            "position": 1,
+            "prefix": "-k",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "<int>           report up to <int> good alignments per read (default: 1)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "l",
+          "type": "null | int",
+          "input_binding": {
+            "position": 1,
+            "prefix": "-l",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "--seedlen <int> seed length for -n (default: 28)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "large_index",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--large-index",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "force usage of a 'large' index, even if a small one is present\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "m",
+          "type": "null | int",
+          "input_binding": {
+            "position": 1,
+            "prefix": "-m",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "<int>           suppress all alignments if > <int> exist (def: no limit)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "mapq",
+          "type": "null | int",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--mapq",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "<int>       default mapping quality (MAPQ) to print for SAM alignments\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "max",
+          "type": "null | string",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--max",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "<fname>      write reads/pairs over -m limit to file(s) <fname>\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "maxbts",
+          "type": "null | int",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--maxbts",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "<int>     max # backtracks for -n 2/3 (default: 125, 800 for --best)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "mm",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--mm",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "use memory-mapped I/O for index; many 'bowtie's can share\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "n",
+          "type": "null | int",
+          "input_binding": {
+            "position": 1,
+            "prefix": "-n",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "--seedmms <int> max mismatches in seed (can be 0-3, default: -n 2)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "nofw",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--nofw",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "--norc      do not align to forward/reverse-complement reference strand\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "nomaqround",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--nomaqround",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "disable Maq-like quality rounding for -n (nearest 10 <= 30)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "o",
+          "type": "null | int",
+          "input_binding": {
+            "position": 1,
+            "prefix": "-o",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "--offrate <int> override offrate of index; must be >= index's offrate\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "output_filename",
+          "type": "null | string",
+          "input_binding": {
+            "position": 90,
+            "prefix": null,
+            "glob": null,
+            "value_from": "$(default_output_filename())"
+          },
+          "doc": "Generates default output filename on the base of upstream_filelist/downstream_filelist files\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "pairtries",
+          "type": "null | int",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--pairtries",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "<int>  max # attempts to find mate for anchor hit (default: 100)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "phred33_quals",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--phred33-quals",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "input quals are Phred+33 (default)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "phred64_quals",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--phred64-quals",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "input quals are Phred+64 (same as --solexa1.3-quals)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "q",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 1,
+            "prefix": "-q",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "query input files are FASTQ .fq/.fastq (default)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "quiet",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--quiet",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "print nothing but the alignments\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "r",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 1,
+            "prefix": "-r",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "query input files are raw one-sequence-per-line\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "reads_per_batch",
+          "type": "null | int",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--reads-per-batch",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "# of reads to read from input file at once (default: 16)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "refidx",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--refidx",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "refer to ref. seqs by 0-based index rather than name\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "refout",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--refout",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "write alignments to files refXXXXX.map, 1 map per reference\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "rf",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--rf",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "--fr/--rf/--ff     -1, -2 mates align fw/rev, rev/fw, fw/fw (default: --fr)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "s",
+          "type": "null | int",
+          "input_binding": {
+            "position": 1,
+            "prefix": "-s",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "--skip <int>    skip the first <int> reads/pairs in the input\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "sam",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 1,
+            "prefix": "-S",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "--sam write hits in SAM format\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "sam_RG",
+          "type": "null | string",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--sam-RG",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "<text>    add <text> (usually \"lab=value\") to @RG line of SAM header\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "sam_nohead",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--sam-nohead",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "supppress header lines (starting with @) for SAM output\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "sam_nosq",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--sam-nosq",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "supppress @SQ header lines for SAM output\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "seed",
+          "type": "null | int",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--seed",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "<int>       seed for random number generator\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "shmem",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--shmem",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "use shared mem for index\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "snpfrac",
+          "type": "null | float",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--snpfrac",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "<dec>    approx. fraction of SNP bases (e.g. 0.001); sets --snpphred\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "snpphred",
+          "type": "null | int",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--snpphred",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "<int>   Phred penalty for SNP when decoding colorspace (def: 30)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "solexa1.3_quals",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--solexa1.3-quals",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "input quals are from GA Pipeline ver. >= 1.3\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "solexa_quals",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--solexa-quals",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "input quals are from GA Pipeline ver. < 1.3\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "strata",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--strata",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "hits in sub-optimal strata aren't reported (requires --best)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "suppress",
+          "type": "null | string",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--suppress",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "<cols>  suppresses given columns (comma-delim'ed) in default output\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "t",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 1,
+            "prefix": "-t",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "--time          print wall-clock time taken by search phases\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "threads",
+          "type": "null | int",
+          "input_binding": {
+            "position": 1,
+            "prefix": "-p",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "--threads <int> number of alignment threads to launch (default: 1)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "u",
+          "type": "null | int",
+          "input_binding": {
+            "position": 1,
+            "prefix": "-u",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "--qupto <int>   stop after first <int> reads/pairs (excl. skipped reads)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "un",
+          "type": "null | string",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--un",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "<fname>       write unaligned reads/pairs to file(s) <fname>\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "upstream_filelist",
+          "type": "null | File | array",
+          "input_binding": {
+            "position": 83,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Comma-separated list of files containing upstream mates (or the\nsequences themselves, if -c is set) paired with mates in <m2>\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "v",
+          "type": "null | int",
+          "input_binding": {
+            "position": 1,
+            "prefix": "-v",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "report end-to-end hits w/ <=v mismatches; ignore qualities\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "verbose",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--verbose",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "verbose output (for debugging)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "y",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 1,
+            "prefix": "-y",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "--tryhard try hard to find valid alignments, at the expense of speed\n",
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "outputs": [
+        {
+          "id": "aligned_file",
+          "type": "null | File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "$(inputs.al)",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "log_file",
+          "type": "File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "$(default_output_filename(\".bw\"))",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "mapped_reads_number",
+          "type": "int",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "$(default_output_filename(\".bw\"))",
+            "value_from": "${\n  let mappedRegex = /alignment\\:.*/;\n  return parseInt(self[0].contents.match(mappedRegex)[0].split(\" \")[1]);\n}\n"
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "multimapped_file",
+          "type": "null | File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "$(inputs.max)",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "refout_file",
+          "type": "null | array",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "*ref*.map*",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "sam_file",
+          "type": "null | File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "$(default_output_filename())",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "total_reads_number",
+          "type": "int",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "$(default_output_filename(\".bw\"))",
+            "value_from": "${\n  let totalRegex = /processed\\:.*/;\n  return parseInt(self[0].contents.match(totalRegex)[0].split(\" \")[1]);\n}\n"
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "unaligned_file",
+          "type": "null | File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "$(inputs.un)",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "unmapped_reads_number",
+          "type": "int",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "$(default_output_filename(\".bw\"))",
+            "value_from": "${\n  let unmappedRegex = /align\\:.*/;\n  return parseInt(self[0].contents.match(unmappedRegex)[0].split(\" \")[1]);\n}\n"
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "requirements": [
+        {
+          "class": "ShellCommandRequirement",
+          "docker_pull": null,
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "ShellCommandRequirement"
+          }
+        },
+        {
+          "class": "InlineJavascriptRequirement",
+          "docker_pull": null,
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "InlineJavascriptRequirement",
+            "expressionLib": [
+              "var default_output_filename = function(ext) { if (inputs.output_filename != \"\" && !ext){ return inputs.output_filename; } ext = ext || \".sam\"; let root = \"\"; if (inputs.output_filename != \"\"){ root = inputs.output_filename.split('.').slice(0,-1).join('.'); return (root == \"\")?inputs.output_filename+ext:root+ext; } else if (Array.isArray(inputs.upstream_filelist) && inputs.upstream_filelist.length > 0){ root = inputs.upstream_filelist[0].basename.split('.').slice(0,-1).join('.'); return (root == \"\")?inputs.upstream_filelist[0].basename+ext:root+ext; } else if (inputs.upstream_filelist != null){ root = inputs.upstream_filelist.basename.split('.').slice(0,-1).join('.'); return (root == \"\")?inputs.upstream_filelist.basename+ext:root+ext; } else if (Array.isArray(inputs.downstream_filelist) && inputs.downstream_filelist.length > 0){ root = inputs.downstream_filelist[0].basename.split('.').slice(0,-1).join('.'); return (root == \"\")?inputs.downstream_filelist[0].basename+ext:root+ext; } else if (inputs.downstream_filelist != null){ root = inputs.downstream_filelist.basename.split('.').slice(0,-1).join('.'); return (root == \"\")?inputs.downstream_filelist.basename+ext:root+ext; } else if (Array.isArray(inputs.crossbow_filelist) && inputs.crossbow_filelist.length > 0){ root = inputs.crossbow_filelist[0].basename.split('.').slice(0,-1).join('.'); return (root == \"\")?inputs.crossbow_filelist[0].basename+ext:root+ext; } else if (inputs.crossbow_filelist != null){ root = inputs.crossbow_filelist.basename.split('.').slice(0,-1).join('.'); return (root == \"\")?inputs.crossbow_filelist.basename+ext:root+ext; } else { return null; } };"
+            ]
+          }
+        },
+        {
+          "class": "DockerRequirement",
+          "docker_pull": "biowardrobe2/bowtie:v1.2.0",
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "DockerRequirement",
+            "dockerPull": "biowardrobe2/bowtie:v1.2.0"
+          }
+        }
+      ],
+      "hints": []
+    },
+    {
+      "id": "extract-fastq.cwl",
+      "label": null,
+      "base_command": [
+        "bash",
+        "-c"
+      ],
+      "arguments": [],
+      "inputs": [
+        {
+          "id": "compressed_file",
+          "type": "File",
+          "input_binding": {
+            "position": 6,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Compressed or uncompressed FASTQ file\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "output_file_ext",
+          "type": "null | string",
+          "input_binding": {
+            "position": 7,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Default extension for the extracted file\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "script",
+          "type": "null | string",
+          "input_binding": {
+            "position": 5,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Bash script to extract compressed FASTQ file\n",
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "outputs": [
+        {
+          "id": "fastq_file",
+          "type": "File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "*",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "requirements": [
+        {
+          "class": "ShellCommandRequirement",
+          "docker_pull": null,
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "ShellCommandRequirement"
+          }
+        },
+        {
+          "class": "DockerRequirement",
+          "docker_pull": "biowardrobe2/scidap:v0.0.3",
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "DockerRequirement",
+            "dockerPull": "biowardrobe2/scidap:v0.0.3"
+          }
+        }
+      ],
+      "hints": []
+    },
+    {
+      "id": "fastx-quality-stats.cwl",
+      "label": null,
+      "base_command": [
+        "fastx_quality_stats"
+      ],
+      "arguments": [],
+      "inputs": [
+        {
+          "id": "input_file",
+          "type": "File",
+          "input_binding": {
+            "position": 10,
+            "prefix": "-i",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "FASTA/Q input file. If FASTA file is given, only nucleotides distribution is calculated (there's no quality info)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "new_output_format",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 5,
+            "prefix": "-N",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "New output format (with more information per nucleotide/cycle).\ncycle (previously called 'column') = cycle number\nmax-count\nFor each nucleotide in the cycle (ALL/A/C/G/T/N):\n    count   = number of bases found in this column.\n    min     = Lowest quality score value found in this column.\n    max     = Highest quality score value found in this column.\n    sum     = Sum of quality score values for this column.\n    mean    = Mean quality score value for this column.\n    Q1\t= 1st quartile quality score.\n    med\t= Median quality score.\n    Q3\t= 3rd quartile quality score.\n    IQR\t= Inter-Quartile range (Q3-Q1).\n    lW\t= 'Left-Whisker' value (for boxplotting).\n    rW\t= 'Right-Whisker' value (for boxplotting).\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "output_filename",
+          "type": "null | string",
+          "input_binding": {
+            "position": 11,
+            "prefix": "-o",
+            "glob": null,
+            "value_from": "${\n    if (self == \"\"){\n      return default_output_filename();\n    } else {\n      return self;\n    }\n}\n"
+          },
+          "doc": "Output file to store generated statistics. If not provided - return from default_output_filename function\n",
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "outputs": [
+        {
+          "id": "statistics_file",
+          "type": "File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "${\n    if (inputs.output_filename == \"\"){\n      return default_output_filename();\n    } else {\n      return inputs.output_filename;\n    }\n}\n",
+            "value_from": null
+          },
+          "doc": "Generated statistics file",
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "requirements": [
+        {
+          "class": "InlineJavascriptRequirement",
+          "docker_pull": null,
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "InlineJavascriptRequirement",
+            "expressionLib": [
+              "var default_output_filename = function() { return inputs.input_file.location.split('/').slice(-1)[0].split('.').slice(0,-1).join('.') + \".fastxstat\" };"
+            ]
+          }
+        },
+        {
+          "class": "DockerRequirement",
+          "docker_pull": "biowardrobe2/fastx_toolkit:v0.0.14",
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "DockerRequirement",
+            "dockerPull": "biowardrobe2/fastx_toolkit:v0.0.14"
+          }
+        }
+      ],
+      "hints": []
+    },
+    {
+      "id": "iaintersect.cwl",
+      "label": null,
+      "base_command": [
+        "iaintersect"
+      ],
+      "arguments": [],
+      "inputs": [
+        {
+          "id": "annotation_filename",
+          "type": "File",
+          "input_binding": {
+            "position": 2,
+            "prefix": "--a=",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Annotation file, tsv\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "ignore_chr",
+          "type": "null | string",
+          "input_binding": {
+            "position": 7,
+            "prefix": "--sam_ignorechr=",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "The chromosome to be ignored, string\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "input_filename",
+          "type": "File",
+          "input_binding": {
+            "position": 1,
+            "prefix": "--in=",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Input filename with MACS2 peak calling results, tsv\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "log_filename",
+          "type": "null | string",
+          "input_binding": {
+            "position": 4,
+            "prefix": "--log=",
+            "glob": null,
+            "value_from": "${\n    if (self == \"\"){\n      return default_output_filename('_iaintersect.log');\n    } else {\n      return self;\n    }\n}\n"
+          },
+          "doc": "Log filename\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "output_filename",
+          "type": "null | string",
+          "input_binding": {
+            "position": 3,
+            "prefix": "--out=",
+            "glob": null,
+            "value_from": "${\n    if (self == \"\"){\n      return default_output_filename('_iaintersect.tsv');\n    } else {\n      return self;\n    }\n}\n"
+          },
+          "doc": "Base output file name, tsv\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "promoter_bp",
+          "type": "null | int",
+          "input_binding": {
+            "position": 5,
+            "prefix": "--promoter=",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Promoter region around TSS, base pairs\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "upstream_bp",
+          "type": "null | int",
+          "input_binding": {
+            "position": 6,
+            "prefix": "--upstream=",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Upstream region before promoter, base pairs\n",
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "outputs": [
+        {
+          "id": "log_file",
+          "type": "File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "${\n  if (inputs.log_filename == \"\"){\n    return default_output_filename('_iaintersect.log');\n  } else {\n    return inputs.log_filename;\n  }\n}\n",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "result_file",
+          "type": "File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "${\n  if (inputs.output_filename == \"\"){\n    return default_output_filename('_iaintersect.tsv');\n  } else {\n    return inputs.output_filename;\n  }\n}\n",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "requirements": [
+        {
+          "class": "InlineJavascriptRequirement",
+          "docker_pull": null,
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "InlineJavascriptRequirement",
+            "expressionLib": [
+              "var default_output_filename = function(ext) { let root = inputs.input_filename.basename.split('.').slice(0,-1).join('.'); return (root == \"\")?inputs.input_filename.basename+ext:root+ext; };"
+            ]
+          }
+        },
+        {
+          "class": "DockerRequirement",
+          "docker_pull": "biowardrobe2/iaintersect:v0.0.2",
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "DockerRequirement",
+            "dockerPull": "biowardrobe2/iaintersect:v0.0.2"
+          }
+        }
+      ],
+      "hints": []
+    },
+    {
+      "id": "linux-sort.cwl",
+      "label": null,
+      "base_command": [
+        "sort"
+      ],
+      "arguments": [],
+      "inputs": [
+        {
+          "id": "key",
+          "type": "array",
+          "input_binding": {
+            "position": 1,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "-k, --key=POS1[,POS2]\nstart a key at POS1, end it at POS2 (origin 1)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "output_filename",
+          "type": "null | string",
+          "input_binding": null,
+          "doc": "Name for generated output file\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "unsorted_file",
+          "type": "File",
+          "input_binding": {
+            "position": 4,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "outputs": [
+        {
+          "id": "sorted_file",
+          "type": "File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "${\n  if (inputs.output_filename == null){\n    return default_output_filename();\n  } else {\n    return inputs.output_filename;\n  }\n}\n",
+            "value_from": null
+          },
+          "doc": "Sorted file\n",
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "requirements": [
+        {
+          "class": "InlineJavascriptRequirement",
+          "docker_pull": null,
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "InlineJavascriptRequirement",
+            "expressionLib": [
+              "var default_output_filename = function() { return inputs.unsorted_file.location.split('/').slice(-1)[0]; };"
+            ]
+          }
+        },
+        {
+          "class": "DockerRequirement",
+          "docker_pull": "biowardrobe2/scidap:v0.0.2",
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "DockerRequirement",
+            "dockerPull": "biowardrobe2/scidap:v0.0.2"
+          }
+        }
+      ],
+      "hints": []
+    },
+    {
+      "id": "macs2-callpeak-biowardrobe-only.cwl",
+      "label": null,
+      "base_command": [
+        "python",
+        "run.py",
+        "macs2 callpeak"
+      ],
+      "arguments": [
+        "{\"valueFrom\":\"${ if (inputs.output_prefix == \\\"\\\"){ return ' 2> ' + default_output_filename('_macs.log'); } else { return ' 2> ' + inputs.output_prefix + '.log'; } }\",\"position\":100000,\"shellQuote\":true}"
+      ],
+      "inputs": [
+        {
+          "id": "bdg",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 17,
+            "prefix": "--bdg",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "If this flag is on, MACS will store the fragment pileup, control lambda, -log10pvalue and -log10qvalue scores in bedGraph files.\nThe bedGraph files will be stored in current directory named NAME+’_treat_pileup.bdg’ for treatment data, NAME+’_control_lambda.bdg’\nfor local lambda values from control, NAME+’_treat_pvalue.bdg’ for Poisson pvalue scores (in -log10(pvalue) form),\nand NAME+’_treat_qvalue.bdg’ for q-value scores from\nBenjamini–Hochberg–Yekutieli procedure <http://en.wikipedia.org/wiki/False_discovery_rate#Dependent_tests>\nDEFAULT: False\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "broad",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 36,
+            "prefix": "--broad",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "If set, MACS will try to call broad peaks by linking nearby highly enriched\nregions. The linking region is controlled by another cutoff through --linking-cutoff.\nThe maximum linking region length is 4 times of d from MACS.\nDEFAULT: False\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "broad_cutoff",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 37,
+            "prefix": "--broad-cutoff",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Cutoff for broad region. This option is not available\nunless --broad is set. If -p is set, this is a pvalue\ncutoff, otherwise, it's a qvalue cutoff.\nDEFAULT: 0.1\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "buffer_size",
+          "type": "null | int",
+          "input_binding": {
+            "position": 16,
+            "prefix": "--buffer-size",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Buffer size for incrementally increasing internal\narray size to store reads alignment information. In\nmost cases, you don't have to change this parameter.\nHowever, if there are large number of\nchromosomes/contigs/scaffolds in your alignment, it's\nrecommended to specify a smaller buffer size in order\nto decrease memory usage (but it will take longer time\nto read alignment files). Minimum memory requested for\nreading an alignment file is about # of CHROMOSOME *\nBUFFER_SIZE * 2 Bytes.\nDEFAULT: 100000\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "bw",
+          "type": "null | int",
+          "input_binding": {
+            "position": 21,
+            "prefix": "--bw",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Band width for picking regions to compute  fragment  size.  This\nvalue is only used while building the shifting model\nDEFAULT: 300\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "call_summits",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 39,
+            "prefix": "--call-summits",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "If set, MACS will use a more sophisticated signal processing approach to\nfind subpeak summits in each enriched peak region.\nDEFAULT: False\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "control_file",
+          "type": "null | File | array",
+          "input_binding": {
+            "position": 12,
+            "prefix": "-c",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "The control or mock data file. Please follow the same direction as for -t/–treatment.\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "cutoff_analysis",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 38,
+            "prefix": "--cutoff-analysis",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "While set, MACS2 will analyze number or total length of peaks that can be\ncalled by different p-value cutoff then output a summary table to help user\ndecide a better cutoff. The table will be saved in NAME_cutoff_analysis.txt\nfile. Note, minlen and maxgap may affect the results. WARNING: May take ~30\nfolds longer time to finish.\nDEFAULT: False\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "down_sample",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 31,
+            "prefix": "--down-sample",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "When set, random sampling method will scale down the bigger sample. By default,\nMACS uses linear scaling. Warning: This option will make your result unstable\nand irreproducible since each time, random reads would be selected. Consider\nto use ''randsample'' script instead. <not implmented>If used together with\n--SPMR, 1 million unique reads will be randomly picked.</not implemented> Caution:\ndue to the implementation, the final number of selected reads may not be as\nyou expected!\nDEFAULT: False\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "extsize",
+          "type": "int",
+          "input_binding": {
+            "position": 26,
+            "prefix": "--extsize",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "The arbitrary extension size in bp. When nomodel is  true, MACS will use\nthis value as fragment size to  extend each read towards 3'' end, then pile\nthem up.  It''s exactly twice the number of obsolete SHIFTSIZE.  In previous\nlanguage, each read is moved 5''->3''  direction to middle of fragment by 1/2\nd, then  extended to both direction with 1/2 d. This is  equivalent to say each\nread is extended towards 5''->3''  into a d size fragment.EXTSIZE\nand  SHIFT can be combined when necessary. Check SHIFT  option.\nDEFAULT: 200\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "fe_cutoff",
+          "type": "null | float",
+          "input_binding": {
+            "position": 40,
+            "prefix": "--fe-cutoff",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "When set, the value will be used to filter out peaks\nwith low fold-enrichment. Note, MACS2 use 1.0 as\npseudocount while calculating fold-enrichment.\nDEFAULT: 1.0\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "fix_bimodal",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 23,
+            "prefix": "--fix-bimodal",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Whether turn on the auto pair model process. If set, when MACS failed to\nbuild paired model, it will use the nomodel settings, the --exsize parameter\nto extend each tags towards 3'' direction. Not to use this automate fixation\nis a default behavior now.\nDEFAULT: False\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "format_mode",
+          "type": "null | string",
+          "input_binding": {
+            "position": 13,
+            "prefix": "-f",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "{AUTO,BAM,SAM,BED,ELAND,ELANDMULTI,ELANDEXPORT,BOWTIE,BAMPE}, --format\n{AUTO,BAM,SAM,BED,ELAND,ELANDMULTI,ELANDEXPORT,BOWTIE,BAMPE} Format of tag file,\n\"AUTO\", \"BED\" or \"ELAND\" or \"ELANDMULTI\" or \"ELANDEXPORT\" or \"SAM\" or \"BAM\"\nor \"BOWTIE\" or \"BAMPE\". The default AUTO option will let MACS decide which format\nthe file is. Note that MACS can''t detect \"BAMPE\" or \"BEDPE\" format with \"AUTO\",\nand you have to implicitly specify the format for \"BAMPE\" and \"BEDPE\".\nDEFAULT: AUTO\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "genome_size",
+          "type": "null | string",
+          "input_binding": {
+            "position": 14,
+            "prefix": "-g",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "It’s the mappable genome size or effective genome size which is defined as the genome size which can be sequenced.\nBecause of the repetitive features on the chromsomes, the actual mappable genome size will be smaller than the\noriginal size, about 90% or 70% of the genome size. The default hs – 2.7e9 is recommended for UCSC human hg18\nassembly. Here are all precompiled parameters for effective genome size:\n  hs:\t2.7e9\n  mm:\t1.87e9\n  ce:\t9e7\n  dm:\t1.2e8\nDEFAULT: hs\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "keep_dup",
+          "type": "null | string",
+          "input_binding": {
+            "position": 15,
+            "prefix": "--keep-dup",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "It controls the MACS behavior towards duplicate tags\nat the exact same location -- the same coordination\nand the same strand. The 'auto' option makes MACS\ncalculate the maximum tags at the exact same location\nbased on binomal distribution using 1e-5 as pvalue\ncutoff; and the 'all' option keeps every tags. If an\ninteger is given, at most this number of tags will be\nkept at the same location. The default is to keep one\ntag at the same location.\nDEFAULT: 1\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "llocal",
+          "type": "null | int",
+          "input_binding": {
+            "position": 35,
+            "prefix": "--llocal",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "The large nearby region in basepairs to calculate\ndynamic lambda. This is used to capture the surround\nbias. If you set this to 0, MACS will skip llocal\nlambda calculation. *Note* that MACS will always\nperform a d-size local lambda calculation. The final\nlocal bias should be the maximum of the lambda value\nfrom d, slocal, and llocal size windows.\nDEFAULT: 10000.\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "mfold",
+          "type": "null | string",
+          "input_binding": {
+            "position": 22,
+            "prefix": "-m",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Select the regions within MFOLD range of high-\nconfidence enrichment ratio against background to\nbuild model. Fold-enrichment in regions must be lower\nthan upper limit, and higher than the lower limit. Use\nas \"-m 10 30\"\nDEFAULT: 5 50\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "nolambda",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 33,
+            "prefix": "--nolambda",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "If True, MACS will use fixed background lambda as local lambda for every\npeak region. Normally, MACS calculates a dynamic local lambda to reflect the\nlocal bias due to potential chromatin structure.\nDEFAULT: False\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "nomodel",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 24,
+            "prefix": "--nomodel",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Whether or not to build the shifting model. If True,  MACS will not build\nmodel. by default it means  shifting size = 100, try to set extsize to change it.\nDEFAULT: False\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "output_prefix",
+          "type": "null | string",
+          "input_binding": {
+            "position": 999,
+            "prefix": "-n",
+            "glob": null,
+            "value_from": "${\n    if (self == \"\"){\n      return default_output_filename();\n    } else {\n      return self;\n    }\n}\n"
+          },
+          "doc": "The name string of the experiment. MACS will use this string NAME to create output files like ‘NAME_peaks.xls’,\n‘NAME_negative_peaks.xls’, ‘NAME_peaks.bed’ , ‘NAME_summits.bed’, ‘NAME_model.r’ and so on.\nSo please avoid any confliction between these filenames and your existing files.\nDEFAULT: generated on the base of the treatment input\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "p_value",
+          "type": "null | float",
+          "input_binding": {
+            "position": 28,
+            "prefix": "-p",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Pvalue cutoff for peak detection. DEFAULT: not set.  -q, and -p are mutually\nexclusive. If pvalue cutoff is set, qvalue will not be calculated and reported\nas -1  in the final .xls file.\nDEFAULT: null\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "q_value",
+          "type": "null | float",
+          "input_binding": {
+            "position": 27,
+            "prefix": "-q",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Minimum FDR (q-value) cutoff for peak detection. -q, and\n-p are mutually exclusive.\nDEFAULT: 0.05\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "ratio",
+          "type": "null | float",
+          "input_binding": {
+            "position": 30,
+            "prefix": "--ratio",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "When set, use a custom scaling ratio of ChIP/control\n(e.g. calculated using NCIS) for linear scaling.\nDEFAULT: null\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "seed",
+          "type": "null | int",
+          "input_binding": {
+            "position": 32,
+            "prefix": "--seed",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Set the random seed while down sampling data. Must be\na non-negative integer in order to be effective.\nDEFAULT: null\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "shift",
+          "type": "null | int",
+          "input_binding": {
+            "position": 25,
+            "prefix": "--shift",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "(NOT the legacy --shiftsize option!) The arbitrary shift in bp. Use discretion\nwhile setting it other than default value. When NOMODEL is set, MACS will use\nthis value to move cutting ends (5'') towards 5''->3'' direction then apply\nEXTSIZE to extend them to fragments. When this value is negative, ends will\nbe moved toward 3''->5'' direction. Recommended to keep it as default 0 for\nChIP-Seq datasets, or -1 * half of EXTSIZE together with EXTSIZE option for\ndetecting enriched cutting loci such as certain DNAseI-Seq datasets. Note, you\ncan''t set values other than 0 if format is BAMPE for paired-end data.\nDEFAULT: 0\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "slocal",
+          "type": "null | int",
+          "input_binding": {
+            "position": 34,
+            "prefix": "--slocal",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "The small nearby region in basepairs to calculate\ndynamic lambda. This is used to capture the bias near\nthe peak summit region. Invalid if there is no control\ndata. If you set this to 0, MACS will skip slocal\nlambda calculation. *Note* that MACS will always\nperform a d-size local lambda calculation. The final\nlocal bias should be the maximum of the lambda value\nfrom d, slocal, and llocal size windows.\nDEFAULT: 1000\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "spmr",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 19,
+            "prefix": "--SPMR",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "If True, MACS will save signal per million reads for fragment pileup profiles.\nRequire --bdg to be set.\nDEFAULT: False\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "to_large",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 29,
+            "prefix": "--to-large",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "When set, scale the small sample up to the bigger sample. By default, the\nbigger dataset will be scaled down towards the smaller dataset, which will lead\nto smaller p/qvalues and more specific results. Keep in mind that scaling down\nwill bring down background noise more.\nDEFAULT: False\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "trackline",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 18,
+            "prefix": "--trackline",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Tells MACS to include trackline with bedGraph files. To include this trackline\nwhile displaying bedGraph at UCSC genome browser, can show name and description\nof the file as well. Require -B to be set.\nDEFAULT: False\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "treatment_file",
+          "type": "File | array",
+          "input_binding": {
+            "position": 10,
+            "prefix": "-t",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "This is the only REQUIRED parameter for MACS. File can be in any supported format specified by –format option.\nCheck –format for detail. If you have more than one alignment files, you can specify them as `-t A B C`.\nMACS will pool up all these files together.\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "tsize",
+          "type": "null | int",
+          "input_binding": {
+            "position": 20,
+            "prefix": "--tsize",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Tag size. This will overide the auto detected tag size.\nDEFAULT: False\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "verbose",
+          "type": "null | int",
+          "input_binding": {
+            "position": 41,
+            "prefix": "--verbose",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Log level\n",
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "outputs": [
+        {
+          "id": "broad_peak_file",
+          "type": "null | File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "${ if (inputs.output_prefix == \"\"){ return default_output_filename('_macs_peaks.broadPeak'); } else { return inputs.output_prefix + '_peaks.broadPeak'; } }",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "control_lambda_bdg_file",
+          "type": "null | File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "${ if (inputs.output_prefix == \"\"){ return default_output_filename('_macs_control_lambda.bdg'); } else { return inputs.output_prefix + '_control_lambda.bdg'; } }",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "gapped_peak_file",
+          "type": "null | File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "${ if (inputs.output_prefix == \"\"){ return default_output_filename('_macs_peaks.gappedPeak'); } else { return inputs.output_prefix + '_peaks.gappedPeak'; } }",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "macs2_fragments_calculated",
+          "type": "int",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "${\n    if (inputs.output_prefix == \"\"){\n      return default_output_filename('_fragment_stat.tsv');\n    } else {\n      return inputs.output_prefix + '_fragment_stat.tsv';\n    }\n}\n",
+            "value_from": "$(parseInt(self[0].contents.split(' ')[0]))"
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "macs2_fragments_expected",
+          "type": "int",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "${\n    if (inputs.output_prefix == \"\"){\n      return default_output_filename('_fragment_stat.tsv');\n    } else {\n      return inputs.output_prefix + '_fragment_stat.tsv';\n    }\n}\n",
+            "value_from": "$(parseInt(self[0].contents.split(' ')[1]))"
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "macs2_islands",
+          "type": "int",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "${\n    if (inputs.output_prefix == \"\"){\n      return default_output_filename('_fragment_stat.tsv');\n    } else {\n      return inputs.output_prefix + '_fragment_stat.tsv';\n    }\n}\n",
+            "value_from": "$(parseInt(self[0].contents.split(' ')[2]))"
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "macs2_stat_file",
+          "type": "File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "${\n    if (inputs.output_prefix == \"\"){\n      return default_output_filename('_fragment_stat.tsv');\n    } else {\n      return inputs.output_prefix + '_fragment_stat.tsv';\n    }\n}\n",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "macs_log",
+          "type": "null | File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "${\n    if (inputs.output_prefix == \"\"){\n      return default_output_filename('_macs.log');\n    } else {\n      return inputs.output_prefix + '.log';\n    }\n}\n",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "moder_r_file",
+          "type": "null | File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "${ if (inputs.output_prefix == \"\"){ return default_output_filename('_macs_model.r'); } else { return inputs.output_prefix + '_model.r'; } }",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "narrow_peak_file",
+          "type": "null | File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "${ if (inputs.output_prefix == \"\"){ return default_output_filename('_macs_peaks.narrowPeak'); } else { return inputs.output_prefix + '_peaks.narrowPeak'; } }",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "peak_summits_file",
+          "type": "null | File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "${ if (inputs.output_prefix == \"\"){ return default_output_filename('_macs_summits.bed'); } else { return inputs.output_prefix + '_summits.bed'; } }",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "peak_xls_file",
+          "type": "null | File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "${ if (inputs.output_prefix == \"\"){ return default_output_filename('_macs_peaks.xls'); } else { return inputs.output_prefix + '_peaks.xls'; } }",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "treat_pileup_bdg_file",
+          "type": "null | File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "${ if (inputs.output_prefix == \"\"){ return default_output_filename('_macs_treat_pileup.bdg'); } else { return inputs.output_prefix + '_treat_pileup.bdg'; } }",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "requirements": [
+        {
+          "class": "ShellCommandRequirement",
+          "docker_pull": null,
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "ShellCommandRequirement"
+          }
+        },
+        {
+          "class": "InlineJavascriptRequirement",
+          "docker_pull": null,
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "InlineJavascriptRequirement",
+            "expressionLib": [
+              "var default_output_filename = function(sufix) { sufix = sufix || \"_macs\"; if (Object.prototype.toString.call(inputs.treatment_file) === '[object Array]'){ let basename = inputs.treatment_file[0].basename; let root = basename.split('.').slice(0,-1).join('.'); return (root == \"\")?basename+sufix:root+sufix; } else { let basename = inputs.treatment_file.basename; let root = basename.split('.').slice(0,-1).join('.'); return (root == \"\")?basename+sufix:root+sufix; } }"
+            ]
+          }
+        },
+        {
+          "class": "InitialWorkDirRequirement",
+          "docker_pull": null,
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "InitialWorkDirRequirement",
+            "listing": [
+              {
+                "entryname": "run.py",
+                "entry": "#!/usr/bin/env python\nimport subprocess\nimport sys\nimport argparse\nimport re\n\ndef arg_parser():\n    \"\"\"Returns argument parser. used only to get -n and --extsize values\"\"\"\n    parser = argparse.ArgumentParser(description='MACS2 Biowardrobe parser')\n    parser.add_argument(\"-n\", help=\"MACS2 string name of the experiment\")\n    parser.add_argument(\"--extsize\", help=\"MACS2 arbitrary extension size in bp\")\n    return parser\n\ndef get_info (name):\n    fragments, islands = 0, 0\n    with open(name+'_peaks.xls', 'r') as infile:\n        for line in infile:\n            if re.match('^# d = ', line):\n                fragments = int(line.split('d = ')[1])\n                continue\n            if re.match('^#', line):\n                continue\n            if line.strip() != \"\":\n                islands = islands + 1\n    islands = islands - 1\n    return fragments, islands\n\nargs, _ = arg_parser().parse_known_args()\nargv=' '.join(sys.argv[1:])\n\nextsize=args.extsize\nname=args.n\n\nruntime_error=False\ncalculated_fragment_size=0\nexpected_fragment_size=0\nisland_count=0\n\ntry:\n    subprocess.check_output(argv, shell=True)\nexcept subprocess.CalledProcessError as e:\n    if '--nomodel' in argv:\n        print \"MACS2 critical error: \", str(e)\n        sys.exit(1) # stop the whole workflow\n    print \"MACS2 will be rerun to fix not critical error: \", str(e)\n    runtime_error=True\n    expected_fragment_size=extsize\nelse:\n    calculated_fragment_size,island_count=get_info(name)\n    expected_fragment_size=calculated_fragment_size\n\nif runtime_error or (calculated_fragment_size < 80 and ('--nomodel' not in argv)):\n    try:\n        subprocess.check_output(argv+' --nomodel', shell=True)\n    except subprocess.CalledProcessError as e:\n        print \"MACS2 forced error: \", str(e)\n        sys.exit(1) # stop the whole workflow\n    else:\n        calculated_fragment_size,island_count=get_info(name)\n\nwith open(name.replace('_macs','')+'_fragment_stat.tsv', 'w') as output_file:\n    output_file.write(' '.join([str(calculated_fragment_size),str(expected_fragment_size),str(island_count)]))\n"
+              }
+            ]
+          }
+        },
+        {
+          "class": "DockerRequirement",
+          "docker_pull": "biowardrobe2/macs2:v2.1.1",
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "DockerRequirement",
+            "dockerPull": "biowardrobe2/macs2:v2.1.1"
+          }
+        }
+      ],
+      "hints": []
+    },
+    {
+      "id": "python-get-stat-chipseq.cwl",
+      "label": null,
+      "base_command": [
+        "python",
+        "-c"
+      ],
+      "arguments": [
+        "{\"valueFrom\":\"$(\\\" > \\\" + get_output_filename())\",\"position\":100000,\"shellQuote\":false}"
+      ],
+      "inputs": [
+        {
+          "id": "bowtie_log",
+          "type": "File",
+          "input_binding": {
+            "position": 6,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Log file from Bowtie\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "output_filename",
+          "type": "null | string",
+          "input_binding": null,
+          "doc": "Name for generated output file\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "rmdup_log",
+          "type": "File",
+          "input_binding": {
+            "position": 7,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Log file from samtools rmdup\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "script",
+          "type": "null | string",
+          "input_binding": {
+            "position": 5,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Python script to get TOTAL, ALIGNED, SUPRESSED, USED values from log files\n",
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "outputs": [
+        {
+          "id": "mapped_reads",
+          "type": "int",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "$(get_output_filename())",
+            "value_from": "$(parseInt(self[0].contents.split(' ')[1]))"
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "output_file",
+          "type": "File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "$(get_output_filename())",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "supressed_reads",
+          "type": "int",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "$(get_output_filename())",
+            "value_from": "$(parseInt(self[0].contents.split(' ')[2]))"
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "total_reads",
+          "type": "int",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "$(get_output_filename())",
+            "value_from": "$(parseInt(self[0].contents.split(' ')[0]))"
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "used_reads",
+          "type": "int",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "$(get_output_filename())",
+            "value_from": "$(parseInt(self[0].contents.split(' ')[3]))"
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "requirements": [
+        {
+          "class": "ShellCommandRequirement",
+          "docker_pull": null,
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "ShellCommandRequirement"
+          }
+        },
+        {
+          "class": "InlineJavascriptRequirement",
+          "docker_pull": null,
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "InlineJavascriptRequirement",
+            "expressionLib": [
+              "var get_output_filename = function() { if (inputs.output_filename == null){ let root = inputs.bowtie_log.basename.split('.').slice(0,-1).join('.'); let ext = \".stat\"; return (root == \"\")?inputs.bowtie_log.basename+ext:root+ext; } else { return inputs.output_filename; } };"
+            ]
+          }
+        },
+        {
+          "class": "DockerRequirement",
+          "docker_pull": "biowardrobe2/scidap:v0.0.2",
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "DockerRequirement",
+            "dockerPull": "biowardrobe2/scidap:v0.0.2"
+          }
+        }
+      ],
+      "hints": []
+    },
+    {
+      "id": "samtools-rmdup.cwl",
+      "label": null,
+      "base_command": [
+        "bash",
+        "-c"
+      ],
+      "arguments": [
+        "{\"valueFrom\":\"${\\n  if (inputs.output_filename == \\\"\\\" || inputs.trigger == false){\\n    return \\\" > \\\" + default_output_filename().split('.').slice(0,-1).join('.') + \\\".rmdup 2>&1\\\";\\n  } else {\\n    return \\\" > \\\" + inputs.output_filename.split('.').slice(0,-1).join('.') + \\\".rmdup 2>&1\\\";\\n  }\\n}\\n\",\"position\":100000,\"shellQuote\":false}"
+      ],
+      "inputs": [
+        {
+          "id": "bam_file",
+          "type": "File",
+          "input_binding": {
+            "position": 10,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Input sorted bam file (index file is optional)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "bash_script",
+          "type": "null | string",
+          "input_binding": {
+            "position": 1,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Bash function to run samtools rmdup with all input parameters or skip it if trigger is false\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "force_single_end",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 4,
+            "prefix": "-S",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "treat PE reads as SE in rmdup (force -s)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "output_filename",
+          "type": "null | string",
+          "input_binding": {
+            "position": 11,
+            "prefix": null,
+            "glob": null,
+            "value_from": "${\n    if (self == \"\" || inputs.trigger == false){\n      return default_output_filename();\n    } else {\n      return self;\n    }\n}\n"
+          },
+          "doc": "Writes the output bam file to output_filename if set,\notherwise generates output_filename on the base of bam_file\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "single_end",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 3,
+            "prefix": "-s",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "rmdup for SE reads\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "trigger",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 2,
+            "prefix": null,
+            "glob": null,
+            "value_from": "${ return self ? \"true\" : \"false\" }\n"
+          },
+          "doc": "If true - run samtools rmdup, if false - return bam_file, previously staged into output directory and optional index file\nUse valueFrom to return string instead of boolean, because if return boolean False, argument is not printed\n",
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "outputs": [
+        {
+          "id": "rmdup_log",
+          "type": "File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "${\n  if (inputs.output_filename == \"\" || inputs.trigger == false){\n    return default_output_filename().split('.').slice(0,-1).join('.') + '.rmdup';\n  } else {\n    return inputs.output_filename.split('.').slice(0,-1).join('.') + '.rmdup';\n  }\n}\n",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "rmdup_output",
+          "type": "File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "${\n    if (inputs.output_filename == \"\" || inputs.trigger == false){\n      return default_output_filename();\n    } else {\n      return inputs.output_filename;\n    }\n}\n",
+            "value_from": null
+          },
+          "doc": "File with removed duplicates or bam_file with optional secondaryFiles",
+          "format": null,
+          "secondary_files": [
+            "${\n    if (inputs.bam_file.secondaryFiles && inputs.trigger == false){\n      return inputs.bam_file.secondaryFiles;\n    } else {\n      return \"null\";\n    }\n  }\n"
+          ]
+        }
+      ],
+      "requirements": [
+        {
+          "class": "ShellCommandRequirement",
+          "docker_pull": null,
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "ShellCommandRequirement"
+          }
+        },
+        {
+          "class": "InlineJavascriptRequirement",
+          "docker_pull": null,
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "InlineJavascriptRequirement",
+            "expressionLib": [
+              "var default_output_filename = function() { return inputs.bam_file.location.split('/').slice(-1)[0]; };"
+            ]
+          }
+        },
+        {
+          "class": "InitialWorkDirRequirement",
+          "docker_pull": null,
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "InitialWorkDirRequirement",
+            "listing": "${\n  return  [\n            {\n              \"entry\": inputs.bam_file,\n              \"entryname\": \"input_file_backup\",\n              \"writable\": true\n            }\n          ]\n}\n"
+          }
+        },
+        {
+          "class": "DockerRequirement",
+          "docker_pull": "biowardrobe2/samtools:v1.4",
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "DockerRequirement",
+            "dockerPull": "biowardrobe2/samtools:v1.4"
+          }
+        }
+      ],
+      "hints": []
+    },
+    {
+      "id": "samtools-sort-index.cwl",
+      "label": null,
+      "base_command": [
+        "bash",
+        "-c"
+      ],
+      "arguments": [
+        "{\"valueFrom\":\"${ return inputs.trigger ? \\\"true\\\" : \\\"false\\\" }\\n\",\"position\":6}",
+        "{\"valueFrom\":\"bam\",\"position\":13,\"prefix\":\"-O\"}",
+        "{\"valueFrom\":\"$(inputs.threads?inputs.threads:1)\",\"position\":15,\"prefix\":\"-@\"}",
+        "{\"valueFrom\":\";\",\"position\":17,\"shellQuote\":false}",
+        "{\"valueFrom\":\"bash\",\"position\":18}",
+        "{\"valueFrom\":\"-c\",\"position\":19}",
+        "{\"valueFrom\":\"${ return inputs.trigger ? \\\"true\\\" : \\\"false\\\" }\\n\",\"position\":21}",
+        "{\"valueFrom\":\"$(inputs.bai?'-b':inputs.csi?'-c':[])\",\"position\":23}",
+        "{\"valueFrom\":\"$(inputs.threads?inputs.threads:1)\",\"position\":25,\"prefix\":\"-@\"}",
+        "{\"valueFrom\":\"${\\n    if (inputs.sort_output_filename == \\\"\\\" || inputs.trigger == false){\\n      return default_bam();\\n    } else {\\n      return inputs.sort_output_filename;\\n    }\\n}\\n\",\"position\":26}",
+        "{\"valueFrom\":\"${\\n    if (inputs.sort_output_filename == \\\"\\\" || inputs.trigger == false){\\n      return default_bam() + ext();\\n    } else {\\n      return inputs.sort_output_filename + ext();\\n    }\\n}\\n\",\"position\":27}"
+      ],
+      "inputs": [
+        {
+          "id": "bai",
+          "type": "null | boolean",
+          "input_binding": null,
+          "doc": "Generate BAI-format index for BAM files [default]. If input isn't cram.\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "bash_script_index",
+          "type": "null | string",
+          "input_binding": {
+            "position": 20,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Bash function to run samtools index with all input parameters or skip it if trigger is false\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "bash_script_sort",
+          "type": "null | string",
+          "input_binding": {
+            "position": 5,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Bash function to run samtools sort with all input parameters or skip it if trigger is false\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "csi",
+          "type": "null | boolean",
+          "input_binding": null,
+          "doc": "Generate CSI-format index for BAM files. If input isn't cram.\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "csi_interval",
+          "type": "null | int",
+          "input_binding": {
+            "position": 24,
+            "prefix": "-m",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Set minimum interval size for CSI indices to 2^INT [14]\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "sort_compression_level",
+          "type": "null | int",
+          "input_binding": {
+            "position": 11,
+            "prefix": "-l",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "SORT: desired compression level for the final output file, ranging from 0 (uncompressed)\nor 1 (fastest but minimal compression) to 9 (best compression but slowest to write),\nsimilarly to gzip(1)'s compression level setting.\nIf -l is not used, the default compression level will apply.\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "sort_input",
+          "type": "File",
+          "input_binding": {
+            "position": 16,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Input only in.sam|in.bam|in.cram. Optionally could be supplemented with index file in secondaryFiles\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "sort_output_filename",
+          "type": "null | string",
+          "input_binding": {
+            "position": 12,
+            "prefix": "-o",
+            "glob": null,
+            "value_from": "${\n    if (self == \"\" || inputs.trigger == false){\n      return default_bam();\n    } else {\n      return self;\n    }\n}\n"
+          },
+          "doc": "Write the final sorted output to FILE. Only out.bam|out.cram.\nIf output file extension is set to SAM, tool will fail on the index step\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "threads",
+          "type": "null | int",
+          "input_binding": null,
+          "doc": "Set number of sorting and compression threads [1] (Only for sorting)\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "trigger",
+          "type": "null | boolean",
+          "input_binding": null,
+          "doc": "If true - run samtools, if false - return sort_input and optional index file in secondaryFiles, previously staged\ninto output directory.\n",
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "outputs": [
+        {
+          "id": "bam_bai_pair",
+          "type": "File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "${\n    if (inputs.sort_output_filename == \"\" || inputs.trigger == false){\n      return default_bam();\n    } else {\n      return inputs.sort_output_filename;\n    }\n}\n",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": [
+            "${ if (inputs.trigger == true){ return self.basename + ext(); } else { return inputs.sort_input.secondaryFiles?inputs.sort_input.secondaryFiles:\"null\"; } }"
+          ]
+        }
+      ],
+      "requirements": [
+        {
+          "class": "ShellCommandRequirement",
+          "docker_pull": null,
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "ShellCommandRequirement"
+          }
+        },
+        {
+          "class": "InitialWorkDirRequirement",
+          "docker_pull": null,
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "InitialWorkDirRequirement",
+            "listing": "${\n  return  [\n            {\n              \"entry\": inputs.sort_input,\n              \"entryname\": inputs.sort_input.basename,\n              \"writable\": true\n            }\n          ]\n}\n"
+          }
+        },
+        {
+          "class": "InlineJavascriptRequirement",
+          "docker_pull": null,
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "InlineJavascriptRequirement",
+            "expressionLib": [
+              "var ext = function() { if (inputs.csi && !inputs.bai){ return '.csi'; } else { return '.bai'; } };",
+              "var default_bam = function() { if (inputs.trigger == true){ return inputs.sort_input.location.split('/').slice(-1)[0].split('.').slice(0,-1).join('.')+\".bam\"; } else { return inputs.sort_input.location.split('/').slice(-1)[0]; } };"
+            ]
+          }
+        },
+        {
+          "class": "DockerRequirement",
+          "docker_pull": "biowardrobe2/samtools:v1.4",
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "DockerRequirement",
+            "dockerPull": "biowardrobe2/samtools:v1.4"
+          }
+        }
+      ],
+      "hints": []
+    },
+    {
+      "id": "ucsc-bedgraphtobigwig.cwl",
+      "label": null,
+      "base_command": [
+        "bedGraphToBigWig"
+      ],
+      "arguments": [],
+      "inputs": [
+        {
+          "id": "bedgraph_file",
+          "type": "File",
+          "input_binding": {
+            "position": 10,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Four column bedGraph file: <chrom> <start> <end> <value>\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "block_size",
+          "type": "null | int",
+          "input_binding": {
+            "position": 7,
+            "prefix": "-blockSize=",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Number of items to bundle in r-tree.  Default 256\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "chrom_length_file",
+          "type": "File",
+          "input_binding": {
+            "position": 11,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Two-column chromosome length file: <chromosome name> <size in bases>\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "items_per_slot",
+          "type": "null | int",
+          "input_binding": {
+            "position": 6,
+            "prefix": "-itemsPerSlot=",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Number of data points bundled at lowest level. Default 1024\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "output_filename",
+          "type": "null | string",
+          "input_binding": {
+            "position": 12,
+            "prefix": null,
+            "glob": null,
+            "value_from": "${\n    if (self == \"\"){\n      return default_output_filename();\n    } else {\n      return self;\n    }\n}\n"
+          },
+          "doc": "If set, writes the output bigWig file to output_filename,\notherwise generates filename from default_output_filename()\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "unc",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 5,
+            "prefix": "-unc",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Disable compression\n",
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "outputs": [
+        {
+          "id": "bigwig_file",
+          "type": "File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "${\n    if (inputs.output_filename == \"\"){\n      return default_output_filename();\n    } else {\n      return inputs.output_filename;\n    }\n}\n",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "requirements": [
+        {
+          "class": "InlineJavascriptRequirement",
+          "docker_pull": null,
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "InlineJavascriptRequirement",
+            "expressionLib": [
+              "var default_output_filename = function() { let basename = inputs.bedgraph_file.location.split('/').slice(-1)[0]; let root = basename.split('.').slice(0,-1).join('.'); let ext = \".bigWig\"; return (root == \"\")?basename+ext:root+ext; };"
+            ]
+          }
+        },
+        {
+          "class": "DockerRequirement",
+          "docker_pull": "biowardrobe2/ucscuserapps:v358",
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "DockerRequirement",
+            "dockerPull": "biowardrobe2/ucscuserapps:v358"
+          }
+        }
+      ],
+      "hints": []
+    },
+    {
+      "id": "bam-bedgraph-bigwig.cwl",
+      "label": null,
+      "base_command": [],
+      "arguments": [],
+      "inputs": [
+        {
+          "id": "bam_file",
+          "type": "File",
+          "input_binding": null,
+          "doc": "Input BAM file, sorted by coordinates",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "bedgraph_filename",
+          "type": "null | string",
+          "input_binding": null,
+          "doc": "Output filename for generated bedGraph",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "bigwig_filename",
+          "type": "null | string",
+          "input_binding": null,
+          "doc": "Output filename for generated bigWig",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "chrom_length_file",
+          "type": "File",
+          "input_binding": null,
+          "doc": "Tab delimited chromosome length file: <chromName><TAB><chromSize>",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "dutp",
+          "type": "null | boolean",
+          "input_binding": null,
+          "doc": "Change strand af the mate read, so both reads come from the same strand",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "fragment_size",
+          "type": "null | int",
+          "input_binding": null,
+          "doc": "Set fixed fragment size for genome coverage calculation",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "mapped_reads_number",
+          "type": "null | int",
+          "input_binding": null,
+          "doc": "Parameter to calculate scale as 1000000/mapped_reads_number. Ignored by bedtools-genomecov.cwl in\nbam_to_bedgraph step if scale is provided\n",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "pairchip",
+          "type": "null | boolean",
+          "input_binding": null,
+          "doc": "Enable paired-end genome coverage calculation",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "scale",
+          "type": "null | float",
+          "input_binding": null,
+          "doc": "Coefficient to scale the genome coverage by a constant factor",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "split",
+          "type": "null | boolean",
+          "input_binding": null,
+          "doc": "Calculate genome coverage for each part of the splitted by 'N' and 'D' read",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "strand",
+          "type": "null | string",
+          "input_binding": null,
+          "doc": "Calculate genome coverage of intervals from a specific strand",
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "outputs": [
+        {
+          "id": "bedgraph_file",
+          "type": "File",
+          "output_binding": null,
+          "doc": "bedGraph output file",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "bigwig_file",
+          "type": "File",
+          "output_binding": null,
+          "doc": "bigWig output file",
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "requirements": [
+        {
+          "class": "StepInputExpressionRequirement",
+          "docker_pull": null,
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "StepInputExpressionRequirement"
+          }
+        },
+        {
+          "class": "InlineJavascriptRequirement",
+          "docker_pull": null,
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "InlineJavascriptRequirement"
+          }
+        }
+      ],
+      "hints": [
+        {
+          "class": "_NestedWorkflow",
+          "docker_pull": null,
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "steps": [
+              {
+                "id": "bam-bedgraph-bigwig.cwl/bam_to_bedgraph",
+                "run": "bedtools-genomecov.cwl"
+              },
+              {
+                "id": "bam-bedgraph-bigwig.cwl/sort_bedgraph",
+                "run": "linux-sort.cwl"
+              },
+              {
+                "id": "bam-bedgraph-bigwig.cwl/sorted_bedgraph_to_bigwig",
+                "run": "ucsc-bedgraphtobigwig.cwl"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "graph": {
+    "nodes": [
+      {
+        "id": "annotation_file",
+        "kind": "workflow-input",
+        "label": "Annotation file"
+      },
+      {
+        "id": "broad_peak",
+        "kind": "workflow-input",
+        "label": "Callpeak broad"
+      },
+      {
+        "id": "chrom_length",
+        "kind": "workflow-input",
+        "label": "Chromosome length file"
+      },
+      {
+        "id": "clip_3p_end",
+        "kind": "workflow-input",
+        "label": "Clip from 3p end"
+      },
+      {
+        "id": "clip_5p_end",
+        "kind": "workflow-input",
+        "label": "Clip from 5p end"
+      },
+      {
+        "id": "control_file",
+        "kind": "workflow-input",
+        "label": "Control BAM file"
+      },
+      {
+        "id": "exp_fragment_size",
+        "kind": "workflow-input",
+        "label": "Expected fragment size"
+      },
+      {
+        "id": "fastq_file",
+        "kind": "workflow-input",
+        "label": "FASTQ input file"
+      },
+      {
+        "id": "force_fragment_size",
+        "kind": "workflow-input",
+        "label": "Force fragment size"
+      },
+      {
+        "id": "genome_size",
+        "kind": "workflow-input",
+        "label": "Effective genome size"
+      },
+      {
+        "id": "indices_folder",
+        "kind": "workflow-input",
+        "label": "BOWTIE indices folder"
+      },
+      {
+        "id": "remove_duplicates",
+        "kind": "workflow-input",
+        "label": "Remove duplicates"
+      },
+      {
+        "id": "threads",
+        "kind": "workflow-input",
+        "label": "Number of threads"
+      },
+      {
+        "id": "atdp_log",
+        "kind": "workflow-output",
+        "label": "ATDP log"
+      },
+      {
+        "id": "atdp_result",
+        "kind": "workflow-output",
+        "label": "ATDP results"
+      },
+      {
+        "id": "bambai_pair",
+        "kind": "workflow-output",
+        "label": "Coordinate sorted BAM alignment file (+index BAI)"
+      },
+      {
+        "id": "bigwig",
+        "kind": "workflow-output",
+        "label": "BigWig file"
+      },
+      {
+        "id": "bowtie_log",
+        "kind": "workflow-output",
+        "label": "BOWTIE alignment log"
+      },
+      {
+        "id": "fastx_statistics",
+        "kind": "workflow-output",
+        "label": "FASTQ statistics"
+      },
+      {
+        "id": "get_stat_log",
+        "kind": "workflow-output",
+        "label": "Bowtie & Samtools Rmdup combined log"
+      },
+      {
+        "id": "iaintersect_log",
+        "kind": "workflow-output",
+        "label": "Island intersect log"
+      },
+      {
+        "id": "iaintersect_result",
+        "kind": "workflow-output",
+        "label": "Island intersect results"
+      },
+      {
+        "id": "macs2_broad_peaks",
+        "kind": "workflow-output",
+        "label": "Broad peaks"
+      },
+      {
+        "id": "macs2_called_peaks",
+        "kind": "workflow-output",
+        "label": "Called peaks"
+      },
+      {
+        "id": "macs2_fragment_stat",
+        "kind": "workflow-output",
+        "label": "FRAGMENT, FRAGMENTE, ISLANDS"
+      },
+      {
+        "id": "macs2_gapped_peak",
+        "kind": "workflow-output",
+        "label": "Gapped peak"
+      },
+      {
+        "id": "macs2_log",
+        "kind": "workflow-output",
+        "label": "MACS2 log"
+      },
+      {
+        "id": "macs2_moder_r",
+        "kind": "workflow-output",
+        "label": "MACS2 generated R script"
+      },
+      {
+        "id": "macs2_narrow_peaks",
+        "kind": "workflow-output",
+        "label": "Narrow peaks"
+      },
+      {
+        "id": "macs2_peak_summits",
+        "kind": "workflow-output",
+        "label": "Peak summits"
+      },
+      {
+        "id": "samtools_rmdup_log",
+        "kind": "workflow-output",
+        "label": "Remove duplicates log"
+      },
+      {
+        "id": "average_tag_density",
+        "kind": "step",
+        "label": "average_tag_density"
+      },
+      {
+        "id": "bam_to_bigwig",
+        "kind": "step",
+        "label": "bam_to_bigwig"
+      },
+      {
+        "id": "bowtie_aligner",
+        "kind": "step",
+        "label": "bowtie_aligner"
+      },
+      {
+        "id": "extract_fastq",
+        "kind": "step",
+        "label": "extract_fastq"
+      },
+      {
+        "id": "fastx_quality_stats",
+        "kind": "step",
+        "label": "fastx_quality_stats"
+      },
+      {
+        "id": "get_stat",
+        "kind": "step",
+        "label": "get_stat"
+      },
+      {
+        "id": "island_intersect",
+        "kind": "step",
+        "label": "island_intersect"
+      },
+      {
+        "id": "macs2_callpeak",
+        "kind": "step",
+        "label": "macs2_callpeak"
+      },
+      {
+        "id": "samtools_rmdup",
+        "kind": "step",
+        "label": "samtools_rmdup"
+      },
+      {
+        "id": "samtools_sort_index",
+        "kind": "step",
+        "label": "samtools_sort_index"
+      },
+      {
+        "id": "samtools_sort_index_after_rmdup",
+        "kind": "step",
+        "label": "samtools_sort_index_after_rmdup"
+      }
+    ],
+    "edges": [
+      {
+        "from": "annotation_file",
+        "to": "average_tag_density/annotation_filename",
+        "via": []
+      },
+      {
+        "from": "macs2_callpeak/macs2_fragments_calculated",
+        "to": "average_tag_density/fragmentsize_bp",
+        "via": []
+      },
+      {
+        "from": "samtools_sort_index_after_rmdup/bam_bai_pair",
+        "to": "average_tag_density/input_file",
+        "via": []
+      },
+      {
+        "from": "get_stat/mapped_reads",
+        "to": "average_tag_density/mapped_reads",
+        "via": []
+      },
+      {
+        "from": "samtools_sort_index_after_rmdup/bam_bai_pair",
+        "to": "bam_to_bigwig/bam_file",
+        "via": []
+      },
+      {
+        "from": "chrom_length",
+        "to": "bam_to_bigwig/chrom_length_file",
+        "via": []
+      },
+      {
+        "from": "macs2_callpeak/macs2_fragments_calculated",
+        "to": "bam_to_bigwig/fragment_size",
+        "via": []
+      },
+      {
+        "from": "get_stat/mapped_reads",
+        "to": "bam_to_bigwig/mapped_reads_number",
+        "via": []
+      },
+      {
+        "from": "clip_3p_end",
+        "to": "bowtie_aligner/clip_3p_end",
+        "via": []
+      },
+      {
+        "from": "clip_5p_end",
+        "to": "bowtie_aligner/clip_5p_end",
+        "via": []
+      },
+      {
+        "from": "indices_folder",
+        "to": "bowtie_aligner/indices_folder",
+        "via": []
+      },
+      {
+        "from": "threads",
+        "to": "bowtie_aligner/threads",
+        "via": []
+      },
+      {
+        "from": "extract_fastq/fastq_file",
+        "to": "bowtie_aligner/upstream_filelist",
+        "via": []
+      },
+      {
+        "from": "fastq_file",
+        "to": "extract_fastq/compressed_file",
+        "via": []
+      },
+      {
+        "from": "extract_fastq/fastq_file",
+        "to": "fastx_quality_stats/input_file",
+        "via": []
+      },
+      {
+        "from": "bowtie_aligner/log_file",
+        "to": "get_stat/bowtie_log",
+        "via": []
+      },
+      {
+        "from": "samtools_rmdup/rmdup_log",
+        "to": "get_stat/rmdup_log",
+        "via": []
+      },
+      {
+        "from": "annotation_file",
+        "to": "island_intersect/annotation_filename",
+        "via": []
+      },
+      {
+        "from": "macs2_callpeak/peak_xls_file",
+        "to": "island_intersect/input_filename",
+        "via": []
+      },
+      {
+        "from": "broad_peak",
+        "to": "macs2_callpeak/broad",
+        "via": []
+      },
+      {
+        "from": "exp_fragment_size",
+        "to": "macs2_callpeak/bw",
+        "via": []
+      },
+      {
+        "from": "broad_peak",
+        "to": "macs2_callpeak/call_summits",
+        "via": [
+          "valueFrom"
+        ]
+      },
+      {
+        "from": "control_file",
+        "to": "macs2_callpeak/control_file",
+        "via": []
+      },
+      {
+        "from": "exp_fragment_size",
+        "to": "macs2_callpeak/extsize",
+        "via": []
+      },
+      {
+        "from": "genome_size",
+        "to": "macs2_callpeak/genome_size",
+        "via": []
+      },
+      {
+        "from": "control_file",
+        "to": "macs2_callpeak/nolambda",
+        "via": [
+          "valueFrom"
+        ]
+      },
+      {
+        "from": "force_fragment_size",
+        "to": "macs2_callpeak/nomodel",
+        "via": []
+      },
+      {
+        "from": "samtools_sort_index_after_rmdup/bam_bai_pair",
+        "to": "macs2_callpeak/treatment_file",
+        "via": []
+      },
+      {
+        "from": "samtools_sort_index/bam_bai_pair",
+        "to": "samtools_rmdup/bam_file",
+        "via": []
+      },
+      {
+        "from": "remove_duplicates",
+        "to": "samtools_rmdup/trigger",
+        "via": []
+      },
+      {
+        "from": "bowtie_aligner/sam_file",
+        "to": "samtools_sort_index/sort_input",
+        "via": []
+      },
+      {
+        "from": "threads",
+        "to": "samtools_sort_index/threads",
+        "via": []
+      },
+      {
+        "from": "samtools_rmdup/rmdup_output",
+        "to": "samtools_sort_index_after_rmdup/sort_input",
+        "via": []
+      },
+      {
+        "from": "threads",
+        "to": "samtools_sort_index_after_rmdup/threads",
+        "via": []
+      },
+      {
+        "from": "remove_duplicates",
+        "to": "samtools_sort_index_after_rmdup/trigger",
+        "via": []
+      },
+      {
+        "from": "average_tag_density/log_file",
+        "to": "atdp_log",
+        "via": []
+      },
+      {
+        "from": "average_tag_density/result_file",
+        "to": "atdp_result",
+        "via": []
+      },
+      {
+        "from": "samtools_sort_index_after_rmdup/bam_bai_pair",
+        "to": "bambai_pair",
+        "via": []
+      },
+      {
+        "from": "bam_to_bigwig/bigwig_file",
+        "to": "bigwig",
+        "via": []
+      },
+      {
+        "from": "bowtie_aligner/log_file",
+        "to": "bowtie_log",
+        "via": []
+      },
+      {
+        "from": "fastx_quality_stats/statistics_file",
+        "to": "fastx_statistics",
+        "via": []
+      },
+      {
+        "from": "get_stat/output_file",
+        "to": "get_stat_log",
+        "via": []
+      },
+      {
+        "from": "island_intersect/log_file",
+        "to": "iaintersect_log",
+        "via": []
+      },
+      {
+        "from": "island_intersect/result_file",
+        "to": "iaintersect_result",
+        "via": []
+      },
+      {
+        "from": "macs2_callpeak/broad_peak_file",
+        "to": "macs2_broad_peaks",
+        "via": []
+      },
+      {
+        "from": "macs2_callpeak/peak_xls_file",
+        "to": "macs2_called_peaks",
+        "via": []
+      },
+      {
+        "from": "macs2_callpeak/macs2_stat_file",
+        "to": "macs2_fragment_stat",
+        "via": []
+      },
+      {
+        "from": "macs2_callpeak/gapped_peak_file",
+        "to": "macs2_gapped_peak",
+        "via": []
+      },
+      {
+        "from": "macs2_callpeak/macs_log",
+        "to": "macs2_log",
+        "via": []
+      },
+      {
+        "from": "macs2_callpeak/moder_r_file",
+        "to": "macs2_moder_r",
+        "via": []
+      },
+      {
+        "from": "macs2_callpeak/narrow_peak_file",
+        "to": "macs2_narrow_peaks",
+        "via": []
+      },
+      {
+        "from": "macs2_callpeak/peak_summits_file",
+        "to": "macs2_peak_summits",
+        "via": []
+      },
+      {
+        "from": "samtools_rmdup/rmdup_log",
+        "to": "samtools_rmdup_log",
+        "via": []
+      }
+    ]
+  },
+  "tests": [
+    {
+      "name": "biowardrobe_chipseq_se",
+      "job_path": "biowardrobe_chipseq_se.yaml",
+      "expected_outputs": [],
+      "provenance": "sibling-yaml: biowardrobe_chipseq_se.yaml job file in repo; no asserted expected outputs"
+    }
+  ],
+  "warnings": [
+    {
+      "code": "expression.javascript",
+      "message": "InlineJavascriptRequirement is active; expressions are preserved, not executed.",
+      "path": "requirements"
+    },
+    {
+      "code": "ref.directory",
+      "message": "indices_folder is a CWL Directory input; downstream Galaxy translation must choose between directory-capable wrappers, explicit files, or collections.",
+      "path": "workflow_inputs/indices_folder"
+    },
+    {
+      "code": "nested.workflow",
+      "message": "Nested workflow #bam-bedgraph-bigwig.cwl in step bam_to_bigwig is preserved as a step target; downstream may need expansion.",
+      "path": "steps/bam_to_bigwig"
+    },
+    {
+      "code": "type.compat",
+      "message": "macs2_callpeak/peak_xls_file is (null|File) but is fed to a sink expecting File; downstream needs null-handling.",
+      "path": "steps/macs2_callpeak"
+    }
+  ]
+}

--- a/casts/claude/skills/_emulated-runs/salmon-rnaseq-cwl-galaxy-5step/cwl-galaxy-data-flow.md
+++ b/casts/claude/skills/_emulated-runs/salmon-rnaseq-cwl-galaxy-5step/cwl-galaxy-data-flow.md
@@ -1,0 +1,106 @@
+# Galaxy data-flow brief — hubmap salmon-rnaseq
+
+Source: `summary-cwl.json` + `cwl-galaxy-interface.md`, with one inspection of `steps/salmon-quantification.cwl` raw because the summary lost nested-workflow `when:` / `pickValue` markers (see refinement).
+Confidence: medium for topology and collection shape, low for the conditional `human|mouse` branch in the nested salmon-quantification subworkflow.
+
+## Abstract topology
+
+Main DAG (7 steps, 1 of which is a nested workflow):
+
+```
+fastq_dir ─┬─► fastqc[scatter:fastq_dir]                                      ► fastqc_dir
+           └─► salmon_quantification (subworkflow)
+                  ├─► count_matrix_h5ad ─► deepscence ─► h5ad_with_ds ─┬─► scanpy_analysis ─┬─► filtered_data_h5ad ─┬─► squidpy_analysis (if img_dir)
+                  │                                                    │                    │                       └─► compute_qc_results
+                  │                                                    └─► scvelo_analysis ─► annotated_h5ad_file
+                  ├─► salmon_output (Directory) ─► compute_qc_results
+                  ├─► raw_count_matrix (File?)
+                  └─► genome_build_json
+
+img_dir, metadata_dir (optional) ─► salmon_quantification + squidpy_analysis
+assay, threads, organism ─► (broadcast scalar)
+```
+
+Nested `salmon_quantification.cwl` (6 inner steps):
+
+```
+fastq_dir ─► adjust_barcodes ─► trim_reads ─┬─► salmon          (when organism == 'human')
+                                            └─► salmon-mouse    (when organism == 'mouse')
+                                                  ↓                   ↓
+                                                  pickValue: first_non_null
+                                                  → alevin_to_anndata → annotate_cells (with img_dir, metadata_dir, fastq_dir, adjust_barcodes.metadata_json)
+```
+
+Edge count, main workflow: ~25 from `summary-cwl.graph.edges`. The nested workflow adds ~14 more inner edges plus two `when:` predicates and one `pickValue` merge.
+
+## Galaxy collection semantics
+
+CWL uses `Directory[]` for per-sample fastq input and scatters `fastqc` over it.
+
+- **`fastq_dir: Directory[]` → Galaxy `list` of (paired or list) collections.** Per [[galaxy-collection-semantics]] and the IWC scRNA-seq exemplars, the outer Galaxy list element represents one sample; the inner element is either a `paired` collection (10x_v3 etc.) or a `list` of FASTQ datasets (Slide-seq / Visium). Two viable shapes:
+  - (a) `list:paired` outer×inner — simplest when assay implies paired reads (most 10x assays).
+  - (b) `list:list` outer×inner — required when the assay produces N-way fastq sets (e.g. 10x_v3 produces R1/R2/I1; Slide-seq does not match strict paired).
+  Recommend (b) `list:list` because it accommodates every assay branch without further wrapping.
+- **`Directory[]` → `list` element mapping.** Each `Directory` element of the outer CWL array becomes one element of the outer Galaxy list. Inside each element, the wrapper-side trim/salmon CLI must accept "treat all inputs under this list element as one sample". This implies the Galaxy wrappers for `trim-reads`, `salmon`, and `adjust-barcodes` consume `data_collection list` inputs, not single files. Likely needs author-galaxy-tool-wrapper.
+- **`fastqc` scatter.** With (b) above, the Galaxy `fastqc` IUC tool maps over the outer list automatically (one FastQC report per inner list of FASTQs) — but FastQC operates on a single file, not on a collection of files for one sample. Realistically, fastqc must `map_over` the *flattened* fastq stream and then a downstream `collect` step regroups by sample if the brief wants `fastqc_dir: Directory[]` preserved. This is one piece of explicit collection wiring.
+- **`img_dir` / `metadata_dir` (Directory?).** Map to optional Galaxy collections (`list`).
+- **`salmon_output: Directory` workflow output.** Either expose as a `list` collection of canonical Alevin files or as a Galaxy composite datatype. Open question (interface brief #3).
+
+## Conditional/expression pressure
+
+1. **`when:` inside `salmon-quantification.cwl` — `organism == 'human'` vs `'mouse'`.** Galaxy has no native CWL-style `when:`. Translation options per [[cwl-when-pickvalue-to-galaxy-branching]]:
+   - (a) **sibling workflows.** Two Galaxy workflows: `salmon-rnaseq-human.gxwf.yml` and `salmon-rnaseq-mouse.gxwf.yml`. Simplest, cleanest, but doubles maintenance.
+   - (b) **paired_or_unpaired-style branching at the salmon tool level.** Build a single Galaxy `salmon-alevin` wrapper that accepts an `organism` enum and selects the cached index internally. Recommend (b) — this is the IWC convention (salmon-alevin tool selects index via data table).
+   - (c) **pick_value workflow module (galaxy#22222).** Could wire `salmon-human` and `salmon-mouse` as two steps and `pick_value: first_non_null` the outputs. Adds complexity without payoff here because the discriminator is a single text input the salmon tool can read directly.
+   Recommend (b). Surface in template Mold as a single `salmon-alevin` step with an `organism` parameter; drop the `when:`-driven duplication.
+2. **`pickValue: first_non_null` on `salmon-quantification.cwl/salmon_output`** (and inner `alevin_to_anndata/alevin_dir`). If (b) above is taken, both pickValue uses collapse to a single non-conditional edge: salmon-alevin always produces exactly one output. The pickValue is a CWL artifact of the `when:`-split branches; it does not need to survive translation.
+3. **`InlineJavascriptRequirement` is declared** at multiple levels. Spot-check shows no expressions at the workflow boundary — only inside tool wrappers (e.g. parameter derivations). No translation pressure at gxformat2 level; surfaces as wrapper-level concerns.
+4. **No `valueFrom` at the workflow step boundary.** All `steps[].in[].value_from` are null in the summary.
+
+## Placeholder transformations
+
+| Edge / shape | CWL marker | Galaxy translation |
+| --- | --- | --- |
+| `fastq_dir (Directory[])` → `fastqc[scatter:fastq_dir]` | scatter dotproduct | `list:list` input; `fastqc` map_over over flattened inner list; `Apply Rules` to regroup by sample if needed |
+| `fastq_dir` → `salmon_quantification.adjust_barcodes` | direct (Directory[]) | direct connection (`list:list` collection in, wrapper consumes per-sample) |
+| `salmon_quantification.count_matrix_h5ad` → `deepscence.h5ad_file` | direct | direct |
+| `deepscence.h5ad_with_ds` → `scanpy_analysis`, `scvelo_analysis`, `compute_qc_results` | one-to-many | direct fan-out (Galaxy supports multiple sinks reading one output) |
+| `scanpy_analysis.filtered_data_h5ad` → `squidpy_analysis`, `compute_qc_results` | one-to-many | direct fan-out |
+| `img_dir (Directory?)` → `salmon_quantification`, `squidpy_analysis` | optional Directory | optional Galaxy `data_collection` input; `squidpy_analysis` step gated on presence (gxformat2 optional connection) |
+| `salmon_output (Directory)` workflow output | pickValue collapsed in nested workflow | typed collection or composite at output |
+| `salmon vs salmon-mouse when: organism` (nested) | `when:` + pickValue | collapse into single `salmon-alevin` wrapper with `organism` parameter |
+| 8 scalar parameter inputs → step inputs | direct | direct |
+
+## Unresolved Galaxy tool needs
+
+13 unique CommandLineTools observed (main + nested):
+
+- `fastqc.cwl` — IUC `fastqc` likely covers it.
+- `compute-qc-metrics.cwl` — HuBMAP-flavored QC; **likely author**.
+- `deepscence.cwl` — DeepScence (senescence scoring); **likely author** (no IUC wrapper expected).
+- `scanpy-analysis.cwl` — IUC `scanpy` tools exist but as discrete steps, not a monolithic per-assay analysis; **likely re-decompose or author**.
+- `scvelo-analysis.cwl` — **likely author**; no canonical IUC scVelo single-step.
+- `squidpy-analysis.cwl` — **likely author**; no canonical IUC squidpy single-step.
+- `adjust-barcodes.cwl`, `trim-reads.cwl`, `salmon.cwl`, `salmon-mouse.cwl`, `alevin-to-anndata.cwl`, `annotate-cells.cwl`, `map_hugo_symbols.cwl` (referenced but unused in main pipeline) — HuBMAP-flavored Salmon-Alevin pipeline steps; **likely author** with the caveat that an IUC `salmon-alevin` wrapper exists and the right move is probably to collapse `salmon` + `salmon-mouse` + `alevin-to-anndata` + `annotate-cells` into the IUC `salmon-alevin` invocation rather than reimplement.
+
+Estimate: 1 likely Tool Shed hit (`fastqc`), ~5 likely-author HuBMAP wrappers if we collapse the salmon pipeline to IUC `salmon-alevin`, more if we don't.
+
+## Confidence
+
+- High for main-workflow topology.
+- Medium for `Directory[] → list:list` collection shape.
+- Medium-low for the `when:` / `pickValue` branch handling — translation strategy is clear but depends on the discover-shed-tool step finding a single salmon-alevin wrapper.
+- Low confidence that any HuBMAP-specific QC / annotation / DeepScence / scVelo / SquidPy step has an IUC equivalent.
+
+## Open questions
+
+1. Collapse the `salmon` + `salmon-mouse` `when:` branches into one Galaxy `salmon-alevin` invocation with an `organism` parameter? Recommend yes.
+2. Flatten `salmon-quantification.cwl` into the main Galaxy workflow vs author a Galaxy sub-workflow? Recommend flatten.
+3. Galaxy collection shape for `fastq_dir: Directory[]` — `list:list` (recommended) or `list:paired`?
+4. `salmon_output: Directory` workflow output → composite datatype or `list` collection?
+5. `fastqc_dir: Directory[]` output → preserve outer grouping via Apply Rules, or accept flattened FastQC report list?
+6. Are the HuBMAP-flavored steps (DeepScence, SquidPy single-step, scVelo single-step, compute-qc-metrics, annotate-cells) candidates for IUC submission, or should each become a workflow-local custom wrapper?
+
+## Note on summary-cwl coverage (refinement)
+
+The extractor I used (and the analogous one from the ga4gh run) only walks the *main* workflow's `steps[]`. Nested workflows are emitted as `tools[]` entries with a coarse `_NestedWorkflow` hint listing inner-step IDs but **without** the inner `in:`/`out:` wiring, `when:` predicates, or `pickValue` merges. I had to read `steps/salmon-quantification.cwl` directly to surface the `when: $(inputs.organism == 'human')` branching that drives the biggest translation decision in this pipeline. This is a refinement candidate for `summarize-cwl` and `cwl-summary-to-galaxy-data-flow`.

--- a/casts/claude/skills/_emulated-runs/salmon-rnaseq-cwl-galaxy-5step/cwl-galaxy-interface.md
+++ b/casts/claude/skills/_emulated-runs/salmon-rnaseq-cwl-galaxy-5step/cwl-galaxy-interface.md
@@ -1,0 +1,57 @@
+# Galaxy interface brief — hubmap salmon-rnaseq
+
+Source: `pipeline.cwl` (HuBMAP `salmon-rnaseq`, single-cell + spatial scRNA-seq via Salmon/Alevin).
+Provenance: summary-cwl @ `summary-cwl.json` (cwlVersion v1.2, 7 main steps, 1 nested workflow `salmon-quantification.cwl` with 9 inner steps, 12 CommandLineTools).
+Confidence: medium-low. Multiple `Directory[]`/`Directory` inputs, a scattered FastQC step, optional `null|File` outputs from conditional analysis branches (scVelo / SquidPy), and a heavy nested subworkflow combine to make this harder than the ga4gh ChIP-seq fixture.
+
+## Workflow inputs (Galaxy-facing)
+
+| Galaxy label | Galaxy shape | CWL source | Notes |
+| --- | --- | --- | --- |
+| `fastq_inputs` | (review) `list:list` collection (outer = "directory", inner = paired/unpaired fastqs) **or** `data_collection` of paired fastqsanger | `fastq_dir` (Directory[]) | **Open question.** CWL passes per-sample directories; Galaxy has no Directory type. Two honest options: (a) one nested collection where the outer list mirrors the CWL Directory[] and inner items are the FASTQ files; (b) require one `paired_collection` per sample and run the workflow scatter at invocation time. Recommend (a) so FastQC's CWL-side `scatter: [fastq_dir]` translates to Galaxy `map_over`. |
+| `image_directory` | optional `data_collection` (datatype `tiff`) | `img_dir` (Directory?) | Visium-only. Map to an optional Galaxy collection of TIFFs; gate downstream `squidpy_analysis` step on its presence. |
+| `metadata_directory` | optional `data_collection` (datatype `tabular` / `txt`) | `metadata_dir` (Directory?) | Visium-only, includes the gpr slide file. Same gating as `image_directory`. |
+| `assay` | parameter (text, restricted select) | `assay` (string) | Open question: enumerate allowed values (`10x_v2`, `10x_v3`, `visium`, `slideseq` …) from the upstream `salmon-quantification.cwl` branches. |
+| `threads` | parameter (integer, default 1) | `threads` (int) | CWL exposes it at workflow level; Galaxy convention buries per-tool thread count. Recommend hiding from public interface unless tools need a shared knob. |
+| `expected_cell_count` | parameter (integer, optional) | `expected_cell_count` (int?) | Used by Alevin. Leave optional. |
+| `keep_all_barcodes` | parameter (boolean, optional) | `keep_all_barcodes` (boolean?) | Alevin flag. |
+| `organism` | parameter (text select, default `human`) | `organism` (string?, default `human`) | Switches reference data branch inside `salmon-quantification.cwl` (salmon vs salmon-mouse). Should drive a Galaxy `select` parameter that maps to the appropriate cached reference data table. |
+
+## Workflow outputs (Galaxy-facing)
+
+Promote as **public** workflow outputs:
+
+- `count_matrix_h5ad` — annotated AnnData (`h5` / `h5ad`). Primary downstream-consumable.
+- `filtered_data_h5ad` — filtered/clustered AnnData (`h5ad`).
+- `salmon_output` — **review** — CWL `Directory`. Map to a Galaxy `data_collection` of the underlying Alevin artifacts (or a tarball composite). Open question.
+- `genome_build_json` — JSON (`json`).
+- `scanpy_qc_results` / `qc_report` — QC results (`tabular` / `json`).
+- `fastqc_dir` — **review** — CWL `Directory[]`. Map to a `list` collection of zipped FastQC bundles (mirror Galaxy IUC `fastqc` wrapper output shape).
+- `umap_plot`, `umap_density_plot`, `dispersion_plot`, `marker_gene_plot_t_test`, `marker_gene_plot_logreg`, `deepscence_plot`, `deepscence_continuous_plot`, `deepscence_binary_plot` — plot images (`png`).
+
+Promote as **optional** public outputs (`null | File`; gate on assay/img branch):
+
+- `raw_count_matrix` (Alevin H5AD with intronic columns as separate columns)
+- `scvelo_annotated_h5ad`, `scvelo_embedding_grid_plot` (RNA velocity branch)
+- `squidpy_annotated_h5ad`, `neighborhood_enrichment_plot`, `co_occurrence_plot`, `interaction_matrix_plot`, `centrality_scores_plot`, `ripley_plot`, `squidpy_spatial_plot`, `spatial_plot` (spatial branch — Visium / Slide-seq)
+
+Promote as **checkpoint** outputs (review-only): none in this fixture. (Logs and intermediate count matrices are not exposed by the CWL workflow.)
+
+## Open questions
+
+1. **Directory[] → Galaxy collection shape.** Single biggest mapping decision. `fastq_dir: Directory[]` plus per-step `scatter: [fastq_dir]` strongly suggests a `list` collection where each element represents one sample/directory. But Alevin needs the FASTQ files themselves, not a directory handle. Two viable paths:
+   - Outer `list` collection of inner `paired` collections of `fastqsanger` (Galaxy-native).
+   - Pre-flatten in a wrapper: one `paired_collection` of `fastqsanger`, plus a sidecar `sample_name` text-list parameter.
+   Recommend resolving with the data-flow brief.
+2. **Optional Directory inputs.** `img_dir` and `metadata_dir` should be Galaxy optional collections; downstream Visium-only steps need explicit `when:` conditioning in gxformat2.
+3. **`salmon_output` Directory output.** CWL outputs the entire Alevin output directory. Galaxy options: (a) extract canonical files (alevin H5AD, `quants_mat.gz`, `cmd_info.json`, `aux_info`) as a typed collection; (b) tarball composite. Recommend (a) with a `salmon_output` `list` collection.
+4. **`fastqc_dir: Directory[]`.** Map to `list` collection of zipped FastQC reports; align with IUC `fastqc` wrapper output naming (`fastqc_html`, `fastqc_text`).
+5. **`assay` allowed values.** Inspect `salmon-quantification.cwl` branches to enumerate. Without this the Galaxy interface is a freetext field that silently breaks at runtime.
+6. **`organism` → reference data.** `organism=human|mouse` switches between `salmon.cwl` and `salmon-mouse.cwl` inside the nested workflow. In Galaxy this should select between cached Salmon indices (data table) rather than re-downloading per run.
+7. **Nested workflow flattening.** `salmon-quantification.cwl` is 9 inner steps (`adjust-barcodes`, `trim-reads`, `salmon` / `salmon-mouse`, `alevin-to-anndata`, `annotate-cells`, `map_hugo_symbols`, …). Flatten into the main workflow or author a Galaxy sub-workflow? Recommend flattening: Galaxy sub-workflows introduce a UI boundary that's only worth it if the inner workflow is reused elsewhere (here it's only called from `pipeline.cwl`).
+8. **`scatter` on fastqc.** Translation depends on (1). If fastq_dir is a `list` collection, Galaxy `map_over` handles it for free; if pre-flattened, the scatter is gone.
+9. **No tests discoverable.** No CWL job file at repo root. Cannot author a Galaxy workflow test without sample inputs; flag for the test-plan Mold downstream.
+
+## Confidence
+
+Medium-low. Compared with the ga4gh ChIP-seq fixture this workflow has roughly the same step count but much higher translation pressure: three Directory-type inputs, one Directory output, a `Directory[]` output, a deep nested workflow, and an assay-driven branching pattern that the CWL surface barely exposes. The downstream data-flow brief should resolve the collection-shape question (1) before the template Mold runs.

--- a/casts/claude/skills/_emulated-runs/salmon-rnaseq-cwl-galaxy-5step/extract.mjs
+++ b/casts/claude/skills/_emulated-runs/salmon-rnaseq-cwl-galaxy-5step/extract.mjs
@@ -1,0 +1,195 @@
+import fs from "fs";
+
+const data = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+const ENTRY = "workflow-fixtures/cwl/hubmapconsortium__salmon-rnaseq/pipeline.cwl";
+const NORM = "normalized/pipeline.packed.json";
+
+const strip = (s) => typeof s === "string" ? s.replace(/^#main\//, "").replace(/^#/, "") : s;
+const sfList = (sf) => (Array.isArray(sf) ? sf : (sf ? [sf] : [])).map((x) => typeof x === "string" ? x : (x.pattern || JSON.stringify(x)));
+
+const main = data.$graph.find((g) => g.id === "#main");
+const tools = data.$graph.filter((g) => g.class === "CommandLineTool");
+const subs = data.$graph.filter((g) => g.class === "Workflow" && g.id !== "#main");
+
+const reqsOf = (item) => {
+  const all = (item.requirements || []).concat(item.hints || []);
+  return all.map((r) => {
+    const docker = r.class === "DockerRequirement" ? (r.dockerPull || null) : null;
+    return {
+      class: r.class || "Unknown",
+      docker_pull: docker,
+      docker_image_id: r.dockerImageId || null,
+      packages: r.class === "SoftwareRequirement" ? (r.packages || []).map((p) => ({ package: p.package, version: p.version || [], specs: p.specs || [] })) : [],
+      raw: r,
+    };
+  });
+};
+
+const typeStr = (t) => {
+  if (typeof t === "string") return t;
+  if (Array.isArray(t)) return t.map(typeStr).join(" | ");
+  if (t && typeof t === "object") return t.type || JSON.stringify(t);
+  return String(t);
+};
+
+const isOptional = (t) => Array.isArray(t) && t.includes("null");
+
+const workflow_inputs = main.inputs.map((i) => ({
+  id: strip(i.id),
+  label: i.label || strip(i.id),
+  type: typeStr(i.type),
+  optional: isOptional(i.type),
+  default: i.default ?? null,
+  doc: i.doc || null,
+  format: i.format || null,
+  secondary_files: sfList(i.secondaryFiles),
+}));
+
+const workflow_outputs = main.outputs.map((o) => ({
+  id: strip(o.id),
+  label: o.label || strip(o.id),
+  type: typeStr(o.type),
+  output_source: Array.isArray(o.outputSource) ? o.outputSource.map(strip) : [strip(o.outputSource)],
+  doc: o.doc || null,
+  format: o.format || null,
+  secondary_files: sfList(o.secondaryFiles),
+}));
+
+const classOfRun = (runId) => {
+  const found = data.$graph.find((g) => g.id === runId);
+  return found ? found.class : "Unknown";
+};
+
+const steps = main.steps.map((s) => {
+  const runId = s.run;
+  return {
+    id: strip(s.id),
+    run: strip(runId),
+    run_class: classOfRun(runId),
+    label: s.label || null,
+    doc: s.doc || null,
+    in: s.in.map((i) => ({
+      id: strip(i.id),
+      source: i.source ? (Array.isArray(i.source) ? i.source.map(strip) : [strip(i.source)]) : [],
+      default: i.default ?? null,
+      value_from: i.valueFrom || null,
+      link_merge: i.linkMerge || null,
+      pick_value: i.pickValue || null,
+    })),
+    out: (s.out || []).map((o) => typeof o === "string" ? strip(o).split("/").pop() : strip(o.id).split("/").pop()),
+    scatter: s.scatter ? (Array.isArray(s.scatter) ? s.scatter.map((x) => strip(x).split("/").pop()) : [strip(s.scatter).split("/").pop()]) : [],
+    scatter_method: s.scatterMethod || null,
+    when: s.when || null,
+    requirements: reqsOf(s),
+    hints: [],
+  };
+});
+
+const bindingOf = (b) => b ? ({
+  position: b.position ?? null,
+  prefix: b.prefix || null,
+  glob: null,
+  value_from: b.valueFrom || null,
+}) : null;
+
+const outBindingOf = (b) => b ? ({
+  position: null,
+  prefix: null,
+  glob: Array.isArray(b.glob) ? b.glob.join(",") : (b.glob || null),
+  value_from: b.outputEval || null,
+}) : null;
+
+const cmdTools = tools.map((t) => ({
+  id: strip(t.id),
+  label: t.label || null,
+  base_command: Array.isArray(t.baseCommand) ? t.baseCommand : (t.baseCommand ? [t.baseCommand] : []),
+  arguments: (t.arguments || []).map((a) => typeof a === "string" ? a : JSON.stringify(a)),
+  inputs: (t.inputs || []).map((i) => ({
+    id: strip(i.id).split("/").pop(),
+    type: typeStr(i.type),
+    input_binding: bindingOf(i.inputBinding),
+    doc: i.doc || null,
+    format: i.format || null,
+    secondary_files: sfList(i.secondaryFiles),
+  })),
+  outputs: (t.outputs || []).map((o) => ({
+    id: strip(o.id).split("/").pop(),
+    type: typeStr(o.type),
+    output_binding: outBindingOf(o.outputBinding),
+    doc: o.doc || null,
+    format: o.format || null,
+    secondary_files: sfList(o.secondaryFiles),
+  })),
+  requirements: reqsOf(t),
+  hints: [],
+}));
+
+const subWorkflows = subs.map((sw) => ({
+  id: strip(sw.id),
+  label: sw.label || null,
+  base_command: [],
+  arguments: [],
+  inputs: (sw.inputs || []).map((i) => ({ id: strip(i.id).split("/").pop(), type: typeStr(i.type), input_binding: null, doc: i.doc || null, format: i.format || null, secondary_files: [] })),
+  outputs: (sw.outputs || []).map((o) => ({ id: strip(o.id).split("/").pop(), type: typeStr(o.type), output_binding: null, doc: o.doc || null, format: o.format || null, secondary_files: [] })),
+  requirements: reqsOf(sw),
+  hints: [{ class: "_NestedWorkflow", docker_pull: null, docker_image_id: null, packages: [], raw: { steps: (sw.steps || []).map((s) => ({ id: strip(s.id), run: strip(s.run), scatter: s.scatter || null })) } }],
+}));
+
+const nodes = [];
+const edges = [];
+for (const i of workflow_inputs) nodes.push({ id: i.id, kind: "workflow-input", label: i.label });
+for (const o of workflow_outputs) nodes.push({ id: o.id, kind: "workflow-output", label: o.label });
+for (const s of steps) nodes.push({ id: s.id, kind: "step", label: s.id });
+
+for (const s of steps) {
+  for (const sin of s.in) {
+    for (const src of sin.source) {
+      const via = [];
+      if (sin.value_from) via.push("valueFrom");
+      if (s.scatter.includes(sin.id.split("/").pop())) via.push("scatter");
+      edges.push({ from: src, to: `${s.id}/${sin.id.split("/").pop()}`, via });
+    }
+  }
+}
+for (const o of workflow_outputs) {
+  for (const src of o.output_source) edges.push({ from: src, to: o.id, via: [] });
+}
+
+const summary = {
+  summary_version: "1",
+  source: {
+    ecosystem: "cwl",
+    workflow: "salmon-rnaseq",
+    url: "https://github.com/hubmapconsortium/salmon-rnaseq/blob/2f77bcfe9d6eaccce04359ed110995de65d03422/pipeline.cwl",
+    version: "2f77bcfe9d6eaccce04359ed110995de65d03422",
+    license: null,
+    slug: "hubmap-salmon-rnaseq",
+    cwl_version: "v1.2",
+    entrypoint: "pipeline.cwl",
+  },
+  documents: {
+    entrypoint: ENTRY,
+    normalized_path: NORM,
+    validation: {
+      command: "cwltool --validate pipeline.cwl",
+      status: "valid",
+      diagnostics: [],
+    },
+  },
+  workflow_inputs,
+  workflow_outputs,
+  steps,
+  tools: [...cmdTools, ...subWorkflows],
+  graph: { nodes, edges },
+  tests: [],
+  warnings: [
+    { code: "ref.directory", message: "fastq_dir, img_dir, metadata_dir are CWL Directory or Directory[] inputs; Galaxy needs a collection or wrapper-side directory handling strategy.", path: "workflow_inputs" },
+    { code: "scatter", message: "fastqc step scatters over fastq_dir (dotproduct) — Galaxy will need a per-element collection mapping or an in-tool loop.", path: "steps/fastqc" },
+    { code: "nested.workflow", message: "salmon_quantification calls a nested Workflow (#salmon-quantification.cwl, 9 inner steps including its own scatter over fastq_dir); downstream Galaxy may flatten or wrap.", path: "steps/salmon_quantification" },
+    { code: "optional.outputs", message: "Several outputs are File? (spatial_plot, scvelo_*, squidpy_*); downstream Galaxy template must allow conditional/optional outputs.", path: "workflow_outputs" },
+    { code: "tests.missing", message: "No CWL job file or sibling test inputs discoverable in repo at root; tests=[] emitted.", path: "tests" },
+  ],
+};
+
+fs.writeFileSync(process.argv[3], JSON.stringify(summary, null, 2));
+console.log("wrote", process.argv[3], "size", fs.statSync(process.argv[3]).size);

--- a/casts/claude/skills/_emulated-runs/salmon-rnaseq-cwl-galaxy-5step/galaxy-workflow-draft.gxwf.yml
+++ b/casts/claude/skills/_emulated-runs/salmon-rnaseq-cwl-galaxy-5step/galaxy-workflow-draft.gxwf.yml
@@ -1,0 +1,341 @@
+class: GalaxyWorkflow
+label: "HuBMAP salmon-rnaseq — CWL→Galaxy draft"
+doc: |
+  Draft gxformat2 skeleton derived from hubmapconsortium/salmon-rnaseq pipeline.cwl
+  (cwlVersion v1.2, SHA 2f77bcf). Topology and edges are settled here; tool_ids and tool_state
+  are TODO and deferred to the per-step authoring Molds. Per the IWC comparison notes:
+    - the salmon vs salmon-mouse `when:` branch is collapsed into a single salmon-alevin step
+      with `organism` parameter (option (b) in the data-flow brief);
+    - the nested salmon-quantification.cwl subworkflow is flattened into main steps;
+    - the fastq input is modeled as a `list:paired` collection per IWC 10x convention,
+      with a TODO note for `list:list` if non-paired assays are required.
+
+inputs:
+  - id: fastq_pairs
+    type: collection
+    collection_type: list:paired
+    optional: false
+    doc: |
+      Per-sample paired FASTQ reads. CWL source `fastq_dir: Directory[]` — translated as
+      list-of-pairs per IWC scrna-seq 10x convention.
+    _plan_context: |
+      Source CWL: workflow_input fastq_dir (Directory[]).
+      IWC reference: scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-v3.gxwf.yml
+      uses `list:paired` named "fastq PE collection". Mirror that label/shape.
+      Fallback shape: `list:list` if downstream assay needs ≥3 reads per sample (Visium etc.).
+      Datatype: fastqsanger.gz (IWC convention).
+
+  - id: image_directory
+    type: collection
+    collection_type: list
+    optional: true
+    doc: "Optional TIFF image data (Visium assay only). CWL source: img_dir (Directory?)."
+    _plan_context: |
+      Source CWL: workflow_input img_dir (Directory?). Optional; gates the squidpy_analysis
+      step. Datatype: tiff. Galaxy mapping: optional `list` collection of TIFF images.
+
+  - id: metadata_directory
+    type: collection
+    collection_type: list
+    optional: true
+    doc: "Optional metadata (gpr slide file etc., Visium-only). CWL source: metadata_dir (Directory?)."
+    _plan_context: |
+      Source CWL: workflow_input metadata_dir (Directory?). Datatype mix (tabular/txt).
+
+  - id: assay
+    type: string
+    optional: false
+    restrictOnConnections: true
+    doc: "scRNA-seq assay type (e.g. 10x_v3, visium, slideseq). Enumerate at per-step authoring."
+    _plan_context: |
+      Source CWL: workflow_input assay (string, required). Enumeration must be discovered
+      from steps/salmon-quantification/salmon.cwl branches (open question, see interface brief).
+
+  - id: organism
+    type: string
+    optional: false
+    restrictOnConnections: true
+    default: human
+    doc: "human or mouse. Selects salmon-alevin reference index."
+    _plan_context: |
+      Source CWL: workflow_input organism (string?, default 'human'). In CWL this drives a
+      `when: $(inputs.organism == 'human')` / `'mouse'` branch over salmon vs salmon-mouse,
+      collapsed here into a single salmon-alevin step with this parameter.
+      Galaxy mapping: select param, restrictOnConnections=true, drives a cached index data-table
+      lookup inside the salmon-alevin wrapper. IWC scanpy-clustering uses `map_param_value`
+      for the analogous CellRanger v2/v3 switch.
+
+  - id: expected_cell_count
+    type: int
+    optional: true
+    doc: "Alevin --expectCells. CWL source: expected_cell_count (int?)."
+
+  - id: keep_all_barcodes
+    type: boolean
+    optional: true
+    doc: "Alevin --keepCBFraction-like flag. CWL source: keep_all_barcodes (boolean?)."
+
+  - id: threads
+    type: int
+    optional: true
+    default: 1
+    doc: "Per-tool thread count. CWL exposes this at workflow level; consider hiding."
+    _plan_context: |
+      Source CWL: workflow_input threads (int, default 1). IWC convention buries thread count
+      in tool config; keep exposed during draft, hide before publishing.
+
+outputs:
+  - id: salmon_output
+    outputSource: salmon_alevin/TODO_salmon_output
+  - id: count_matrix_h5ad
+    outputSource: annotate_cells/TODO_annotated_h5ad
+  - id: raw_count_matrix
+    outputSource: alevin_to_anndata/TODO_raw_expr_h5ad
+  - id: genome_build_json
+    outputSource: alevin_to_anndata/TODO_genome_build_json
+  - id: fastqc_reports
+    outputSource: fastqc/TODO_html
+  - id: fastqc_data
+    outputSource: fastqc/TODO_text
+  - id: deepscence_h5ad
+    outputSource: deepscence/TODO_h5ad_with_ds
+  - id: deepscence_plot
+    outputSource: deepscence/TODO_plot
+  - id: filtered_data_h5ad
+    outputSource: scanpy_analysis/TODO_filtered_h5ad
+  - id: umap_plot
+    outputSource: scanpy_analysis/TODO_umap_plot
+  - id: umap_density_plot
+    outputSource: scanpy_analysis/TODO_umap_density_plot
+  - id: dispersion_plot
+    outputSource: scanpy_analysis/TODO_dispersion_plot
+  - id: marker_gene_plot_t_test
+    outputSource: scanpy_analysis/TODO_marker_t_test
+  - id: marker_gene_plot_logreg
+    outputSource: scanpy_analysis/TODO_marker_logreg
+  - id: deepscence_continuous_plot
+    outputSource: scanpy_analysis/TODO_deepscence_continuous
+  - id: deepscence_binary_plot
+    outputSource: scanpy_analysis/TODO_deepscence_binary
+  - id: spatial_plot
+    outputSource: scanpy_analysis/TODO_spatial_plot
+  - id: scvelo_annotated_h5ad
+    outputSource: scvelo_analysis/TODO_annotated_h5ad
+  - id: scvelo_embedding_grid_plot
+    outputSource: scvelo_analysis/TODO_embedding_grid_plot
+  - id: squidpy_annotated_h5ad
+    outputSource: squidpy_analysis/TODO_squidpy_h5ad
+  - id: neighborhood_enrichment_plot
+    outputSource: squidpy_analysis/TODO_neighborhood_enrichment
+  - id: co_occurrence_plot
+    outputSource: squidpy_analysis/TODO_co_occurrence
+  - id: interaction_matrix_plot
+    outputSource: squidpy_analysis/TODO_interaction_matrix
+  - id: centrality_scores_plot
+    outputSource: squidpy_analysis/TODO_centrality_scores
+  - id: ripley_plot
+    outputSource: squidpy_analysis/TODO_ripley
+  - id: squidpy_spatial_plot
+    outputSource: squidpy_analysis/TODO_squidpy_spatial
+  - id: scanpy_qc_results
+    outputSource: compute_qc_results/TODO_scanpy_qc
+  - id: qc_report
+    outputSource: compute_qc_results/TODO_qc_metrics
+
+steps:
+  - id: fastqc
+    label: "FastQC over per-sample FASTQs"
+    tool_id: toolshed.g2.bx.psu.edu/repos/iuc/fastqc/fastqc/TODO_version
+    tool_version: TODO
+    in:
+      TODO_input_file: fastq_pairs
+      TODO_threads: threads
+    out:
+      - id: TODO_html
+      - id: TODO_text
+    _plan_state: "IUC fastqc; map_over the list:paired collection. CWL source: fastqc.cwl (scatter on fastq_dir)."
+    _plan_context: |
+      Source CWL: steps/fastqc.cwl, baseCommand fastqc.
+      Docker: hubmap/fastqc (per workflow doc; check).
+      IWC convention: fastqc maps over list:paired transparently; no Apply Rules needed for
+      this output unless the data-flow brief restores Directory[] grouping (it does not).
+
+  - id: adjust_barcodes
+    label: "Adjust per-sample barcodes (HuBMAP)"
+    tool_id: TODO_author
+    tool_version: TODO
+    in:
+      TODO_fastq_pairs: fastq_pairs
+      TODO_assay: assay
+    out:
+      - id: TODO_adj_fastq_dir
+      - id: TODO_metadata_json
+    _plan_state: "Flattened from nested salmon-quantification.cwl; HuBMAP-specific. Likely author."
+    _plan_context: |
+      Source CWL: steps/salmon-quantification/adjust-barcodes.cwl. Per-assay barcode adjustment.
+      No IUC equivalent. SoftwareRequirement / DockerRequirement: check sibling Dockerfile.
+
+  - id: trim_reads
+    label: "Trim reads (HuBMAP per-assay)"
+    tool_id: TODO_author
+    tool_version: TODO
+    in:
+      TODO_orig_fastq_pairs: fastq_pairs
+      TODO_adj_fastq_dir: adjust_barcodes/TODO_adj_fastq_dir
+      TODO_assay: assay
+      TODO_threads: threads
+    out:
+      - id: TODO_trimmed_fastq_dir
+    _plan_state: "Flattened from nested salmon-quantification.cwl; HuBMAP-specific trim wrapper. Likely author."
+    _plan_context: |
+      Source CWL: steps/salmon-quantification/trim-reads.cwl.
+      Possible IUC overlap: cutadapt / trim-galore — but per-assay logic likely needs author.
+
+  - id: salmon_alevin
+    label: "Salmon Alevin quantification"
+    tool_id: TODO_author_or_iuc_salmon_alevin
+    tool_version: TODO
+    in:
+      TODO_orig_fastq_pairs: fastq_pairs
+      TODO_trimmed_fastq_dir: trim_reads/TODO_trimmed_fastq_dir
+      TODO_assay: assay
+      TODO_organism: organism
+      TODO_threads: threads
+      TODO_expected_cell_count: expected_cell_count
+      TODO_keep_all_barcodes: keep_all_barcodes
+    out:
+      - id: TODO_salmon_output
+    _plan_state: "Collapses CWL salmon + salmon-mouse `when:` branches into one step parameterized by `organism`."
+    _plan_context: |
+      Source CWL: steps/salmon-quantification/salmon.cwl AND salmon-mouse.cwl with complementary
+      `when:` predicates and a `pickValue: first_non_null` merge on output_dir. Galaxy translation
+      collapses both into one wrapper that resolves the index by `organism` data table.
+      Open question: confirm IUC salmon-alevin scRNA-seq wrapper availability; if absent, author.
+
+  - id: alevin_to_anndata
+    label: "Alevin output to AnnData"
+    tool_id: TODO_author
+    tool_version: TODO
+    in:
+      TODO_alevin_dir: salmon_alevin/TODO_salmon_output
+      TODO_assay: assay
+      TODO_organism: organism
+    out:
+      - id: TODO_expr_h5ad
+      - id: TODO_raw_expr_h5ad
+      - id: TODO_genome_build_json
+    _plan_state: "HuBMAP-specific; likely author. The `expr_h5ad` is the canonical handoff to annotate_cells."
+    _plan_context: |
+      Source CWL: steps/salmon-quantification/alevin-to-anndata.cwl. Receives the pickValue-merged
+      salmon output (now single-source under the collapsed salmon_alevin step).
+
+  - id: annotate_cells
+    label: "Annotate cells (HuBMAP)"
+    tool_id: TODO_author
+    tool_version: TODO
+    in:
+      TODO_orig_fastq_pairs: fastq_pairs
+      TODO_assay: assay
+      TODO_h5ad_file: alevin_to_anndata/TODO_expr_h5ad
+      TODO_img_dir: image_directory
+      TODO_metadata_dir: metadata_directory
+      TODO_metadata_json: adjust_barcodes/TODO_metadata_json
+    out:
+      - id: TODO_annotated_h5ad
+    _plan_state: "HuBMAP-specific cell annotation; likely author."
+    _plan_context: |
+      Source CWL: steps/salmon-quantification/annotate-cells.cwl. Note: optional img_dir /
+      metadata_dir are forwarded; wrapper must accept them as optional.
+
+  - id: deepscence
+    label: "DeepScence senescence scoring"
+    tool_id: TODO_author
+    tool_version: TODO
+    in:
+      TODO_h5ad_file: annotate_cells/TODO_annotated_h5ad
+    out:
+      - id: TODO_h5ad_with_ds
+      - id: TODO_plot
+    _plan_state: "Domain-novel; no IUC wrapper. Likely author."
+    _plan_context: |
+      Source CWL: steps/deepscence.cwl. Adds senescence scores to AnnData.
+
+  - id: scanpy_analysis
+    label: "Scanpy analysis (HuBMAP monolith)"
+    tool_id: TODO_author_or_iuc_decompose
+    tool_version: TODO
+    in:
+      TODO_assay: assay
+      TODO_h5ad_file: deepscence/TODO_h5ad_with_ds
+    out:
+      - id: TODO_filtered_h5ad
+      - id: TODO_umap_plot
+      - id: TODO_marker_t_test
+      - id: TODO_marker_logreg
+      - id: TODO_dispersion_plot
+      - id: TODO_umap_density_plot
+      - id: TODO_spatial_plot
+      - id: TODO_deepscence_continuous
+      - id: TODO_deepscence_binary
+    _plan_state: "HuBMAP packages many scanpy operations into one CommandLineTool. Author a single wrapper now; decompose later per IWC scanpy-clustering exemplar if review demands."
+    _plan_context: |
+      Source CWL: steps/scanpy-analysis.cwl. IWC reference: scRNAseq/scanpy-clustering provides
+      a fine-grained chain (anndata_import → scanpy_normalize → scanpy_filter_cells →
+      scanpy_filter_genes → scanpy_run_pca → scanpy_compute_neighbors → scanpy_run_umap →
+      scanpy_cluster → scanpy_run_rank_genes_groups → various plots). Decomposing yields ~12
+      Galaxy steps; the monolith keeps 1. Decision deferred to per-step authoring.
+
+  - id: scvelo_analysis
+    label: "scVelo RNA velocity"
+    tool_id: TODO_author
+    tool_version: TODO
+    in:
+      TODO_spliced_h5ad: deepscence/TODO_h5ad_with_ds
+      TODO_assay_name: assay
+    out:
+      - id: TODO_annotated_h5ad
+      - id: TODO_embedding_grid_plot
+    _plan_state: "Domain-novel; no IUC scVelo single-step. Likely author."
+    _plan_context: |
+      Source CWL: steps/scvelo-analysis.cwl. Outputs are typed File? — gate via optional output
+      handling at workflow level (no Galaxy `when:` needed; absent outputs are tolerated).
+
+  - id: squidpy_analysis
+    label: "SquidPy spatial analysis (Visium-gated)"
+    tool_id: TODO_author
+    tool_version: TODO
+    in:
+      TODO_assay: assay
+      TODO_h5ad_file: scanpy_analysis/TODO_filtered_h5ad
+      TODO_img_dir: image_directory
+    out:
+      - id: TODO_squidpy_h5ad
+      - id: TODO_neighborhood_enrichment
+      - id: TODO_co_occurrence
+      - id: TODO_interaction_matrix
+      - id: TODO_ripley
+      - id: TODO_centrality_scores
+      - id: TODO_squidpy_spatial
+    _plan_state: "Visium/spatial branch. Spaces with no image_directory get optional/empty outputs."
+    _plan_context: |
+      Source CWL: steps/squidpy-analysis.cwl. All declared outputs are File?; Galaxy gates on
+      presence of optional `image_directory` input through the wrapper's own assay-check
+      logic. No gxformat2 `when:` (Galaxy lacks step-level conditional execution; rely on
+      optional-output convention).
+
+  - id: compute_qc_results
+    label: "Compute QC metrics (HuBMAP)"
+    tool_id: TODO_author
+    tool_version: TODO
+    in:
+      TODO_assay: assay
+      TODO_primary_matrix: deepscence/TODO_h5ad_with_ds
+      TODO_secondary_matrix: scanpy_analysis/TODO_filtered_h5ad
+      TODO_salmon_dir: salmon_alevin/TODO_salmon_output
+    out:
+      - id: TODO_scanpy_qc
+      - id: TODO_qc_metrics
+    _plan_state: "HuBMAP-specific QC metrics. Likely author."
+    _plan_context: |
+      Source CWL: steps/compute-qc-metrics.cwl. Reads primary + secondary AnnData + Alevin
+      output directory.

--- a/casts/claude/skills/_emulated-runs/salmon-rnaseq-cwl-galaxy-5step/iwc-comparison-notes.md
+++ b/casts/claude/skills/_emulated-runs/salmon-rnaseq-cwl-galaxy-5step/iwc-comparison-notes.md
@@ -1,0 +1,90 @@
+# IWC exemplar comparison — hubmap salmon-rnaseq
+
+Source briefs: `cwl-galaxy-interface.md`, `cwl-galaxy-data-flow.md`.
+Inputs to comparison: 7-step main workflow with one nested salmon-quantification subworkflow; primary tool families = Salmon/Alevin, Scanpy, scVelo, SquidPy, DeepScence; primary output families = anndata (`h5ad`), FastQC reports, plots.
+
+## Nearest exemplar(s)
+
+Searched `~/projects/repositories/workflow-fixtures/iwc-format2/scRNAseq/`. Five workflows live there:
+
+| IWC workflow | Why considered |
+| --- | --- |
+| `scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-v3.gxwf.yml` | Same intent for **front-half** of the pipeline (FASTQ → count matrix). Uses STARsolo + DropletUtils, not Salmon. |
+| `scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex.gxwf.yml` | Same front-half intent; cellplex variant — closer in input topology to multi-fastq directories. |
+| `scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy.gxwf.yml` | Closest match to the **back-half** of the pipeline (h5ad → QC plots → UMAP → clustering → marker genes). |
+| `scRNAseq/velocyto/Velocyto-on10X-from-bundled.gxwf.yml` | Closest match for the **scVelo branch** — velocity from 10x, but uses Velocyto not scVelo. |
+| `scRNAseq/baredsc/*` | Bayesian dropout-aware single-cell — adjacent but not on this path. |
+
+**No single exemplar covers the whole salmon-rnaseq pipeline.** This is fundamentally a *concatenation* of three IWC-shaped subworkflows: fastq-to-matrix, scanpy-clustering, velocyto-style velocity, plus a HuBMAP-specific QC/spatial tail.
+
+## Confidence
+
+**Medium for the back-half, low for the front-half, none for the spatial (SquidPy/DeepScence) branch.**
+
+- Back-half overlap with `Preprocessing-and-Clustering-of-...-Scanpy.gxwf.yml` is high at the *intent* level (h5ad → QC → cluster → marker genes → UMAPs) but the IWC workflow uses fine-grained IUC `scanpy_*` tools per step, while the HuBMAP CWL packages all of that into one `scanpy-analysis.cwl` CommandLineTool. Translation choice: either author one wrapper that mirrors `scanpy-analysis.cwl` or decompose into ~12 IUC scanpy steps following the IWC exemplar.
+- Front-half: IWC uses STARsolo/DropletUtils, not Salmon-Alevin. There is **no IWC Salmon-Alevin scRNA-seq exemplar** in the local mirror. A `salmon_quant` / `salmon-alevin` IUC tool likely exists for bulk RNA-seq (not checked) but no IWC workflow wires it for single-cell.
+- Spatial branch (`squidpy_analysis`) has no IWC exemplar — `imaging/` and `scRNAseq/` directories don't include SquidPy workflows.
+- DeepScence has no IWC exemplar — domain-novel.
+
+## Structural diff (proposed Galaxy design vs nearest exemplars)
+
+### Input topology
+
+- Proposed: `list:list` of FASTQs per sample (CWL `Directory[]`).
+- IWC 10x-v3 exemplar: `list:paired` of FASTQs per sample (R1 + R2 pair per sample).
+- **Diff.** The 10x-v3 IWC convention is `list:paired`, not `list:list`. For the salmon-rnaseq pipeline targeting 10x assays, prefer `list:paired` and accept that exotic non-paired assays (Slide-seq, Visium spatial) need a different shape. Update the data-flow brief recommendation from `list:list` to `list:paired`, with `list:list` as the fallback for non-paired assays.
+- Both exemplar workflows also expose a reference-genome `select` input (`reference genome` text restrictOnConnections, plus a cached `gtf` data table). The HuBMAP CWL has `organism: human|mouse` instead. Convention diff: use a single `genome` text select wired into the salmon-alevin tool via a `map_param_value` step, the same pattern the `scanpy-clustering` exemplar uses for CellRanger version mapping.
+
+### Tool families
+
+- IWC 10x-v3: STARsolo, DropletUtils, MultiQC, collection-element-identifiers, tp_replace_in_line, RELABEL_FROM_FILE, MERGE_COLLECTION, APPLY_RULES.
+- Proposed for salmon-rnaseq: Salmon-Alevin, alevin-to-anndata, DeepScence, Scanpy (or scanpy-analysis monolith), scVelo, SquidPy, FastQC, optional MultiQC.
+- **Diff.** Only `fastqc`/`multiqc` overlap. Front-half is a Salmon path with no IWC exemplar; the comparison cannot use IWC tool selection guidance here.
+
+### DAG motifs
+
+- IWC 10x-v3 motif: `STARsolo → DropletUtils → reorganize/relabel → outputs`. Heavy use of `__RELABEL_FROM_FILE__`, `__MERGE_COLLECTION__`, `__APPLY_RULES__` to reshape STARsolo output into Seurat/Read10X-compatible layout.
+- IWC scanpy-clustering motif: long linear chain of `anndata_import → scanpy_normalize → scanpy_filter_cells → scanpy_filter_genes → ... → scanpy_cluster → scanpy_plot_umap → scanpy_run_rank_genes_groups`. Conditional plumbing via `pick_value` and `map_param_value` for CellRanger v2 vs v3.
+- Proposed salmon-rnaseq motif: `salmon-alevin → annotate → deepscence → scanpy_analysis (monolith) → scvelo / squidpy / compute-qc`.
+- **Diff.** The IWC scanpy-clustering exemplar uses `pick_value` (IUC tool) to merge CellRanger-version branches. **The HuBMAP CWL uses `pickValue: first_non_null` on `salmon` vs `salmon-mouse` `when:` branches** — this is the same shape and translates cleanly to IUC `pick_value` (or to a single salmon-alevin call with an `organism` parameter, which the data-flow brief recommends). The IWC pattern endorses the second option.
+
+### Outputs / report shape
+
+- IWC scanpy-clustering exposes 20+ promoted plot outputs. Proposed salmon-rnaseq exposes ~25 outputs including conditional `null|File` (scVelo/SquidPy branches).
+- **Diff.** No structural concern — IWC accepts large output surfaces. Optional outputs from gated steps are common in IWC (cf. the `pick_value`-mediated branches in scanpy-clustering).
+
+### Test fixture shape
+
+- IWC norms: every workflow ships a `*-tests.yml` sibling with concrete dataset fixtures and assertion blocks.
+- Proposed salmon-rnaseq: **no CWL job file at repo root.** No fixture inputs to draft a Galaxy `*-tests.yml` from. Template Mold should leave the test plan as an open question rather than invent a fixture.
+
+### Anti-patterns / shortcuts to avoid
+
+- Do not promote logs as public outputs (none proposed; good).
+- Do not bake `threads` into the workflow interface as a public parameter (proposed brief already flags hiding it; aligned with IWC).
+- Avoid building monolithic per-language wrappers (scanpy-analysis.cwl, scvelo-analysis.cwl, squidpy-analysis.cwl). IWC convention is fine-grained IUC steps. Either accept a HuBMAP-flavored monolith wrapper (faster ship, lower review value) or decompose (slower, higher IWC alignment). Recommend decomposing the scanpy branch into IUC steps following `Preprocessing-and-Clustering-of-...-Scanpy.gxwf.yml`; accept monolith wrappers for scVelo and SquidPy because no IWC decomposition exists.
+
+## Guidance for the template Mold
+
+1. Set workflow input shape to `list:paired` for the FASTQ collection (default for 10x v3 assays). Mention `list:list` as a fallback in a comment-only TODO.
+2. Use a single `salmon-alevin` step with `organism` parameter instead of two `salmon` / `salmon-mouse` Galaxy steps with `pick_value`. (Equivalent to data-flow open question #1 recommendation.)
+3. For the scanpy branch, draft *either*:
+   - a single `scanpy-analysis` author-wrapper step (placeholder tool_id), or
+   - a fine-grained chain following `Preprocessing-and-Clustering-of-...-Scanpy.gxwf.yml`. Recommend the second when downstream `implement-galaxy-tool-step` work happens; for the template skeleton, the first is acceptable as a black box.
+4. For scVelo and SquidPy, draft single author-wrapper steps with placeholder tool_ids.
+5. Promote outputs match the data-flow brief; do not invent additional outputs to match IWC scanpy-clustering's 20+ surface.
+6. Leave the `*-tests.yml` test plan empty (no fixtures); flag for downstream `cwl-test-to-galaxy-test-plan` / `paper-to-test-data`.
+7. The IWC `Preprocessing-and-Clustering-of-...-Scanpy.gxwf.yml` provides a concrete `pick_value` usage example; **the template should mirror that idiom only if option (b) collapse-to-single-salmon-alevin is rejected.**
+
+## Open questions
+
+1. Is there an IWC Salmon-Alevin scRNA-seq workflow elsewhere (outside the local mirror)? Worth a one-off check before authoring all-new Salmon-Alevin Galaxy plumbing.
+2. Should the spatial branch (Visium / Slide-seq) be split into a sibling Galaxy workflow rather than gated optional steps inside one workflow? The conditional surface area is large (8 optional outputs + an optional image_dir input) and IWC has no precedent.
+
+## Confidence
+
+Medium-low overall. The back-half scanpy branch has a useful exemplar; the front-half Salmon-Alevin path is unprecedented in the local IWC mirror; the spatial / senescence branches are domain-novel. Template authoring should treat IWC alignment as advisory only for back-half steps.
+
+## Refinement candidate
+
+`compare-against-iwc-exemplar`'s `eval.md` cases are all nf-core-flavored. **No CWL-flavored eval cases exist** (same gap noted in the ga4gh run). This run cannot be scored against the existing eval; the gap should be addressed in `content/molds/compare-against-iwc-exemplar/eval.md`.

--- a/casts/claude/skills/_emulated-runs/salmon-rnaseq-cwl-galaxy-5step/run-summary.md
+++ b/casts/claude/skills/_emulated-runs/salmon-rnaseq-cwl-galaxy-5step/run-summary.md
@@ -1,0 +1,126 @@
+# Run summary — salmon-rnaseq-cwl-galaxy-5step
+
+## Scenario
+
+Test-drive phases 1–5 of `content/pipelines/cwl-to-galaxy.md` against
+`workflow-fixtures/cwl/hubmapconsortium__salmon-rnaseq/pipeline.cwl`
+(SHA `2f77bcf`, cwlVersion v1.2, 7 main steps + 1 nested `salmon-quantification.cwl` subworkflow
+with 6 inner steps, 13 unique CommandLineTools).
+
+User instruction: `cwl-utils` has a bug; build/use the patched checkout at
+`/Users/jxc755/projects/repositories/cwl-utils` (branch `fix-normalizer-ruamel-018`).
+
+## Molds exercised
+
+| # | Mold | Mode | Output |
+| --- | --- | --- | --- |
+| 1 | `summarize-cwl` | emulation + `cwltool --validate` + `cwltool --pack` + `extract.mjs` + `foundry validate-summary-cwl` | `summary-cwl.json` (68 KB, valid) |
+| 2 | `cwl-summary-to-galaxy-interface` | emulation | `cwl-galaxy-interface.md` |
+| 3 | `cwl-summary-to-galaxy-data-flow` | emulation | `cwl-galaxy-data-flow.md` |
+| 4 | `compare-against-iwc-exemplar` | emulation against local `~/projects/repositories/workflow-fixtures/iwc-format2/scRNAseq/` | `iwc-comparison-notes.md` |
+| 5 | `cwl-summary-to-galaxy-template` | emulation + `gxwf validate --no-tool-state` | `galaxy-workflow-draft.gxwf.yml` (structural validation OK) |
+
+## Inputs consumed
+
+- `workflow-fixtures/cwl/hubmapconsortium__salmon-rnaseq/pipeline.cwl` @ `2f77bcf`.
+- Nested `steps/salmon-quantification.cwl` read directly to recover `when:` / `pickValue` markers the summary lost.
+- `~/projects/repositories/workflow-fixtures/iwc-format2/scRNAseq/*` (local IWC mirror).
+- Patched `cwl-utils` from `/Users/jxc755/projects/repositories/cwl-utils` (branch `fix-normalizer-ruamel-018`), installed via `uv tool install --from <local-path> cwl-utils`.
+
+## Outputs produced (all under the run dir)
+
+- `normalized/pipeline.packed.json` — `cwltool --pack` output (used in lieu of `cwl-normalizer`, see process notes)
+- `extract.mjs` — one-off extractor
+- `summary-cwl.json` (valid against `summary-cwl` schema)
+- `cwl-galaxy-interface.md`
+- `cwl-galaxy-data-flow.md`
+- `iwc-comparison-notes.md`
+- `galaxy-workflow-draft.gxwf.yml`
+
+## Eval results
+
+### summarize-cwl
+
+| Case | Verdict | Note |
+| --- | --- | --- |
+| user-guide simple validates | N/A | targets a different fixture |
+| scatter recorded | ✅ | `steps.fastqc.scatter = ["fastq_dir"]`, edge to `fastqc/fastq_dir` carries `via: ["scatter"]` |
+| nested workflow preserved | ⚠ | preserved as `tools[]` entry with `_NestedWorkflow` hint listing inner-step ids only. Inner `in:` / `out:` / `when:` / `pickValue` not captured. |
+| conditional `when:` | ❌ | the nested `salmon` vs `salmon-mouse` `when:` predicates and the `pickValue: first_non_null` merge are absent from the summary. Main workflow has no `when:` so the missing inner markers are the only failures, but they are exactly the markers the downstream Molds need. |
+| cross-document refs resolve | ✅ | all 13 tools + 1 nested workflow appear in `tools[]`; no unresolved `run:` strings |
+| step input shape fields survive | ✅ | shape present (all null at main-workflow level for this fixture) |
+| **high-level** | ⚠ | Output validates and is structurally faithful at the main-workflow level. The nested-workflow gap is the same issue as the ga4gh run but bites harder here because the salmon-rnaseq pipeline's real translation pressure lives inside the nested workflow. |
+
+### cwl-summary-to-galaxy-interface
+
+| Case | Verdict | Note |
+| --- | --- | --- |
+| secondaryFiles flagged | N/A | source has no `secondaryFiles` |
+| outputs testable | ✅ | 26 stable output labels named; optional `null|File` outputs (scVelo / SquidPy / spatial branches) flagged separately |
+| downstream Mold can consume | ✅ | data-flow brief consumed it without re-deriving from source CWL |
+| **high-level** | ⚠ | Good shape but stalled on three Directory inputs and one Directory output for lack of a `cwl-directory-to-galaxy-collection` reference note. |
+
+### cwl-summary-to-galaxy-data-flow
+
+| Case | Verdict | Note |
+| --- | --- | --- |
+| secondaryFiles plumbing | N/A | none |
+| no invented Tool Shed IDs | ✅ | placeholders only; IUC candidates mentioned only in IWC comparison brief |
+| pickValue not silently dropped | ⚠ | the brief surfaces the `pickValue: first_non_null` on `salmon`/`salmon-mouse` and the recommended translation — but I had to read the nested CWL directly to find it, because the summary lost it. The Mold's *output* passes; the Mold's *honesty floor* (using only the summary) does not. |
+| ExpressionTool surfaced | N/A | none |
+| template Mold can consume | ✅ | step 5 used the brief directly |
+| **high-level** | ⚠ | Same root cause as summarize-cwl: nested-workflow blindness. The brief did the right thing at the cost of cheating the contract. |
+
+### compare-against-iwc-exemplar
+
+| Case | Verdict | Note |
+| --- | --- | --- |
+| nf-core/rnaseq exemplar | N/A | this is CWL, not nf-core |
+| viralrecon | N/A | as above |
+| mag | N/A | as above |
+| no acceptable exemplar | N/A (in spirit) | the brief honestly returned "no single exemplar" and used three partial slices — closest analogue is this case but it does not name a single weak candidate; it names three |
+| IWC clone reuse | ✅ | reused local mirror |
+| **high-level** | ⚠ | Same gap as the ga4gh run: every eval case is nf-core-flavored. Run unscored. Refinement entry filed. |
+
+### cwl-summary-to-galaxy-template
+
+| Case | Verdict | Note |
+| --- | --- | --- |
+| draft is a stub, not runnable | ✅ | TODO `tool_id` / `tool_version` / `tool_state` on every step; structural `gxwf validate` passes only because tool-state checking is skipped |
+| preserves prior design decisions | ✅ | collapsed-salmon-alevin call, flattened nested workflow, `list:paired` per IWC, all consistent with the data-flow + IWC briefs |
+| TODO placeholders are actionable | ✅ | every step's `_plan_context` carries the source CWL filename, the data-flow brief recommendation, and the IWC reference (when one exists) |
+| collection inputs use gxformat2-compatible structure | ✅ | `type: collection`, `collection_type: list:paired`, `optional`, `restrictOnConnections` all valid |
+| outputs labeled | ✅ | 27 workflow outputs match the interface brief's promoted/optional split |
+| IWC findings are guidance, not hidden rewrites | ✅ | `list:paired` shape, `salmon-alevin` collapse, and `map_param_value` patterns are captured in `_plan_context`; low-confidence choices (decompose-vs-monolith for scanpy) live as `_plan_state` TODOs |
+| **high-level** | ✅ | The brief is the most directly usable artifact of the run. The shape is right; the per-step TODOs are pointed enough that a sane `implement-galaxy-tool-step` pass would have signal to act on. |
+
+## Process observations
+
+- `cwl-normalizer` is still broken on v1.2 input. The user's `fix-normalizer-ruamel-018` patch fixes the ruamel-0.18 incompatibility (`round_trip_load_all` removal) but does not address the more fundamental bug: `normalizer.py:87` only upgrades `draft-3 | v1.0 | v1.1` and errors out on anything else, including v1.2. The error-format call shape is also broken (passes a tuple as a single arg to a 2-placeholder format string, which throws inside stdlib `logging`). Workaround: `cwltool --pack` produces the equivalent `$graph` JSON. Two separate issues worth filing upstream.
+- `cwltool` writes INFO logs to stdout in some configurations; the first attempt to `> file 2>&1 | tail` polluted the JSON output. Real fix: `cwltool --pack <file> 2>/dev/null > out.json`. Worth mentioning in the SKILL.md procedure or in the `references/cli/cwltool.md` reference.
+- `foundry validate-summary-cwl` requires building `packages/foundry` first; the convenient `npx foundry ...` form doesn't work because the package is local-only. SKILL.md says `npx --package @galaxy-foundry/foundry foundry ...`, which is the right invocation; I started with the wrong one and lost ~30 seconds.
+- The extractor I wrote (`extract.mjs`) is the third one of its kind in this project (`ga4gh-challenge-cwl-galaxy-5step`, `mgnify-seqprep-subwf`, this run). Same gaps each time. A `foundry summarize-cwl` CLI would replace the per-run improvisation.
+
+## Refinement entries written
+
+- `content/molds/summarize-cwl/refinements/2026-05-11-salmon-rnaseq-cwl-galaxy-5step.md` — decision: `schema-change` (nested workflows + array.items)
+- `content/molds/cwl-summary-to-galaxy-interface/refinements/2026-05-11-salmon-rnaseq-cwl-galaxy-5step.md` — decision: `keep` (with reference-note gap noted)
+- `content/molds/cwl-summary-to-galaxy-data-flow/refinements/2026-05-11-salmon-rnaseq-cwl-galaxy-5step.md` — decision: `schema-change`
+- `content/molds/compare-against-iwc-exemplar/refinements/2026-05-11-salmon-rnaseq-cwl-galaxy-5step.md` — decision: `eval-add`
+- `content/molds/cwl-summary-to-galaxy-template/refinements/2026-05-11-salmon-rnaseq-cwl-galaxy-5step.md` — decision: `keep` (with `_plan_*` extension suggestions)
+
+## Cross-cutting open questions
+
+- `summary-cwl` nested workflow gap — extend schema to carry inner `inputs/outputs/steps/in/out/when/pickValue`, or promote to top-level `subworkflows[]`? (highest leverage)
+- `cwl-normalizer` v1.2 + error-format bugs — open upstream issues against `cwl-utils`?
+- `cwltool --pack` substitution — accept as procedure, or pin a working `cwl-utils` version?
+- `cwl-directory-to-galaxy-collection.md` reference — add a focused note, or section in `galaxy-collection-semantics.md`?
+- `compare-against-iwc-exemplar/eval.md` CWL cases — add a CWL-flavored case set (carried over from prior ga4gh run; still not done).
+- `foundry summarize-cwl` CLI — scope and ship.
+
+## Suggested follow-ups
+
+- Open upstream `cwl-utils` issues for the v1.2 + error-format bugs (separate from the ruamel patch already shipped).
+- Promote the nested-workflow gap into a schema change for `summary-cwl` plus a procedure update for `cwl-summary-to-galaxy-data-flow`.
+- Add CWL-flavored cases to `compare-against-iwc-exemplar/eval.md` (track from the ga4gh refinement entry, still open).
+- Scope `foundry summarize-cwl` as a deterministic CLI; the third one-off extractor is sufficient evidence.

--- a/casts/claude/skills/_emulated-runs/salmon-rnaseq-cwl-galaxy-5step/summary-cwl.json
+++ b/casts/claude/skills/_emulated-runs/salmon-rnaseq-cwl-galaxy-5step/summary-cwl.json
@@ -1,0 +1,2712 @@
+{
+  "summary_version": "1",
+  "source": {
+    "ecosystem": "cwl",
+    "workflow": "salmon-rnaseq",
+    "url": "https://github.com/hubmapconsortium/salmon-rnaseq/blob/2f77bcfe9d6eaccce04359ed110995de65d03422/pipeline.cwl",
+    "version": "2f77bcfe9d6eaccce04359ed110995de65d03422",
+    "license": null,
+    "slug": "hubmap-salmon-rnaseq",
+    "cwl_version": "v1.2",
+    "entrypoint": "pipeline.cwl"
+  },
+  "documents": {
+    "entrypoint": "workflow-fixtures/cwl/hubmapconsortium__salmon-rnaseq/pipeline.cwl",
+    "normalized_path": "normalized/pipeline.packed.json",
+    "validation": {
+      "command": "cwltool --validate pipeline.cwl",
+      "status": "valid",
+      "diagnostics": []
+    }
+  },
+  "workflow_inputs": [
+    {
+      "id": "assay",
+      "label": "scRNA-seq assay",
+      "type": "string",
+      "optional": false,
+      "default": null,
+      "doc": null,
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "expected_cell_count",
+      "label": "expected_cell_count",
+      "type": "null | int",
+      "optional": true,
+      "default": null,
+      "doc": null,
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "fastq_dir",
+      "label": "Directory containing FASTQ files",
+      "type": "array",
+      "optional": false,
+      "default": null,
+      "doc": null,
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "img_dir",
+      "label": "Directory containing TIFF image data (for Visium assay)",
+      "type": "null | Directory",
+      "optional": true,
+      "default": null,
+      "doc": null,
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "keep_all_barcodes",
+      "label": "keep_all_barcodes",
+      "type": "null | boolean",
+      "optional": true,
+      "default": null,
+      "doc": null,
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "metadata_dir",
+      "label": "Directory containing metadata, including gpr slide file (for Visium assay)",
+      "type": "null | Directory",
+      "optional": true,
+      "default": null,
+      "doc": null,
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "organism",
+      "label": "organism",
+      "type": "null | string",
+      "optional": true,
+      "default": "human",
+      "doc": null,
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "threads",
+      "label": "Number of threads for Salmon",
+      "type": "int",
+      "optional": false,
+      "default": 1,
+      "doc": null,
+      "format": null,
+      "secondary_files": []
+    }
+  ],
+  "workflow_outputs": [
+    {
+      "id": "centrality_scores_plot",
+      "label": "centrality_scores_plot",
+      "type": "null | File",
+      "output_source": [
+        "squidpy_analysis/centrality_scores_plot"
+      ],
+      "doc": null,
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "co_occurrence_plot",
+      "label": "co_occurrence_plot",
+      "type": "null | File",
+      "output_source": [
+        "squidpy_analysis/co_occurrence_plot"
+      ],
+      "doc": null,
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "count_matrix_h5ad",
+      "label": "Unfiltered count matrix from Alevin, converted to H5AD, spliced and unspliced counts, scenesence scores",
+      "type": "File",
+      "output_source": [
+        "deepscence/h5ad_with_ds"
+      ],
+      "doc": null,
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "deepscence_binary_plot",
+      "label": "Umap with coloring by DeepScence binary results",
+      "type": "File",
+      "output_source": [
+        "scanpy_analysis/deepscence_binary_plot"
+      ],
+      "doc": null,
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "deepscence_continuous_plot",
+      "label": "Umap with coloring by DeepScence scores",
+      "type": "File",
+      "output_source": [
+        "scanpy_analysis/deepscence_continuous_plot"
+      ],
+      "doc": null,
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "deepscence_plot",
+      "label": "deepscence_plot",
+      "type": "File",
+      "output_source": [
+        "deepscence/deepscence_plot"
+      ],
+      "doc": null,
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "dispersion_plot",
+      "label": "Gene expression dispersion plot",
+      "type": "File",
+      "output_source": [
+        "scanpy_analysis/dispersion_plot"
+      ],
+      "doc": null,
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "fastqc_dir",
+      "label": "Directory of FastQC output files, mirroring input directory structure",
+      "type": "array",
+      "output_source": [
+        "fastqc/fastqc_dir"
+      ],
+      "doc": null,
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "filtered_data_h5ad",
+      "label": "Full data set of filtered results",
+      "type": "File",
+      "output_source": [
+        "scanpy_analysis/filtered_data_h5ad"
+      ],
+      "doc": "Full data set of filtered results: expression matrix, coordinates in dimensionality-reduced space (PCA and UMAP), cluster assignments via the Leiden algorithm, and marker genes for one cluster vs. rest",
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "genome_build_json",
+      "label": "Genome build information in JSON format",
+      "type": "File",
+      "output_source": [
+        "salmon_quantification/genome_build_json"
+      ],
+      "doc": null,
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "interaction_matrix_plot",
+      "label": "interaction_matrix_plot",
+      "type": "null | File",
+      "output_source": [
+        "squidpy_analysis/interaction_matrix_plot"
+      ],
+      "doc": null,
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "marker_gene_plot_logreg",
+      "label": "Cluster marker genes, logreg method",
+      "type": "File",
+      "output_source": [
+        "scanpy_analysis/marker_gene_plot_logreg"
+      ],
+      "doc": null,
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "marker_gene_plot_t_test",
+      "label": "Cluster marker genes, t-test",
+      "type": "File",
+      "output_source": [
+        "scanpy_analysis/marker_gene_plot_t_test"
+      ],
+      "doc": null,
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "neighborhood_enrichment_plot",
+      "label": "neighborhood_enrichment_plot",
+      "type": "null | File",
+      "output_source": [
+        "squidpy_analysis/neighborhood_enrichment_plot"
+      ],
+      "doc": null,
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "qc_report",
+      "label": "Quality control report in JSON format",
+      "type": "File",
+      "output_source": [
+        "compute_qc_results/qc_metrics"
+      ],
+      "doc": null,
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "raw_count_matrix",
+      "label": "Unfiltered count matrix from Alevin, converted to H5AD, with intronic counts as separate columns",
+      "type": "null | File",
+      "output_source": [
+        "salmon_quantification/raw_count_matrix"
+      ],
+      "doc": null,
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "ripley_plot",
+      "label": "ripley_plot",
+      "type": "null | File",
+      "output_source": [
+        "squidpy_analysis/ripley_plot"
+      ],
+      "doc": null,
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "salmon_output",
+      "label": "Full output of `salmon alevin`",
+      "type": "Directory",
+      "output_source": [
+        "salmon_quantification/salmon_output"
+      ],
+      "doc": null,
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "scanpy_qc_results",
+      "label": "Quality control metrics from Scanpy",
+      "type": "File",
+      "output_source": [
+        "compute_qc_results/scanpy_qc_results"
+      ],
+      "doc": null,
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "scvelo_annotated_h5ad",
+      "label": "scVelo-annotated h5ad file, including cell RNA velocity",
+      "type": "null | File",
+      "output_source": [
+        "scvelo_analysis/annotated_h5ad_file"
+      ],
+      "doc": null,
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "scvelo_embedding_grid_plot",
+      "label": "scVelo velocity embedding grid plot",
+      "type": "null | File",
+      "output_source": [
+        "scvelo_analysis/embedding_grid_plot"
+      ],
+      "doc": null,
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "spatial_plot",
+      "label": "Slide-seq bead plot, colored by Leiden cluster",
+      "type": "null | File",
+      "output_source": [
+        "scanpy_analysis/spatial_plot"
+      ],
+      "doc": null,
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "squidpy_annotated_h5ad",
+      "label": "squidpy_annotated_h5ad",
+      "type": "null | File",
+      "output_source": [
+        "squidpy_analysis/squidpy_annotated_h5ad"
+      ],
+      "doc": null,
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "squidpy_spatial_plot",
+      "label": "squidpy_spatial_plot",
+      "type": "null | File",
+      "output_source": [
+        "squidpy_analysis/spatial_plot"
+      ],
+      "doc": null,
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "umap_density_plot",
+      "label": "UMAP dimensionality reduction plot, colored by cell density",
+      "type": "File",
+      "output_source": [
+        "scanpy_analysis/umap_density_plot"
+      ],
+      "doc": null,
+      "format": null,
+      "secondary_files": []
+    },
+    {
+      "id": "umap_plot",
+      "label": "UMAP dimensionality reduction plot",
+      "type": "File",
+      "output_source": [
+        "scanpy_analysis/umap_plot"
+      ],
+      "doc": null,
+      "format": null,
+      "secondary_files": []
+    }
+  ],
+  "steps": [
+    {
+      "id": "compute_qc_results",
+      "run": "compute-qc-metrics.cwl",
+      "run_class": "CommandLineTool",
+      "label": "Compute QC metrics",
+      "doc": null,
+      "in": [
+        {
+          "id": "compute_qc_results/assay",
+          "source": [
+            "assay"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "compute_qc_results/primary_matrix_path",
+          "source": [
+            "deepscence/h5ad_with_ds"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "compute_qc_results/salmon_dir",
+          "source": [
+            "salmon_quantification/salmon_output"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "compute_qc_results/secondary_matrix_path",
+          "source": [
+            "scanpy_analysis/filtered_data_h5ad"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        }
+      ],
+      "out": [
+        "scanpy_qc_results",
+        "qc_metrics"
+      ],
+      "scatter": [],
+      "scatter_method": null,
+      "when": null,
+      "requirements": [],
+      "hints": []
+    },
+    {
+      "id": "deepscence",
+      "run": "deepscence.cwl",
+      "run_class": "CommandLineTool",
+      "label": "Run DeepScence method to get cell scenesense scores",
+      "doc": null,
+      "in": [
+        {
+          "id": "deepscence/h5ad_file",
+          "source": [
+            "salmon_quantification/count_matrix_h5ad"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        }
+      ],
+      "out": [
+        "h5ad_with_ds",
+        "deepscence_plot"
+      ],
+      "scatter": [],
+      "scatter_method": null,
+      "when": null,
+      "requirements": [],
+      "hints": []
+    },
+    {
+      "id": "fastqc",
+      "run": "fastqc.cwl",
+      "run_class": "CommandLineTool",
+      "label": "Run fastqc on all fastq files in fastq directory",
+      "doc": null,
+      "in": [
+        {
+          "id": "fastqc/fastq_dir",
+          "source": [
+            "fastq_dir"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "fastqc/threads",
+          "source": [
+            "threads"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        }
+      ],
+      "out": [
+        "fastqc_dir"
+      ],
+      "scatter": [
+        "fastq_dir"
+      ],
+      "scatter_method": "dotproduct",
+      "when": null,
+      "requirements": [],
+      "hints": []
+    },
+    {
+      "id": "salmon_quantification",
+      "run": "salmon-quantification.cwl",
+      "run_class": "Workflow",
+      "label": null,
+      "doc": null,
+      "in": [
+        {
+          "id": "salmon_quantification/assay",
+          "source": [
+            "assay"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "salmon_quantification/expected_cell_count",
+          "source": [
+            "expected_cell_count"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "salmon_quantification/fastq_dir",
+          "source": [
+            "fastq_dir"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "salmon_quantification/img_dir",
+          "source": [
+            "img_dir"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "salmon_quantification/keep_all_barcodes",
+          "source": [
+            "keep_all_barcodes"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "salmon_quantification/metadata_dir",
+          "source": [
+            "metadata_dir"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "salmon_quantification/organism",
+          "source": [
+            "organism"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "salmon_quantification/threads",
+          "source": [
+            "threads"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        }
+      ],
+      "out": [
+        "salmon_output",
+        "count_matrix_h5ad",
+        "raw_count_matrix",
+        "genome_build_json"
+      ],
+      "scatter": [],
+      "scatter_method": null,
+      "when": null,
+      "requirements": [],
+      "hints": []
+    },
+    {
+      "id": "scanpy_analysis",
+      "run": "scanpy-analysis.cwl",
+      "run_class": "CommandLineTool",
+      "label": "Secondary analysis via ScanPy",
+      "doc": null,
+      "in": [
+        {
+          "id": "scanpy_analysis/assay",
+          "source": [
+            "assay"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "scanpy_analysis/h5ad_file",
+          "source": [
+            "deepscence/h5ad_with_ds"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        }
+      ],
+      "out": [
+        "filtered_data_h5ad",
+        "umap_plot",
+        "marker_gene_plot_t_test",
+        "marker_gene_plot_logreg",
+        "dispersion_plot",
+        "umap_density_plot",
+        "spatial_plot",
+        "deepscence_continuous_plot",
+        "deepscence_binary_plot"
+      ],
+      "scatter": [],
+      "scatter_method": null,
+      "when": null,
+      "requirements": [],
+      "hints": []
+    },
+    {
+      "id": "scvelo_analysis",
+      "run": "scvelo-analysis.cwl",
+      "run_class": "CommandLineTool",
+      "label": "RNA velocity analysis via scVelo",
+      "doc": null,
+      "in": [
+        {
+          "id": "scvelo_analysis/assay_name",
+          "source": [
+            "assay"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "scvelo_analysis/spliced_h5ad_file",
+          "source": [
+            "deepscence/h5ad_with_ds"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        }
+      ],
+      "out": [
+        "annotated_h5ad_file",
+        "embedding_grid_plot"
+      ],
+      "scatter": [],
+      "scatter_method": null,
+      "when": null,
+      "requirements": [],
+      "hints": []
+    },
+    {
+      "id": "squidpy_analysis",
+      "run": "squidpy-analysis.cwl",
+      "run_class": "CommandLineTool",
+      "label": "Spatial analysis via SquidPy",
+      "doc": null,
+      "in": [
+        {
+          "id": "squidpy_analysis/assay",
+          "source": [
+            "assay"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "squidpy_analysis/h5ad_file",
+          "source": [
+            "scanpy_analysis/filtered_data_h5ad"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        },
+        {
+          "id": "squidpy_analysis/img_dir",
+          "source": [
+            "img_dir"
+          ],
+          "default": null,
+          "value_from": null,
+          "link_merge": null,
+          "pick_value": null
+        }
+      ],
+      "out": [
+        "squidpy_annotated_h5ad",
+        "neighborhood_enrichment_plot",
+        "co_occurrence_plot",
+        "interaction_matrix_plot",
+        "ripley_plot",
+        "centrality_scores_plot",
+        "spatial_plot"
+      ],
+      "scatter": [],
+      "scatter_method": null,
+      "when": null,
+      "requirements": [],
+      "hints": []
+    }
+  ],
+  "tools": [
+    {
+      "id": "compute-qc-metrics.cwl",
+      "label": "Compute QC metrics",
+      "base_command": [
+        "/opt/compute_qc_metrics.py"
+      ],
+      "arguments": [],
+      "inputs": [
+        {
+          "id": "assay",
+          "type": "string",
+          "input_binding": {
+            "position": 0,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "primary_matrix_path",
+          "type": "File",
+          "input_binding": {
+            "position": 1,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "salmon_dir",
+          "type": "Directory",
+          "input_binding": {
+            "position": 3,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "secondary_matrix_path",
+          "type": "File",
+          "input_binding": {
+            "position": 2,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "outputs": [
+        {
+          "id": "qc_metrics",
+          "type": "File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "qc_results.json",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "scanpy_qc_results",
+          "type": "File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "qc_results.hdf5",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "requirements": [
+        {
+          "class": "DockerRequirement",
+          "docker_pull": "hubmap/scrna-analysis:latest",
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "dockerPull": "hubmap/scrna-analysis:latest",
+            "class": "DockerRequirement"
+          }
+        }
+      ],
+      "hints": []
+    },
+    {
+      "id": "deepscence.cwl",
+      "label": "Identify and score scenescent cells",
+      "base_command": [
+        "/opt/deepscence.py"
+      ],
+      "arguments": [],
+      "inputs": [
+        {
+          "id": "h5ad_file",
+          "type": "File",
+          "input_binding": {
+            "position": 0,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "outputs": [
+        {
+          "id": "deepscence_plot",
+          "type": "File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "deepscence.pdf",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "h5ad_with_ds",
+          "type": "File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "expr.h5ad",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "requirements": [
+        {
+          "class": "DockerRequirement",
+          "docker_pull": "hubmap/scrna-analysis:latest",
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "dockerPull": "hubmap/scrna-analysis:latest",
+            "class": "DockerRequirement"
+          }
+        }
+      ],
+      "hints": []
+    },
+    {
+      "id": "fastqc.cwl",
+      "label": "Runs fastQC on each fastq file in fastq directory",
+      "base_command": [
+        "/opt/fastqc_wrapper.py"
+      ],
+      "arguments": [],
+      "inputs": [
+        {
+          "id": "fastq_dir",
+          "type": "Directory",
+          "input_binding": {
+            "position": 1,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "Directory containing fastq files to be evaluated",
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "threads",
+          "type": "int",
+          "input_binding": {
+            "position": 2,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": "The number of threads to use for fastqc",
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "outputs": [
+        {
+          "id": "fastqc_dir",
+          "type": "Directory",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "fastqc_output",
+            "value_from": null
+          },
+          "doc": "Individual graph files and additional data files containing the raw data from which plots were drawn.",
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "requirements": [
+        {
+          "class": "DockerRequirement",
+          "docker_pull": "hubmap/scrna-analysis:latest",
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "dockerPull": "hubmap/scrna-analysis:latest",
+            "class": "DockerRequirement"
+          }
+        }
+      ],
+      "hints": []
+    },
+    {
+      "id": "adjust-barcodes.cwl",
+      "label": "Assay-specific adjustment of cell barcodes",
+      "base_command": [
+        "/opt/adjust_barcodes.py"
+      ],
+      "arguments": [],
+      "inputs": [
+        {
+          "id": "assay",
+          "type": "string",
+          "input_binding": {
+            "position": 0,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "fastq_dir",
+          "type": "array",
+          "input_binding": {
+            "position": 1,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "outputs": [
+        {
+          "id": "adj_fastq_dir",
+          "type": "Directory",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "adj_fastq",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "metadata_json",
+          "type": "null | File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "metadata.json",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "requirements": [
+        {
+          "class": "DockerRequirement",
+          "docker_pull": "hubmap/scrna-barcode-adj:latest",
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "dockerPull": "hubmap/scrna-barcode-adj:latest",
+            "class": "DockerRequirement"
+          }
+        }
+      ],
+      "hints": []
+    },
+    {
+      "id": "alevin-to-anndata.cwl",
+      "label": "Convert Alevin sparse output to anndata.AnnData object, save as h5ad",
+      "base_command": [
+        "/opt/alevin_to_anndata.py"
+      ],
+      "arguments": [],
+      "inputs": [
+        {
+          "id": "alevin_dir",
+          "type": "Directory",
+          "input_binding": {
+            "position": 1,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "assay",
+          "type": "string",
+          "input_binding": {
+            "position": 0,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "organism",
+          "type": "null | string",
+          "input_binding": {
+            "position": 2,
+            "prefix": "--organism",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "outputs": [
+        {
+          "id": "expr_h5ad",
+          "type": "File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "expr.h5ad",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "genome_build_json",
+          "type": "File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "genome_build.json",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "raw_expr_h5ad",
+          "type": "null | File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "raw_expr.h5ad",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "requirements": [
+        {
+          "class": "DockerRequirement",
+          "docker_pull": "hubmap/scrna-analysis:latest",
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "dockerPull": "hubmap/scrna-analysis:latest",
+            "class": "DockerRequirement"
+          }
+        },
+        {
+          "class": "MultipleInputFeatureRequirement",
+          "docker_pull": null,
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "MultipleInputFeatureRequirement"
+          }
+        }
+      ],
+      "hints": []
+    },
+    {
+      "id": "annotate-cells.cwl",
+      "label": "Assay-specific annotation of cell barcodes after quantification",
+      "base_command": [
+        "/opt/annotate_cells.py"
+      ],
+      "arguments": [],
+      "inputs": [
+        {
+          "id": "assay",
+          "type": "string",
+          "input_binding": {
+            "position": 0,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "h5ad_file",
+          "type": "File",
+          "input_binding": {
+            "position": 1,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "img_dir",
+          "type": "null | Directory",
+          "input_binding": {
+            "position": 3,
+            "prefix": "--img_dir",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "metadata_dir",
+          "type": "null | Directory",
+          "input_binding": {
+            "position": 4,
+            "prefix": "--metadata_dir",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "metadata_json",
+          "type": "null | File",
+          "input_binding": {
+            "position": 5,
+            "prefix": "--metadata_json",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "orig_fastq_dirs",
+          "type": "array",
+          "input_binding": {
+            "position": 2,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "outputs": [
+        {
+          "id": "annotated_h5ad_file",
+          "type": "File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "expr.h5ad",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "requirements": [
+        {
+          "class": "DockerRequirement",
+          "docker_pull": "hubmap/scrna-analysis:latest",
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "dockerPull": "hubmap/scrna-analysis:latest",
+            "class": "DockerRequirement"
+          }
+        }
+      ],
+      "hints": []
+    },
+    {
+      "id": "salmon-mouse.cwl",
+      "label": "Run Salmon Alevin tool on FASTQ input",
+      "base_command": [
+        "/opt/salmon_wrapper.py"
+      ],
+      "arguments": [],
+      "inputs": [
+        {
+          "id": "assay",
+          "type": "string",
+          "input_binding": {
+            "position": 0,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "expected_cell_count",
+          "type": "null | int",
+          "input_binding": {
+            "position": 4,
+            "prefix": "--expected-cell-count",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "keep_all_barcodes",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 5,
+            "prefix": "--keep-all-barcodes",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "organism",
+          "type": "null | string",
+          "input_binding": {
+            "position": 6,
+            "prefix": "--organism",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "orig_fastq_dirs",
+          "type": "array",
+          "input_binding": {
+            "position": 2,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "threads",
+          "type": "int",
+          "input_binding": {
+            "position": 3,
+            "prefix": "--threads",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "trimmed_fastq_dir",
+          "type": "Directory",
+          "input_binding": {
+            "position": 1,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "outputs": [
+        {
+          "id": "output_dir",
+          "type": "Directory",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "salmon_out",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "requirements": [
+        {
+          "class": "DockerRequirement",
+          "docker_pull": "hubmap/salmon-grcm39:latest",
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "dockerPull": "hubmap/salmon-grcm39:latest",
+            "class": "DockerRequirement"
+          }
+        },
+        {
+          "class": "ResourceRequirement",
+          "docker_pull": null,
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "ramMin": 28672,
+            "class": "ResourceRequirement"
+          }
+        }
+      ],
+      "hints": []
+    },
+    {
+      "id": "salmon.cwl",
+      "label": "Run Salmon Alevin tool on FASTQ input",
+      "base_command": [
+        "/opt/salmon_wrapper.py"
+      ],
+      "arguments": [],
+      "inputs": [
+        {
+          "id": "assay",
+          "type": "string",
+          "input_binding": {
+            "position": 0,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "expected_cell_count",
+          "type": "null | int",
+          "input_binding": {
+            "position": 4,
+            "prefix": "--expected-cell-count",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "keep_all_barcodes",
+          "type": "null | boolean",
+          "input_binding": {
+            "position": 5,
+            "prefix": "--keep-all-barcodes",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "orig_fastq_dirs",
+          "type": "array",
+          "input_binding": {
+            "position": 2,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "threads",
+          "type": "int",
+          "input_binding": {
+            "position": 3,
+            "prefix": "--threads",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "trimmed_fastq_dir",
+          "type": "Directory",
+          "input_binding": {
+            "position": 1,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "outputs": [
+        {
+          "id": "output_dir",
+          "type": "Directory",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "salmon_out",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "requirements": [
+        {
+          "class": "DockerRequirement",
+          "docker_pull": "hubmap/salmon-grch38:latest",
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "dockerPull": "hubmap/salmon-grch38:latest",
+            "class": "DockerRequirement"
+          }
+        },
+        {
+          "class": "ResourceRequirement",
+          "docker_pull": null,
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "ramMin": 28672,
+            "class": "ResourceRequirement"
+          }
+        }
+      ],
+      "hints": []
+    },
+    {
+      "id": "trim-reads.cwl",
+      "label": "Trim FASTQ files",
+      "base_command": [
+        "/opt/trim_reads.py"
+      ],
+      "arguments": [],
+      "inputs": [
+        {
+          "id": "adj_fastq_dir",
+          "type": "Directory",
+          "input_binding": {
+            "position": 1,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "assay",
+          "type": "string",
+          "input_binding": {
+            "position": 0,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "orig_fastq_dirs",
+          "type": "array",
+          "input_binding": {
+            "position": 2,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "threads",
+          "type": "int",
+          "input_binding": {
+            "position": 3,
+            "prefix": "--threads",
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "outputs": [
+        {
+          "id": "trimmed_fastq_dir",
+          "type": "Directory",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "trimmed",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "requirements": [
+        {
+          "class": "DockerRequirement",
+          "docker_pull": "hubmap/scrna-trim-reads:latest",
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "dockerPull": "hubmap/scrna-trim-reads:latest",
+            "class": "DockerRequirement"
+          }
+        }
+      ],
+      "hints": []
+    },
+    {
+      "id": "scanpy-analysis.cwl",
+      "label": "Dimensionality reduction and clustering",
+      "base_command": [
+        "/opt/scanpy_entry_point.py"
+      ],
+      "arguments": [],
+      "inputs": [
+        {
+          "id": "assay",
+          "type": "string",
+          "input_binding": {
+            "position": 0,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "h5ad_file",
+          "type": "File",
+          "input_binding": {
+            "position": 1,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "outputs": [
+        {
+          "id": "deepscence_binary_plot",
+          "type": "File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "umap_by_deepscence_binary.pdf",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "deepscence_continuous_plot",
+          "type": "File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "umap_by_deepscence_continuous.pdf",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "dispersion_plot",
+          "type": "File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "dispersion_plot.pdf",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "filtered_data_h5ad",
+          "type": "File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "secondary_analysis.h5ad",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "marker_gene_plot_logreg",
+          "type": "File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "marker_genes_by_cluster_logreg.pdf",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "marker_gene_plot_t_test",
+          "type": "File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "marker_genes_by_cluster_t_test.pdf",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "spatial_plot",
+          "type": "null | File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "spatial_pos_by_leiden_cluster.pdf",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "umap_density_plot",
+          "type": "File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "umap_embedding_density.pdf",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "umap_plot",
+          "type": "File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "umap_by_leiden_cluster.pdf",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "requirements": [
+        {
+          "class": "DockerRequirement",
+          "docker_pull": "hubmap/scrna-analysis:latest",
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "dockerPull": "hubmap/scrna-analysis:latest",
+            "class": "DockerRequirement"
+          }
+        }
+      ],
+      "hints": []
+    },
+    {
+      "id": "scvelo-analysis.cwl",
+      "label": "RNA velocity analysis via scVelo",
+      "base_command": [
+        "/opt/scvelo_analysis.py"
+      ],
+      "arguments": [],
+      "inputs": [
+        {
+          "id": "assay_name",
+          "type": "string",
+          "input_binding": {
+            "position": 2,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "spliced_h5ad_file",
+          "type": "File",
+          "input_binding": {
+            "position": 1,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "outputs": [
+        {
+          "id": "annotated_h5ad_file",
+          "type": "null | File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "scvelo_annotated.h5ad",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "embedding_grid_plot",
+          "type": "null | File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "scvelo_embedding_grid.pdf",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "requirements": [
+        {
+          "class": "DockerRequirement",
+          "docker_pull": "hubmap/scrna-analysis:latest",
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "dockerPull": "hubmap/scrna-analysis:latest",
+            "class": "DockerRequirement"
+          }
+        },
+        {
+          "class": "EnvVarRequirement",
+          "docker_pull": null,
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "envDef": [
+              {
+                "envValue": "/tmp",
+                "envName": "TMPDIR"
+              }
+            ],
+            "class": "EnvVarRequirement"
+          }
+        }
+      ],
+      "hints": []
+    },
+    {
+      "id": "squidpy-analysis.cwl",
+      "label": "Dimensionality reduction and clustering",
+      "base_command": [
+        "/opt/squidpy_entry_point.py"
+      ],
+      "arguments": [],
+      "inputs": [
+        {
+          "id": "assay",
+          "type": "string",
+          "input_binding": {
+            "position": 0,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "h5ad_file",
+          "type": "File",
+          "input_binding": {
+            "position": 1,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "img_dir",
+          "type": "null | Directory",
+          "input_binding": {
+            "position": 2,
+            "prefix": null,
+            "glob": null,
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "outputs": [
+        {
+          "id": "centrality_scores_plot",
+          "type": "null | File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "centrality_scores.pdf",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "co_occurrence_plot",
+          "type": "null | File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "co_occurrence.pdf",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "interaction_matrix_plot",
+          "type": "null | File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "interaction_matrix.pdf",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "neighborhood_enrichment_plot",
+          "type": "null | File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "neighborhood_enrichment.pdf",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "ripley_plot",
+          "type": "null | File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "ripley.pdf",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "spatial_plot",
+          "type": "null | File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "spatial_scatter.pdf",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "squidpy_annotated_h5ad",
+          "type": "null | File",
+          "output_binding": {
+            "position": null,
+            "prefix": null,
+            "glob": "squidpy_annotated.h5ad",
+            "value_from": null
+          },
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "requirements": [
+        {
+          "class": "DockerRequirement",
+          "docker_pull": "hubmap/squidpy-analysis:latest",
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "dockerPull": "hubmap/squidpy-analysis:latest",
+            "class": "DockerRequirement"
+          }
+        }
+      ],
+      "hints": []
+    },
+    {
+      "id": "salmon-quantification.cwl",
+      "label": "Salmon quantification, FASTQ -> H5AD count matrix",
+      "base_command": [],
+      "arguments": [],
+      "inputs": [
+        {
+          "id": "assay",
+          "type": "string",
+          "input_binding": null,
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "expected_cell_count",
+          "type": "null | int",
+          "input_binding": null,
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "fastq_dir",
+          "type": "array",
+          "input_binding": null,
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "img_dir",
+          "type": "null | Directory",
+          "input_binding": null,
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "keep_all_barcodes",
+          "type": "null | boolean",
+          "input_binding": null,
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "metadata_dir",
+          "type": "null | Directory",
+          "input_binding": null,
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "organism",
+          "type": "null | string",
+          "input_binding": null,
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "threads",
+          "type": "int",
+          "input_binding": null,
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "outputs": [
+        {
+          "id": "count_matrix_h5ad",
+          "type": "File",
+          "output_binding": null,
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "genome_build_json",
+          "type": "File",
+          "output_binding": null,
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "raw_count_matrix",
+          "type": "null | File",
+          "output_binding": null,
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        },
+        {
+          "id": "salmon_output",
+          "type": "Directory",
+          "output_binding": null,
+          "doc": null,
+          "format": null,
+          "secondary_files": []
+        }
+      ],
+      "requirements": [
+        {
+          "class": "InlineJavascriptRequirement",
+          "docker_pull": null,
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "InlineJavascriptRequirement"
+          }
+        },
+        {
+          "class": "MultipleInputFeatureRequirement",
+          "docker_pull": null,
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "class": "MultipleInputFeatureRequirement"
+          }
+        }
+      ],
+      "hints": [
+        {
+          "class": "_NestedWorkflow",
+          "docker_pull": null,
+          "docker_image_id": null,
+          "packages": [],
+          "raw": {
+            "steps": [
+              {
+                "id": "salmon-quantification.cwl/adjust_barcodes",
+                "run": "adjust-barcodes.cwl",
+                "scatter": null
+              },
+              {
+                "id": "salmon-quantification.cwl/alevin_to_anndata",
+                "run": "alevin-to-anndata.cwl",
+                "scatter": null
+              },
+              {
+                "id": "salmon-quantification.cwl/annotate_cells",
+                "run": "annotate-cells.cwl",
+                "scatter": null
+              },
+              {
+                "id": "salmon-quantification.cwl/salmon",
+                "run": "salmon.cwl",
+                "scatter": null
+              },
+              {
+                "id": "salmon-quantification.cwl/salmon-mouse",
+                "run": "salmon-mouse.cwl",
+                "scatter": null
+              },
+              {
+                "id": "salmon-quantification.cwl/trim_reads",
+                "run": "trim-reads.cwl",
+                "scatter": null
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "graph": {
+    "nodes": [
+      {
+        "id": "assay",
+        "kind": "workflow-input",
+        "label": "scRNA-seq assay"
+      },
+      {
+        "id": "expected_cell_count",
+        "kind": "workflow-input",
+        "label": "expected_cell_count"
+      },
+      {
+        "id": "fastq_dir",
+        "kind": "workflow-input",
+        "label": "Directory containing FASTQ files"
+      },
+      {
+        "id": "img_dir",
+        "kind": "workflow-input",
+        "label": "Directory containing TIFF image data (for Visium assay)"
+      },
+      {
+        "id": "keep_all_barcodes",
+        "kind": "workflow-input",
+        "label": "keep_all_barcodes"
+      },
+      {
+        "id": "metadata_dir",
+        "kind": "workflow-input",
+        "label": "Directory containing metadata, including gpr slide file (for Visium assay)"
+      },
+      {
+        "id": "organism",
+        "kind": "workflow-input",
+        "label": "organism"
+      },
+      {
+        "id": "threads",
+        "kind": "workflow-input",
+        "label": "Number of threads for Salmon"
+      },
+      {
+        "id": "centrality_scores_plot",
+        "kind": "workflow-output",
+        "label": "centrality_scores_plot"
+      },
+      {
+        "id": "co_occurrence_plot",
+        "kind": "workflow-output",
+        "label": "co_occurrence_plot"
+      },
+      {
+        "id": "count_matrix_h5ad",
+        "kind": "workflow-output",
+        "label": "Unfiltered count matrix from Alevin, converted to H5AD, spliced and unspliced counts, scenesence scores"
+      },
+      {
+        "id": "deepscence_binary_plot",
+        "kind": "workflow-output",
+        "label": "Umap with coloring by DeepScence binary results"
+      },
+      {
+        "id": "deepscence_continuous_plot",
+        "kind": "workflow-output",
+        "label": "Umap with coloring by DeepScence scores"
+      },
+      {
+        "id": "deepscence_plot",
+        "kind": "workflow-output",
+        "label": "deepscence_plot"
+      },
+      {
+        "id": "dispersion_plot",
+        "kind": "workflow-output",
+        "label": "Gene expression dispersion plot"
+      },
+      {
+        "id": "fastqc_dir",
+        "kind": "workflow-output",
+        "label": "Directory of FastQC output files, mirroring input directory structure"
+      },
+      {
+        "id": "filtered_data_h5ad",
+        "kind": "workflow-output",
+        "label": "Full data set of filtered results"
+      },
+      {
+        "id": "genome_build_json",
+        "kind": "workflow-output",
+        "label": "Genome build information in JSON format"
+      },
+      {
+        "id": "interaction_matrix_plot",
+        "kind": "workflow-output",
+        "label": "interaction_matrix_plot"
+      },
+      {
+        "id": "marker_gene_plot_logreg",
+        "kind": "workflow-output",
+        "label": "Cluster marker genes, logreg method"
+      },
+      {
+        "id": "marker_gene_plot_t_test",
+        "kind": "workflow-output",
+        "label": "Cluster marker genes, t-test"
+      },
+      {
+        "id": "neighborhood_enrichment_plot",
+        "kind": "workflow-output",
+        "label": "neighborhood_enrichment_plot"
+      },
+      {
+        "id": "qc_report",
+        "kind": "workflow-output",
+        "label": "Quality control report in JSON format"
+      },
+      {
+        "id": "raw_count_matrix",
+        "kind": "workflow-output",
+        "label": "Unfiltered count matrix from Alevin, converted to H5AD, with intronic counts as separate columns"
+      },
+      {
+        "id": "ripley_plot",
+        "kind": "workflow-output",
+        "label": "ripley_plot"
+      },
+      {
+        "id": "salmon_output",
+        "kind": "workflow-output",
+        "label": "Full output of `salmon alevin`"
+      },
+      {
+        "id": "scanpy_qc_results",
+        "kind": "workflow-output",
+        "label": "Quality control metrics from Scanpy"
+      },
+      {
+        "id": "scvelo_annotated_h5ad",
+        "kind": "workflow-output",
+        "label": "scVelo-annotated h5ad file, including cell RNA velocity"
+      },
+      {
+        "id": "scvelo_embedding_grid_plot",
+        "kind": "workflow-output",
+        "label": "scVelo velocity embedding grid plot"
+      },
+      {
+        "id": "spatial_plot",
+        "kind": "workflow-output",
+        "label": "Slide-seq bead plot, colored by Leiden cluster"
+      },
+      {
+        "id": "squidpy_annotated_h5ad",
+        "kind": "workflow-output",
+        "label": "squidpy_annotated_h5ad"
+      },
+      {
+        "id": "squidpy_spatial_plot",
+        "kind": "workflow-output",
+        "label": "squidpy_spatial_plot"
+      },
+      {
+        "id": "umap_density_plot",
+        "kind": "workflow-output",
+        "label": "UMAP dimensionality reduction plot, colored by cell density"
+      },
+      {
+        "id": "umap_plot",
+        "kind": "workflow-output",
+        "label": "UMAP dimensionality reduction plot"
+      },
+      {
+        "id": "compute_qc_results",
+        "kind": "step",
+        "label": "compute_qc_results"
+      },
+      {
+        "id": "deepscence",
+        "kind": "step",
+        "label": "deepscence"
+      },
+      {
+        "id": "fastqc",
+        "kind": "step",
+        "label": "fastqc"
+      },
+      {
+        "id": "salmon_quantification",
+        "kind": "step",
+        "label": "salmon_quantification"
+      },
+      {
+        "id": "scanpy_analysis",
+        "kind": "step",
+        "label": "scanpy_analysis"
+      },
+      {
+        "id": "scvelo_analysis",
+        "kind": "step",
+        "label": "scvelo_analysis"
+      },
+      {
+        "id": "squidpy_analysis",
+        "kind": "step",
+        "label": "squidpy_analysis"
+      }
+    ],
+    "edges": [
+      {
+        "from": "assay",
+        "to": "compute_qc_results/assay",
+        "via": []
+      },
+      {
+        "from": "deepscence/h5ad_with_ds",
+        "to": "compute_qc_results/primary_matrix_path",
+        "via": []
+      },
+      {
+        "from": "salmon_quantification/salmon_output",
+        "to": "compute_qc_results/salmon_dir",
+        "via": []
+      },
+      {
+        "from": "scanpy_analysis/filtered_data_h5ad",
+        "to": "compute_qc_results/secondary_matrix_path",
+        "via": []
+      },
+      {
+        "from": "salmon_quantification/count_matrix_h5ad",
+        "to": "deepscence/h5ad_file",
+        "via": []
+      },
+      {
+        "from": "fastq_dir",
+        "to": "fastqc/fastq_dir",
+        "via": [
+          "scatter"
+        ]
+      },
+      {
+        "from": "threads",
+        "to": "fastqc/threads",
+        "via": []
+      },
+      {
+        "from": "assay",
+        "to": "salmon_quantification/assay",
+        "via": []
+      },
+      {
+        "from": "expected_cell_count",
+        "to": "salmon_quantification/expected_cell_count",
+        "via": []
+      },
+      {
+        "from": "fastq_dir",
+        "to": "salmon_quantification/fastq_dir",
+        "via": []
+      },
+      {
+        "from": "img_dir",
+        "to": "salmon_quantification/img_dir",
+        "via": []
+      },
+      {
+        "from": "keep_all_barcodes",
+        "to": "salmon_quantification/keep_all_barcodes",
+        "via": []
+      },
+      {
+        "from": "metadata_dir",
+        "to": "salmon_quantification/metadata_dir",
+        "via": []
+      },
+      {
+        "from": "organism",
+        "to": "salmon_quantification/organism",
+        "via": []
+      },
+      {
+        "from": "threads",
+        "to": "salmon_quantification/threads",
+        "via": []
+      },
+      {
+        "from": "assay",
+        "to": "scanpy_analysis/assay",
+        "via": []
+      },
+      {
+        "from": "deepscence/h5ad_with_ds",
+        "to": "scanpy_analysis/h5ad_file",
+        "via": []
+      },
+      {
+        "from": "assay",
+        "to": "scvelo_analysis/assay_name",
+        "via": []
+      },
+      {
+        "from": "deepscence/h5ad_with_ds",
+        "to": "scvelo_analysis/spliced_h5ad_file",
+        "via": []
+      },
+      {
+        "from": "assay",
+        "to": "squidpy_analysis/assay",
+        "via": []
+      },
+      {
+        "from": "scanpy_analysis/filtered_data_h5ad",
+        "to": "squidpy_analysis/h5ad_file",
+        "via": []
+      },
+      {
+        "from": "img_dir",
+        "to": "squidpy_analysis/img_dir",
+        "via": []
+      },
+      {
+        "from": "squidpy_analysis/centrality_scores_plot",
+        "to": "centrality_scores_plot",
+        "via": []
+      },
+      {
+        "from": "squidpy_analysis/co_occurrence_plot",
+        "to": "co_occurrence_plot",
+        "via": []
+      },
+      {
+        "from": "deepscence/h5ad_with_ds",
+        "to": "count_matrix_h5ad",
+        "via": []
+      },
+      {
+        "from": "scanpy_analysis/deepscence_binary_plot",
+        "to": "deepscence_binary_plot",
+        "via": []
+      },
+      {
+        "from": "scanpy_analysis/deepscence_continuous_plot",
+        "to": "deepscence_continuous_plot",
+        "via": []
+      },
+      {
+        "from": "deepscence/deepscence_plot",
+        "to": "deepscence_plot",
+        "via": []
+      },
+      {
+        "from": "scanpy_analysis/dispersion_plot",
+        "to": "dispersion_plot",
+        "via": []
+      },
+      {
+        "from": "fastqc/fastqc_dir",
+        "to": "fastqc_dir",
+        "via": []
+      },
+      {
+        "from": "scanpy_analysis/filtered_data_h5ad",
+        "to": "filtered_data_h5ad",
+        "via": []
+      },
+      {
+        "from": "salmon_quantification/genome_build_json",
+        "to": "genome_build_json",
+        "via": []
+      },
+      {
+        "from": "squidpy_analysis/interaction_matrix_plot",
+        "to": "interaction_matrix_plot",
+        "via": []
+      },
+      {
+        "from": "scanpy_analysis/marker_gene_plot_logreg",
+        "to": "marker_gene_plot_logreg",
+        "via": []
+      },
+      {
+        "from": "scanpy_analysis/marker_gene_plot_t_test",
+        "to": "marker_gene_plot_t_test",
+        "via": []
+      },
+      {
+        "from": "squidpy_analysis/neighborhood_enrichment_plot",
+        "to": "neighborhood_enrichment_plot",
+        "via": []
+      },
+      {
+        "from": "compute_qc_results/qc_metrics",
+        "to": "qc_report",
+        "via": []
+      },
+      {
+        "from": "salmon_quantification/raw_count_matrix",
+        "to": "raw_count_matrix",
+        "via": []
+      },
+      {
+        "from": "squidpy_analysis/ripley_plot",
+        "to": "ripley_plot",
+        "via": []
+      },
+      {
+        "from": "salmon_quantification/salmon_output",
+        "to": "salmon_output",
+        "via": []
+      },
+      {
+        "from": "compute_qc_results/scanpy_qc_results",
+        "to": "scanpy_qc_results",
+        "via": []
+      },
+      {
+        "from": "scvelo_analysis/annotated_h5ad_file",
+        "to": "scvelo_annotated_h5ad",
+        "via": []
+      },
+      {
+        "from": "scvelo_analysis/embedding_grid_plot",
+        "to": "scvelo_embedding_grid_plot",
+        "via": []
+      },
+      {
+        "from": "scanpy_analysis/spatial_plot",
+        "to": "spatial_plot",
+        "via": []
+      },
+      {
+        "from": "squidpy_analysis/squidpy_annotated_h5ad",
+        "to": "squidpy_annotated_h5ad",
+        "via": []
+      },
+      {
+        "from": "squidpy_analysis/spatial_plot",
+        "to": "squidpy_spatial_plot",
+        "via": []
+      },
+      {
+        "from": "scanpy_analysis/umap_density_plot",
+        "to": "umap_density_plot",
+        "via": []
+      },
+      {
+        "from": "scanpy_analysis/umap_plot",
+        "to": "umap_plot",
+        "via": []
+      }
+    ]
+  },
+  "tests": [],
+  "warnings": [
+    {
+      "code": "ref.directory",
+      "message": "fastq_dir, img_dir, metadata_dir are CWL Directory or Directory[] inputs; Galaxy needs a collection or wrapper-side directory handling strategy.",
+      "path": "workflow_inputs"
+    },
+    {
+      "code": "scatter",
+      "message": "fastqc step scatters over fastq_dir (dotproduct) — Galaxy will need a per-element collection mapping or an in-tool loop.",
+      "path": "steps/fastqc"
+    },
+    {
+      "code": "nested.workflow",
+      "message": "salmon_quantification calls a nested Workflow (#salmon-quantification.cwl, 9 inner steps including its own scatter over fastq_dir); downstream Galaxy may flatten or wrap.",
+      "path": "steps/salmon_quantification"
+    },
+    {
+      "code": "optional.outputs",
+      "message": "Several outputs are File? (spatial_plot, scvelo_*, squidpy_*); downstream Galaxy template must allow conditional/optional outputs.",
+      "path": "workflow_outputs"
+    },
+    {
+      "code": "tests.missing",
+      "message": "No CWL job file or sibling test inputs discoverable in repo at root; tests=[] emitted.",
+      "path": "tests"
+    }
+  ]
+}

--- a/casts/claude/skills/cwl-summary-to-galaxy-data-flow/SKILL.md
+++ b/casts/claude/skills/cwl-summary-to-galaxy-data-flow/SKILL.md
@@ -20,6 +20,10 @@ Follow the procedure below and use the artifact/reference sections as the runtim
 
 - Write artifact `cwl-galaxy-data-flow` as `cwl-galaxy-data-flow.md`. Format: `markdown`. Reviewable Markdown brief: abstract topology, Galaxy collection semantics, placeholder transformations, unresolved Galaxy tool needs.
 
+## Required Tools
+
+- None declared. Procedure should not assume external CLIs are present.
+
 ## Load Upfront
 
 - `references/notes/component-cwl-workflow-anatomy.md`: Research note copied verbatim into the bundle. Use CWL's native graph and mark only the features that need Galaxy reinterpretation.

--- a/casts/claude/skills/cwl-summary-to-galaxy-data-flow/_provenance.json
+++ b/casts/claude/skills/cwl-summary-to-galaxy-data-flow/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/cwl-summary-to-galaxy-data-flow/index.md",
     "revision": 2,
     "content_hash": "34149e0dac3a2d6bfb0b6e9c4f8706320489f79e385b58c31e63d48c1e3d3c00",
-    "commit": "2cc40cf0b5be4a3d4858e017783df537cd39be01"
+    "commit": "97effead63ef05cbac9d7f7227d8695a9e571e79"
   },
-  "cast_at": "2026-05-11T17:53:01.075Z",
+  "cast_at": "2026-05-11T20:45:01.763Z",
   "refs": [
     {
       "kind": "pattern",
@@ -80,8 +80,8 @@
       "evidence": "corpus-observed",
       "purpose": "Translate CWL arrays, records, scatter, and secondary-file shapes into Galaxy dataset and collection semantics.",
       "trigger": "When CWL input/output or step wiring implies Galaxy collections, map-over, reduction, or shape changes.",
-      "src_hash": "7ab0d19256c0c547ea89ef6fe29bf1ad0689b266011d33bd5b1a7e76ebd945d4",
-      "dst_hash": "7ab0d19256c0c547ea89ef6fe29bf1ad0689b266011d33bd5b1a7e76ebd945d4",
+      "src_hash": "4a4facb6a8a4498638e4c5af1314b83dde5d5481f1b89dee57b1efcaebfad45f",
+      "dst_hash": "4a4facb6a8a4498638e4c5af1314b83dde5d5481f1b89dee57b1efcaebfad45f",
       "source": "deterministic"
     },
     {
@@ -118,14 +118,14 @@
       "kind": "schema",
       "mode": "verbatim",
       "ref": "[[summary-cwl]]",
-      "src": "package://@galaxy-foundry/summary-cwl-schema#summaryCwlSchema",
+      "src": "package://@galaxy-foundry/foundry#summaryCwlSchema",
       "dst": "references/schemas/summary-cwl.schema.json",
       "used_at": "runtime",
       "load": "upfront",
       "evidence": "cast-validated",
       "purpose": "Read CWL step graph, edge markers, scatter, conditionals, secondary files, and tool requirements while drafting Galaxy-facing data flow.",
-      "src_hash": "fa129417d48b9d70ab6051e6e0dad8af2f5c5ff86932bde9ec8d8f384acab581",
-      "dst_hash": "fa129417d48b9d70ab6051e6e0dad8af2f5c5ff86932bde9ec8d8f384acab581",
+      "src_hash": "0f2afd3d103658dcbcbb4416d803e8d81d02aa749d1c9c98d72d5abe7f34ccd5",
+      "dst_hash": "0f2afd3d103658dcbcbb4416d803e8d81d02aa749d1c9c98d72d5abe7f34ccd5",
       "source": "deterministic"
     }
   ],

--- a/casts/claude/skills/cwl-summary-to-galaxy-data-flow/_verify.json
+++ b/casts/claude/skills/cwl-summary-to-galaxy-data-flow/_verify.json
@@ -7,8 +7,9 @@
       "kind": "json",
       "default_filename": "summary-cwl.json",
       "schema": "[[summary-cwl]]",
-      "validator_bin": "validate-summary-cwl",
+      "validator_bin": "foundry",
       "args": [
+        "validate-summary-cwl",
         "{artifact_path}"
       ]
     }

--- a/casts/claude/skills/cwl-summary-to-galaxy-data-flow/references/notes/galaxy-collection-semantics.md
+++ b/casts/claude/skills/cwl-summary-to-galaxy-data-flow/references/notes/galaxy-collection-semantics.md
@@ -19,6 +19,7 @@ related_notes:
   - "[[galaxy-tool-job-failure-reference]]"
   - "[[galaxy-workflow-invocation-failure-reference]]"
   - "[[iwc-transformations-survey]]"
+  - "[[galaxy-discover-datasets]]"
 sources:
   - "https://github.com/galaxyproject/galaxy/blob/7765fae934fbfdee77e3be5f5b235e43735273ae/lib/galaxy/model/dataset_collections/types/collection_semantics.yml"
 summary: "Vendored formal spec of Galaxy dataset-collection mapping/reduction semantics, with labeled examples and pinned test references."

--- a/casts/claude/skills/cwl-summary-to-galaxy-data-flow/references/schemas/summary-cwl.schema.json
+++ b/casts/claude/skills/cwl-summary-to-galaxy-data-flow/references/schemas/summary-cwl.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://galaxyproject.org/foundry/schemas/summary-cwl.schema.json",
-  "$comment": "Canonical source: packages/summary-cwl-schema/src/summary-cwl.schema.json in jmchilton/foundry. Mold frontmatter cites this schema via [[summary-cwl]] wiki-links; the cast pipeline imports the `summaryCwlSchema` runtime export and serializes it into cast bundles.",
+  "$comment": "Canonical source: packages/foundry/src/schemas/summary-cwl/summary-cwl.schema.json in jmchilton/foundry. Mold frontmatter cites this schema via [[summary-cwl]] wiki-links; the cast pipeline imports the `summaryCwlSchema` runtime export and serializes it into cast bundles.",
   "title": "CWL Workflow Summary",
   "description": "Structured per-source summary emitted by the summarize-cwl Mold. CWL is already a typed workflow language, so this schema records validated and normalized workflow/tool structure rather than inferred pipeline semantics.",
   "type": "object",

--- a/casts/claude/skills/cwl-summary-to-galaxy-interface/SKILL.md
+++ b/casts/claude/skills/cwl-summary-to-galaxy-interface/SKILL.md
@@ -19,6 +19,10 @@ Follow the procedure below and use the artifact/reference sections as the runtim
 
 - Write artifact `cwl-galaxy-interface` as `cwl-galaxy-interface.md`. Format: `markdown`. Reviewable Markdown brief: Galaxy workflow inputs, outputs, labels, exposed and checkpoint outputs, source provenance, confidence.
 
+## Required Tools
+
+- None declared. Procedure should not assume external CLIs are present.
+
 ## Load Upfront
 
 - `references/notes/component-cwl-workflow-anatomy.md`: Research note copied verbatim into the bundle. Keep source-faithful CWL facts separate from Galaxy-facing interface choices.

--- a/casts/claude/skills/cwl-summary-to-galaxy-interface/_provenance.json
+++ b/casts/claude/skills/cwl-summary-to-galaxy-interface/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/cwl-summary-to-galaxy-interface/index.md",
     "revision": 2,
     "content_hash": "62e3ac902a2416bc0c28b4c7577f845a1061e4abf05ae706d6c6952bd0e46fca",
-    "commit": "2cc40cf0b5be4a3d4858e017783df537cd39be01"
+    "commit": "97effead63ef05cbac9d7f7227d8695a9e571e79"
   },
-  "cast_at": "2026-05-11T17:53:01.690Z",
+  "cast_at": "2026-05-11T20:45:00.633Z",
   "refs": [
     {
       "kind": "research",
@@ -51,8 +51,8 @@
       "evidence": "corpus-observed",
       "purpose": "Choose Galaxy collection input shapes from CWL arrays, scatter inputs, records, Directory values, and secondary-file contracts.",
       "trigger": "When CWL types include arrays, records, Directory, secondaryFiles, or scatter over File-like inputs.",
-      "src_hash": "7ab0d19256c0c547ea89ef6fe29bf1ad0689b266011d33bd5b1a7e76ebd945d4",
-      "dst_hash": "7ab0d19256c0c547ea89ef6fe29bf1ad0689b266011d33bd5b1a7e76ebd945d4",
+      "src_hash": "4a4facb6a8a4498638e4c5af1314b83dde5d5481f1b89dee57b1efcaebfad45f",
+      "dst_hash": "4a4facb6a8a4498638e4c5af1314b83dde5d5481f1b89dee57b1efcaebfad45f",
       "source": "deterministic"
     },
     {
@@ -89,14 +89,14 @@
       "kind": "schema",
       "mode": "verbatim",
       "ref": "[[summary-cwl]]",
-      "src": "package://@galaxy-foundry/summary-cwl-schema#summaryCwlSchema",
+      "src": "package://@galaxy-foundry/foundry#summaryCwlSchema",
       "dst": "references/schemas/summary-cwl.schema.json",
       "used_at": "runtime",
       "load": "upfront",
       "evidence": "cast-validated",
       "purpose": "Read CWL workflow inputs, outputs, types, formats, secondary files, scatter, and requirement evidence before choosing the Galaxy interface.",
-      "src_hash": "fa129417d48b9d70ab6051e6e0dad8af2f5c5ff86932bde9ec8d8f384acab581",
-      "dst_hash": "fa129417d48b9d70ab6051e6e0dad8af2f5c5ff86932bde9ec8d8f384acab581",
+      "src_hash": "0f2afd3d103658dcbcbb4416d803e8d81d02aa749d1c9c98d72d5abe7f34ccd5",
+      "dst_hash": "0f2afd3d103658dcbcbb4416d803e8d81d02aa749d1c9c98d72d5abe7f34ccd5",
       "source": "deterministic"
     }
   ],

--- a/casts/claude/skills/cwl-summary-to-galaxy-interface/_verify.json
+++ b/casts/claude/skills/cwl-summary-to-galaxy-interface/_verify.json
@@ -7,8 +7,9 @@
       "kind": "json",
       "default_filename": "summary-cwl.json",
       "schema": "[[summary-cwl]]",
-      "validator_bin": "validate-summary-cwl",
+      "validator_bin": "foundry",
       "args": [
+        "validate-summary-cwl",
         "{artifact_path}"
       ]
     }

--- a/casts/claude/skills/cwl-summary-to-galaxy-interface/references/notes/galaxy-collection-semantics.md
+++ b/casts/claude/skills/cwl-summary-to-galaxy-interface/references/notes/galaxy-collection-semantics.md
@@ -19,6 +19,7 @@ related_notes:
   - "[[galaxy-tool-job-failure-reference]]"
   - "[[galaxy-workflow-invocation-failure-reference]]"
   - "[[iwc-transformations-survey]]"
+  - "[[galaxy-discover-datasets]]"
 sources:
   - "https://github.com/galaxyproject/galaxy/blob/7765fae934fbfdee77e3be5f5b235e43735273ae/lib/galaxy/model/dataset_collections/types/collection_semantics.yml"
 summary: "Vendored formal spec of Galaxy dataset-collection mapping/reduction semantics, with labeled examples and pinned test references."

--- a/casts/claude/skills/cwl-summary-to-galaxy-interface/references/schemas/summary-cwl.schema.json
+++ b/casts/claude/skills/cwl-summary-to-galaxy-interface/references/schemas/summary-cwl.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://galaxyproject.org/foundry/schemas/summary-cwl.schema.json",
-  "$comment": "Canonical source: packages/summary-cwl-schema/src/summary-cwl.schema.json in jmchilton/foundry. Mold frontmatter cites this schema via [[summary-cwl]] wiki-links; the cast pipeline imports the `summaryCwlSchema` runtime export and serializes it into cast bundles.",
+  "$comment": "Canonical source: packages/foundry/src/schemas/summary-cwl/summary-cwl.schema.json in jmchilton/foundry. Mold frontmatter cites this schema via [[summary-cwl]] wiki-links; the cast pipeline imports the `summaryCwlSchema` runtime export and serializes it into cast bundles.",
   "title": "CWL Workflow Summary",
   "description": "Structured per-source summary emitted by the summarize-cwl Mold. CWL is already a typed workflow language, so this schema records validated and normalized workflow/tool structure rather than inferred pipeline semantics.",
   "type": "object",

--- a/casts/claude/skills/cwl-summary-to-galaxy-template/SKILL.md
+++ b/casts/claude/skills/cwl-summary-to-galaxy-template/SKILL.md
@@ -22,6 +22,10 @@ Follow the procedure below and use the artifact/reference sections as the runtim
 
 - Write artifact `galaxy-workflow-draft` as `galaxy-workflow-draft.gxwf.yml`. Format: `yaml`. gxformat2 draft (see galaxy-workflow-draft-format): topology fully resolved (workflow inputs, outputs, step set, edges); tool_id / tool_state / tool_shed_repository and wrapper-determined port names may be TODO with free-text _plan_state / _plan_context / _plan_in / _plan_out per step for later implementation Molds.
 
+## Required Tools
+
+- None declared. Procedure should not assume external CLIs are present.
+
 ## Load Upfront
 
 - `references/notes/component-cwl-workflow-anatomy.md`: Research note copied verbatim into the bundle. Preserve the lightweight CWL boundary and avoid re-inferring structure already present in the summary.

--- a/casts/claude/skills/cwl-summary-to-galaxy-template/_provenance.json
+++ b/casts/claude/skills/cwl-summary-to-galaxy-template/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/cwl-summary-to-galaxy-template/index.md",
     "revision": 3,
     "content_hash": "c459c675508e1e9ad170fefa2de04054de97e74dcdedfd444f7f319f7e09f55b",
-    "commit": "2cc40cf0b5be4a3d4858e017783df537cd39be01"
+    "commit": "97effead63ef05cbac9d7f7227d8695a9e571e79"
   },
-  "cast_at": "2026-05-11T17:10:13.565Z",
+  "cast_at": "2026-05-11T20:45:02.980Z",
   "refs": [
     {
       "kind": "pattern",
@@ -66,8 +66,8 @@
       "evidence": "corpus-observed",
       "purpose": "Translate CWL arrays, records, scatter, and secondary-file shapes into Galaxy collection typing and map-over/reduction semantics.",
       "trigger": "When creating workflow inputs, outputs, and placeholder connections involving collections.",
-      "src_hash": "7ab0d19256c0c547ea89ef6fe29bf1ad0689b266011d33bd5b1a7e76ebd945d4",
-      "dst_hash": "7ab0d19256c0c547ea89ef6fe29bf1ad0689b266011d33bd5b1a7e76ebd945d4",
+      "src_hash": "4a4facb6a8a4498638e4c5af1314b83dde5d5481f1b89dee57b1efcaebfad45f",
+      "dst_hash": "4a4facb6a8a4498638e4c5af1314b83dde5d5481f1b89dee57b1efcaebfad45f",
       "source": "deterministic"
     },
     {
@@ -134,14 +134,14 @@
       "kind": "schema",
       "mode": "verbatim",
       "ref": "[[summary-cwl]]",
-      "src": "package://@galaxy-foundry/summary-cwl-schema#summaryCwlSchema",
+      "src": "package://@galaxy-foundry/foundry#summaryCwlSchema",
       "dst": "references/schemas/summary-cwl.schema.json",
       "used_at": "runtime",
       "load": "upfront",
       "evidence": "cast-validated",
       "purpose": "Read CWL source graph, step ids, command surfaces, scatter, conditionals, requirements, and warnings while emitting placeholder steps.",
-      "src_hash": "fa129417d48b9d70ab6051e6e0dad8af2f5c5ff86932bde9ec8d8f384acab581",
-      "dst_hash": "fa129417d48b9d70ab6051e6e0dad8af2f5c5ff86932bde9ec8d8f384acab581",
+      "src_hash": "0f2afd3d103658dcbcbb4416d803e8d81d02aa749d1c9c98d72d5abe7f34ccd5",
+      "dst_hash": "0f2afd3d103658dcbcbb4416d803e8d81d02aa749d1c9c98d72d5abe7f34ccd5",
       "source": "deterministic"
     }
   ],

--- a/casts/claude/skills/cwl-summary-to-galaxy-template/_verify.json
+++ b/casts/claude/skills/cwl-summary-to-galaxy-template/_verify.json
@@ -7,8 +7,9 @@
       "kind": "json",
       "default_filename": "summary-cwl.json",
       "schema": "[[summary-cwl]]",
-      "validator_bin": "validate-summary-cwl",
+      "validator_bin": "foundry",
       "args": [
+        "validate-summary-cwl",
         "{artifact_path}"
       ]
     }

--- a/casts/claude/skills/cwl-summary-to-galaxy-template/references/notes/galaxy-collection-semantics.md
+++ b/casts/claude/skills/cwl-summary-to-galaxy-template/references/notes/galaxy-collection-semantics.md
@@ -19,6 +19,7 @@ related_notes:
   - "[[galaxy-tool-job-failure-reference]]"
   - "[[galaxy-workflow-invocation-failure-reference]]"
   - "[[iwc-transformations-survey]]"
+  - "[[galaxy-discover-datasets]]"
 sources:
   - "https://github.com/galaxyproject/galaxy/blob/7765fae934fbfdee77e3be5f5b235e43735273ae/lib/galaxy/model/dataset_collections/types/collection_semantics.yml"
 summary: "Vendored formal spec of Galaxy dataset-collection mapping/reduction semantics, with labeled examples and pinned test references."

--- a/casts/claude/skills/cwl-summary-to-galaxy-template/references/schemas/summary-cwl.schema.json
+++ b/casts/claude/skills/cwl-summary-to-galaxy-template/references/schemas/summary-cwl.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://galaxyproject.org/foundry/schemas/summary-cwl.schema.json",
-  "$comment": "Canonical source: packages/summary-cwl-schema/src/summary-cwl.schema.json in jmchilton/foundry. Mold frontmatter cites this schema via [[summary-cwl]] wiki-links; the cast pipeline imports the `summaryCwlSchema` runtime export and serializes it into cast bundles.",
+  "$comment": "Canonical source: packages/foundry/src/schemas/summary-cwl/summary-cwl.schema.json in jmchilton/foundry. Mold frontmatter cites this schema via [[summary-cwl]] wiki-links; the cast pipeline imports the `summaryCwlSchema` runtime export and serializes it into cast bundles.",
   "title": "CWL Workflow Summary",
   "description": "Structured per-source summary emitted by the summarize-cwl Mold. CWL is already a typed workflow language, so this schema records validated and normalized workflow/tool structure rather than inferred pipeline semantics.",
   "type": "object",

--- a/casts/claude/skills/summarize-cwl/_provenance.json
+++ b/casts/claude/skills/summarize-cwl/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/summarize-cwl/index.md",
     "revision": 2,
     "content_hash": "fc96f678cb072237347f4990644a86c47d84f4fff303160fbb4ae3a92a55e1c5",
-    "commit": "8fed7f97a38f7fdd34a8d173a6a11177404091b0"
+    "commit": "97effead63ef05cbac9d7f7227d8695a9e571e79"
   },
-  "cast_at": "2026-05-11T14:24:12.123Z",
+  "cast_at": "2026-05-11T20:44:59.438Z",
   "refs": [
     {
       "kind": "cli-tool",
@@ -50,8 +50,8 @@
       "load": "upfront",
       "evidence": "cast-validated",
       "purpose": "Schema-check summary-cwl.json before returning it from the skill.",
-      "src_hash": "10511e9fde995a675800000f4aff9ba6734c35f08cbb11311a7ce12167044851",
-      "dst_hash": "10511e9fde995a675800000f4aff9ba6734c35f08cbb11311a7ce12167044851",
+      "src_hash": "4bdf7a69637c360258e86738aab65b946347629f84695f1c7e6bf7c49fc75b32",
+      "dst_hash": "4bdf7a69637c360258e86738aab65b946347629f84695f1c7e6bf7c49fc75b32",
       "source": "deterministic"
     },
     {

--- a/casts/claude/skills/summarize-cwl/references/cli/foundry.md
+++ b/casts/claude/skills/summarize-cwl/references/cli/foundry.md
@@ -20,16 +20,7 @@ summary: "Foundry CLI: bundles all Mold IO validators and a summarize-nextflow s
 
 # foundry
 
-Unified Foundry CLI. Subcommands cover every Mold IO validator plus a `summarize-nextflow` wrapper around the standalone `@galaxy-foundry/summarize-nextflow` package.
-
-## Subcommands
-
-- `foundry validate-summary-nextflow <file>` — AJV gate for [[summary-nextflow]] artifacts.
-- `foundry validate-summary-cwl <file>` — AJV gate for [[summary-cwl]] artifacts.
-- `foundry validate-galaxy-tool-discovery <file>` — AJV gate for [[galaxy-tool-discovery]] recommendations.
-- `foundry validate-galaxy-tool-summary <file>` — AJV gate for [[galaxy-tool-summary]] manifests, including the nested `parsed_tool` subtree against [[parsed-tool]].
-- `foundry validate-tests-format <file>` — AJV gate for planemo-format workflow tests against [[tests-format]].
-- `foundry summarize-nextflow <pipeline>` — wraps `@galaxy-foundry/summarize-nextflow`'s `buildSummary` + `validateSummary` via library import.
+Unified Foundry CLI. Subcommands cover every Mold IO validator plus a `summarize-nextflow` wrapper around the standalone `@galaxy-foundry/summarize-nextflow` package. Per-subcommand synopsis, args, and options are rendered from `@galaxy-foundry/foundry/meta`.
 
 ## Install
 

--- a/content/molds/compare-against-iwc-exemplar/refinements/2026-05-11-ga4gh-challenge-cwl-galaxy-5step.md
+++ b/content/molds/compare-against-iwc-exemplar/refinements/2026-05-11-ga4gh-challenge-cwl-galaxy-5step.md
@@ -1,0 +1,33 @@
+---
+mold: compare-against-iwc-exemplar
+date: 2026-05-11
+intent: 5-step CWL→Galaxy emulation on Barski-Lab/ga4gh_challenge biowardrobe_chipseq_se.cwl
+decision: eval-add
+---
+
+## What worked
+
+- Procedure adapted cleanly from a CWL-source brief. The Feature Hierarchy (domain → topology → tool family → DAG → outputs → tests) drove a useful structural diff against `epigenetics/chipseq-sr`.
+- Routing-findings categories (template/data-flow, pattern, tool-step, test) mapped 1:1 to actionable handoffs for the downstream template skill and for future pattern work.
+- "No tool discovery" non-goal held: I named IUC candidates ("`iuc/macs2`", "`devteam/bowtie2`") at the candidate level only, not at the `tool_id` level.
+
+## Gaps surfaced
+
+1. **Eval has zero CWL-source cases.** `eval.md` currently contains five cases:
+   - `nf-core rnaseq nearest exemplar`
+   - `nf-core viralrecon nearest exemplar`
+   - `nf-core mag nearest exemplar`
+   - `no acceptable exemplar`
+   - `IWC clone reuse`
+
+   The first four are Nextflow-flavored; the fifth is source-agnostic. The Mold is positioned in three pipelines (`nextflow-to-galaxy`, `cwl-to-galaxy`, `paper-to-galaxy`) but only one is exercised by eval. This run was unscored on every domain-specific case. **Recommend adding at least one CWL-source case** (ChIP-seq, RNA-seq, or metagenomics) so CWL drift is caught by eval.
+
+2. **CWL-specific feature: nested workflow boundary.** The fixture's nested `#bam-bedgraph-bigwig.cwl` is a CWL idiom that has no direct nf-core analog (Nextflow subworkflows live in a different place in the source structure). The IWC comparison surfaced "inline as three Galaxy steps" as the right move, but the routing-findings vocabulary doesn't have a category for "this CWL nested-workflow boundary should be inlined vs. authored as a Galaxy sub-workflow." Consider whether nested-workflow handling needs to be a separate finding type or whether the existing template/data-flow category absorbs it cleanly.
+
+3. **Faithful-conversion vs IWC-alignment is recurring.** Five of six routing findings in this run were of the form "the source CWL does X; the IWC chipseq-sr does Y; pick fidelity or alignment." This is the central tension when converting a real foreign workflow, but the current procedure doesn't name it. Worth adding to the Mold's prose: "When the source pipeline diverges from the IWC exemplar, name the fidelity-vs-alignment tradeoff and let the template skill decide per step rather than picking globally."
+
+## Open questions
+
+- Add a CWL eval case keyed on `epigenetics/chipseq-sr` and the ga4gh_challenge fixture? Or wait until the corpus has more CWL emulation runs?
+- Promote the faithful-vs-aligned framing to a first-class section in the SKILL.md procedure?
+- Should "Directory → reference data table" be surfaced as a candidate pattern page from this Mold's routing findings, or is that a step too far?

--- a/content/molds/compare-against-iwc-exemplar/refinements/2026-05-11-salmon-rnaseq-cwl-galaxy-5step.md
+++ b/content/molds/compare-against-iwc-exemplar/refinements/2026-05-11-salmon-rnaseq-cwl-galaxy-5step.md
@@ -1,0 +1,27 @@
+---
+mold: compare-against-iwc-exemplar
+date: 2026-05-11
+intent: 5-step CWL→Galaxy emulation on hubmapconsortium/salmon-rnaseq pipeline.cwl
+decision: eval-add
+---
+
+## What worked
+
+- Local IWC mirror (`~/projects/repositories/workflow-fixtures/iwc-format2/`) was already populated; reuse case (eval "IWC clone reuse") passed.
+- "No single exemplar covers the whole workflow" framing emerged honestly — the brief carved the pipeline into three slices (fastq-to-matrix front-half, scanpy-clustering back-half, velocity branch) and matched each independently. None forced a high-confidence claim.
+- Concrete IWC reference workflows (10x v3, scanpy-clustering, velocyto) gave actionable structural guidance to the downstream template Mold — especially the `pick_value` idiom and `map_param_value`-for-version-switching pattern.
+
+## Gaps surfaced
+
+1. **`eval.md` has zero CWL-flavored cases.** Same finding as the ga4gh run. Every existing case (`nf-core rnaseq`, `nf-core viralrecon`, `nf-core mag`, `no acceptable exemplar`, `IWC clone reuse`) is nf-core-flavored; only `IWC clone reuse` is fixture-agnostic enough to apply to a CWL run. This run is unscored against the eval. Add at minimum:
+   - "CWL scRNA-seq workflow nearest exemplar" — expected to surface the scRNAseq subdirectory exemplars at medium confidence and call out the slice-by-slice mismatch.
+   - "CWL multi-slice translation" — when the source pipeline has no single IWC analogue but multiple partial analogues, the brief should *not* force one exemplar.
+
+2. **No IUC Salmon-Alevin scRNA-seq workflow in the local mirror.** I asserted this from the local clone only. Worth a quick GitHub-side check to confirm before refining; if absent, the Mold should surface "no exemplar for primary tool family" as a low-confidence ranking signal, not as a Mold gap.
+
+3. **The brief leaned on tool selection (IUC `pick_value`, `map_param_value`) that the data-flow brief did not name.** This is fine — IWC comparison is the natural place to suggest IUC tools — but it crosses into territory the data-flow Mold deliberately keeps neutral on (no invented tool IDs). The boundary between "IWC comparison may name tools" and "data-flow stays neutral" is implicit; worth a short sentence in the Mold procedure.
+
+## Open questions
+
+- Add a CWL-flavored case set to `eval.md`? Recommend yes.
+- Is the "name IUC tools observed in nearest exemplars" boundary deliberate? Document either way.

--- a/content/molds/cwl-summary-to-galaxy-data-flow/refinements/2026-05-11-salmon-rnaseq-cwl-galaxy-5step.md
+++ b/content/molds/cwl-summary-to-galaxy-data-flow/refinements/2026-05-11-salmon-rnaseq-cwl-galaxy-5step.md
@@ -1,0 +1,28 @@
+---
+mold: cwl-summary-to-galaxy-data-flow
+date: 2026-05-11
+intent: 5-step CWL→Galaxy emulation on hubmapconsortium/salmon-rnaseq pipeline.cwl
+decision: schema-change
+---
+
+## What worked
+
+- The brief consumed both the interface brief and the `summary-cwl.json` graph cleanly for the *main* workflow.
+- The `when:` / `pickValue` translation framing in `cwl-when-pickvalue-to-galaxy-branching` mapped onto the salmon-rnaseq case naturally: collapse-into-single-parameterized-tool was the obvious recommendation once the branch was visible.
+- The downstream template Mold consumed the brief without re-asking for collection-shape, topology, or branch-handling decisions.
+
+## Gaps surfaced
+
+1. **Nested-workflow `when:` / `pickValue` invisible from the summary.** This is the same root cause as the matching `summarize-cwl` refinement, but it bit hardest in this Mold. The whole point of the data-flow brief is to surface translation pressure: scatter, when, pickValue, ExpressionTool, secondaryFiles. Of those, this fixture has all of them concentrated inside `steps/salmon-quantification.cwl` — and the summary surfaced none. I had to drop down to raw CWL to write the brief honestly. Two `eval.md` cases are at risk: "pickValue is not silently dropped" and "ExpressionTool steps surface as placeholders". A faithful run of *this* Mold can pass those cases only if the upstream summary actually carries the markers.
+
+   The data-flow Mold's procedure should either (a) require that the summary carry nested-workflow internals (and refuse to operate if it doesn't), or (b) acknowledge the source CWL as a fallback input and document the fallback. (a) is the right answer; the Mold is the consumer that breaks first when the contract is incomplete.
+
+2. **`Directory` → Galaxy collection shape is underspecified.** The reference note `galaxy-collection-semantics.md` covers list / paired / list:paired / paired_or_unpaired / sample_sheet, but does not have a worked recipe for CWL `Directory` / `Directory[]` inputs. The brief recommends `list:list` (and then the IWC comparison brief flipped that to `list:paired`). The Mold has to make a guess here. A short reference note `cwl-directory-to-galaxy-collection.md` covering the four common cases (`Directory`, `Directory[]`, `Directory?`, `Directory` + scatter) would prevent the guess.
+
+3. **No native gxformat2 `when:` is hard to express clearly.** The brief acknowledged Galaxy's lack of step-level conditional execution but the framing for "use optional outputs and let absent ones be empty" is fragmented across `galaxy-collection-semantics.md` and `cwl-when-pickvalue-to-galaxy-branching.md`. The latter focuses on `when:` driven by *input topology* (paired vs unpaired reads), not by *parameter values* (organism=human|mouse). A reference note (or a section in the existing one) covering "parameter-driven when:" specifically would help.
+
+## Open questions
+
+- Should this Mold's procedure declare a hard precondition: nested-workflow internals must be in the summary, or operation halts?
+- Worth a focused `cwl-directory-to-galaxy-collection.md` note (4 shapes × 2 contexts) or a section in the existing `galaxy-collection-semantics.md`?
+- Where should "parameter-driven `when:` translation" live — extend `cwl-when-pickvalue-to-galaxy-branching.md` or add a sibling note?

--- a/content/molds/cwl-summary-to-galaxy-interface/refinements/2026-05-11-salmon-rnaseq-cwl-galaxy-5step.md
+++ b/content/molds/cwl-summary-to-galaxy-interface/refinements/2026-05-11-salmon-rnaseq-cwl-galaxy-5step.md
@@ -1,0 +1,25 @@
+---
+mold: cwl-summary-to-galaxy-interface
+date: 2026-05-11
+intent: 5-step CWL→Galaxy emulation on hubmapconsortium/salmon-rnaseq pipeline.cwl
+decision: keep
+---
+
+## What worked
+
+- Workflow inputs and outputs map cleanly from the summary; the Directory[] → list:list discussion landed in "open questions" without forcing a choice prematurely.
+- Optional `null|File` workflow outputs (scVelo / SquidPy branches) surfaced as "optional public outputs" rather than being collapsed; downstream data-flow brief and template both used the distinction.
+- "Promote as public / optional / checkpoint" structure carries over well from the ga4gh run.
+
+## Gaps surfaced
+
+1. **Three Directory-typed inputs and one Directory-typed output, no IUC convention to lean on.** The brief stalled on every Directory case the same way: "open question, recommend X". With three Directory inputs (`fastq_dir: Directory[]`, `img_dir: Directory?`, `metadata_dir: Directory?`) and one Directory workflow output (`salmon_output`), this fixture is the worst-case for the gap. A reference note `cwl-directory-to-galaxy-collection.md` (or section in the existing collection-semantics note) would let the brief converge.
+
+2. **`assay` enum allowed values come from a nested CWL document, not the summary.** The brief flagged this as open question #5, but a faithful "interface" Mold should be able to enumerate select-parameter allowed values when the source CWL constrains them. Currently the constraint is buried in `salmon-quantification.cwl` and `salmon.cwl` (presumably a switch on `assay` string), and `summarize-cwl` doesn't surface enum-like discriminators. Probably out of scope for *this* Mold to fix; flag for `summarize-cwl`.
+
+3. **`organism` is a `when:`-discriminator masquerading as a free string.** The CWL declares `organism: string?, default: human` but inside the nested workflow it gates `salmon` vs `salmon-mouse` via `when:`. From a `summary-cwl.json` perspective the field is just `string?`. The interface brief recommended treating it as a select (correct call), but only because I read the nested CWL directly. Same root cause as the data-flow refinement: nested-workflow `when:` markers should reach this Mold.
+
+## Open questions
+
+- Same as data-flow: where should "CWL Directory → Galaxy collection" reference live?
+- Should the interface Mold's procedure explicitly say "when the summary exposes a value-driven `when:` predicate against a workflow input, treat that input as a select parameter with the enumerated values"?

--- a/content/molds/cwl-summary-to-galaxy-template/refinements/2026-05-11-salmon-rnaseq-cwl-galaxy-5step.md
+++ b/content/molds/cwl-summary-to-galaxy-template/refinements/2026-05-11-salmon-rnaseq-cwl-galaxy-5step.md
@@ -1,0 +1,27 @@
+---
+mold: cwl-summary-to-galaxy-template
+date: 2026-05-11
+intent: 5-step CWL→Galaxy emulation on hubmapconsortium/salmon-rnaseq pipeline.cwl
+decision: keep
+---
+
+## What worked
+
+- Skeleton structurally validates via `gxwf validate --no-tool-state` despite carrying TODO `tool_id` / `tool_version` and TODO_-prefixed port names everywhere. `_plan_state` / `_plan_context` survives validation untouched.
+- Collapsing the CWL `salmon` + `salmon-mouse` `when:` branches into one parameterized `salmon_alevin` step (per the data-flow brief's recommendation) produced a single linear path with no `pick_value` step — cleaner than mirroring the CWL shape.
+- Flattening `salmon-quantification.cwl` into the main workflow eliminated a workflow boundary that exists in CWL only because the nested workflow was reused-by-design but is never actually reused.
+- Per-step `_plan_context` blocks captured the source CWL filename for every step, which is what `implement-galaxy-tool-step` will need first.
+
+## Gaps surfaced
+
+1. **`gxwf validate --no-tool-state` accepts `TODO_*` connections without complaint.** This is fine — the eval explicitly says "draft is expected to *fail* a strict validate" — but `--no-tool-state` is permissive enough that it also misses real wiring bugs. Two of my output `outputSource: step/TODO_output_id` references would never resolve at runtime because the named outputs only exist in the matching step's `out:` list, where I also wrote `TODO_*`. The draft is internally consistent only by convention: I used the same TODO suffix on both sides. A stricter "TODO-aware" lint that requires `outputSource: X/Y` to match a `step X` with an `out: [{id: Y}]` would catch the cases where the suffix drifts. This is a gxwf concern more than a Mold concern, but the Mold could emit a self-check comment.
+
+2. **Optional `image_directory` flowing into `squidpy_analysis` is wired but ungated.** Galaxy gxformat2 has no step-level `when:`, so the brief routes the conditional through "wrappers tolerate absent inputs". The skeleton wires `TODO_img_dir: image_directory` directly. This is correct for gxformat2 semantics but the per-step authoring Mold downstream needs to know the wrapper *must* accept absent input. The current `_plan_state` captures it for `squidpy_analysis` but not for `annotate_cells`, which also takes optional `image_directory` and `metadata_directory`. Tightening: every step that consumes an optional workflow input should call that out in `_plan_state` (or a dedicated `_plan_optional_inputs` field).
+
+3. **No `_plan_test_*` or fixture hint slot.** The data-flow brief flagged "no tests discoverable" and the template Mold has nowhere to land that signal beyond a top-level `doc:`. Either the template emits a placeholder `_plan_tests` block at the workflow root or the format explicitly carries "test plan deferred" as a structured signal so `cwl-test-to-galaxy-test-plan` can pick it up without re-reading the data-flow brief.
+
+## Open questions
+
+- Strengthen `_plan_state` to require optional-input flags per step?
+- Add a workflow-level `_plan_tests` / `_plan_fixtures` block to the gxformat2 draft format?
+- Is it worth emitting a one-line `_plan_self_check` per step asserting that the `outputSource` suffix matches one of the listed `out:` ids, even when both sides are TODO?

--- a/content/molds/summarize-cwl/refinements/2026-05-11-ga4gh-challenge-cwl-galaxy-5step.md
+++ b/content/molds/summarize-cwl/refinements/2026-05-11-ga4gh-challenge-cwl-galaxy-5step.md
@@ -1,0 +1,26 @@
+---
+mold: summarize-cwl
+date: 2026-05-11
+intent: 5-step CWL→Galaxy emulation on Barski-Lab/ga4gh_challenge biowardrobe_chipseq_se.cwl
+decision: open-question
+---
+
+## What worked
+
+- Procedure as written is sufficient: `cwltool --validate` → normalize → extract structure → schema-validate. The fixture (1 main workflow, 1 nested workflow, 12 CommandLineTools, no scatter/when/pickValue) sat comfortably inside the schema.
+- The `summary-cwl` schema accommodated the fixture with no edits — including the nested workflow (treated as a `Workflow`-class entry in `tools[]` with a `_NestedWorkflow` hint in `requirements/raw`).
+- Validation against `foundry validate-summary-cwl` caught real authoring bugs (graph-node `kind` enum, `provenance: string`, `diagnostics: string[]`). Schema-as-contract held.
+
+## Gaps surfaced
+
+1. **`cwl-normalizer` is broken with current `cwl-utils` + `ruamel.yaml`.** `uvx --from cwl-utils cwl-normalizer` errors with `'round_trip_load_all()' has been removed`. The skill bundle names `cwl-normalizer` as a required tool but it's unusable as of this run. Working alternative: `cwltool --pack` produces a `$graph`-bundled JSON document that is structurally equivalent for extraction purposes and is what this run used. The SKILL.md should either pin a working `cwl-utils` version or accept `cwltool --pack` as the normalization step.
+
+2. **No CLI implementation.** `summarize-nextflow` has a deterministic CLI (`foundry summarize-nextflow ...`); `summarize-cwl` does not. The procedure expects the LLM to read the packed CWL document and emit `summary-cwl.json` directly. For a 14-document workflow that's ~3700 lines of normalized JSON and ~160 KB of output — feasible but expensive per run, and easy to get the enum/type fields wrong. I had to write a 130-line one-off `extract.mjs` to do the structural extraction deterministically. A `foundry summarize-cwl` companion would pay for itself fast and would make `eval.md`'s `check: deterministic` cases meaningfully deterministic.
+
+3. **Cast verify error on `summarize-cwl`.** After re-cast, `scripts/cast-skill-verify.ts summarize-cwl --target=claude` reports `error: _provenance.json: /refs/1/kind must be equal to one of the allowed values` for refs `1` and `2` (the two `cli-command` references). The other 4 CWL→Galaxy Molds verify clean. Worth investigating whether the `kind: cli-command` value or the verify schema is the outlier.
+
+## Open questions
+
+- Should the SKILL.md's "Required Tools" be updated to either pin a working `cwl-utils` or accept `cwltool --pack` as the normalization step?
+- Is `foundry summarize-cwl` worth scoping as a CLI?
+- What's the right shape for representing a nested CWL `Workflow` in `tools[]`? This run used a `_NestedWorkflow`-classed entry inside `requirements`; the schema accepts it but does not endorse it.

--- a/content/molds/summarize-cwl/refinements/2026-05-11-salmon-rnaseq-cwl-galaxy-5step.md
+++ b/content/molds/summarize-cwl/refinements/2026-05-11-salmon-rnaseq-cwl-galaxy-5step.md
@@ -1,0 +1,29 @@
+---
+mold: summarize-cwl
+date: 2026-05-11
+intent: 5-step CWL→Galaxy emulation on hubmapconsortium/salmon-rnaseq pipeline.cwl
+decision: schema-change
+---
+
+## What worked
+
+- `cwltool --validate` + `cwltool --pack` produced a clean 14-entry `$graph` JSON for a v1.2 source. Procedure survives the v1.2 case once the normalizer is sidestepped.
+- Schema accommodated the fixture: scatter at the workflow level (fastqc), array inputs (`Directory[]`), optional Directory inputs, a nested Workflow with its own `when:` and `pickValue` machinery.
+
+## Gaps surfaced
+
+1. **`cwl-normalizer` rejects v1.2 inputs outright.** The user's patched `cwl-utils` (`fix-normalizer-ruamel-018`) fixes the ruamel-0.18 breakage but does **not** address the more fundamental bug: `normalizer.py` only upgrades `draft-3 | v1.0 | v1.1` and falls through to an error for any other version, including v1.2. The error message itself is also broken — `_logger.error("Sorry, %s in %s is not a supported CWL version by this tool.", (version, document))` passes a tuple as a single arg and trips a `TypeError: not enough arguments for format string` in stdlib `logging`. Two separate bugs: (a) v1.2 should be a no-op upgrade, not an error, and (b) the error-formatting call shape is wrong. Same workaround as the ga4gh run: `cwltool --pack` substitutes for `cwl-normalizer`.
+
+2. **Extractor (and skill procedure) loses nested-workflow wiring.** This is the salmon-rnaseq–specific finding: the LLM-emulated `summary-cwl.json` represents `salmon-quantification.cwl` as a `tools[]` entry with a `_NestedWorkflow` hint that lists only `{id, run, scatter}` per inner step. The nested workflow's `in:` / `out:` graph, its `when: $(inputs.organism == 'human')` predicates, and its `pickValue: first_non_null` merge on `output_dir` are **not** in the summary. I had to read `steps/salmon-quantification.cwl` directly to drive the data-flow brief. The biggest Galaxy translation decision in this workflow (collapse `when:`-split salmon vs salmon-mouse into one parameterized step) is invisible in the summary.
+
+   This is the highest-leverage `summarize-cwl` improvement: the schema and the procedure should preserve nested-workflow internals — at minimum `inputs`, `outputs`, `steps[].in[]`, `steps[].out`, `steps[].when`, and `steps[].in[].pick_value`. Either by extending the nested-workflow record shape in `tools[]`, or by promoting nested workflows into their own top-level `subworkflows[]` array. The latter feels right: nested workflows are workflows, not tools.
+
+3. **`Directory[]` workflow input + workflow-step `scatter` over it.** The schema accepted it; the brief consumed it. But the summary's `workflow_inputs[].type: "array"` is lossy — the array's `items` (Directory) is gone. Galaxy collection-shape choice (list:paired vs list:list vs Apply Rules) hinges on the inner type. The summary should preserve `array.items` either as a structured field or as a more discriminating type string (`Directory[]` rather than `array`).
+
+4. **No tests discoverable, no jobs file at repo root.** The HuBMAP repo has no sibling job YAML / inputs JSON at the entrypoint location; the `data/` directory contains references but no per-assay job. The procedure correctly emitted `tests: []` but the user-facing experience is that the downstream test-plan Mold is blocked with no breadcrumbs. Worth a procedure note: when `tests: []` is emitted, surface what locations were searched.
+
+## Open questions
+
+- Promote nested workflows to a structured `subworkflows[]` array rather than smuggling them through `tools[]` with a `_NestedWorkflow` hint?
+- Should `summary-cwl` retain `array.items` (or use a richer type representation) so collection-shape downstream Molds don't lose the inner type?
+- Is it worth opening a `cwl-utils` issue for the v1.2-input and error-format bugs in `cwl-normalizer`?

--- a/workflow-fixtures/fixtures.yaml
+++ b/workflow-fixtures/fixtures.yaml
@@ -406,6 +406,122 @@ cwl_repositories:
       surfaces and comparing DockerRequirement/SoftwareRequirement evidence
       with Galaxy Tool Shed wrapper discovery.
 
+  - name: Barski-Lab/ga4gh_challenge
+    flavor: bio-workflow
+    tier: tiny
+    repo: https://github.com/Barski-Lab/ga4gh_challenge.git
+    sha: f28d47bd0911e5e7210c4dc83f75653a1e0297c9
+    entrypoints:
+      - biowardrobe_chipseq_se.cwl
+    notes: >
+      GA4GH workflow-execution challenge entry: a single SE ChIP-seq workflow
+      with one subworkflow. Small, self-contained, fully resolvable — good
+      baseline for end-to-end CWL→Galaxy conversion smoke tests.
+
+  - name: pitagora-network/pitagora-cwl
+    flavor: bio-workflow
+    tier: small
+    repo: https://github.com/pitagora-network/pitagora-cwl.git
+    sha: 4e84905f265e1db212c406d34ae4db2bf565e856
+    entrypoints:
+      - workflows/bwa/BwaWorkflow-pe.cwl
+      - workflows/bowtie2/Bowtie2Workflow-pe.cwl
+      - workflows/download-fastq/download-fastq.cwl
+      - workflows/download-fastq/download-fastq.packed.cwl
+      - workflows/hisat2-cufflinks/paired_end/hisat2-cufflinks_wf_pe.cwl
+    notes: >
+      Many small bio workflows (aligners + RNA-seq quantification) over a
+      shared tools/ library. Mostly linear, modest scatter usage. Includes a
+      `.packed.cwl` single-document variant for exercising the packed-workflow
+      parse path.
+
+  - name: Duke-GCB/GGR-cwl
+    flavor: bio-workflow
+    tier: small
+    repo: https://github.com/Duke-GCB/GGR-cwl.git
+    sha: 487af88ef0b971f76ecd1a215639bb47e3ee94e1
+    entrypoints:
+      - v1.0/ChIP-seq_pipeline/pipeline-se.cwl
+      - v1.0/ATAC-seq_pipeline/pipeline-pe.cwl
+      - v1.0/RNA-seq_pipeline/pipeline-pe-unstranded.cwl
+    notes: >
+      Duke GCB ChIP-seq / ATAC-seq / RNA-seq pipelines. Sibling v1.0 and
+      draft-3 trees in one repo — useful for CWL version diversity. Numbered
+      stage subworkflows wired by a top-level pipeline workflow; clean
+      mid-tier bio exemplar.
+
+  - name: h3abionet/h3agatk
+    flavor: bio-workflow
+    tier: small
+    repo: https://github.com/h3abionet/h3agatk.git
+    sha: d01ce5540114abba7b54fde0f865e5865c21dc64
+    entrypoints:
+      - workflows/GATK/GATK-complete-WES-Workflow-h3abionet.cwl
+      - workflows/GATK/GATK-complete-WGS-Workflow-h3abionet.cwl
+    notes: >
+      H3ABioNet GATK germline variant-calling workflow in CWL. Real
+      reference-data pressure (FASTA + multiple index secondaryFiles, dbSNP,
+      known indels) and large multi-step DAG — natural CWL counterpart to
+      nf-core/sarek.
+
+  - name: Barski-Lab/workflows
+    flavor: bio-workflow
+    tier: large
+    repo: https://github.com/Barski-Lab/workflows.git
+    sha: 4723ce567089dc9ee51e067b813c5b527a3da16a
+    entrypoints:
+      - workflows/chipseq-se.cwl
+      - workflows/chipseq-pe.cwl
+      - workflows/rnaseq-se.cwl
+      - workflows/rnaseq-pe.cwl
+    notes: >
+      BioWardrobe / SciDAP CWL workflow library. Heavy use of CWL extensions
+      (sd:* metadata hints), many sibling workflows over a shared tool tree.
+      Stresses extension handling and "ignore unknown hints" tolerance in
+      summarize-cwl.
+
+  - name: NCI-GDC/gdc-dnaseq-cwl
+    flavor: bio-workflow
+    tier: large
+    repo: https://github.com/NCI-GDC/gdc-dnaseq-cwl.git
+    sha: 65510af2ab705bfd3e9d4ca7281335de2adba2df
+    entrypoints:
+      - gdc-dnaseq-aln-cwl/gdc_dnaseq.bamfastq_align.workflow.cwl
+      - subworkflows/main/gdc_dnaseq_main_workflow.cwl
+    notes: >
+      NCI GDC production DNA-seq harmonization workflow. Deeply nested
+      subworkflow tree (extract / align / metrics / utils), conditional
+      markduplicates, custom `decider_*` tools. Hard mode for CWL→Galaxy
+      conversion — many subworkflow boundaries and decision points.
+
+  - name: NCI-GDC/gdc-rnaseq-cwl
+    flavor: bio-workflow
+    tier: large
+    repo: https://github.com/NCI-GDC/gdc-rnaseq-cwl.git
+    sha: 05460f7dfca5a900d7635ccae0e1b28cf764a02f
+    entrypoints:
+      - rnaseq-star-align/star2pass.rnaseq_harmonization.cwl
+      - rnaseq-star-align/subworkflows/gdc_rnaseq_main_workflow.cwl
+    notes: >
+      NCI GDC production RNA-seq harmonization workflow (STAR 2-pass).
+      Companion to gdc-dnaseq-cwl — same nested-subworkflow style, different
+      domain. Good for testing whether summarize-cwl output stays useful at
+      production scale.
+
+  - name: hubmapconsortium/salmon-rnaseq
+    flavor: bio-workflow
+    tier: small
+    repo: https://github.com/hubmapconsortium/salmon-rnaseq.git
+    sha: 2f77bcfe9d6eaccce04359ed110995de65d03422
+    entrypoints:
+      - pipeline.cwl
+      - bulk-pipeline.cwl
+    notes: >
+      HuBMAP single-cell + bulk RNA-seq via salmon/alevin. Modern Python-
+      analysis-heavy steps (scanpy, scvelo, squidpy). Both single-cell and
+      bulk entrypoints share a steps/ tree — useful for two-entrypoint
+      summary behavior.
+
 # IWC corpus — single rolling repo, no tag. Pin SHA from main.
 # Materialized into iwc-src/ then cleaned + converted to format2 under iwc-format2/
 # by scripts/build-iwc.sh (uses gxwf via @galaxy-tool-util/cli).


### PR DESCRIPTION
## Summary

- Test-drives the cwl-to-galaxy pipeline (`summarize-cwl` → interface → data-flow → `compare-against-iwc-exemplar` → template) end-to-end against two fresh CWL fixtures.
- Adds 8 pinned CWL bio-workflow fixtures (`Barski-Lab/ga4gh_challenge`, `pitagora-network/pitagora-cwl`, `Duke-GCB/GGR-cwl`, `h3abionet/h3agatk`, `Barski-Lab/workflows`, `NCI-GDC/gdc-{dnaseq,rnaseq}-cwl`, `hubmapconsortium/salmon-rnaseq`).
- Captures emulated artifacts under `casts/claude/skills/_emulated-runs/` and per-Mold refinement notes for every Mold the run exercised.
- Re-casts the four cwl→galaxy bundles against current `main` (picks up `galaxy-collection-semantics` related-notes refresh, schema whitespace, and the meta-driven `foundry` CLI reference).
- Adjusts `/test-drive` prompt to require a high-level eval of bundled research and to frame follow-ups as generalizations of lessons learned.

Surfaced gaps (captured in refinement notes, not fixed here):

- `cwl-normalizer` is broken upstream against current `cwl-utils` + `ruamel.yaml`; the runs fell back to `cwltool --pack`.
- No `foundry summarize-cwl` CLI yet — extraction had to be emulated via a one-off `extract.mjs`.
- `_verify.json` rejects `kind: cli-command` for the `summarize-cwl` cast (verifier outlier; other cwl→galaxy bundles are clean).
- Open shape question: how to represent nested CWL `Workflow` entries inside `tools[]`.

## Test plan

- [x] `npm run validate` — 0 errors, only pre-existing advisory warnings.
- [x] `npm run test` — 100 tests pass.
- [ ] Decide on follow-up issues for the four gaps above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)