### PR TITLE
rename pipeline INTERVIEW → WORKFLOW to INTERVIEW → GALAXY

### DIFF
--- a/content/Dashboard.md
+++ b/content/Dashboard.md
@@ -6,7 +6,7 @@ Generated from `dashboard_sections.json` and content frontmatter. Do not edit by
 
 | Name | Summary | Status | Revised | Rev |
 | --- | --- | --- | --- | --- |
-| [[interview-to-workflow]] | Interview-driven path to a Galaxy gxformat2 workflow through the shared freeform-summary handoff. | draft | 2026-05-22 | 1 |
+| [[interview-to-galaxy]] | Interview-driven path to a Galaxy gxformat2 workflow through the shared freeform-summary handoff. | draft | 2026-05-22 | 1 |
 | [[nextflow-to-galaxy]] | Direct path from a Nextflow pipeline to a Galaxy gxformat2 workflow. | draft | 2026-05-10 | 3 |
 | [[cwl-to-galaxy]] | Path from a CWL Workflow to a Galaxy gxformat2 workflow. Lighter upstream extraction. | draft | 2026-04-30 | 2 |
 | [[nextflow-to-cwl]] | Direct path from a Nextflow pipeline to a CWL Workflow + CommandLineTool set. | draft | 2026-04-30 | 2 |

--- a/content/Index.md
+++ b/content/Index.md
@@ -5,7 +5,7 @@ Generated from content frontmatter. Do not edit by hand.
 ## Pipelines
 
 - [[cwl-to-galaxy]] — Path from a CWL Workflow to a Galaxy gxformat2 workflow. Lighter upstream extraction.
-- [[interview-to-workflow]] — Interview-driven path to a Galaxy gxformat2 workflow through the shared freeform-summary handoff.
+- [[interview-to-galaxy]] — Interview-driven path to a Galaxy gxformat2 workflow through the shared freeform-summary handoff.
 - [[nextflow-to-cwl]] — Direct path from a Nextflow pipeline to a CWL Workflow + CommandLineTool set.
 - [[nextflow-to-galaxy]] — Direct path from a Nextflow pipeline to a Galaxy gxformat2 workflow.
 - [[paper-to-cwl]] — Direct path from a paper to a CWL Workflow + CommandLineTool set.

--- a/content/molds/compare-against-iwc-exemplar/index.md
+++ b/content/molds/compare-against-iwc-exemplar/index.md
@@ -22,7 +22,7 @@ input_artifacts:
   - id: cwl-galaxy-data-flow
     description: "Galaxy data-flow brief from [[cwl-summary-to-galaxy-data-flow]] when running the CWL → GALAXY pipeline."
   - id: freeform-galaxy-design
-    description: "Combined Galaxy interface + data-flow design brief from [[freeform-summary-to-galaxy-design]] when running PAPER → GALAXY or INTERVIEW → WORKFLOW pipelines."
+    description: "Combined Galaxy interface + data-flow design brief from [[freeform-summary-to-galaxy-design]] when running PAPER → GALAXY or INTERVIEW → GALAXY pipelines."
 output_artifacts:
   - id: iwc-comparison-notes
     kind: markdown

--- a/content/pipelines/interview-to-galaxy.md
+++ b/content/pipelines/interview-to-galaxy.md
@@ -1,6 +1,6 @@
 ---
 type: pipeline
-title: INTERVIEW → WORKFLOW
+title: INTERVIEW → GALAXY
 tags:
   - pipeline
   - source/interview
@@ -28,7 +28,7 @@ phases:
   - mold: "[[debug-galaxy-workflow-output]]"
 ---
 
-# INTERVIEW → WORKFLOW
+# INTERVIEW → GALAXY
 
 Interview-driven Galaxy workflow path. The live interview mechanics are harness-owned; this pipeline records the Mold spine after an interview has been normalized into the shared `freeform-summary` handoff.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -453,7 +453,7 @@ foundry/
 │   │       └── .gitkeep
 │   ├── pipelines/
 │   │   ├── paper-to-galaxy.md
-│   │   ├── interview-to-workflow.md
+│   │   ├── interview-to-galaxy.md
 │   │   ├── nextflow-to-galaxy.md
 │   │   ├── cwl-to-galaxy.md
 │   │   ├── paper-to-cwl.md

--- a/docs/HARNESS_PIPELINES.md
+++ b/docs/HARNESS_PIPELINES.md
@@ -12,7 +12,7 @@ Harness pipelines for the Galaxy Workflow Foundry. Each named pipeline phase cor
 
 CWL is unofficially positioned as a **low-level, high-structure interchange format** — suitable as an intermediate target between an unstructured/loosely-structured source (a paper, a Nextflow pipeline) and Galaxy. The Foundry must support **both direct and composed paths** as first-class options:
 
-- `PAPER → GALAXY` (direct), `INTERVIEW → WORKFLOW` (interview-normalized direct Galaxy path), and `PAPER → CWL → GALAXY` (composed) are valid.
+- `PAPER → GALAXY` (direct), `INTERVIEW → GALAXY` (interview-normalized direct Galaxy path), and `PAPER → CWL → GALAXY` (composed) are valid.
 - `NEXTFLOW → GALAXY` (direct) and `NEXTFLOW → CWL → GALAXY` (composed) are both valid.
 - Direct paths are simpler to run and debug. Composed paths buy a structured checkpoint (CWL) at the cost of running two harnesses.
 - Whether composition is reliable enough to *prefer* over direct is a longer-term research question. For now: both paths must be possible from the Mold inventory; the harness picks.
@@ -124,9 +124,9 @@ CWL is already structured; the upstream extraction work is much lighter.
 10. `run-workflow-test` — execute via Planemo.
 11. `debug-galaxy-workflow-output`
 
-### INTERVIEW → WORKFLOW
+### INTERVIEW → GALAXY
 
-The interview path is a Galaxy-targeting pipeline for now. The title stays user-facing because the interview starts from workflow intent rather than an existing technical artifact.
+The interview path is a Galaxy-targeting pipeline, named to match the other `→ GALAXY` pipelines. Unlike them it starts from workflow intent gathered in an interview rather than an existing technical artifact, normalized into the shared `freeform-summary` handoff.
 
 1. `interview-to-freeform-summary` — normalize a user interview transcript or interactive session into the shared `freeform-summary` handoff.
 2. `freeform-summary-to-galaxy-design`


### PR DESCRIPTION
> Opened by Claude (AI assistant) on jmchilton's behalf.

Aligns the interview pipeline's slug and title to the other three Galaxy-target pipelines (`cwl-to-galaxy`, `nextflow-to-galaxy`, `paper-to-galaxy`). Its frontmatter already declared `target/galaxy`; only the name was an outlier.

## Changes
- `content/pipelines/interview-to-workflow.md` → `interview-to-galaxy.md` (git mv); `title` + H1 → `INTERVIEW → GALAXY`
- `docs/HARNESS_PIPELINES.md` — path list, `###` section heading, and rewrote the rationale that previously defended keeping "WORKFLOW" (now explains the `→ GALAXY` naming + interview-intent distinction)
- `docs/ARCHITECTURE.md` — directory tree entry
- `content/molds/compare-against-iwc-exemplar/index.md` — prose reference
- `content/Dashboard.md` / `content/Index.md` — regenerated (new `[[interview-to-galaxy]]` slug + title)

## Validation
`npm run validate` → 0 errors; no leftover `interview-to-workflow` / `INTERVIEW → WORKFLOW` references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)