### PR TITLE
Surface converted gxformat2 view of nearest IWC exemplar (#280)

### DIFF
--- a/casts/claude/skills/compare-against-iwc-exemplar/SKILL.md
+++ b/casts/claude/skills/compare-against-iwc-exemplar/SKILL.md
@@ -22,7 +22,8 @@ Follow the procedure below and use the artifact/reference sections as the runtim
 
 ## Outputs
 
-- Write artifact `iwc-comparison-notes` as `iwc-comparison-notes.md`. Format: `markdown`. Structural diff against the nearest IWC exemplar(s); guidance for the downstream *-summary-to-galaxy-template Mold before per-step authoring.
+- Write artifact `iwc-comparison-notes` as `iwc-comparison-notes.md`. Format: `markdown`. Structural diff against the nearest IWC exemplar(s); guidance for the downstream *-summary-to-galaxy-template Mold before per-step authoring. Carries an inline, bounded gxformat2 excerpt of the nearest exemplar's relevant subgraph under a labeled section, cross-referencing the iwc-exemplar-gxformat2 sibling file.
+- Write artifact `iwc-exemplar-gxformat2` as `iwc-exemplar.gxwf.yml`. Format: `yaml`. Cleaned gxformat2 conversion (via convert --to format2 --compact) of the nearest IWC exemplar's relevant subgraph — the concrete idiom the downstream template draft pattern-matches against. Bounded to the relevant subgraph, not the whole workflow. Absent when no nearest exemplar is found.
 
 ## Required Tools
 
@@ -37,7 +38,7 @@ Follow the procedure below and use the artifact/reference sections as the runtim
 
 ## Load On Demand
 
-- `references/cli/convert.json`: CLI command reference packaged as a sidecar. Normalize fetched IWC workflows into a consistent representation for structural comparison. Use when: after fetching a candidate IWC workflow file and before structural comparison.
+- `references/cli/convert.json`: CLI command reference packaged as a sidecar. Normalize fetched IWC workflows into a consistent representation for structural comparison, and surface the nearest exemplar forward as a cleaned gxformat2 view (sibling file plus inline excerpt) for the downstream template Mold. Use when: after fetching a candidate IWC workflow file and before structural comparison; and again on the nearest exemplar after ranking to emit the iwc-exemplar-gxformat2 view.
 - `references/notes/galaxy-data-flow-draft-contract.md`: Research note copied verbatim into the bundle. Compare against the design briefs' abstract intent without turning exemplar comparison into tool resolution. Use when: deciding whether to compare abstract data-flow shape, interface structure, or speculative implementation details.
 - `references/notes/iwc-shortcuts-anti-patterns.md`: Research note copied verbatim into the bundle. Flag proposed shortcuts that are accepted in IWC versus shortcuts that should be treated as smells. Use when: the design briefs propose tests, assertions, labels, or expected-output comparisons.
 - `references/notes/iwc-test-data-conventions.md`: Research note copied verbatim into the bundle. Compare proposed test-data placement and fixture shapes against IWC conventions. Use when: the design briefs hint at workflow tests or input fixture organization.
@@ -57,6 +58,7 @@ This skill is the corpus-first check in Galaxy-targeting pipelines. It runs afte
 - Clone or pull and merge the IWC `<url>` to `~/.foundry/iwc`.
 - Normalize candidate workflows with convert as needed for structural comparison.
 - Find the closest workflow and rank it.
+- Surface the nearest exemplar forward (skip when the result is "no nearest exemplar"): see *Nearest exemplar (gxformat2) view*.
 
 ### Feature Hierarchy
 
@@ -88,6 +90,18 @@ Each finding should name the authoring surface most likely to own the fix:
 - Test issue: defer to `*-test-to-galaxy-test-plan` or `implement-galaxy-workflow-test`.
 
 Do not block downstream authoring on low-confidence exemplar mismatches. Report them as review guidance for the template skill and the user.
+
+### Nearest exemplar (gxformat2) view
+
+The schema tells the template skill what is *legal* gxformat2; it does not show *idiom*. A real, domain-adjacent gxformat2 workflow is high-value signal for constructing the draft — input/collection shapes, map-over wiring, output promotion, post-job actions. Agents have seen far more legacy `.ga` JSON than gxformat2 YAML in training, so surface the converted view rather than leaving it as prose.
+
+Once the nearest exemplar is chosen (High or Medium confidence):
+
+- Convert it with convert (`--to format2 --compact`).
+- Write the cleaned gxformat2 of the **relevant subgraph** to the `iwc-exemplar.gxwf.yml` sibling artifact — the slice that matches the briefs' structure, not the whole workflow.
+- Inline a bounded excerpt (~10–40 lines) of that subgraph under a labeled section in `iwc-comparison-notes.md`, and cite the abstract IWC workflow ID (e.g. `transcriptomics/rnaseq-pe/rnaseq-pe`) plus the step labels it covers. Cross-reference the sibling file for the fuller view.
+
+Keep it size-bounded — a whole large workflow is noise; the relevant subgraph is the signal. When the result is "no nearest exemplar," emit neither the sibling file nor the excerpt. A Low-confidence cross-domain match may surface a short excerpt for pattern comparison but should be labeled as such, not as a domain exemplar.
 
 ### Non-goals
 

--- a/casts/claude/skills/compare-against-iwc-exemplar/_provenance.json
+++ b/casts/claude/skills/compare-against-iwc-exemplar/_provenance.json
@@ -4,11 +4,11 @@
   "mold": {
     "name": "compare-against-iwc-exemplar",
     "path": "content/molds/compare-against-iwc-exemplar/index.md",
-    "revision": 6,
-    "content_hash": "45938bb76109a84d50368f6c8ffde5bd61e6ad685f68a114f802fcd99ffa2e50",
-    "commit": "613d9a59ab74fc752defd79cdd07fffa0c790591"
+    "revision": 7,
+    "content_hash": "ba2f0742d39c52293e7c307ed4bdaa63994a017332de9915df3087835dff45a7",
+    "commit": "046ce4a6a63a0f125271d901af4470997073960c"
   },
-  "cast_at": "2026-06-10T23:36:00.175Z",
+  "cast_at": "2026-06-11T12:14:41.821Z",
   "cast_date": "2026-05-07",
   "cast_revision": 3,
   "cast_history": [
@@ -38,8 +38,8 @@
       "used_at": "runtime",
       "load": "on-demand",
       "evidence": "corpus-observed",
-      "purpose": "Normalize fetched IWC workflows into a consistent representation for structural comparison.",
-      "trigger": "After fetching a candidate IWC workflow file and before structural comparison.",
+      "purpose": "Normalize fetched IWC workflows into a consistent representation for structural comparison, and surface the nearest exemplar forward as a cleaned gxformat2 view (sibling file plus inline excerpt) for the downstream template Mold.",
+      "trigger": "After fetching a candidate IWC workflow file and before structural comparison; and again on the nearest exemplar after ranking to emit the iwc-exemplar-gxformat2 view.",
       "src_hash": "24b91f53b0e7850d1dfc38df1074f2d4270c72f20778d0e4d710545bf64be3e0",
       "dst_hash": "fad8586b1d2afeed3ee70189fb7db7a8019c77e24cc4fd4697b2210d9bc3012c",
       "source": "deterministic"
@@ -97,7 +97,13 @@
         "id": "iwc-comparison-notes",
         "kind": "markdown",
         "default_filename": "iwc-comparison-notes.md",
-        "description": "Structural diff against the nearest IWC exemplar(s); guidance for the downstream *-summary-to-galaxy-template Mold before per-step authoring."
+        "description": "Structural diff against the nearest IWC exemplar(s); guidance for the downstream *-summary-to-galaxy-template Mold before per-step authoring. Carries an inline, bounded gxformat2 excerpt of the nearest exemplar's relevant subgraph under a labeled section, cross-referencing the iwc-exemplar-gxformat2 sibling file."
+      },
+      {
+        "id": "iwc-exemplar-gxformat2",
+        "kind": "yaml",
+        "default_filename": "iwc-exemplar.gxwf.yml",
+        "description": "Cleaned gxformat2 conversion (via [[convert]] --to format2 --compact) of the nearest IWC exemplar's relevant subgraph — the concrete idiom the downstream template draft pattern-matches against. Bounded to the relevant subgraph, not the whole workflow. Absent when no nearest exemplar is found."
       }
     ],
     "consumes": [

--- a/casts/claude/skills/freeform-summary-to-galaxy-data-flow/references/patterns/galaxy-collection-patterns.md
+++ b/casts/claude/skills/freeform-summary-to-galaxy-data-flow/references/patterns/galaxy-collection-patterns.md
@@ -88,3 +88,5 @@ This is the runtime-facing map for Galaxy collection transformation choices. Use
 
 - [[iwc-transformations-survey]] — collection-transform survey and evidence trail.
 - [[galaxy-tabular-patterns]] — companion MOC for tabular operations.
+- [[galaxy-interval-patterns]] — companion MOC for coordinate-feature operations.
+- [[galaxy-sequence-patterns]] — companion MOC for sequence-record operations.

--- a/casts/claude/skills/freeform-summary-to-galaxy-data-flow/references/patterns/galaxy-tabular-patterns.md
+++ b/casts/claude/skills/freeform-summary-to-galaxy-data-flow/references/patterns/galaxy-tabular-patterns.md
@@ -78,4 +78,6 @@ This is the runtime-facing map for Galaxy tabular transformation choices. Use it
 ## See also
 
 - [[iwc-tabular-operations-survey]] — tabular-operation survey and evidence trail.
+- [[galaxy-sequence-patterns]] — companion MOC for sequence-record operations; FASTA↔tabular is the dominant sequence seam.
+- [[galaxy-interval-patterns]] — companion MOC for coordinate-feature operations.
 - [[galaxy-collection-patterns]] — companion MOC for collection operations.

--- a/content/molds/compare-against-iwc-exemplar/eval.md
+++ b/content/molds/compare-against-iwc-exemplar/eval.md
@@ -22,7 +22,13 @@
 
 - check: deterministic + llm-judged
 - fixture: Galaxy interface + data-flow design briefs whose domain, tool families, topology, or output intent has no close IWC match.
-- expectation: returns "no nearest exemplar" instead of forcing a nearest, lists the top weak candidates with rationale, and refuses high confidence on tool-overlap-only matches (`MultiQC`, `fastp`, `awk`, `datamash`).
+- expectation: returns "no nearest exemplar" instead of forcing a nearest, lists the top weak candidates with rationale, and refuses high confidence on tool-overlap-only matches (`MultiQC`, `fastp`, `awk`, `datamash`). Emits no gxformat2 view — no `iwc-exemplar.gxwf.yml` sibling and no inline excerpt in the notes.
+
+## Case: nearest exemplar gxformat2 view surfaced
+
+- check: deterministic + llm-judged
+- fixture: a run that selects a High- or Medium-confidence nearest exemplar (e.g. the nf-core rnaseq case).
+- expectation: writes a cleaned gxformat2 `iwc-exemplar.gxwf.yml` sibling for the nearest exemplar's relevant subgraph (via `convert --to format2 --compact`), and inlines a bounded (~10–40 line) excerpt of that subgraph under a labeled section in `iwc-comparison-notes.md`, citing the abstract IWC workflow ID and the step labels covered. The excerpt is the relevant subgraph, not the whole workflow.
 
 ## Case: IWC clone reuse
 

--- a/content/molds/compare-against-iwc-exemplar/index.md
+++ b/content/molds/compare-against-iwc-exemplar/index.md
@@ -8,8 +8,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-05-06
-revision: 6
+revised: 2026-06-11
+revision: 7
 ai_generated: true
 summary: "Find nearest IWC exemplar(s) and surface a structural diff against the upstream Galaxy design briefs to guide template authoring."
 input_artifacts:
@@ -29,7 +29,11 @@ output_artifacts:
   - id: iwc-comparison-notes
     kind: markdown
     default_filename: iwc-comparison-notes.md
-    description: "Structural diff against the nearest IWC exemplar(s); guidance for the downstream *-summary-to-galaxy-template Mold before per-step authoring."
+    description: "Structural diff against the nearest IWC exemplar(s); guidance for the downstream *-summary-to-galaxy-template Mold before per-step authoring. Carries an inline, bounded gxformat2 excerpt of the nearest exemplar's relevant subgraph under a labeled section, cross-referencing the iwc-exemplar-gxformat2 sibling file."
+  - id: iwc-exemplar-gxformat2
+    kind: yaml
+    default_filename: iwc-exemplar.gxwf.yml
+    description: "Cleaned gxformat2 conversion (via [[convert]] --to format2 --compact) of the nearest IWC exemplar's relevant subgraph — the concrete idiom the downstream template draft pattern-matches against. Bounded to the relevant subgraph, not the whole workflow. Absent when no nearest exemplar is found."
 references:
   - kind: cli-command
     ref: "[[convert]]"
@@ -37,8 +41,8 @@ references:
     load: on-demand
     mode: sidecar
     evidence: corpus-observed
-    purpose: "Normalize fetched IWC workflows into a consistent representation for structural comparison."
-    trigger: "After fetching a candidate IWC workflow file and before structural comparison."
+    purpose: "Normalize fetched IWC workflows into a consistent representation for structural comparison, and surface the nearest exemplar forward as a cleaned gxformat2 view (sibling file plus inline excerpt) for the downstream template Mold."
+    trigger: "After fetching a candidate IWC workflow file and before structural comparison; and again on the nearest exemplar after ranking to emit the iwc-exemplar-gxformat2 view."
   - kind: research
     ref: "[[galaxy-data-flow-draft-contract]]"
     used_at: runtime
@@ -76,6 +80,7 @@ This Mold is the corpus-first check in Galaxy-targeting pipelines. It runs after
 - Clone or pull and merge the IWC `<url>` to `~/.foundry/iwc`.
 - Normalize candidate workflows with [[convert]] as needed for structural comparison.
 - Find the closest workflow and rank it.
+- Surface the nearest exemplar forward (skip when the result is "no nearest exemplar"): see *Nearest exemplar (gxformat2) view*.
 
 ## Feature Hierarchy
 
@@ -107,6 +112,18 @@ Each finding should name the authoring surface most likely to own the fix:
 - Test issue: defer to `*-test-to-galaxy-test-plan` or `implement-galaxy-workflow-test`.
 
 Do not block downstream authoring on low-confidence exemplar mismatches. Report them as review guidance for the template Mold and the user.
+
+## Nearest exemplar (gxformat2) view
+
+The schema tells the template Mold what is *legal* gxformat2; it does not show *idiom*. A real, domain-adjacent gxformat2 workflow is high-value signal for constructing the draft — input/collection shapes, map-over wiring, output promotion, post-job actions. Agents have seen far more legacy `.ga` JSON than gxformat2 YAML in training, so surface the converted view rather than leaving it as prose.
+
+Once the nearest exemplar is chosen (High or Medium confidence):
+
+- Convert it with [[convert]] (`--to format2 --compact`).
+- Write the cleaned gxformat2 of the **relevant subgraph** to the `iwc-exemplar.gxwf.yml` sibling artifact — the slice that matches the briefs' structure, not the whole workflow.
+- Inline a bounded excerpt (~10–40 lines) of that subgraph under a labeled section in `iwc-comparison-notes.md`, and cite the abstract IWC workflow ID (e.g. `transcriptomics/rnaseq-pe/rnaseq-pe`) plus the step labels it covers. Cross-reference the sibling file for the fuller view.
+
+Keep it size-bounded — a whole large workflow is noise; the relevant subgraph is the signal. When the result is "no nearest exemplar," emit neither the sibling file nor the excerpt. A Low-confidence cross-domain match may surface a short excerpt for pattern comparison but should be labeled as such, not as a domain exemplar.
 
 ## Non-goals
 

--- a/content/molds/cwl-summary-to-galaxy-template/index.md
+++ b/content/molds/cwl-summary-to-galaxy-template/index.md
@@ -10,8 +10,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-05-05
-revised: 2026-05-10
-revision: 3
+revised: 2026-06-11
+revision: 4
 ai_generated: true
 summary: "gxformat2 skeleton with per-step TODOs from a CWL summary and prior Galaxy design briefs."
 input_artifacts:
@@ -22,7 +22,9 @@ input_artifacts:
   - id: cwl-galaxy-data-flow
     description: "Galaxy data-flow brief from [[cwl-summary-to-galaxy-data-flow]] that pins abstract operations and collection choices."
   - id: iwc-comparison-notes
-    description: "Structural diff guidance from [[compare-against-iwc-exemplar]] (run on the design briefs); steers the skeleton toward IWC-aligned structure before per-step authoring."
+    description: "Structural diff guidance from [[compare-against-iwc-exemplar]] (run on the design briefs); steers the skeleton toward IWC-aligned structure before per-step authoring. Carries an inline gxformat2 excerpt of the nearest exemplar."
+  - id: iwc-exemplar-gxformat2
+    description: "Cleaned gxformat2 view of the nearest IWC exemplar's relevant subgraph from [[compare-against-iwc-exemplar]]; pattern-match the draft's input/collection shapes, map-over wiring, output promotion, and post-job actions against this concrete idiom. Absent when no nearest exemplar was found."
 output_artifacts:
   - id: galaxy-workflow-draft
     kind: yaml

--- a/content/molds/freeform-summary-to-galaxy-template/index.md
+++ b/content/molds/freeform-summary-to-galaxy-template/index.md
@@ -10,8 +10,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-05-05
-revised: 2026-05-10
-revision: 3
+revised: 2026-06-11
+revision: 4
 ai_generated: true
 summary: "gxformat2 skeleton with per-step TODOs from a free-form summary and Galaxy design brief."
 input_artifacts:
@@ -22,7 +22,9 @@ input_artifacts:
   - id: freeform-galaxy-data-flow
     description: "Galaxy data-flow brief from [[freeform-summary-to-galaxy-data-flow]] that pins abstract operations and collection choices."
   - id: iwc-comparison-notes
-    description: "Structural diff guidance from [[compare-against-iwc-exemplar]] (run on the design brief); steers the skeleton toward IWC-aligned structure before per-step authoring."
+    description: "Structural diff guidance from [[compare-against-iwc-exemplar]] (run on the design brief); steers the skeleton toward IWC-aligned structure before per-step authoring. Carries an inline gxformat2 excerpt of the nearest exemplar."
+  - id: iwc-exemplar-gxformat2
+    description: "Cleaned gxformat2 view of the nearest IWC exemplar's relevant subgraph from [[compare-against-iwc-exemplar]]; pattern-match the draft's input/collection shapes, map-over wiring, output promotion, and post-job actions against this concrete idiom. Absent when no nearest exemplar was found."
 output_artifacts:
   - id: galaxy-workflow-draft
     kind: yaml

--- a/content/molds/nextflow-summary-to-galaxy-template/index.md
+++ b/content/molds/nextflow-summary-to-galaxy-template/index.md
@@ -10,8 +10,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-05-05
-revised: 2026-05-10
-revision: 6
+revised: 2026-06-11
+revision: 7
 ai_generated: true
 summary: "gxformat2 skeleton with per-step TODOs from a Nextflow summary and prior Galaxy design briefs."
 input_artifacts:
@@ -24,7 +24,9 @@ input_artifacts:
   - id: nextflow-galaxy-data-flow
     description: "Galaxy data-flow brief from [[nextflow-summary-to-galaxy-data-flow]] that pins abstract operations and collection choices."
   - id: iwc-comparison-notes
-    description: "Structural diff guidance from [[compare-against-iwc-exemplar]] (run on the design briefs); steers the skeleton toward IWC-aligned structure before per-step authoring."
+    description: "Structural diff guidance from [[compare-against-iwc-exemplar]] (run on the design briefs); steers the skeleton toward IWC-aligned structure before per-step authoring. Carries an inline gxformat2 excerpt of the nearest exemplar."
+  - id: iwc-exemplar-gxformat2
+    description: "Cleaned gxformat2 view of the nearest IWC exemplar's relevant subgraph from [[compare-against-iwc-exemplar]]; pattern-match the draft's input/collection shapes, map-over wiring, output promotion, and post-job actions against this concrete idiom. Absent when no nearest exemplar was found."
 output_artifacts:
   - id: galaxy-workflow-draft
     kind: yaml


### PR DESCRIPTION
> Opened by Claude (AI assistant) on behalf of @jmchilton — not authored by them personally.

Closes #280.

## Problem

`compare-against-iwc-exemplar` finds the nearest IWC exemplar and emits a **prose** structural diff. `gxwf convert` is already a declared dependency and the procedure already normalizes candidates with it — but the converted artifact was never handed forward. The downstream `*-summary-to-galaxy-template` Molds got the JSON Schema (what's *legal*) + prose (what *differs*), never a concrete gxformat2 snippet to pattern-match *idiom* against. Agents have seen far more legacy `.ga` JSON than gxformat2 YAML in training, so a real domain-adjacent gxformat2 workflow is high-value signal for input/collection shapes, map-over wiring, output promotion, and post-job actions.

## Change — both shapes, size-bounded

**Producer (`compare-against-iwc-exemplar`):**
- New `iwc-exemplar-gxformat2` output artifact → `iwc-exemplar.gxwf.yml` (cleaned `convert --to format2 --compact` of the nearest exemplar's **relevant subgraph**, not the whole workflow; no `schema:` — it's a faithful convert of a real IWC workflow, not the draft superset).
- Inline bounded (~10–40 line) excerpt under a labeled "Nearest exemplar (gxformat2) view" section in `iwc-comparison-notes.md`, citing the abstract IWC workflow ID.
- Procedure step + `convert` reference purpose/trigger updated. Both gated on a real nearest exemplar — emitted on High/Medium, skipped on "no nearest exemplar."
- `eval.md`: new "view surfaced" case; "no acceptable exemplar" case now asserts *absence* of both sibling and excerpt.

**Consumers (`nextflow`/`cwl`/`freeform-summary-to-galaxy-template`):** declare the `iwc-exemplar-gxformat2` input + a light clause to pattern-match the draft against the concrete idiom.

**Cast bundle** regenerated (`foundry-build cast`).

## Validation

`npm run validate` → **0 errors**; warning count unchanged (172→172). Producer↔consumer `id` binding resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)