### PR TITLE
Reclassify 5 nfcore→galaxy notes: pattern → research/design-problem

### DIFF
--- a/content/Dashboard.md
+++ b/content/Dashboard.md
@@ -17,11 +17,11 @@ Generated from `dashboard_sections.json` and content frontmatter. Do not edit by
 
 | Name | Summary | Status | Revised | Rev |
 | --- | --- | --- | --- | --- |
+| [[convert-nfcore-module-to-galaxy-tool]] | Convert one nf-core module dir into a Galaxy tool wrapper (tool.xml + macros.xml + _provenance.yml + remote-URL <test> blocks). | draft | 2026-06-10 | 3 |
 | [[freeform-summary-to-galaxy-data-flow]] | Translate a free-form source summary into a Galaxy data-flow design brief. | draft | 2026-06-09 | 1 |
 | [[freeform-summary-to-galaxy-interface]] | Map a free-form source summary into a Galaxy workflow interface design brief. | draft | 2026-06-09 | 1 |
 | [[advance-galaxy-draft-step]] | Advance the gxformat2 draft by one step: pick the next drafty step, resolve a wrapper, implement the step, and validate. | draft | 2026-06-02 | 1 |
 | [[interview-to-freeform-summary]] | Normalize a free-form user interview into the shared freeform-summary workflow handoff. | draft | 2026-05-22 | 1 |
-| [[convert-nfcore-module-to-galaxy-tool]] | Convert one nf-core module dir into a Galaxy tool wrapper (tool.xml + macros.xml + _provenance.yml + remote-URL <test> blocks). | draft | 2026-05-11 | 2 |
 | [[implement-galaxy-workflow-test]] | Assemble Galaxy workflow test fixtures and assertions. | draft | 2026-05-11 | 6 |
 | [[cwl-summary-to-galaxy-data-flow]] | Translate a CWL summary into a Galaxy data-flow design brief. | draft | 2026-05-10 | 2 |
 | [[cwl-summary-to-galaxy-interface]] | Map a CWL summary into a Galaxy workflow interface design brief. | draft | 2026-05-10 | 2 |
@@ -61,11 +61,6 @@ Generated from `dashboard_sections.json` and content frontmatter. Do not edit by
 
 | Name | Summary | Status | Revised | Rev |
 | --- | --- | --- | --- | --- |
-| [[nfcore-channel-input-to-galaxy-collection]] | Map an nf-core process's tuple(meta, path) input channel to a Galaxy <param type="data"> or paired/list collection input. | draft | 2026-05-10 | 2 |
-| [[nfcore-meta-map-to-galaxy-params]] | Promote nf-core meta-map keys to Galaxy <param>s only when they drive script behavior; drop identity-only keys; pull naming from $input.element_identifier. | draft | 2026-05-10 | 2 |
-| [[nfcore-stub-block-to-galaxy-noop-test]] | nf-core's stub: block has no Galaxy analog; the convert Mold drops it intentionally and records the drop in _provenance.yml. | draft | 2026-05-10 | 2 |
-| [[nfcore-task-ext-args-to-galaxy-additional-options]] | Map nf-core's task.ext.args escape hatch to a single Galaxy text param surfacing extra command-line arguments. | draft | 2026-05-10 | 2 |
-| [[nfcore-versions-emit-to-galaxy-version-command]] | Translate nf-core's versions emit (heredoc or topic: versions) into Galaxy's <version_command>, dropping the versions output channel. | draft | 2026-05-10 | 2 |
 | [[cleanup-sync-and-publish-nonempty-results]] | Clean sparse mapped outputs, keep sibling collections aligned, then gate report publishing on non-empty results. | draft | 2026-05-04 | 1 |
 | [[fan-in-bundle-consume-and-flatten]] | Bundle parallel outputs into a collection consumer, then flatten nested results for pooled downstream processing. | draft | 2026-05-04 | 1 |
 | [[manifest-to-mapped-collection-lifecycle]] | Use a manifest or table to build a collection, map a tool per row, then relabel or reshape outputs. | draft | 2026-05-04 | 1 |
@@ -212,3 +207,13 @@ Generated from `dashboard_sections.json` and content frontmatter. Do not edit by
 | [[component-nextflow-inspect]] | White paper on Nextflow's native introspection subcommands — `nextflow inspect`, `nextflow config`, and adjacent tooling. Survey, not decision. | draft | 2026-05-01 | 1 |
 | [[component-nextflow-pipeline-anatomy]] | Stub. DSL2 layout, channel idioms, operator-chain reading rules. Grows from cast contact with rnaseq/sarek/ad-hoc — see issue #17. | draft | 2026-05-01 | 1 |
 | [[component-nf-core-tools]] | White paper on nf-core/tools — conventions, CLI surface, schema universe, container resolution. Survey, not decision. | draft | 2026-05-01 | 1 |
