### PR TITLE
Add galaxy-sequence-patterns MOC + survey (#272)

### DIFF
--- a/content/patterns/galaxy-collection-patterns.md
+++ b/content/patterns/galaxy-collection-patterns.md
@@ -88,3 +88,5 @@ This is the runtime-facing map for Galaxy collection transformation choices. Use
 
 - [[iwc-transformations-survey]] — collection-transform survey and evidence trail.
 - [[galaxy-tabular-patterns]] — companion MOC for tabular operations.
+- [[galaxy-interval-patterns]] — companion MOC for coordinate-feature operations.
+- [[galaxy-sequence-patterns]] — companion MOC for sequence-record operations.

--- a/content/patterns/galaxy-interval-patterns.md
+++ b/content/patterns/galaxy-interval-patterns.md
@@ -84,5 +84,6 @@ These are tracked as IWC-input-blocked candidates (GitHub `requires-iwc-inputs`)
 ## See also
 
 - [[iwc-interval-operations-survey]] — interval-operation survey and evidence trail.
+- [[galaxy-sequence-patterns]] — companion MOC for sequence-record operations; shares the extract/mask-by-region bridge (`getfasta`/`maskfasta` produce sequence from these intervals).
 - [[galaxy-tabular-patterns]] — companion MOC for opaque-column tabular operations.
 - [[galaxy-collection-patterns]] — companion MOC for collection-container operations.

--- a/content/patterns/galaxy-sequence-patterns.md
+++ b/content/patterns/galaxy-sequence-patterns.md
@@ -1,0 +1,99 @@
+---
+type: pattern
+pattern_kind: moc
+evidence: corpus-observed
+title: "Galaxy: sequence patterns"
+aliases:
+  - "Galaxy sequence pattern MOC"
+  - "sequence-record transformation patterns"
+  - "IWC sequence pattern map"
+tags:
+  - pattern
+  - target/galaxy
+  - topic/galaxy-transform
+  - topic/sequence-transform
+status: draft
+created: 2026-06-10
+revised: 2026-06-10
+revision: 1
+ai_generated: true
+summary: "Use this MOC to choose corpus-grounded Galaxy operations on sequence records (FASTA) — interconvert, reformat, merge, length, extract/mask by region."
+related_notes:
+  - "[[iwc-sequence-operations-survey]]"
+related_patterns:
+  - "[[sequence-fasta-tabular-interconvert]]"
+  - "[[sequence-reformat-line-width]]"
+  - "[[sequence-merge-and-dedup]]"
+  - "[[sequence-compute-length]]"
+  - "[[sequence-extract-by-region]]"
+  - "[[relabel-fasta-headers-via-tabular]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+  - "[[nextflow-summary-to-galaxy-data-flow]]"
+  - "[[cwl-summary-to-galaxy-data-flow]]"
+  - "[[nextflow-summary-to-galaxy-template]]"
+  - "[[cwl-summary-to-galaxy-template]]"
+  - "[[paper-summary-to-galaxy-template]]"
+  - "[[compare-against-iwc-exemplar]]"
+---
+
+# Galaxy: sequence patterns
+
+The runtime-facing map for Galaxy **sequence-record** choices — operations that read, reshape, subset, or interconvert FASTA (nucleotide or protein) records, as opposed to opaque-column [[galaxy-tabular-patterns]], coordinate-feature [[galaxy-interval-patterns]], or container-shaped [[galaxy-collection-patterns]]. Use it before loading raw survey notes; [[iwc-sequence-operations-survey]] is the evidence backing, these pages are the actionable references.
+
+Sequence records are arguably the most fundamental bioinformatics data shape, but in IWC the **record-manipulation** cluster (as opposed to the domain analysis that consumes sequence) is moderate, and its center of gravity is the **FASTA ↔ tabular seam**: the corpus reaches for a table whenever it needs to edit records, especially headers. Reach for the relabel recipe first when your need is header surgery across many records.
+
+## Interconvert (the dominant seam)
+
+- [[sequence-fasta-tabular-interconvert]] — open records to a (header, sequence) table and back (`fasta2tab` / `tab2fasta`) so tabular tools can edit them.
+
+## Reformat & combine
+
+- [[sequence-reformat-line-width]] — rewrap FASTA to a fixed line width (`cshl_fasta_formatter`).
+- [[sequence-merge-and-dedup]] — concatenate several FASTAs and drop duplicate records by sequence identity (`fasta_merge_files_and_filter_unique_sequences`).
+
+## Compute
+
+- [[sequence-compute-length]] — emit a (id, length) table for downstream tabular thresholding (`fasta_compute_length`). Per-record length only, not assembly statistics.
+
+## Extract & mask by region (interval/annotation bridge)
+
+- [[sequence-extract-by-region]] — turn coordinates into sequence: extract at BED intervals (`bedtools getfasta`), mask regions by BED (`bedtools maskfasta`), or extract transcript/CDS FASTA from a GFF (`gffread`).
+
+## Recipes
+
+- [[relabel-fasta-headers-via-tabular]] — the high-value construct: edit FASTA headers you cannot easily regex in place — `fasta2tab` → find/replace on column 1 → `tab2fasta`.
+
+## Bridges
+
+- **sequence ↔ tabular** — the dominant seam. `fasta2tab`/`tab2fasta` interconvert; `fasta_compute_length` emits a length table; the relabel recipe lives entirely here. The line: tabular treats the record as opaque columns (header = col 1, sequence = col 2); sequence operations understand FASTA structure. See [[galaxy-tabular-patterns]].
+- **sequence ↔ interval** — `getfasta` (intervals → sequence) and `maskfasta` (intervals + sequence → masked sequence) consume coordinate features and emit sequence. [[galaxy-interval-patterns]] owns the BED that feeds them on the output-shape rule; this MOC owns the extraction. See [[sequence-extract-by-region]] and [[galaxy-interval-patterns]].
+- **alignment / annotation → sequence** — `samtools_fastx` (BAM → FASTQ/FASTA) and `gffread` (GFF + genome → transcript FASTA) bridge from upstream domains into sequence records. `bamtobed` (BAM → BED) is the interval-side analogue owned by [[galaxy-interval-patterns]].
+
+## Thin — tracked, not yet paged
+
+Corpus-present but single-source; documented so the omission is deliberate. A page follows when a second independent exemplar appears (the same hold-if-thin discipline as the interval MOC):
+
+- **subset by id list** — `seqtk_subseq` (iuc; also does ranges) and `filter_by_fasta_ids` (galaxyp; discarded-complement + regex anchoring) each appear once. When paged, lead with `seqtk_subseq` and footnote `filter_by_fasta_ids`.
+- **filter by length** — `fasta_filter_by_length` (one VGP-decontamination use).
+- **translate (nt → protein)** — `seqkit_translate` (one metagenomic-gene-catalogue use).
+- **FASTQ → FASTA** — `fastq_to_fasta_python` (mgnify reads QC); record-format interconversion at the reads-domain edge.
+
+## Gaps (no corpus exemplar, no page)
+
+Per corpus-first, zero IWC uptake → no page; documented here so the absence is explicit:
+
+- **reverse-complement** (standalone), **sequence sort**, **composition / GC compute**, **standalone dedup** (`seqkit_rmdup`), **EMBOSS `seqret`/`transeq`**, `fasta_nucleotide_changer`. Common in GTN training material and the Tool Shed, but no IWC workflow reaches for them.
+
+These are tracked as IWC-input-blocked candidates; a page follows only when an IWC workflow uses the operation.
+
+## Out of scope
+
+Domain analysis that consumes or emits sequence but does not manipulate records: assembly (`gfastats` — the corpus's largest FASTA-touching tool, all VGP), metagenomic binning, proteomics search-DB build, alignment, annotation, variant calling, search, profiling. These route through tool discovery, not patterns. See [[iwc-sequence-operations-survey]] §6.
+
+## See also
+
+- [[iwc-sequence-operations-survey]] — sequence-operation survey and evidence trail.
+- [[galaxy-tabular-patterns]] — companion MOC for opaque-column tabular operations.
+- [[galaxy-interval-patterns]] — companion MOC for coordinate-feature operations; shares the extract/mask bridge.
+- [[galaxy-collection-patterns]] — companion MOC for collection-container operations.

--- a/content/patterns/galaxy-tabular-patterns.md
+++ b/content/patterns/galaxy-tabular-patterns.md
@@ -78,4 +78,6 @@ This is the runtime-facing map for Galaxy tabular transformation choices. Use it
 ## See also
 
 - [[iwc-tabular-operations-survey]] — tabular-operation survey and evidence trail.
+- [[galaxy-sequence-patterns]] — companion MOC for sequence-record operations; FASTA↔tabular is the dominant sequence seam.
+- [[galaxy-interval-patterns]] — companion MOC for coordinate-feature operations.
 - [[galaxy-collection-patterns]] — companion MOC for collection operations.

--- a/content/patterns/relabel-fasta-headers-via-tabular.md
+++ b/content/patterns/relabel-fasta-headers-via-tabular.md
@@ -1,0 +1,99 @@
+---
+type: pattern
+pattern_kind: recipe
+evidence: corpus-observed
+title: "Sequence: relabel FASTA headers via tabular"
+aliases:
+  - "edit FASTA headers through a table"
+  - "fasta2tab find-replace tab2fasta"
+  - "inject sample id into FASTA header"
+tags:
+  - pattern
+  - target/galaxy
+  - topic/galaxy-transform
+  - topic/sequence-transform
+status: draft
+created: 2026-06-10
+revised: 2026-06-10
+revision: 1
+ai_generated: true
+summary: "Edit FASTA headers you cannot easily regex in place: fasta2tab, rewrite column 1 with find/replace, then tab2fasta back. The high-value sequence recipe."
+related_notes:
+  - "[[iwc-sequence-operations-survey]]"
+related_patterns:
+  - "[[sequence-fasta-tabular-interconvert]]"
+  - "[[regex-relabel-via-tabular]]"
+  - "[[galaxy-tabular-patterns]]"
+  - "[[galaxy-sequence-patterns]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+iwc_exemplars:
+  - workflow: microbiome/pathogen-identification/gene-based-pathogen-identification/Gene-based-Pathogen-Identification
+    steps:
+      - label: "sample_specific_contigs_tabular_file_preparation"
+      - label: "sample_specific_contigs_tabular_file"
+      - label: "contigs"
+    why: "fasta2tab -> tp_find_and_replace on column 1 (inject per-sample id into the header) -> tab2fasta, the full confirmed round-trip."
+    confidence: high
+  - workflow: microbiome/metagenomic-genes-catalogue/metagenomic-genes-catalogue
+    why: "Same fasta2tab...tab2fasta envelope around tabular header processing of gene records."
+    confidence: medium
+  - workflow: microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation
+    why: "Interconversion pair co-present with tabular text-processing between, relabeling aggregated records."
+    confidence: medium
+---
+
+# Sequence: relabel FASTA headers via tabular
+
+Use this recipe when the change you need is to the **FASTA header line** — inject a sample id, strip or rewrite a prefix, normalize accession formatting — and doing it on raw FASTA is awkward. The corpus's move is to detour through tabular: open the records so the header is column 1, rewrite that column with ordinary text processing, and close them back to FASTA. It is the highest-value sequence construct in IWC, recurring across the pathogen-identification and metagenomic-gene-catalogue families.
+
+This is a sequence-record cousin of [[regex-relabel-via-tabular]] — that pattern relabels **collection identifiers**; this one relabels the **header inside each sequence record**. Same instinct (let tabular tools do the string work), different target.
+
+## The shape
+
+`fasta2tab` → `tp_find_and_replace` on column 1 → `tab2fasta`. Three steps, the first and last being [[sequence-fasta-tabular-interconvert]].
+
+## 1. Open records to a table
+
+`toolshed.g2.bx.psu.edu/repos/devteam/fasta_to_tabular/fasta2tab` with `descr_columns: "1"`, `keep_first: "0"` — header becomes column 1, full sequence column 2 (`Gene-based-Pathogen-Identification`, step "sample_specific_contigs_tabular_file_preparation").
+
+## 2. Rewrite the header column
+
+`toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace` scoped to **`column: "1"`** so only the header is touched, the sequence in column 2 left intact. In the corpus the replacement is a regex over the whole header with a **connected** `replace_pattern` — the per-sample id is computed upstream (via `compose_text_param`) and injected into every header:
+
+```yaml
+tool_id: toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace
+tool_state:
+  infile: { __class__: ConnectedValue }      # the fasta2tab table
+  find_and_replace:
+    - find_pattern: ^(.+)$
+      replace_pattern: { __class__: ConnectedValue }   # computed per-sample id
+      is_regex: true
+      global: true
+      searchwhere: { searchwhere_select: column, column: "1" }
+```
+
+The `searchwhere_select: column` + `column: "1"` pin is load-bearing — without it the find/replace would also rewrite the sequence in column 2.
+
+## 3. Close the table back to FASTA
+
+`toolshed.g2.bx.psu.edu/repos/devteam/tabular_to_fasta/tab2fasta` on the edited table (`Gene-based-Pathogen-Identification`, step "contigs"). Headers carry the new label; sequences are unchanged.
+
+## Why this shape
+
+FASTA headers are interleaved with sequence lines, so a naive find/replace over the whole file risks matching sequence content and cannot easily target "the header only." Splitting to two columns makes the header an addressable column; `searchwhere column: "1"` then guarantees the sequence is never touched. The round-trip is the price of that safety, and it is cheap.
+
+## Pitfalls
+
+- **Scope the find/replace to column 1.** Dropping `searchwhere column: "1"` lets the pattern hit the sequence column and silently corrupt bases. This is the one mistake that turns the recipe from safe to dangerous.
+- **Keep the interconversion symmetric.** `descr_columns: "1"` out, single-header-column in. An asymmetric split (see [[sequence-fasta-tabular-interconvert]]) rebuilds malformed headers.
+- **A connected `replace_pattern` means the id is computed upstream.** The corpus builds the per-sample string with `compose_text_param` before this step; if you hard-code the replacement you lose the per-sample parameterization that makes the recipe reusable across a collection.
+- **Don't reach for this to wrap lines or filter.** Header editing only — width rewrap is [[sequence-reformat-line-width]], record dedup is [[sequence-merge-and-dedup]].
+
+## See also
+
+- [[sequence-fasta-tabular-interconvert]] — the open/close operation this recipe is built on.
+- [[regex-relabel-via-tabular]] — the collection-identifier analogue.
+- [[galaxy-tabular-patterns]] — the find/replace and compose-param mechanics.
+- [[galaxy-sequence-patterns]] — the sequence pattern map.
+- [[iwc-sequence-operations-survey]] — corpus evidence.

--- a/content/patterns/sequence-compute-length.md
+++ b/content/patterns/sequence-compute-length.md
@@ -1,0 +1,81 @@
+---
+type: pattern
+pattern_kind: operation
+evidence: corpus-observed
+title: "Sequence: compute record lengths"
+aliases:
+  - "fasta_compute_length in Galaxy"
+  - "FASTA length table"
+  - "sequence lengths to tabular"
+tags:
+  - pattern
+  - target/galaxy
+  - topic/galaxy-transform
+  - topic/sequence-transform
+status: draft
+created: 2026-06-10
+revised: 2026-06-10
+revision: 1
+ai_generated: true
+summary: "Emit a (id, length) table from a FASTA so downstream tabular steps can filter, sort, or threshold records by length; fasta_compute_length."
+related_notes:
+  - "[[iwc-sequence-operations-survey]]"
+related_patterns:
+  - "[[sequence-fasta-tabular-interconvert]]"
+  - "[[galaxy-sequence-patterns]]"
+  - "[[galaxy-tabular-patterns]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+iwc_exemplars:
+  - workflow: VGP-assembly-v2/Purge-duplicate-contigs-VGP6/Purge-duplicate-contigs-VGP6
+    why: "fasta_compute_length (keep_first 0, keep_first_word false) producing a per-contig length table for downstream thresholding."
+    confidence: high
+---
+
+# Sequence: compute record lengths
+
+## Operation
+
+Produce a **tabular (id, length)** table from a FASTA — one row per record — so the length can be filtered, sorted, joined, or thresholded with ordinary tabular tools ([[galaxy-tabular-patterns]]). The corpus uses:
+
+`toolshed.g2.bx.psu.edu/repos/devteam/fasta_compute_length` ("Compute sequence length").
+
+This is a **sequence → tabular** move, narrower than [[sequence-fasta-tabular-interconvert]]: it drops the sequence and keeps only id + length. Keep its scope to the length table; aggregate **assembly statistics** (N50, total bases, GC) are a different concern handled by domain tools (`fasta_stats`, `gfastats`) that this pattern deliberately excludes — see [[iwc-sequence-operations-survey]] §2. Parameter names below are corpus-inferred from `tool_state`.
+
+## When to reach for it
+
+- You need to **filter or threshold records by length** downstream (drop short contigs, keep scaffolds above N bp) and want the length as a column to filter on.
+- You need a length distribution table for reporting or to join against other per-record data on the id.
+
+For a one-shot length **filter** where you never need the table, a dedicated filter-by-length tool is more direct; this pattern is for when the length table itself is useful.
+
+## Parameters
+
+- `ref.ref_source`: `history` — the FASTA comes from the history (connected `input`).
+- `keep_first`: limit to the first N records; **`"0"`** (all) in the corpus.
+- `keep_first_word`: use only the first whitespace-delimited header token as the id; **`false`** in the corpus (full header as id).
+
+## Idiomatic shape
+
+```yaml
+tool_id: toolshed.g2.bx.psu.edu/repos/devteam/fasta_compute_length/1.0.3
+tool_state:
+  ref:
+    ref_source: history
+    input: { __class__: ConnectedValue }
+    keep_first: "0"
+    keep_first_word: false
+```
+
+## Pitfalls
+
+- **The output is a table, not FASTA.** It carries no sequence — you cannot reconstruct records from it. To keep the sequence alongside, use [[sequence-fasta-tabular-interconvert]] instead.
+- **`keep_first_word` changes the join key.** With `false` the whole header is the id; a downstream join on a short accession will miss unless you also trim the header (or set `keep_first_word: true`).
+- **Not assembly statistics.** This computes per-record length only. N50 / total-length / GC summaries are out of scope; reaching for `gfastats`/`fasta_stats` pulls in assembly-domain tooling this pattern intentionally avoids.
+
+## See also
+
+- [[sequence-fasta-tabular-interconvert]] — the broader FASTA↔tabular move that keeps the sequence.
+- [[galaxy-tabular-patterns]] — filter/sort/threshold the length table.
+- [[galaxy-sequence-patterns]] — the sequence pattern map.
+- [[iwc-sequence-operations-survey]] — corpus evidence.

--- a/content/patterns/sequence-extract-by-region.md
+++ b/content/patterns/sequence-extract-by-region.md
@@ -1,0 +1,118 @@
+---
+type: pattern
+pattern_kind: operation
+evidence: corpus-observed
+title: "Sequence: extract or mask by region"
+aliases:
+  - "bedtools getfasta in Galaxy"
+  - "bedtools maskfasta"
+  - "gffread extract transcripts"
+  - "intervals to sequence"
+tags:
+  - pattern
+  - target/galaxy
+  - topic/galaxy-transform
+  - topic/sequence-transform
+status: draft
+created: 2026-06-10
+revised: 2026-06-10
+revision: 1
+ai_generated: true
+summary: "Turn coordinates into sequence: extract FASTA at BED intervals (getfasta), mask regions by BED (maskfasta), or extract transcripts from a GFF (gffread)."
+related_notes:
+  - "[[iwc-sequence-operations-survey]]"
+related_patterns:
+  - "[[galaxy-sequence-patterns]]"
+  - "[[galaxy-interval-patterns]]"
+  - "[[sequence-fasta-tabular-interconvert]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+iwc_exemplars:
+  - workflow: microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation
+    why: "bedtools getfasta extracting sequence at a BED of feature coordinates from a history FASTA."
+    confidence: high
+  - workflow: amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-its/mgnify-amplicon-pipeline-v5-its
+    steps:
+      - label: "ITS FASTA files"
+    why: "bedtools maskfasta hard-masking regions named by a BED with mask character N."
+    confidence: high
+  - workflow: genome_annotation/annotation-maker/Genome_annotation_with_maker_short
+    steps:
+      - label: "GFFRead"
+    why: "gffread extracting transcript/CDS FASTA from an annotation GFF plus the genome FASTA."
+    confidence: high
+---
+
+# Sequence: extract or mask by region
+
+## Operation
+
+Turn **coordinates into sequence**: given regions (a BED of intervals, or a GFF of annotated features) and a genome/source FASTA, produce sequence records — either the sub-sequences at those regions, or the source with those regions masked. Three corpus moves share this shape; they differ in what the region set is and whether the output is the extract or the masked whole.
+
+This page sits on the **interval/annotation ↔ sequence bridge**. The regions are produced by interval algebra ([[galaxy-interval-patterns]]) or annotation tools; the output is sequence, which is why these operations live in the sequence MOC and were held *out* of the interval MOC (see [[iwc-sequence-operations-survey]] §5 and the interval survey's scope note). Parameter names below are corpus-inferred from `tool_state`.
+
+## Move 1 — extract FASTA at intervals (`bedtools getfasta`)
+
+`toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_getfastabed` ("bedtools getfasta"). Pull the sub-sequence at each BED interval out of a FASTA.
+
+- `fasta_source.fasta_source_selector`: **`history`** in the corpus — the source FASTA is a history dataset (connected); `cached` would use a built-in genome.
+- `input`: the BED of intervals (connected).
+- `nameOnly` / `split` / `strand` / `tab`: output toggles, all **`false`** in the corpus (default name handling, no strand-aware reverse-complement, FASTA not tabular output).
+
+```yaml
+tool_id: toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_getfastabed/2.30.0+galaxy1
+tool_state:
+  fasta_source: { fasta_source_selector: history, fasta: { __class__: ConnectedValue } }
+  input: { __class__: ConnectedValue }
+  nameOnly: false
+  split: false
+  strand: false
+  tab: false
+```
+
+## Move 2 — mask FASTA regions by BED (`bedtools maskfasta`)
+
+`toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_maskfastabed` ("bedtools maskfasta"). Keep the whole FASTA but replace the bases inside the BED regions. The corpus instances (mgnify ITS and complete pipelines) rename the masked output "ITS FASTA files".
+
+- `fasta` / `input`: source FASTA and the BED of regions to mask (connected).
+- `soft`: **`false`** = hard mask (replace bases with the mask character); `true` would lowercase instead.
+- `mc`: mask character, **`N`** in the corpus.
+- `fullheader`: **`false`** (use the short header).
+
+```yaml
+tool_id: toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_maskfastabed/2.31.1
+tool_state:
+  fasta: { __class__: ConnectedValue }
+  input: { __class__: ConnectedValue }
+  soft: false
+  mc: N
+  fullheader: false
+```
+
+## Move 3 — extract transcript/CDS FASTA from annotation (`gffread`)
+
+`toolshed.g2.bx.psu.edu/repos/devteam/gffread` ("gffread"). Given an annotation GFF/GTF and the genome FASTA, emit the spliced transcript or CDS sequences. Every corpus use is inside a `genome_annotation` pipeline (maker, braker3, helixer, lncRNAs) — the operation is sequence extraction, but its region set comes from an annotation step rather than interval algebra.
+
+- `input`: the GFF/GTF (connected).
+- `reference_genome.genome_fasta`: the genome FASTA the features index into (connected).
+- The corpus leaves filtering/merging/attribute options at defaults; reach for them only when the annotation needs cleaning first.
+
+## When to reach for each
+
+- **Region → just the sub-sequences**: `getfasta`.
+- **Region → the whole source with those spans hidden**: `maskfasta` (e.g. masking low-confidence or repeat regions before a consensus or search).
+- **Annotation features → their spliced sequences**: `gffread` (transcripts/CDS from a gene model).
+
+## Pitfalls
+
+- **Strand matters for extraction.** `getfasta` with `strand: false` returns the plus-strand sequence regardless of the feature's strand; set `strand: true` when you need strand-aware (reverse-complemented) extraction. The corpus extracts plus-strand.
+- **Soft vs hard mask is a downstream contract.** `maskfasta soft: false` writes `N`s (most tools treat as ambiguous); `soft: true` lowercases (repeat-masker convention some aligners honor). Picking the wrong one silently changes how a downstream tool reads the masked bases.
+- **The BED must match the FASTA's coordinate system and chrom names.** A region whose `chrom` does not match a FASTA header yields nothing extracted / nothing masked — no error, just empty or unchanged output. The region set usually comes from [[galaxy-interval-patterns]]; keep names consistent.
+- **`gffread` is annotation-domain-resident.** It is a sequence-extraction operation, but it presumes a cleaned gene model; if your features come from interval algebra rather than an annotator, `getfasta` is the simpler fit.
+
+## See also
+
+- [[galaxy-interval-patterns]] — produces the BED regions feeding moves 1–2; cross-MOC bridge.
+- [[galaxy-sequence-patterns]] — the sequence pattern map.
+- [[sequence-fasta-tabular-interconvert]] — when the extracted records then need header edits.
+- [[iwc-sequence-operations-survey]] — corpus evidence and the bridge scope note.

--- a/content/patterns/sequence-fasta-tabular-interconvert.md
+++ b/content/patterns/sequence-fasta-tabular-interconvert.md
@@ -1,0 +1,112 @@
+---
+type: pattern
+pattern_kind: operation
+evidence: corpus-observed
+title: "Sequence: interconvert FASTA and tabular"
+aliases:
+  - "fasta2tab tab2fasta in Galaxy"
+  - "FASTA to tabular and back"
+  - "sequence records as a table"
+tags:
+  - pattern
+  - target/galaxy
+  - topic/galaxy-transform
+  - topic/sequence-transform
+status: draft
+created: 2026-06-10
+revised: 2026-06-10
+revision: 1
+ai_generated: true
+summary: "Move sequence records between FASTA and a (header, sequence) table so tabular tools can edit them; fasta2tab one way, tab2fasta back."
+related_notes:
+  - "[[iwc-sequence-operations-survey]]"
+related_patterns:
+  - "[[relabel-fasta-headers-via-tabular]]"
+  - "[[sequence-compute-length]]"
+  - "[[galaxy-sequence-patterns]]"
+  - "[[galaxy-tabular-patterns]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+iwc_exemplars:
+  - workflow: microbiome/pathogen-identification/gene-based-pathogen-identification/Gene-based-Pathogen-Identification
+    steps:
+      - label: "sample_specific_contigs_tabular_file_preparation"
+      - label: "contigs"
+    why: "fasta2tab (descr_columns 1, keep_first 0) opens records to a two-column table; tab2fasta closes them back after a header edit."
+    confidence: high
+  - workflow: microbiome/metagenomic-genes-catalogue/metagenomic-genes-catalogue
+    why: "Same fasta2tab...tab2fasta envelope around tabular text-processing of gene records."
+    confidence: high
+  - workflow: proteomics/clinicalmp/clinicalmp-discovery/iwc-clinicalmp-discovery-workflow
+    steps:
+      - label: "FASTA to Tabular"
+    why: "One-way fasta2tab feeding a downstream tabular step — interconversion without a return trip."
+    confidence: medium
+---
+
+# Sequence: interconvert FASTA and tabular
+
+## Operation
+
+Move sequence records between FASTA and a tabular form where the **header is one column and the sequence is another**, so the corpus's tabular tools ([[galaxy-tabular-patterns]]) can read, filter, join, or rewrite records that FASTA tooling cannot easily touch. This is the most-reached-for sequence operation in IWC and the substrate for the [[relabel-fasta-headers-via-tabular]] recipe.
+
+Two tools, inverse of each other:
+
+- `toolshed.g2.bx.psu.edu/repos/devteam/fasta_to_tabular/fasta2tab` ("FASTA-to-Tabular") — FASTA → tabular.
+- `toolshed.g2.bx.psu.edu/repos/devteam/tabular_to_fasta/tab2fasta` ("Tabular-to-FASTA") — tabular → FASTA.
+
+Parameter names below are corpus-inferred from `tool_state`; verify against the live form when authoring.
+
+## When to reach for it
+
+- You need to **edit FASTA headers** — inject a sample id, strip a prefix, regex-rewrite — which is awkward on raw FASTA but trivial as column 1 of a table. Pair with [[relabel-fasta-headers-via-tabular]].
+- You need to **join sequence records against a table** (annotations, scores, ids) on the header. Convert one way (`fasta2tab`) and stay tabular (`clinicalmp-discovery` opens a protein DB to tabular and never returns to FASTA).
+- You need a per-record table for counting or filtering that carries the sequence too. For length only, [[sequence-compute-length]] is leaner (it drops the sequence).
+
+## Parameters
+
+### fasta2tab
+
+- `input`: the FASTA (connected).
+- `descr_columns`: how many leading whitespace-delimited header tokens become their own columns. Corpus pins **`"1"`** — the whole description line is column 1, the sequence is column 2.
+- `keep_first`: truncate each sequence to the first N characters; **`"0"`** (keep all) in the corpus.
+
+### tab2fasta
+
+- `input`: the table (connected). Expects the header column(s) then the sequence column.
+- Title/sequence column selection mirrors the `descr_columns` split produced by `fasta2tab`; round-trip with the same shape.
+
+## Idiomatic shape
+
+Open records to a two-column table, ready for a column-1 header edit:
+
+```yaml
+tool_id: toolshed.g2.bx.psu.edu/repos/devteam/fasta_to_tabular/fasta2tab/1.1.1
+tool_state:
+  input: { __class__: ConnectedValue }
+  descr_columns: "1"
+  keep_first: "0"
+```
+
+Then convert back after the edit:
+
+```yaml
+tool_id: toolshed.g2.bx.psu.edu/repos/devteam/tabular_to_fasta/tab2fasta/1.1.1
+tool_state:
+  input: { __class__: ConnectedValue }   # the edited table
+```
+
+## Pitfalls
+
+- **`descr_columns: "1"` is load-bearing for the round-trip.** If you split the header into multiple columns going out (`descr_columns > 1`) but reassemble assuming one, `tab2fasta` rebuilds the header from the wrong column set. Keep the split symmetric.
+- **`keep_first` silently truncates.** A non-zero value clips sequences; the corpus never uses it for interconversion. Leave it `"0"` unless you actually want a prefix.
+- **The table is opaque to coordinates.** Once in tabular form the record is just text columns — see [[galaxy-tabular-patterns]]. This is the right tool for header/string edits, the wrong one for anything needing sequence semantics (length, translate, masking live on their own pages).
+- **One-way is fine.** Not every use returns to FASTA; `clinicalmp-discovery` converts once and joins. Don't add a `tab2fasta` you don't need.
+
+## See also
+
+- [[relabel-fasta-headers-via-tabular]] — the recipe this operation underpins.
+- [[sequence-compute-length]] — when you only want (id, length), not the sequence.
+- [[galaxy-sequence-patterns]] — the sequence pattern map.
+- [[galaxy-tabular-patterns]] — what to do while the records are tabular.
+- [[iwc-sequence-operations-survey]] — corpus evidence.

--- a/content/patterns/sequence-merge-and-dedup.md
+++ b/content/patterns/sequence-merge-and-dedup.md
@@ -1,0 +1,88 @@
+---
+type: pattern
+pattern_kind: operation
+evidence: corpus-observed
+title: "Sequence: merge FASTA and filter unique"
+aliases:
+  - "fasta_merge_files_and_filter_unique_sequences in Galaxy"
+  - "concatenate FASTA and dedup"
+  - "merge sequence files unique"
+tags:
+  - pattern
+  - target/galaxy
+  - topic/galaxy-transform
+  - topic/sequence-transform
+status: draft
+created: 2026-06-10
+revised: 2026-06-10
+revision: 1
+ai_generated: true
+summary: "Concatenate several FASTA files into one and drop duplicate records by sequence identity in a single step; fasta_merge_files_and_filter_unique_sequences."
+related_notes:
+  - "[[iwc-sequence-operations-survey]]"
+related_patterns:
+  - "[[sequence-reformat-line-width]]"
+  - "[[sequence-fasta-tabular-interconvert]]"
+  - "[[galaxy-sequence-patterns]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+iwc_exemplars:
+  - workflow: microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation
+    why: "Merge mode over a set of per-sample FASTAs with uniqueness_criterion sequence and an accession_parser regex pulling the id from each header."
+    confidence: high
+  - workflow: proteomics/clinicalmp/clinicalmp-database-generation/iwc-clinicalmp-database-generation
+    steps:
+      - label: "Human UniProt Microbial Proteins cRAP for MetaNovo"
+    why: "Merge mode building a non-redundant proteomics search database from UniProt, microbial, and cRAP FASTAs."
+    confidence: high
+---
+
+# Sequence: merge FASTA and filter unique
+
+## Operation
+
+Combine several FASTA files into one **and** drop duplicate records in the same step, where "duplicate" is decided by **sequence identity**, not header. The corpus uses:
+
+`toolshed.g2.bx.psu.edu/repos/galaxyp/fasta_merge_files_and_filter_unique_sequences` ("FASTA Merge Files and Filter Unique Sequences").
+
+The differentiator from a plain text concatenation (`cat`, `tp_cat`) is the dedup: the same sequence can arrive under different headers across inputs, and this tool collapses them to one record. That is the reason to reach for it; if you do not need dedup, a concatenation is simpler. Parameter names below are corpus-inferred from `tool_state`.
+
+## When to reach for it
+
+- Building a **non-redundant reference** — a proteomics search database, a merged contig/sequence set — from per-source FASTAs where the same sequence recurs (the corpus uses it for clinical-MP search DBs and pathogen-contig aggregation).
+- Pooling a collection of FASTAs into a single file with duplicates removed.
+
+If you want to keep duplicates (e.g. preserving every record for counting), this is the wrong tool — concatenate instead.
+
+## Parameters
+
+- `batchmode.processmode`: **`merge`** — merge all inputs into one output (vs per-input processing).
+- `batchmode.input_fastas`: the FASTA set (connected; a collection or multiple inputs).
+- `uniqueness_criterion`: **`sequence`** in the corpus — dedup by sequence content. (Dedup-by-header would keep same-sequence/different-header records.)
+- `accession_parser`: a regex extracting the accession/id from each header for the retained record. Corpus value `^>([^ ]+).*$` — take the first whitespace-delimited token after `>`.
+
+## Idiomatic shape
+
+```yaml
+tool_id: toolshed.g2.bx.psu.edu/repos/galaxyp/fasta_merge_files_and_filter_unique_sequences/fasta_merge_files_and_filter_unique_sequences/1.2.0
+tool_state:
+  batchmode:
+    processmode: merge
+    input_fastas: { __class__: ConnectedValue }
+  uniqueness_criterion: sequence
+  accession_parser: ^>([^ ]+).*$
+```
+
+## Pitfalls
+
+- **Dedup is by sequence, not header — confirm that is what you want.** Two genuinely distinct records that happen to share a sequence collapse to one; if headers carry meaning you need to keep, dedup elsewhere or preserve provenance first.
+- **`processmode: merge` vs per-input.** Merge pools everything into one file. If you wanted one deduped output *per* input, that is a different mode.
+- **`accession_parser` decides which header survives.** A regex that does not match a header shape leaves records mis-parsed; verify it against the actual `>` lines (the corpus's `^>([^ ]+).*$` keeps the first token).
+- **Not a concatenation substitute.** If you do not need dedup, this tool's parsing and uniqueness machinery is overhead — use a plain concat.
+
+## See also
+
+- [[sequence-reformat-line-width]] — normalize the merged output's wrapping.
+- [[sequence-fasta-tabular-interconvert]] — when dedup or merge needs header logic a table expresses better.
+- [[galaxy-sequence-patterns]] — the sequence pattern map.
+- [[iwc-sequence-operations-survey]] — corpus evidence.

--- a/content/patterns/sequence-reformat-line-width.md
+++ b/content/patterns/sequence-reformat-line-width.md
@@ -1,0 +1,80 @@
+---
+type: pattern
+pattern_kind: operation
+evidence: corpus-observed
+title: "Sequence: reformat FASTA line width"
+aliases:
+  - "fasta_formatter in Galaxy"
+  - "rewrap FASTA"
+  - "normalize FASTA line length"
+tags:
+  - pattern
+  - target/galaxy
+  - topic/galaxy-transform
+  - topic/sequence-transform
+status: draft
+created: 2026-06-10
+revised: 2026-06-10
+revision: 1
+ai_generated: true
+summary: "Rewrap FASTA records to a fixed sequence-line width so downstream tools and viewers get canonical 60/70/80-column output; cshl_fasta_formatter."
+related_notes:
+  - "[[iwc-sequence-operations-survey]]"
+related_patterns:
+  - "[[sequence-merge-and-dedup]]"
+  - "[[galaxy-sequence-patterns]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+iwc_exemplars:
+  - workflow: amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-quality-control-paired-end/mgnify-amplicon-pipeline-v5-quality-control-paired-end
+    steps:
+      - label: "Paired-end post quality control FASTA files"
+    why: "Rewrap post-QC reads to 60-column FASTA before downstream consumption."
+    confidence: high
+  - workflow: amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction
+    why: "Same width rewrap in the rRNA-prediction sibling of the mgnify family."
+    confidence: medium
+---
+
+# Sequence: reformat FASTA line width
+
+## Operation
+
+Rewrap FASTA records so each sequence is broken into fixed-width lines (the canonical 60/70/80-column convention) rather than one long line per record or whatever width an upstream tool emitted. The corpus uses one tool:
+
+`toolshed.g2.bx.psu.edu/repos/devteam/fasta_formatter/cshl_fasta_formatter` ("FASTA Width formatter").
+
+The tool is part of the FASTX-Toolkit and can also fold case or emit single-line records, but **the only mode the IWC corpus exercises is width rewrap** — every occurrence is the mgnify amplicon family normalizing reads after quality control. Parameter names below are corpus-inferred from `tool_state`.
+
+## When to reach for it
+
+- A downstream tool, viewer, or diff expects standard wrapped FASTA and an upstream step emitted single-line (or oddly wrapped) sequences.
+- You are normalizing reads/contigs for distribution or for a reproducible test fixture and want stable line breaks.
+
+If your need is editing headers rather than wrapping bodies, that is [[sequence-fasta-tabular-interconvert]] + [[relabel-fasta-headers-via-tabular]], not this. Case folding and header rewriting are catalog capabilities of this tool with **zero corpus uptake** — don't reach for them speculatively.
+
+## Parameters
+
+- `input`: the FASTA (connected).
+- `width`: characters per sequence line. Corpus value **`"60"`**. `0` would emit each sequence on a single line (unused here).
+
+## Idiomatic shape
+
+```yaml
+tool_id: toolshed.g2.bx.psu.edu/repos/devteam/fasta_formatter/cshl_fasta_formatter/1.0.1+galaxy2
+tool_state:
+  input: { __class__: ConnectedValue }
+  width: "60"
+```
+
+## Pitfalls
+
+- **Reformatting is not filtering or editing.** This only changes line breaks; record count, ids, and sequence content are unchanged. If duplicates or short records are the problem, see [[sequence-merge-and-dedup]] or filter-by-length.
+- **Don't use it as a FASTA validator.** A malformed record may pass through reformatted; it is not a correctness gate.
+- **`width: "0"` collapses wrapping.** Single-line-per-record output breaks tools that read fixed-width FASTA; only set it when a consumer explicitly wants unwrapped sequences.
+
+## See also
+
+- [[sequence-merge-and-dedup]] — combine multiple FASTAs and drop duplicates.
+- [[galaxy-sequence-patterns]] — the sequence pattern map.
+- [[iwc-sequence-operations-survey]] — corpus evidence.

--- a/content/research/iwc-sequence-operations-survey.md
+++ b/content/research/iwc-sequence-operations-survey.md
@@ -1,0 +1,189 @@
+---
+type: research
+subtype: component
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-06-10
+revised: 2026-06-10
+revision: 1
+ai_generated: true
+related_notes:
+  - "[[iwc-tabular-operations-survey]]"
+  - "[[iwc-interval-operations-survey]]"
+  - "[[iwc-transformations-survey]]"
+  - "[[iwc-shortcuts-anti-patterns]]"
+  - "[[galaxy-tabular-patterns]]"
+  - "[[galaxy-interval-patterns]]"
+  - "[[regex-relabel-via-tabular]]"
+  - "[[tabular-synthesize-bed-from-3col]]"
+  - "[[galaxy-sequence-patterns]]"
+  - "[[sequence-fasta-tabular-interconvert]]"
+  - "[[sequence-reformat-line-width]]"
+  - "[[sequence-merge-and-dedup]]"
+  - "[[sequence-compute-length]]"
+  - "[[sequence-extract-by-region]]"
+  - "[[relabel-fasta-headers-via-tabular]]"
+summary: "IWC survey of record-level FASTA manipulation (interconversion, reformat, merge/dedup, subset, extract-at-intervals); sizes a galaxy-sequence-patterns MOC."
+---
+
+# IWC sequence-record operations survey
+
+Backs #272 — a candidate `galaxy-sequence-patterns` MOC, fourth sibling to [[galaxy-collection-patterns]], [[galaxy-tabular-patterns]], and [[galaxy-interval-patterns]]. Scope is **record-level sequence (FASTA / nucleotide-or-protein record) manipulation** — operations that read, reshape, subset, or interconvert sequence records — **not** the domain tools that analyze sequence (alignment, assembly, annotation, variant calling, search, profiling). Same discipline as #268: scope by **data-shape family + manipulation algebra**, not domain. The issue framed a **hold-if-thin gate**; the survey's first job is to size the cluster honestly.
+
+Source corpus: `$IWC_FORMAT2/` — 120 `.gxwf.yml` files. Citations are `$IWC_FORMAT2/path` plus step label or tool name; line numbers only for stable parameter snippets.
+
+## TL;DR — the sizing finding
+
+**Sequence-record manipulation is real and slightly broader than interval algebra, but moderate — not the rich cluster the issue's headline counts imply.** The issue's table ranks operations by **tool_id-occurrence** count (fasta_formatter 20, getfasta 16, merge 14, …). Those counts reproduce exactly, but they are inflated by the same subworkflow embedding the interval survey caught: distinct **workflow** counts are far lower.
+
+| Operation (corpus-observed) | tool | tool_id occ | **distinct wf** |
+|---|---|---|---|
+| FASTA reformat (line width) | `devteam/fasta_formatter` (`cshl_fasta_formatter`) | 20 | **4** |
+| Extract sequence at intervals | `iuc/bedtools` (`bedtools_getfastabed`) | 16 | **3** |
+| Merge FASTA + filter unique sequences | `galaxyp/fasta_merge_files_and_filter_unique_sequences` | 14 | **4** |
+| FASTA → tabular | `devteam/fasta_to_tabular` (`fasta2tab`) | 13 | **4** |
+| tabular → FASTA | `devteam/tabular_to_fasta` (`tab2fasta`) | 11 | **3** |
+| Sequence length compute | `devteam/fasta_compute_length` | 7 | **3** |
+| Mask sequence by intervals | `iuc/bedtools` (`bedtools_maskfastabed`) | 5 | **2** |
+| Extract transcript/CDS FASTA from annotation | `devteam/gffread` | 8 | **4** |
+| Filter by length | `devteam/fasta_filter_by_length` | 2 | **1** |
+| Translate (nt → protein) | `iuc/seqkit_translate` | 2 | **1** |
+| Subset by id list | `iuc/seqtk` (`seqtk_subseq`) | 2 | **1** |
+| Subset/filter by id list | `galaxyp/filter_by_fasta_ids` | 3 | **1** |
+| FASTQ → FASTA | `devteam/fastqtofasta` (`fastq_to_fasta_python`) | 10 | **3** |
+
+Three findings sharpen the gate:
+
+1. **The healthy core is interconversion + reformat, not the interval-bridge tools.** `getfasta`/`maskfasta` are the operations the #268 scope-edge analysis surfaced, but in distinct-workflow terms they are mid-pack (3 / 2). The operations that actually recur are **fasta↔tabular interconversion** (`fasta2tab`/`tab2fasta`, 4 / 3) and **reformat** (`fasta_formatter`, 4) and **merge+dedup** (4). The single most reusable *construct* is a multi-step recipe — relabel FASTA headers by detouring through tabular — not any one operation (§3).
+2. **The 20-occurrence headline (`fasta_formatter`) is ~2–3 authoring contexts.** All four `fasta_formatter` workflows are the mgnify amplicon family (`mgnify-amplicon-pipeline-v5-{quality-control-paired-end,quality-control-single-end,rrna-prediction,complete}`); `…-complete` embeds the other three as subworkflows. Same inflation hits `fasta2tab`/`tab2fasta` (the pathogen-identification family) and `getfasta`. Distinct-context counts run roughly **half** the workflow counts above.
+3. **The biggest FASTA-touching tool in the corpus is out of scope and must be named, or the inventory looks absurd.** `bgruening/gfastats` has **113** tool_id occurrences across 10 VGP-assembly workflows — it dwarfs everything here. But it is an **assembly** tool (FASTA↔GFA conversion + assembly statistics: "Convert purged fasta to gfa", "gfastats gfa hap1", `$IWC_FORMAT2/VGP-assembly-v2/...`), domain-out per the issue. Counting it would make "sequence manipulation" read as a VGP-assembly concern, which it is not. Held out; recorded here so the hole is deliberate.
+
+Net for the gate (the decision belongs to `/iwc-survey-act`, not here): a sequence MOC is defensible and modestly broader than interval, but should lead with the **interconversion seam and its relabel recipe**, keep the thin operations (translate, filter-by-length, subset-by-id) as footnoted ingredients, and treat `getfasta`/`maskfasta` as **shared bridges with #268**, not the headline.
+
+## 1. What exists — operation inventory
+
+Distinct sequence-record operations, by the move they make. Counts are evidence, not the headline; distinct-workflow counts lead (§TL;DR).
+
+### FASTA ↔ tabular interconversion — the strongest seam (4 / 3 workflows)
+
+The corpus reaches for the tabular form whenever it needs to *edit* sequence records (headers especially), because FASTA headers are awkward to regex in place but trivial as column 1 of a table.
+
+- `fasta2tab` (devteam) — FASTA → tabular, header in col 1, sequence in col 2. `descr_columns: "1"`, `keep_first: "0"` (`$IWC_FORMAT2/microbiome/pathogen-identification/gene-based-pathogen-identification/Gene-based-Pathogen-Identification.gxwf.yml:286`, step "sample_specific_contigs_tabular_file_preparation"). Also `$IWC_FORMAT2/microbiome/metagenomic-genes-catalogue/metagenomic-genes-catalogue.gxwf.yml`, `$IWC_FORMAT2/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation.gxwf.yml`, `$IWC_FORMAT2/proteomics/clinicalmp/clinicalmp-discovery/iwc-clinicalmp-discovery-workflow.gxwf.yml`.
+- `tab2fasta` (devteam) — tabular → FASTA, the inverse. Co-occurs with `fasta2tab` in three of the four interconversion workflows (the pathogen-identification + metagenomic-genes family); `clinicalmp-discovery` uses `fasta2tab` one-way only (FASTA into a downstream tabular join).
+
+### FASTA reformat — line-width rewrap (4 workflows, ~2 contexts)
+
+- `cshl_fasta_formatter` (devteam) — rewrap to fixed line width. `width: "60"`, single connected input (`$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-quality-control-paired-end/mgnify-amplicon-pipeline-v5-quality-control-paired-end.gxwf.yml:661-664`, step "Paired-end post quality control FASTA files"). The width rewrap is the only parameter exercised in the corpus — case folding and header-only output are catalog capabilities with zero uptake here.
+
+### Merge + dedup (4 workflows)
+
+- `fasta_merge_files_and_filter_unique_sequences` (galaxyp) — concatenate a set of FASTAs **and** drop duplicate records in one step. The corpus pins `uniqueness_criterion: sequence` (dedup by sequence content, not header) with `accession_parser: ^>([^ ]+).*$` and `batchmode.processmode: merge` (`$IWC_FORMAT2/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation.gxwf.yml:1204`). The dedup-aware merge is the differentiator from a plain `cat` of FASTA files.
+
+### Sequence length → tabular (3 workflows)
+
+- `fasta_compute_length` (devteam) — emit a tabular (id, length) table. `keep_first: "0"` (all), `keep_first_word: false` (`$IWC_FORMAT2/VGP-assembly-v2/Purge-duplicate-contigs-VGP6/Purge-duplicate-contigs-VGP6.gxwf.yml:1655`). Output is tabular, so this is also a sequence→tabular bridge (§5), distinct in purpose from `fasta2tab` (which carries the sequence too).
+
+### Extract / mask by intervals — the #268 shared seam (3 / 2 workflows)
+
+- `bedtools_getfastabed` (iuc) — extract FASTA at BED intervals. `fasta_source_selector: history`, `nameOnly/split/strand/tab: false` (`$IWC_FORMAT2/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation.gxwf.yml:576`).
+- `bedtools_maskfastabed` (iuc) — mask FASTA regions named by a BED. `mc: N` (mask character), `soft: false` (hard mask, lowercase when soft) (`$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/mgnify-amplicon-pipeline-v5-complete.gxwf.yml:3770`).
+
+These two consume intervals and produce sequence. #268 deliberately held them out of interval algebra on the **output-shape** rule (produces sequence records → sequence, not interval); see [[iwc-interval-operations-survey]] §5. They are the canonical cross-MOC bridge, not the sequence core.
+
+### Extract transcript/CDS FASTA from annotation (4 workflows; pulled in per scope decision)
+
+- `gffread` (devteam) — read a GFF/GTF + genome FASTA, emit transcript/CDS FASTA. `$IWC_FORMAT2/genome_annotation/annotation-maker/Genome_annotation_with_maker_short.gxwf.yml:406`; also annotation-braker3, annotation-helixer, lncRNAs-annotation. The operation is record-level sequence extraction (annotation→sequence, parallel to getfasta's interval→sequence), so it is in scope per the #272 scope-edge decision — but every corpus instance lives in a `genome_annotation` pipeline, so it is annotation-domain-flavored. Treat as an in-scope operation with a Bridges note (§5).
+
+### Subset by id list — a two-tool redundancy (1 + 1 workflows)
+
+- `seqtk_subseq` (iuc) — keep records whose names appear in a connected name list. `source.type: name`, `name_list` connected, `l: "0"` (`$IWC_FORMAT2/virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping.gxwf.yml:505`).
+- `filter_by_fasta_ids` (galaxyp) — same job, different tool: `header_criteria_select: id_list`, `identifiers` connected, `id_regex.find: beginning`, `dedup: false`, plus an `output_discarded` complement and a `sequence_criteria` branch (`$IWC_FORMAT2/microbiome/metagenomic-genes-catalogue/metagenomic-genes-catalogue.gxwf.yml:934`, step "Filter FASTA to keep CDS corresponding to ARGs"). Decision-point in §2.
+
+### Filter by length / translate / FASTQ→FASTA (thin — 1, 1, 3 workflows)
+
+- `fasta_filter_by_length` (devteam) — `min_length: "0"`, connected `max_length` (`$IWC_FORMAT2/VGP-assembly-v2/Assembly-decontamination-VGP9/Assembly-decontamination-VGP9.gxwf.yml:515`, filtering to short mitochondrial scaffolds).
+- `seqkit_translate` (iuc) — nucleotide → protein, `frame: "1"`, `transl_table: "1"` (`$IWC_FORMAT2/microbiome/metagenomic-genes-catalogue/metagenomic-genes-catalogue.gxwf.yml:1332`).
+- `fastq_to_fasta_python` (devteam) — FASTQ → FASTA, no parameters; pure record-format interconversion (`$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-quality-control-paired-end/mgnify-amplicon-pipeline-v5-quality-control-paired-end.gxwf.yml:566`). In scope as interconversion per the #272 decision, though it sits at the reads-domain edge.
+
+### Absent — catalog capabilities with zero corpus uptake
+
+Reverse-complement (standalone — `reverse_complement: none` appears only as a *parameter* inside HyPhy codon tools, `$IWC_FORMAT2/comparative_genomics/hyphy/hyphy-core.gxwf.yml:157`, not a sequence operation), sequence sort, GC/composition compute, standalone dedup (`seqkit_rmdup`), EMBOSS `seqret`/`transeq`, `fasta_nucleotide_changer`, `fastx_collapser`, `fasta_clipping_histogram`. Per corpus-first these are documented gaps, **not** candidate patterns; none is anti-pattern evidence, just no exemplar.
+
+## 2. Redundancy / decision-points
+
+Where the corpus shows more than one tool for one job — the boundaries a MOC must adjudicate.
+
+1. **Subset FASTA by id list — `seqtk_subseq` (iuc) vs `filter_by_fasta_ids` (galaxyp).** Both keep records named by a connected id list. `filter_by_fasta_ids` adds a discarded-complement output, regex anchoring (`id_regex.find: beginning`), an in-line `dedup`, and a `sequence_criteria` branch; `seqtk_subseq` is leaner and also does region/range subsetting (`l:` flank). Split cleanly by domain (virology reaches for seqtk; proteomics/microbiome for filter_by_fasta_ids), mirroring the `bedtools`-vs-`gops` and `tp_grep`-vs-`Grep1` redundancies the sibling surveys resolved. → Q1.
+2. **Sequence length / stats — `fasta_compute_length` (devteam) vs `fasta_stats` (iuc) vs `gfastats` (bgruening).** `fasta_compute_length` emits a clean (id, length) table — the record-level move. `fasta_stats` (`$IWC_FORMAT2/genome-assembly/assembly-with-flye/Genome-assembly-with-Flye.gxwf.yml`, "Fasta Statistics") and `gfastats` are aggregate-statistics / assembly tools. The length-table operation is in scope; aggregate-stats is domain. The page must not absorb assembly stats. → Q2.
+3. **Merge FASTA — dedup-aware merge vs plain concatenation.** `fasta_merge_files_and_filter_unique_sequences` merges *and* dedups by sequence; four workflows reach for it specifically when duplicate records must go (proteomics search DBs, pathogen aggregation). A plain `tp_cat`/text concat would merge without dedup. The page should make the dedup criterion (`uniqueness_criterion: sequence`) the reason-to-use, not the merge alone. → Q3.
+4. **Interconversion direction vs purpose.** `fasta2tab` appears both as the front half of a roundtrip (→ edit → `tab2fasta`) and one-way (FASTA into a tabular join, `clinicalmp-discovery`). One operation page covering both directions, with the roundtrip as a separate recipe? → Q4.
+
+## 3. Recurring idioms
+
+### Single-tool parameter idioms (with citations)
+
+- **`fasta_formatter` only ever rewraps width** in the corpus (`width: "60"`, `…quality-control-paired-end…:664`). Case folding / header-only modes are unused.
+- **`fasta_merge_files_and_filter_unique_sequences` dedups by *sequence*, not header** (`uniqueness_criterion: sequence`, `…PathoGFAIR…:1204`) — the same record can carry different headers across inputs; sequence-identity dedup is the point.
+- **`fasta2tab` splits to exactly two columns** (`descr_columns: "1"`, `keep_first: "0"`) so the header is col 1 and the full sequence is col 2 — the shape the relabel recipe (below) depends on.
+- **`maskfasta` picks hard vs soft via `soft:`** (`soft: false` + `mc: N` = replace with N; `soft: true` = lowercase), `…mgnify…complete…:3770`.
+
+### Multi-step recipe — relabel FASTA headers via the tabular detour (the high-value unit)
+
+Invisible to grep; the most reusable sequence construct in the corpus. **`fasta2tab` → `tp_find_and_replace` on column 1 → `tab2fasta`** — convert records to a (header, sequence) table, rewrite the header column with text processing, convert back. Confirmed tight in `$IWC_FORMAT2/microbiome/pathogen-identification/gene-based-pathogen-identification/Gene-based-Pathogen-Identification.gxwf.yml` (`fasta2tab` step 9 `:272` → `tp_find_and_replace` on `column: "1"` step 12 `:347-375` → `tab2fasta` step 15 `:474`); the find/replace injects a per-sample id into each header via a connected `replace_pattern`. The same `fasta2tab`…`tab2fasta` envelope recurs in `metagenomic-genes-catalogue` and `PathoGFAIR` (interconversion pair co-present, with tabular text-processing between). This is a sequence-record-specific cousin of [[regex-relabel-via-tabular]] (which relabels *collection identifiers*, not record headers) — distinct enough to warrant its own page, cross-linked to the tabular relabel patterns. **Keep.**
+
+## 4. Candidate pattern boundaries
+
+Operation-/recipe-anchored names per `docs/PATTERNS.md`. Because the interconversion seam and its recipe carry the value, the keep-set is interconversion-led with a recipe at the top.
+
+**Recipe (keep — highest value):**
+
+- **`recipe: relabel-fasta-headers-via-tabular`** — §3 recipe. Evidence: 3 workflows, one tight-confirmed wiring. **Keep.** The flagship sequence construct; cross-link [[regex-relabel-via-tabular]] and [[galaxy-tabular-patterns]].
+
+**Operations (keep ≥2-workflow ones as standalone; thin ones become ingredients/footnotes):**
+
+- **`sequence-fasta-tabular-interconvert`** (`fasta2tab` + `tab2fasta`, both directions) — Evidence: 4 / 3 workflows. **Keep** — the strongest standalone operation; it underpins the recipe and the sequence↔tabular bridge. Q4 decides one page vs two.
+- **`sequence-reformat-line-width`** (`fasta_formatter` width rewrap) — Evidence: 4 workflows (≈2 contexts). **Keep**, scoped tightly to the width-rewrap move (the only one used).
+- **`sequence-merge-and-dedup`** (`fasta_merge_files_and_filter_unique_sequences`) — Evidence: 4 workflows. **Keep**; lead with the dedup-by-sequence criterion (Q3).
+- **`sequence-compute-length`** (`fasta_compute_length` → id/length table) — Evidence: 3 workflows. **Keep**, fenced off from aggregate assembly stats (Q2).
+- **`sequence-extract-at-intervals`** (`getfasta`) — Evidence: 3 workflows. **Keep**, but author as a **bridge page** shared with #268 (output-shape rule), not a standalone interval-ignorant op.
+- **`sequence-subset-by-id`** (`seqtk_subseq` / `filter_by_fasta_ids`) — Evidence: 2 workflows across two tools. **Keep, flag the redundancy** (Q1); lead-tool TBD.
+- **`sequence-mask-by-intervals`** (`maskfasta`) — Evidence: 2 workflows. **Keep-or-merge** into the extract-at-intervals bridge page as its sibling move. → Q5.
+- **`sequence-extract-from-annotation`** (`gffread`) — Evidence: 4 workflows, all genome_annotation. **Keep, flag domain-embedding**; or fold into the extract bridge family. → Q5.
+
+**Drop as standalone (thin / single-source — document as ingredients or footnotes):**
+
+- **filter-by-length** (`fasta_filter_by_length`, 1 wf), **translate** (`seqkit_translate`, 1 wf), **FASTQ→FASTA** (`fastq_to_fasta_python`, reads-edge). Single-source; mention inside the MOC's operation list, no standalone pages unless a second exemplar appears. → Q6.
+
+**Gaps (document, no page):** reverse-complement, sequence sort, composition/GC, standalone dedup, EMBOSS seqret/transeq — §1 "Absent".
+
+## 5. Bridges (cross-shape seams the MOC should cross-link)
+
+- **sequence ↔ tabular.** The dominant seam. `fasta2tab`/`tab2fasta` interconvert; `fasta_compute_length` emits a (id, length) table; the relabel recipe lives entirely on this seam. The line is: tabular treats the record as opaque columns (header = col 1, sequence = col 2); sequence operations understand FASTA record structure. Cross-link [[galaxy-tabular-patterns]] and [[iwc-tabular-operations-survey]].
+- **sequence ↔ interval.** `getfasta` (intervals → sequence) and `maskfasta` (intervals + sequence → masked sequence) are the inverse-facing seam to #268, which already documented these as out-of-interval-scope on the output-shape rule (see [[iwc-interval-operations-survey]] §5). Each MOC's `## Bridges` should point at the other; the sequence MOC owns the operations, #268 owns the BED that feeds them. Cross-link [[galaxy-interval-patterns]].
+- **alignment → sequence (scope edge).** `samtools_fastx` (BAM → FASTQ/FASTA, 2 workflows: host-contamination-removal, nanopore pre-processing) and `bedtools_bamtobed` (BAM → BED, owned by #268) convert alignment records to sequence/interval. The sequence MOC notes `samtools_fastx` as an input bridge; it is not a sequence-record *manipulation*, so no page.
+- **annotation → sequence (scope edge).** `gffread` extracts transcript/CDS FASTA from GFF + genome. Pulled in as an operation per the #272 decision, but flagged here as annotation-domain-resident; the Bridges note links it to the annotation pipelines that produce its GFF input.
+
+## 6. Out of scope — the assembly elephant and domain consumers
+
+Named so the held-out set is deliberate, not an oversight:
+
+- **`gfastats`** (bgruening, 113 occ / 10 VGP workflows) — assembly FASTA↔GFA conversion + assembly statistics. Domain (assembly). The corpus's largest FASTA-touching tool; out.
+- **`Fasta_to_Contig2Bin`, `concoct_cut_up_fasta`, `concoct_extract_fasta_bins`** — metagenomic binning. Domain.
+- **`peptideshaker fasta_cli`** — proteomics search-DB build. Domain.
+- **`fastqc`** (7 wf), **assembly/alignment/annotation/variant/search tools** — consume or emit sequence but do not manipulate records. Domain, per the #272 scope rule.
+
+## 7. Beyond IWC (not surveyed)
+
+Unlike the interval survey, this cluster did **not** need a GTN cross-reference to justify graduation — the IWC corpus carries enough record-level operations on its own. The absent capabilities in §1 (reverse-complement, sequence sort, composition) are common in GTN training material and the Tool Shed, but per corpus-first they stay gaps until an IWC exemplar appears. No GTN mining was performed this run; flag if `/iwc-survey-act` wants the absent-everywhere vs IWC-absent distinction the interval survey drew for `closest`.
+
+## 8. Open questions
+
+1. **Q1 — subset-by-id lead tool.** `seqtk_subseq` (iuc, leaner, also does ranges) vs `filter_by_fasta_ids` (galaxyp, discarded-complement + regex anchoring)? Both single-workflow; pick a recommended tool and footnote the other, or present co-equal pending a tiebreak? Evidence §2.1.
+2. **Q2 — length vs stats boundary.** Confirm `sequence-compute-length` covers only the (id, length) table and explicitly excludes `fasta_stats`/`gfastats` aggregate assembly stats. Evidence §2.2.
+3. **Q3 — merge page framing.** Lead `sequence-merge-and-dedup` with the dedup-by-sequence criterion (vs plain concat)? Or split "merge" from "dedup"? Evidence §2.3.
+4. **Q4 — interconversion page shape.** One `sequence-fasta-tabular-interconvert` page covering both directions, with `relabel-fasta-headers-via-tabular` as a separate recipe; or fold the one-way `fasta2tab→join` case in too? Evidence §1, §3.
+5. **Q5 — extract/mask bridge granularity.** Is there one `sequence-extract-at-intervals` bridge page that also holds `maskfasta` (mask-by-intervals) and `gffread` (extract-at-annotation) as sibling moves, or three pages? Lean: one bridge page with three moves, given each is thin. Evidence §4, §5. *(Resolved in the #272 PR: one page, authored as `sequence-extract-by-region` with three moves.)*
+6. **Q6 — does the MOC graduate now, or hold?** The gate. Moderate corpus, interconversion-led, recipe-carried, with several thin single-source operations and the motivating interval-bridge tools shared with #268. Graduate a modest interconversion-led MOC, or hold the thin operations (translate, filter-by-length, subset-by-id) until second exemplars appear? Decision owned by `/iwc-survey-act`. Evidence: TL;DR + §4.
+7. **Q7 — MOC naming.** Issue specifies slug `galaxy-sequence-patterns`, title "Galaxy: sequence patterns", topic tag `topic/sequence-transform`. *(Resolved in the #272 PR: naming confirmed as specified; `topic/sequence-transform` registered in `meta_tags.yml`.)*

--- a/meta_tags.yml
+++ b/meta_tags.yml
@@ -80,3 +80,5 @@ topic/tabular-transform:
   description: "Galaxy tabular transformation pattern map"
 topic/interval-transform:
   description: "Galaxy genomic interval transformation pattern map"
+topic/sequence-transform:
+  description: "Galaxy sequence-record (FASTA) transformation pattern map"


### PR DESCRIPTION
> Authored by Claude (AI assistant) on jmchilton's behalf via `/iwc-survey` + `/iwc-survey-act`.

Closes #272. Fourth data-shape pattern-MOC sibling, after collection/tabular/interval (#268).

## Process
Survey-first (the de-risker), then act: `/iwc-survey` → `/iwc-survey-act` → review subagent → fixes. Same discipline as #268.

## Sizing finding (the premise correction)
The issue ranked this cluster by **tool_id-occurrence** counts (fasta_formatter 20, getfasta 16, merge 14…), reproduced exactly here — but those are inflated by mgnify/VGP/pathogen subworkflow embedding. Distinct-**workflow** counts run ~half (fasta_formatter 4, getfasta 3, merge 4, fasta2tab 4…), so the cluster is **moderate, comparable to interval, not "healthier."** The survey leads with the honest metric and the hold-if-thin gate applies the same as #268.

The strongest sub-cluster is the **FASTA ↔ tabular seam** and its relabel recipe — not the interval-bridge tools.

## What's here
- **Survey** `content/research/iwc-sequence-operations-survey.md` — inventory, redundancy/decision-points, idioms, recipes, bridges, gaps, 7 open Qs (resolved in this PR).
- **MOC** `content/patterns/galaxy-sequence-patterns.md` ("Galaxy: sequence patterns", `topic/sequence-transform`).
- **5 operations**: `sequence-fasta-tabular-interconvert`, `sequence-reformat-line-width`, `sequence-merge-and-dedup`, `sequence-compute-length`, `sequence-extract-by-region` (getfasta/maskfasta/gffread bridge, one page/3 moves).
- **1 recipe**: `relabel-fasta-headers-via-tabular` (the flagship: `fasta2tab` → find/replace on column 1 → `tab2fasta`).
- `meta_tags.yml` registers `topic/sequence-transform`; sibling MOCs cross-linked in See-also.

## Scope calls
- Operation-shaped edge tools (`gffread`, `fastq_to_fasta`) pulled in; `samtools_fastx`/`bamtobed` kept as bridges.
- Thin single-source ops (translate, filter-by-length, subset-by-id [`seqtk_subseq`-lead], fastq→fasta) deferred as **tracked-not-paged** in the MOC.
- `gfastats` (113 occ, all VGP) explicitly held out as assembly-domain.
- `getfasta`/`maskfasta` are the shared bridge with #268 (output-shape rule).

## Verification
- `npm run validate` — 0 errors (advisory backlink warnings only, same convention as the interval sibling).
- `npm run test` — 102/102.
- Review subagent verified every count/parameter/citation against `iwc-format2`; caught and fixed 4 exemplar errors (wrong merge workflow, mislabeled step, maskfasta workflow/version drift).

## Follow-up (not in scope here)
The issue mentions wiring the MOC into the data-flow/template Molds "as a pattern ref." The interval sibling didn't edit Mold files either (only `related_molds` on the MOC, mirrored here). The in-Mold reference is unfilled in both — worth a separate pass if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
