### PR TITLE
Sync site/package-lock.json to package.json (@galaxy-tool-util 1.7.2)

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "@fontsource/atkinson-hyperlegible": "^5.2.8",
         "@galaxy-foundry/foundry": "file:../packages/foundry",
-        "@galaxy-tool-util/cli": "^1.4.0",
-        "@galaxy-tool-util/schema": "^1.1.0",
+        "@galaxy-tool-util/cli": "^1.7.2",
+        "@galaxy-tool-util/schema": "^1.7.2",
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "4.1.18",
         "astro": "^5.17.1",
@@ -34,11 +34,11 @@
     },
     "../packages/foundry": {
       "name": "@galaxy-foundry/foundry",
-      "version": "0.1.0",
+      "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
         "@galaxy-foundry/summarize-nextflow": "workspace:*",
-        "@galaxy-tool-util/schema": "^1.2.0",
+        "@galaxy-tool-util/schema": "^1.7.2",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "commander": "^12.1.0",
@@ -798,15 +798,15 @@
       "link": true
     },
     "node_modules/@galaxy-tool-util/cli": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@galaxy-tool-util/cli/-/cli-1.4.0.tgz",
-      "integrity": "sha512-H8jazKK0R/LJPOw0ek6d98pIKCJ6q56IxREd3C8AQ6RDmiQlFW0DDRpYATHifcPoNHMk4vLxbo2HgZJ0a508wA==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@galaxy-tool-util/cli/-/cli-1.7.2.tgz",
+      "integrity": "sha512-gNEDPi5J3QqNd27nWO583ev/+uuI/a3rUSMHQV137n1KZsFh2DEiGdHP7NUKjk7+HpsvTMZ1iA3HqytFEB8n/Q==",
       "license": "MIT",
       "dependencies": {
-        "@galaxy-tool-util/connection-validation": "1.2.0",
-        "@galaxy-tool-util/core": "1.2.0",
-        "@galaxy-tool-util/schema": "1.2.0",
-        "@galaxy-tool-util/search": "1.2.0",
+        "@galaxy-tool-util/connection-validation": "1.7.2",
+        "@galaxy-tool-util/core": "1.7.2",
+        "@galaxy-tool-util/schema": "1.7.2",
+        "@galaxy-tool-util/search": "1.7.2",
         "ajv": "^8.18.0",
         "commander": "^14.0.0",
         "effect": "^3.21.0",
@@ -862,30 +862,30 @@
       }
     },
     "node_modules/@galaxy-tool-util/connection-validation": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@galaxy-tool-util/connection-validation/-/connection-validation-1.2.0.tgz",
-      "integrity": "sha512-LTDXriF6hcoTP889rU1wwDPwzc4+l5IuJVtHXLzWYR0pFJS2uTE1coov49G+HmX4pJXrqUeb3tFh0U4be7vqXQ==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@galaxy-tool-util/connection-validation/-/connection-validation-1.7.2.tgz",
+      "integrity": "sha512-Rc87P9LHp+UN6oD79kRXh8iZ9GvqhYngTku6KgT71R3MwRwJUWLQoRQkwaOFtFItQQFeGxmRxTKceh5/r8E86A==",
       "license": "MIT",
       "dependencies": {
-        "@galaxy-tool-util/schema": "1.2.0",
+        "@galaxy-tool-util/schema": "1.7.2",
         "@galaxy-tool-util/workflow-graph": "1.2.0"
       }
     },
     "node_modules/@galaxy-tool-util/core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@galaxy-tool-util/core/-/core-1.2.0.tgz",
-      "integrity": "sha512-TcX6vrtQX56Ra3ibbYi0R9kJ3C8jEFtz0DLalcve7KcM7ZGumwZbj9pZCD7andZHSe6L7ZEqQihc8HsCHvce8A==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@galaxy-tool-util/core/-/core-1.7.2.tgz",
+      "integrity": "sha512-I8gZ9i5nINyAjkVyrajCGv4GAuLxveczawEa/q+Xy2NXxNqE/mOzg3mZRTikB1HoMrRRH9YeFpmmX33Mtt/CRA==",
       "license": "MIT",
       "dependencies": {
-        "@galaxy-tool-util/schema": "1.2.0",
+        "@galaxy-tool-util/schema": "1.7.2",
         "effect": "^3.21.0",
         "yaml": "^2.8.3"
       }
     },
     "node_modules/@galaxy-tool-util/schema": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@galaxy-tool-util/schema/-/schema-1.2.0.tgz",
-      "integrity": "sha512-0OOemrWHa/wGtxJZehCa4Y6D2thLxub1iAJ+Fmifj9TeRkTE0f1taZHAutwV4mJeBZ/xzgBgFUZu8ZWWzeKpPg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@galaxy-tool-util/schema/-/schema-1.7.2.tgz",
+      "integrity": "sha512-9udM+HHHg3jhly6dQ2FfZNg8Z8Ydi6fObFG9/Ff6OxSt1zmtieTmOFAB9YfdhlOLDuBp3qFfcvv+su5wqZD/Ww==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.18.0",
@@ -895,13 +895,13 @@
       }
     },
     "node_modules/@galaxy-tool-util/search": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@galaxy-tool-util/search/-/search-1.2.0.tgz",
-      "integrity": "sha512-0nQe6/JBE0bIuQ138H5RqM1HlPaB3BfJYN89ka5OIaU/n8wsgm+ToQirUPfJLM8Ltv816l7Q59FnAdkhpLlEnw==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@galaxy-tool-util/search/-/search-1.7.2.tgz",
+      "integrity": "sha512-kxIaG25/9UayDeNJCgA09OrWc40b4AbXXbkdSc+nGSrb5PE7fsoWzQnIYVZSsUdTHIZvo7I8HoOsLWEdwuKeYQ==",
       "license": "MIT",
       "dependencies": {
-        "@galaxy-tool-util/core": "1.2.0",
-        "@galaxy-tool-util/schema": "1.2.0"
+        "@galaxy-tool-util/core": "1.7.2",
+        "@galaxy-tool-util/schema": "1.7.2"
       }
     },
     "node_modules/@galaxy-tool-util/workflow-graph": {
@@ -3549,9 +3549,9 @@
       }
     },
     "node_modules/effect": {
-      "version": "3.21.2",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.2.tgz",
-      "integrity": "sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg==",
+      "version": "3.21.3",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.3.tgz",
+      "integrity": "sha512-RqwU7WnJ6CqYhyjpOVJA5vh1Sgkn6eVECO6mnD0EjlbWcC2M3LJaPglXXr13Rdo/Y+B+wTEPzGRYFNL2xKxNeQ==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",


### PR DESCRIPTION
> Opened by Claude (AI assistant) on jmchilton's behalf.

## What

`site/package-lock.json` had drifted behind `site/package.json`: the lock pinned `@galaxy-tool-util/cli ^1.4.0` and `@galaxy-tool-util/schema ^1.1.0`, while `package.json` already declared `^1.7.2`. Because of the mismatch, `npm ci` refused to install and `astro` couldn't be resolved — which broke `npm run typecheck` (`astro check`) and the `cli-registry` vitest (it loads `site/tsconfig.json`, which `extends astro/tsconfigs/strict`).

`npm install` regenerated the lock against the existing `package.json`, bumping the `@galaxy-tool-util/*` chain to `1.7.2` (matching the root workspace) plus a minor transitive `effect` bump. No `package.json` changes — lockfile only.

## Effect

With this lock, a clean `npm ci` in `site/` succeeds and `astro check` passes (0 errors). Root `npm run typecheck` and `npm run test` (now 100 passing) go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)