+
+## Design Problems
+
+| Name | Summary | Status | Revised | Rev |
+| --- | --- | --- | --- | --- |
+| [[nfcore-channel-input-to-galaxy-collection]] | Map an nf-core process's tuple(meta, path) input channel to a Galaxy <param type="data"> or paired/list collection input. | draft | 2026-06-10 | 3 |
+| [[nfcore-meta-map-to-galaxy-params]] | Promote nf-core meta-map keys to Galaxy <param>s only when they drive script behavior; drop identity-only keys; pull naming from $input.element_identifier. | draft | 2026-06-10 | 3 |
+| [[nfcore-stub-block-to-galaxy-noop-test]] | nf-core's stub: block has no Galaxy analog; the convert Mold drops it intentionally and records the drop in _provenance.yml. | draft | 2026-06-10 | 3 |
+| [[nfcore-task-ext-args-to-galaxy-additional-options]] | Map nf-core's task.ext.args escape hatch to a single Galaxy text param surfacing extra command-line arguments. | draft | 2026-06-10 | 3 |
+| [[nfcore-versions-emit-to-galaxy-version-command]] | Translate nf-core's versions emit (heredoc or topic: versions) into Galaxy's <version_command>, dropping the versions output channel. | draft | 2026-06-10 | 3 |

--- a/content/Index.md
+++ b/content/Index.md
@@ -76,11 +76,6 @@ Generated from content frontmatter. Do not edit by hand.
 - [[galaxy-conditionals-patterns]] — Use this MOC to choose corpus-grounded Galaxy when and pick_value conditional patterns.
 - [[galaxy-tabular-patterns]] — Use this MOC to choose corpus-grounded Galaxy tabular transformation patterns.
 - [[manifest-to-mapped-collection-lifecycle]] — Use a manifest or table to build a collection, map a tool per row, then relabel or reshape outputs.
-- [[nfcore-channel-input-to-galaxy-collection]] — Map an nf-core process's tuple(meta, path) input channel to a Galaxy <param type="data"> or paired/list collection input.
-- [[nfcore-meta-map-to-galaxy-params]] — Promote nf-core meta-map keys to Galaxy <param>s only when they drive script behavior; drop identity-only keys; pull naming from $input.element_identifier.
-- [[nfcore-stub-block-to-galaxy-noop-test]] — nf-core's stub: block has no Galaxy analog; the convert Mold drops it intentionally and records the drop in _provenance.yml.
-- [[nfcore-task-ext-args-to-galaxy-additional-options]] — Map nf-core's task.ext.args escape hatch to a single Galaxy text param surfacing extra command-line arguments.
-- [[nfcore-versions-emit-to-galaxy-version-command]] — Translate nf-core's versions emit (heredoc or topic: versions) into Galaxy's <version_command>, dropping the versions output channel.
 - [[compose-runtime-text-parameter]] — Use compose_text_param to build connected text expressions from constants plus runtime scalar values.
 - [[derive-parameter-from-file]] — Read a one-value dataset with param_value_from_file, including count recipes that feed typed parameters.
 - [[map-workflow-enum-to-tool-parameter]] — Use map_param_value to translate workflow enum values into downstream tool codes, flags, or snippets.
@@ -198,6 +193,14 @@ Generated from content frontmatter. Do not edit by hand.
 - [[nf-schema-samplesheet-galaxy-gaps]] — nf-schema validation mapped to Galaxy column_definitions: what survives, degrades, or is lost; Galaxy work items + cast loss-recording vocabulary.
 - [[planemo-asserts-idioms]] — Decision and idiom guide for picking planemo workflow-test assertions: which family per output type, how to size tolerances, when to validate.
 - [[planemo-workflow-test-architecture]] — Reference for Planemo workflow test/run architecture, Galaxy modes, API polling, and noisy failure boundaries.
