### PR TITLE
fix(release): run version-packages via npm script so && chains work

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
           # the bumped packages to npm and creates per-package git tags.
           # `pnpm -r sync` regenerates the foundry meta's version.generated.ts
           # so the Version Packages PR commits a consistent meta version too.
-          version: pnpm changeset version && pnpm -r sync
+          version: pnpm run version-packages
           publish: pnpm changeset publish
           title: "chore(release): version packages"
           commit: "chore(release): version packages"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "packages-format-fix": "prettier --write 'packages/*/src/**/*.ts' 'packages/*/test/**/*.ts'",
     "smoke:packages": "node scripts/smoke-packages.mjs",
     "changeset": "changeset",
-    "version-packages": "changeset version",
+    "version-packages": "changeset version && pnpm -r sync",
     "release": "pnpm -r build && changeset publish",
     "site:dev": "npm --prefix site run dev",
     "site:build": "npm --prefix site run build",


### PR DESCRIPTION
## Problem

The Release workflow failed: [run 27281060651](https://github.com/galaxyproject/foundry/actions/runs/27281060651/job/80575371708).

Two independent issues:

1. **`Too many arguments passed to changesets`** — the `changesets/action` `version:` input is **not** shell-evaluated; it execs the string directly. So `pnpm changeset version && pnpm -r sync` was parsed as a single `pnpm` call with `version && pnpm -r sync` passed as args to the `changeset` script.
2. **`GitHub Actions is not permitted to create or approve pull requests`** — repo setting `can_approve_pull_request_reviews` was `false`. Already flipped to `true` via the Actions permissions API (not part of this diff).

## Fix (this PR)

Move the `&&` chain into a package.json script (those run in a shell):

- `package.json`: `version-packages` → `changeset version && pnpm -r sync`
- `.github/workflows/release.yml`: `version:` → `pnpm run version-packages`

🤖 Generated with [Claude Code](https://claude.com/claude-code)