+
+## Design Problems
+
+- [[nfcore-channel-input-to-galaxy-collection]] — Map an nf-core process's tuple(meta, path) input channel to a Galaxy <param type="data"> or paired/list collection input.
+- [[nfcore-meta-map-to-galaxy-params]] — Promote nf-core meta-map keys to Galaxy <param>s only when they drive script behavior; drop identity-only keys; pull naming from $input.element_identifier.
+- [[nfcore-stub-block-to-galaxy-noop-test]] — nf-core's stub: block has no Galaxy analog; the convert Mold drops it intentionally and records the drop in _provenance.yml.
+- [[nfcore-task-ext-args-to-galaxy-additional-options]] — Map nf-core's task.ext.args escape hatch to a single Galaxy text param surfacing extra command-line arguments.
+- [[nfcore-versions-emit-to-galaxy-version-command]] — Translate nf-core's versions emit (heredoc or topic: versions) into Galaxy's <version_command>, dropping the versions output channel.
 
 ## Design Specs
 

--- a/content/molds/convert-nfcore-module-to-galaxy-tool/index.md
+++ b/content/molds/convert-nfcore-module-to-galaxy-tool/index.md
@@ -9,12 +9,12 @@ tags:
   - source/nextflow
 status: draft
 created: 2026-05-10
-revised: 2026-05-11
-revision: 2
+revised: 2026-06-10
+revision: 3
 ai_generated: true
 summary: "Convert one nf-core module dir into a Galaxy tool wrapper (tool.xml + macros.xml + _provenance.yml + remote-URL <test> blocks)."
 references:
-  - kind: pattern
+  - kind: research
     ref: "[[nfcore-channel-input-to-galaxy-collection]]"
     used_at: both
     load: upfront
@@ -23,7 +23,7 @@ references:
     purpose: "Map process input channels (tuple(meta, path)) to Galaxy <param type=\"data\"> / <param type=\"data_collection\">."
     trigger: "When emitting <inputs> for a module."
     verification: "Cast and run against fastp (paired, tuple(meta, [path,path])) and seqkit/grep (single, tuple(meta, path)); confirm Galaxy <inputs> shape matches the channel cardinality."
-  - kind: pattern
+  - kind: research
     ref: "[[nfcore-meta-map-to-galaxy-params]]"
     used_at: both
     load: upfront
@@ -32,7 +32,7 @@ references:
     purpose: "Triage meta-map keys: behavior-driving keys become Galaxy <param>s; identity keys are dropped."
     trigger: "When a process consumes a meta-map and any meta keys influence the script: body."
     verification: "Cast against a paired-aware module (fastp); confirm meta.single_end becomes a <conditional>, meta.id is dropped."
-  - kind: pattern
+  - kind: research
     ref: "[[nfcore-task-ext-args-to-galaxy-additional-options]]"
     used_at: both
     load: upfront
@@ -41,7 +41,7 @@ references:
     purpose: "Surface task.ext.args as a single Galaxy text param; do not enumerate per-flag inputs."
     trigger: "When the upstream script: body interpolates ${task.ext.args} (or args2/args3)."
     verification: "Cast against a module with task.ext.args (samtools/sort); confirm a single extra_args text param is emitted with sane sanitization."
-  - kind: pattern
+  - kind: research
     ref: "[[nfcore-versions-emit-to-galaxy-version-command]]"
     used_at: both
     load: upfront
@@ -50,7 +50,7 @@ references:
     purpose: "Translate the versions.yml emit block (or topic: versions) into Galaxy's <version_command>."
     trigger: "When the script: body or output: declarations contain a versions emit."
     verification: "Cast against fastp; confirm <version_command> reproduces the upstream version string for the primary tool."
-  - kind: pattern
+  - kind: research
     ref: "[[nfcore-stub-block-to-galaxy-noop-test]]"
     used_at: both
     load: upfront

--- a/content/research/galaxy-discover-datasets.md
+++ b/content/research/galaxy-discover-datasets.md
@@ -8,14 +8,12 @@ tags:
 component: "Galaxy <discover_datasets> XML element"
 status: draft
 created: 2026-05-10
-revised: 2026-05-10
-revision: 1
+revised: 2026-06-10
+revision: 2
 ai_generated: true
 summary: "Reference for the <discover_datasets> Galaxy XML element — attributes, named/regex patterns, <data> vs <collection> contexts, test assertions."
 related_molds:
   - "[[convert-nfcore-module-to-galaxy-tool]]"
-related_patterns:
-  - "[[nfcore-channel-input-to-galaxy-collection]]"
 related_notes:
   - "[[convert-nfcore-module-to-galaxy-tool]]"
   - "[[nfcore-channel-input-to-galaxy-collection]]"

--- a/content/research/nfcore-channel-input-to-galaxy-collection.md
+++ b/content/research/nfcore-channel-input-to-galaxy-collection.md
@@ -1,22 +1,21 @@
 ---
-type: pattern
-pattern_kind: operation
-evidence: hypothesis
+type: research
+subtype: design-problem
 title: "nf-core channel input → Galaxy data / collection"
 tags:
-  - pattern
+  - research/design-problem
+  - source/nextflow
   - target/galaxy
 status: draft
 created: 2026-05-10
-revised: 2026-05-10
-revision: 2
+revised: 2026-06-10
+revision: 3
 ai_generated: true
 summary: "Map an nf-core process's tuple(meta, path) input channel to a Galaxy <param type=\"data\"> or paired/list collection input."
 related_molds:
   - "[[convert-nfcore-module-to-galaxy-tool]]"
-related_patterns:
-  - "[[nfcore-meta-map-to-galaxy-params]]"
 related_notes:
+  - "[[nfcore-meta-map-to-galaxy-params]]"
   - "[[galaxy-discover-datasets]]"
 sources:
   - "https://github.com/nf-core/modules/tree/9b261a459473bc8e2d830bfc626f480c0733f4fe"
@@ -154,5 +153,5 @@ The convert Mold's posture should match IUC: emit `single` + `paired_collection`
 
 - `[[nfcore-meta-map-to-galaxy-params]]` — sibling: how to handle the `meta` map keys that travel with the data path.
 - `[[galaxy-discover-datasets]]` — reference for the `<discover_datasets>` element used in the glob-input mapping.
-- `[[convert-nfcore-module-to-galaxy-tool]]` — Mold that consumes this pattern.
+- `[[convert-nfcore-module-to-galaxy-tool]]` — Mold that consumes this note.
 - `tools-iuc/tools/fastp/fastp.xml` — canonical IUC paired/single conditional shape.

--- a/content/research/nfcore-meta-map-to-galaxy-params.md
+++ b/content/research/nfcore-meta-map-to-galaxy-params.md
@@ -1,20 +1,20 @@
 ---
-type: pattern
-pattern_kind: operation
-evidence: hypothesis
+type: research
+subtype: design-problem
 title: "nf-core meta-map → Galaxy params"
 tags:
-  - pattern
+  - research/design-problem
+  - source/nextflow
   - target/galaxy
 status: draft
 created: 2026-05-10
-revised: 2026-05-10
-revision: 2
+revised: 2026-06-10
+revision: 3
 ai_generated: true
 summary: "Promote nf-core meta-map keys to Galaxy <param>s only when they drive script behavior; drop identity-only keys; pull naming from $input.element_identifier."
 related_molds:
   - "[[convert-nfcore-module-to-galaxy-tool]]"
-related_patterns:
+related_notes:
   - "[[nfcore-channel-input-to-galaxy-collection]]"
 sources:
   - "https://github.com/nf-core/modules/tree/9b261a459473bc8e2d830bfc626f480c0733f4fe"
@@ -115,5 +115,5 @@ Option 1 is right unless the upstream tool genuinely supports two distinct ident
 
 ## See also
 
-- `[[nfcore-channel-input-to-galaxy-collection]]` — sibling pattern: meta-driven input shape decisions.
-- `[[convert-nfcore-module-to-galaxy-tool]]` — Mold that consumes this pattern.
+- `[[nfcore-channel-input-to-galaxy-collection]]` — sibling note: meta-driven input shape decisions.
+- `[[convert-nfcore-module-to-galaxy-tool]]` — Mold that consumes this note.

--- a/content/research/nfcore-stub-block-to-galaxy-noop-test.md
+++ b/content/research/nfcore-stub-block-to-galaxy-noop-test.md
@@ -1,15 +1,15 @@
 ---
-type: pattern
-pattern_kind: operation
-evidence: hypothesis
+type: research
+subtype: design-problem
 title: "nf-core stub: block → Galaxy (intentional drop)"
 tags:
-  - pattern
+  - research/design-problem
+  - source/nextflow
   - target/galaxy
 status: draft
 created: 2026-05-10
-revised: 2026-05-10
-revision: 2
+revised: 2026-06-10
+revision: 3
 ai_generated: true
 summary: "nf-core's stub: block has no Galaxy analog; the convert Mold drops it intentionally and records the drop in _provenance.yml."
 related_molds:
@@ -90,6 +90,6 @@ In all three the convert Mold's deliverable is identical: tool.xml + macros.xml 
 
 ## See also
 
-- `[[convert-nfcore-module-to-galaxy-tool]]` — Mold that consumes this pattern.
+- `[[convert-nfcore-module-to-galaxy-tool]]` — Mold that consumes this note.
 - `planemo test` — the runtime sink that makes the drop safe.
 - `planemo lint` — the XML-shape gate that fills in for the DAG-resolution part of `-stub-run`.

--- a/content/research/nfcore-task-ext-args-to-galaxy-additional-options.md
+++ b/content/research/nfcore-task-ext-args-to-galaxy-additional-options.md
@@ -1,15 +1,15 @@
 ---
-type: pattern
-pattern_kind: operation
-evidence: hypothesis
+type: research
+subtype: design-problem
 title: "nf-core task.ext.args → Galaxy additional-options bag"
 tags:
-  - pattern
+  - research/design-problem
+  - source/nextflow
   - target/galaxy
 status: draft
 created: 2026-05-10
-revised: 2026-05-10
-revision: 2
+revised: 2026-06-10
+revision: 3
 ai_generated: true
 summary: "Map nf-core's task.ext.args escape hatch to a single Galaxy text param surfacing extra command-line arguments."
 related_molds:
@@ -118,5 +118,5 @@ The convert Mold defaults to (1) because it preserves the rest of Galaxy's input
 ## See also
 
 - `[[nfcore-meta-map-to-galaxy-params]]` — sibling: handling identity vs behavior keys.
-- `[[convert-nfcore-module-to-galaxy-tool]]` — Mold that consumes this pattern.
+- `[[convert-nfcore-module-to-galaxy-tool]]` — Mold that consumes this note.
 - `tools-iuc/tools/fastp/fastp.xml` — IUC's per-flag promotion choice (option 2 above).

--- a/content/research/nfcore-versions-emit-to-galaxy-version-command.md
+++ b/content/research/nfcore-versions-emit-to-galaxy-version-command.md
@@ -1,15 +1,15 @@
 ---
-type: pattern
-pattern_kind: operation
-evidence: hypothesis
+type: research
+subtype: design-problem
 title: "nf-core versions emit → Galaxy <version_command>"
 tags:
-  - pattern
+  - research/design-problem
+  - source/nextflow
   - target/galaxy
 status: draft
 created: 2026-05-10
-revised: 2026-05-10
-revision: 2
+revised: 2026-06-10
+revision: 3
 ai_generated: true
 summary: "Translate nf-core's versions emit (heredoc or topic: versions) into Galaxy's <version_command>, dropping the versions output channel."
 related_molds:
@@ -111,5 +111,5 @@ Translation is identical: extract the `eval(...)` argument; emit one `<version_c
 
 ## See also
 
-- `[[convert-nfcore-module-to-galaxy-tool]]` — Mold that consumes this pattern.
+- `[[convert-nfcore-module-to-galaxy-tool]]` — Mold that consumes this note.
 - `tools-iuc/tools/fastp/fastp.xml` — IUC's `<version_command>` posture (often shorter than nf-core's because IUC wraps a single tool).


### PR DESCRIPTION
> Opened by Claude (AI assistant) on jmchilton's behalf.

## What

Five `nfcore-*-to-galaxy-*` notes were typed as `pattern` (`target/galaxy`) and so rendered in the **Galaxy patterns** list — but they describe **nf-core → Galaxy tool-authoring mappings** consumed by `convert-nfcore-module-to-galaxy-tool`, not reusable Galaxy patterns. This reclassifies them as `research` / `subtype: design-problem`.

## Changes

- **Retype + move:** `type: pattern` → `research` (`subtype: design-problem`); `content/patterns/` → `content/research/`. Slugs are basename-derived, so all `[[wiki-link]]`s survive the move.
- **Tags:** `pattern` + `target/galaxy` → `research/design-problem` + `source/nextflow` + `target/galaxy`.
- **convert-nfcore Mold manifest:** the 5 references flip `kind: pattern` → `kind: research` (validator maps `kind: research → type: research`, so note + ref move in lockstep).
- **Cross-links:** sibling `related_patterns` → `related_notes` (channel-input, meta-map) and dropped the now-invalid `related_patterns` block from `galaxy-discover-datasets.md`; footer prose "consumes this pattern" → "this note".
- **Generated:** regenerated `Dashboard.md` / `Index.md` — the five now appear under **Design Problems**, no longer Patterns.

The fifth note (`nfcore-versions-emit-to-galaxy-version-command`) is the same 2026-05-10 batch and was folded in.

## Validation

`npm run validate` → **0 errors**. `npm run test` → 100 pass. `npm run typecheck` → 0 errors.

## Follow-up (not in this PR)

The `convert-nfcore-module-to-galaxy-tool` **cast bundle** still copies these under `references/patterns/` and labels them "Pattern note"; it needs a clean recast (deferred — needs the cast skill's condense step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)