### PR TITLE
Assemble Foundry pipelines into stop-gap harness skills

### DIFF
--- a/.claude/commands/assemble-pipeline.md
+++ b/.claude/commands/assemble-pipeline.md
@@ -1,0 +1,148 @@
+---
+description: Assemble a Foundry Pipeline into a lightweight harness skill that runs its Mold casts in order.
+argument-hint: "<pipeline-slug> [harness-name]"
+---
+
+# Assemble a Pipeline into a Harness Skill
+
+Read Pipeline `$1` and generate a harness skill that orchestrates its phase casts in order, sets up a per-run working directory, and degrades gracefully where a phase is not yet cast.
+
+A harness is **Not a Mold** (glossary): it is hand/LLM-authored orchestration glue, not a cast of a Mold. This command produces one such harness from a Pipeline note's machine-readable `phases:` spine. The harness lands under `casts/claude/skills/` (next to mold casts, namespaced by the `pipeline-` prefix) so `.claude/skills` picks it up, but it is assembled here — not produced by `foundry-build cast`.
+
+`docs/ARCHITECTURE.md` (§14, §15) frames the production harness surface as an open research question that belongs downstream. An assembled `pipeline-*` skill is the deliberate in-repo **stop-gap**: a trivial linear exercise of the pipeline spine for test-driving the casts end-to-end. Not the production harness surface; not a commitment to in-repo orchestration.
+
+`$1` is a Pipeline slug under `content/pipelines/`. Optional `$2` overrides the harness skill name (default `pipeline-<slug>`).
+
+Examples:
+
+- `/assemble-pipeline interview-to-galaxy`
+- `/assemble-pipeline nextflow-to-galaxy`
+
+## 0. Orient
+
+- `content/glossary.md` — **Pipeline**, **Phase**, **Branch**, **Loop**, **Harness**, **Not a Mold**, **Routing pattern**. Load these before reasoning about phase kinds.
+- `docs/HARNESS_PIPELINES.md` — the narrative the pipelines were lifted from.
+
+Resolve `$1` to `content/pipelines/<slug>.md`. If it does not resolve, list the available pipelines and stop. If `$1` looks like a near-miss of a real slug (typo, plural/singular drift), recommend the correction before proceeding — do not assemble a harness under a misspelled name.
+
+## 1. Read the Pipeline
+
+Read the note. Pull from frontmatter: `title`, `summary`, `tags` (the `source/*` and `target/*` axes), and the ordered `phases:` array. The body is human context; the `phases:` array is the spine you compile.
+
+Each phase is one of:
+
+- **Mold phase** — `mold: "[[<slug>]]"`, optionally `loop: true`.
+- **Branch phase** — `branch: <routing-pattern>` with either `branches:`/`fallthrough:` (binary) or `chain:` (sequential fallback), whose inner items are Mold wiki-links or terminal sentinels (e.g. `user-supplied`).
+
+## 2. Resolve each phase to a cast
+
+For every Mold wiki-link (top-level phases and branch inner items), check whether `casts/claude/skills/<slug>/SKILL.md` exists.
+
+- **Cast present** → the harness invokes that skill by name.
+- **Cast absent** (e.g. `find-test-data`, `debug-galaxy-workflow-output` today) → the harness must **not** silently skip it. Emit a manual checkpoint step: name the missing skill, summarize what that Mold is supposed to accomplish (read `content/molds/<slug>/index.md` `summary`/body for the one-line intent), and pause for the user to do it by hand before continuing.
+
+Record the full resolution (phase → skill, cast present/absent, loop/branch shape) — you write it to the assembly sidecar in step 5.
+
+## 3. Plan loop & branch handling
+
+**Loop phases (`loop: true`).** The wrapped Mold is a single-entry / single-exit orchestrator that **owns its own endstate oracle** — the harness does not invent loop logic. (`advance-galaxy-draft-step` owns `gxwf draft-next-step`; it reports `draft: false` when no drafty step remains.) The harness reduces to: re-invoke the skill until it reports no remaining work, then fall through. State this generically in the generated skill — the harness re-invokes and watches for the skill's own done-signal; it does not re-implement the oracle.
+
+**Branch phases.** Expand the routing pattern:
+
+- `test-data-resolution` (a `chain:`) — try each entry in order; stop at the first that yields acceptable output. A terminal sentinel (`user-supplied`) means *ask the user to supply it*, not a skill. If a chain entry's Mold has no cast, render it as a MANUAL sub-step within the branch (per step 2) rather than an invocation.
+- `discover-or-author` (binary `branches:` + `fallthrough:`) — run the primary; on fallthrough, run the fallback. (Not present inline in current pipelines — `advance-galaxy-draft-step` absorbed it — but handle it generically.)
+
+## 4. Author the harness SKILL.md
+
+Write `casts/claude/skills/<harness-name>/SKILL.md` (default `<harness-name>` = `pipeline-<slug>`). Follow this shape:
+
+```markdown
+---
+name: pipeline-<slug>
+description: "<pipeline summary> — orchestrates the <N> Foundry skills of the <TITLE> pipeline in order, in a per-run working directory."
+---
+
+# pipeline-<slug>
+
+Harness for the **<TITLE>** Foundry pipeline. Runs the constituent skills in order
+inside a single per-run working directory. Assembled from `content/pipelines/<slug>.md`
+(revision <rev>) — regenerate with `/assemble-pipeline <slug>` if the pipeline changes;
+do not hand-edit.
+
+## When To Use
+
+- <pipeline summary>
+
+## Working directory (do this first)
+
+Every constituent skill writes fixed filenames to its working directory. To keep one run's
+artifacts namespaced and avoid clobbering a prior run (foundry#282):
+
+1. Pick a run slug — use the harness argument if given, else ask the user for a short
+   project name up front. Do **not** wait to derive it from a source id/title: the
+   directory must exist before phase 1 writes its first artifact. Default `<slug>-run`.
+2. Create `./<run-slug>/` in the current directory. If it exists, suffix `-2`, `-3`, … .
+3. Run **every** skill invocation below with `./<run-slug>/` as its working directory:
+   **prefix every default input and output filename with `./<run-slug>/`** when you invoke
+   the skill. The skills preserve their declared basenames (e.g. `freeform-summary.md`,
+   `galaxy-workflow-draft.gxwf.yml`) and honor a harness-supplied directory; you supply the
+   prefix on **both reads and writes**, so each phase finds the prior phase's output and
+   nothing lands in the repo root (foundry#282).
+
+Announce the chosen directory before starting.
+
+## Pipeline
+
+Run these phases in order. After each, confirm the expected artifact exists in the run
+directory before advancing.
+
+1. **<skill-name>** — invoke the `<skill-name>` skill. <one-line of what it produces>
+2. ... (one numbered entry per Mold phase, in pipeline order) ...
+
+   For a **loop phase**: "Re-invoke `<skill-name>` repeatedly. It owns its own endstate
+   oracle and advances the work by one unit per call; stop when it reports no remaining
+   work, then continue."
+
+   For a **branch phase**: "Resolve <pattern>: try <entry-1>, then <entry-2>, …; stop at
+   the first that yields acceptable output. `user-supplied` means ask the user to provide
+   it directly."
+
+   For an **un-cast phase**: "MANUAL — `<skill-name>` is not yet cast. It should
+   <one-line intent>. Do this by hand (or skip if not applicable) and confirm before
+   continuing."
+
+## Done
+
+Report the final artifacts in `./<run-slug>/` and any phases that were handled manually.
+
+## Notes
+
+- Do not re-implement any skill's internal logic here; this harness only sequences and
+  routes. Endstate detection for loop phases belongs to the looped skill.
+- Carry unresolved assumptions forward as notes rather than inventing missing inputs.
+```
+
+Fill every `<...>` from the pipeline. Number the Pipeline section with one entry per Mold-shaped phase in order; expand loop/branch/un-cast phases using the inline guidance above. Keep the description under the skill-frontmatter length the other casts use (one sentence).
+
+## 5. Write the assembly sidecar
+
+Write `casts/claude/skills/<harness-name>/_assembly.json` recording provenance and drift signal:
+
+```json
+{
+  "source_pipeline": "<slug>",
+  "source_revision": <rev>,
+  "harness_name": "<harness-name>",
+  "phases": [
+    { "phase": 1, "kind": "mold", "skill": "<slug>", "cast_present": true, "loop": false },
+    { "phase": 2, "kind": "branch", "pattern": "test-data-resolution",
+      "chain": ["find-test-data", "user-supplied"], "cast_present": [false, null] }
+  ]
+}
+```
+
+This is a harness artifact, not a cast `_provenance.json`; the cast verifier does not read it. It exists so a later run can detect that the pipeline changed since assembly.
+
+## 6. Report
+
+Summarize: harness path, phase count, which phases resolved to real casts vs. manual checkpoints, and the working-directory convention. Then, per the project's plan-completion convention, offer the user next-step options via AskUserQuestion — including launching a review subagent and proceeding to assemble another pipeline.

--- a/casts/claude/skills/pipeline-cwl-to-galaxy/SKILL.md
+++ b/casts/claude/skills/pipeline-cwl-to-galaxy/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: pipeline-cwl-to-galaxy
+description: "Path from a CWL Workflow to a Galaxy gxformat2 workflow — orchestrates the Foundry skills of the CWL → GALAXY pipeline in order, in a per-run working directory."
+---
+
+# pipeline-cwl-to-galaxy
+
+Harness for the **CWL → GALAXY** Foundry pipeline. Runs the constituent skills in order inside a single per-run working directory. Assembled from `content/pipelines/cwl-to-galaxy.md` (revision 2) — regenerate with `/assemble-pipeline cwl-to-galaxy` if the pipeline changes; do not hand-edit.
+
+## When To Use
+
+- Path from a CWL Workflow to a Galaxy gxformat2 workflow. Lighter upstream extraction (CWL is already structured).
+
+## Working directory (do this first)
+
+Every constituent skill writes fixed filenames to its working directory. To keep one run's artifacts namespaced and avoid clobbering a prior run (foundry#282):
+
+1. Pick a run slug — use the harness argument if given; else ask the user for a short project name up front (the directory must exist before phase 1 writes its first artifact, so don't wait for a source title); else default `cwl-to-galaxy-run`.
+2. Create `./<run-slug>/` in the current directory. If it exists, suffix `-2`, `-3`, … .
+3. Run **every** skill invocation below with `./<run-slug>/` as its working directory: **prefix every default input and output filename with `./<run-slug>/`** when you invoke the skill. The skills preserve their declared basenames and honor a harness-supplied directory; you supply the prefix on **both reads and writes**, so each phase finds the prior phase's output and nothing lands in the repo root.
+
+Announce the chosen directory before starting.
+
+## Pipeline
+
+Run these phases in order. After each, confirm the expected artifact exists in the run directory before advancing.
+
+1. **summarize-cwl** — invoke the `summarize-cwl` skill. Validates and normalizes the CWL Workflow tree and emits a structured summary for downstream translation.
+2. **cwl-summary-to-galaxy-interface** — invoke the `cwl-summary-to-galaxy-interface` skill. Maps the CWL summary into a Galaxy workflow interface design brief.
+3. **cwl-summary-to-galaxy-data-flow** — invoke the `cwl-summary-to-galaxy-data-flow` skill. Translates the CWL summary into a Galaxy data-flow design brief.
+4. **compare-against-iwc-exemplar** — invoke the `compare-against-iwc-exemplar` skill. Surfaces the nearest IWC exemplar(s) and a structural diff to guide template authoring.
+5. **cwl-summary-to-galaxy-template** — invoke the `cwl-summary-to-galaxy-template` skill. Emits the gxformat2 skeleton with per-step TODOs (`galaxy-workflow-draft.gxwf.yml`).
+6. **advance-galaxy-draft-step** (loop) — re-invoke the `advance-galaxy-draft-step` skill repeatedly. It owns its own endstate oracle (`gxwf draft-next-step`) and concretizes one drafty step per call; stop when it reports `draft: false` (no remaining drafty steps), then continue.
+7. **cwl-test-to-galaxy-test-plan** — MANUAL — `cwl-test-to-galaxy-test-plan` is not yet cast. It should translate CWL test fixtures into a Galaxy workflow test plan. Do this by hand and confirm before continuing.
+8. **implement-galaxy-workflow-test** — invoke the `implement-galaxy-workflow-test` skill. Assembles the Galaxy workflow test fixtures and assertions.
+9. **validate-galaxy-workflow** — invoke the `validate-galaxy-workflow` skill. Runs terminal gxwf validation on the assembled workflow and classifies failures.
+10. **run-workflow-test** — invoke the `run-workflow-test` skill. Executes the workflow's tests via Planemo; emits structured pass/fail and outputs.
+11. **debug-galaxy-workflow-output** — MANUAL — `debug-galaxy-workflow-output` is not yet cast. It should triage failing Galaxy run outputs, classify failure modes, and propose fixes. Do this by hand if `run-workflow-test` reported failures; otherwise skip.
+
+## Done
+
+Report the final artifacts in `./<run-slug>/` (notably the concretized `galaxy-workflow-draft.gxwf.yml` and the test outputs) and any phases that were handled manually (`cwl-test-to-galaxy-test-plan`, `debug-galaxy-workflow-output`).
+
+## Notes
+
+- Do not re-implement any skill's internal logic here; this harness only sequences and routes. Endstate detection for the per-step loop belongs to `advance-galaxy-draft-step`.
+- Carry unresolved assumptions forward as notes rather than inventing missing inputs.

--- a/casts/claude/skills/pipeline-cwl-to-galaxy/_assembly.json
+++ b/casts/claude/skills/pipeline-cwl-to-galaxy/_assembly.json
@@ -1,0 +1,18 @@
+{
+  "source_pipeline": "cwl-to-galaxy",
+  "source_revision": 2,
+  "harness_name": "pipeline-cwl-to-galaxy",
+  "phases": [
+    { "phase": 1, "kind": "mold", "skill": "summarize-cwl", "cast_present": true, "loop": false },
+    { "phase": 2, "kind": "mold", "skill": "cwl-summary-to-galaxy-interface", "cast_present": true, "loop": false },
+    { "phase": 3, "kind": "mold", "skill": "cwl-summary-to-galaxy-data-flow", "cast_present": true, "loop": false },
+    { "phase": 4, "kind": "mold", "skill": "compare-against-iwc-exemplar", "cast_present": true, "loop": false },
+    { "phase": 5, "kind": "mold", "skill": "cwl-summary-to-galaxy-template", "cast_present": true, "loop": false },
+    { "phase": 6, "kind": "mold", "skill": "advance-galaxy-draft-step", "cast_present": true, "loop": true },
+    { "phase": 7, "kind": "mold", "skill": "cwl-test-to-galaxy-test-plan", "cast_present": false, "loop": false },
+    { "phase": 8, "kind": "mold", "skill": "implement-galaxy-workflow-test", "cast_present": true, "loop": false },
+    { "phase": 9, "kind": "mold", "skill": "validate-galaxy-workflow", "cast_present": true, "loop": false },
+    { "phase": 10, "kind": "mold", "skill": "run-workflow-test", "cast_present": true, "loop": false },
+    { "phase": 11, "kind": "mold", "skill": "debug-galaxy-workflow-output", "cast_present": false, "loop": false }
+  ]
+}

--- a/casts/claude/skills/pipeline-interview-to-galaxy/SKILL.md
+++ b/casts/claude/skills/pipeline-interview-to-galaxy/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: pipeline-interview-to-galaxy
+description: "Interview-driven path to a Galaxy gxformat2 workflow — orchestrates the Foundry skills of the INTERVIEW → GALAXY pipeline in order, in a per-run working directory."
+---
+
+# pipeline-interview-to-galaxy
+
+Harness for the **INTERVIEW → GALAXY** Foundry pipeline. Runs the constituent skills in order inside a single per-run working directory. Assembled from `content/pipelines/interview-to-galaxy.md` (revision 1) — regenerate with `/assemble-pipeline interview-to-galaxy` if the pipeline changes; do not hand-edit.
+
+## When To Use
+
+- Interview-driven path to a Galaxy gxformat2 workflow through the shared freeform-summary handoff.
+
+## Working directory (do this first)
+
+Every constituent skill writes fixed filenames to its working directory. To keep one run's artifacts namespaced and avoid clobbering a prior run (foundry#282):
+
+1. Pick a run slug — use the harness argument if given; else ask the user for a short project name up front (the directory must exist before phase 1 writes `freeform-summary.md`, so don't wait for a source title); else default `interview-to-galaxy-run`.
+2. Create `./<run-slug>/` in the current directory. If it exists, suffix `-2`, `-3`, … .
+3. Run **every** skill invocation below with `./<run-slug>/` as its working directory: **prefix every default input and output filename with `./<run-slug>/`** when you invoke the skill. The skills preserve their declared basenames (`freeform-summary.md`, `galaxy-workflow-draft.gxwf.yml`, …) and honor a harness-supplied directory; you supply the prefix on **both reads and writes**, so each phase finds the prior phase's output and nothing lands in the repo root.
+
+Announce the chosen directory before starting.
+
+## Pipeline
+
+Run these phases in order. After each, confirm the expected artifact exists in the run directory before advancing.
+
+1. **interview-to-freeform-summary** — invoke the `interview-to-freeform-summary` skill. Normalizes the user interview into the shared `freeform-summary` handoff (`freeform-summary.md`).
+2. **freeform-summary-to-galaxy-interface** — invoke the `freeform-summary-to-galaxy-interface` skill. Maps the summary into a Galaxy workflow interface design brief.
+3. **freeform-summary-to-galaxy-data-flow** — invoke the `freeform-summary-to-galaxy-data-flow` skill. Translates the summary into a Galaxy data-flow design brief.
+4. **compare-against-iwc-exemplar** — invoke the `compare-against-iwc-exemplar` skill. Surfaces the nearest IWC exemplar(s) and a structural diff to guide template authoring.
+5. **freeform-summary-to-galaxy-template** — invoke the `freeform-summary-to-galaxy-template` skill. Emits the gxformat2 skeleton with per-step TODOs (`galaxy-workflow-draft.gxwf.yml`).
+6. **advance-galaxy-draft-step** (loop) — re-invoke the `advance-galaxy-draft-step` skill repeatedly. It owns its own endstate oracle (`gxwf draft-next-step`) and concretizes one drafty step per call; stop when it reports `draft: false` (no remaining drafty steps), then continue.
+7. **test-data-resolution** (branch) — resolve the test-data chain: first try `find-test-data`; if that yields nothing acceptable, fall through to `user-supplied` — ask the user to provide test data directly. Stop at the first that yields acceptable test data.
+   - MANUAL — `find-test-data` is not yet cast. It should search IWC fixtures and public sources for test data matching the data-flow shape. Do this by hand and confirm before continuing; if nothing fits, fall through to asking the user.
+8. **implement-galaxy-workflow-test** — invoke the `implement-galaxy-workflow-test` skill. Assembles the Galaxy workflow test fixtures and assertions.
+9. **validate-galaxy-workflow** — invoke the `validate-galaxy-workflow` skill. Runs terminal gxwf validation on the assembled workflow and classifies failures.
+10. **run-workflow-test** — invoke the `run-workflow-test` skill. Executes the workflow's tests via Planemo; emits structured pass/fail and outputs.
+11. **debug-galaxy-workflow-output** — MANUAL — `debug-galaxy-workflow-output` is not yet cast. It should triage failing Galaxy run outputs, classify failure modes, and propose fixes. Do this by hand if `run-workflow-test` reported failures; otherwise skip.
+
+## Done
+
+Report the final artifacts in `./<run-slug>/` (notably the concretized `galaxy-workflow-draft.gxwf.yml` and the test outputs) and any phases that were handled manually (`find-test-data`, `debug-galaxy-workflow-output`).
+
+## Notes
+
+- Do not re-implement any skill's internal logic here; this harness only sequences and routes. Endstate detection for the per-step loop belongs to `advance-galaxy-draft-step`.
+- Carry unresolved assumptions forward as notes rather than inventing missing inputs.
+- v1 "workflow" means a Galaxy `gxformat2` workflow; the live interview mechanics are harness-owned and precede phase 1.

--- a/casts/claude/skills/pipeline-interview-to-galaxy/_assembly.json
+++ b/casts/claude/skills/pipeline-interview-to-galaxy/_assembly.json
@@ -1,0 +1,18 @@
+{
+  "source_pipeline": "interview-to-galaxy",
+  "source_revision": 1,
+  "harness_name": "pipeline-interview-to-galaxy",
+  "phases": [
+    { "phase": 1, "kind": "mold", "skill": "interview-to-freeform-summary", "cast_present": true, "loop": false },
+    { "phase": 2, "kind": "mold", "skill": "freeform-summary-to-galaxy-interface", "cast_present": true, "loop": false },
+    { "phase": 3, "kind": "mold", "skill": "freeform-summary-to-galaxy-data-flow", "cast_present": true, "loop": false },
+    { "phase": 4, "kind": "mold", "skill": "compare-against-iwc-exemplar", "cast_present": true, "loop": false },
+    { "phase": 5, "kind": "mold", "skill": "freeform-summary-to-galaxy-template", "cast_present": true, "loop": false },
+    { "phase": 6, "kind": "mold", "skill": "advance-galaxy-draft-step", "cast_present": true, "loop": true },
+    { "phase": 7, "kind": "branch", "pattern": "test-data-resolution", "chain": ["find-test-data", "user-supplied"], "cast_present": [false, null] },
+    { "phase": 8, "kind": "mold", "skill": "implement-galaxy-workflow-test", "cast_present": true, "loop": false },
+    { "phase": 9, "kind": "mold", "skill": "validate-galaxy-workflow", "cast_present": true, "loop": false },
+    { "phase": 10, "kind": "mold", "skill": "run-workflow-test", "cast_present": true, "loop": false },
+    { "phase": 11, "kind": "mold", "skill": "debug-galaxy-workflow-output", "cast_present": false, "loop": false }
+  ]
+}

--- a/casts/claude/skills/pipeline-nextflow-to-cwl/SKILL.md
+++ b/casts/claude/skills/pipeline-nextflow-to-cwl/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: pipeline-nextflow-to-cwl
+description: "Direct path from a Nextflow pipeline to a CWL Workflow + CommandLineTool set — orchestrates the Foundry skills of the NEXTFLOW → CWL pipeline in order, in a per-run working directory."
+---
+
+# pipeline-nextflow-to-cwl
+
+Harness for the **NEXTFLOW → CWL** Foundry pipeline. Runs the constituent skills in order inside a single per-run working directory. Assembled from `content/pipelines/nextflow-to-cwl.md` (revision 2) — regenerate with `/assemble-pipeline nextflow-to-cwl` if the pipeline changes; do not hand-edit.
+
+Most CWL-targeting Molds are not yet cast, so this harness is mostly manual checkpoints today; it still fixes the phase order, the per-run working directory, and the few real casts. It strengthens as the CWL Molds land.
+
+## When To Use
+
+- Direct path from a Nextflow pipeline to a CWL Workflow + CommandLineTool set.
+
+## Working directory (do this first)
+
+Every constituent skill writes fixed filenames to its working directory. To keep one run's artifacts namespaced and avoid clobbering a prior run (foundry#282):
+
+1. Pick a run slug — use the harness argument if given; else ask the user for a short project name up front (the directory must exist before phase 1 writes its first artifact, so don't wait for a source title); else default `nextflow-to-cwl-run`.
+2. Create `./<run-slug>/` in the current directory. If it exists, suffix `-2`, `-3`, … .
+3. Run **every** skill invocation below with `./<run-slug>/` as its working directory: **prefix every default input and output filename with `./<run-slug>/`** when you invoke the skill. The skills preserve their declared basenames and honor a harness-supplied directory; you supply the prefix on **both reads and writes**, so each phase finds the prior phase's output and nothing lands in the repo root.
+
+Announce the chosen directory before starting.
+
+## Pipeline
+
+Run these phases in order. After each, confirm the expected artifact exists in the run directory before advancing.
+
+1. **summarize-nextflow** — invoke the `summarize-nextflow` skill. Reads the Nextflow pipeline source tree and emits a structured JSON summary for downstream translation.
+2. **nextflow-summary-to-cwl-interface** — MANUAL — `nextflow-summary-to-cwl-interface` is not yet cast. It should map the Nextflow summary into a CWL Workflow interface design brief. Do this by hand and confirm before continuing.
+3. **nextflow-summary-to-cwl-data-flow** — MANUAL — `nextflow-summary-to-cwl-data-flow` is not yet cast. It should translate the Nextflow summary into a CWL data-flow design brief. Do this by hand and confirm before continuing.
+4. **summary-to-cwl-template** — MANUAL — `summary-to-cwl-template` is not yet cast. It should emit a CWL Workflow skeleton with per-step TODOs from the source and design handoffs. Do this by hand and confirm before continuing.
+5. **summarize-cwl-tool** (loop, once per CWL tool/step) — MANUAL — `summarize-cwl-tool` is not yet cast. It should derive a CommandLineTool description (container, baseCommand, IO) for each tool/step in the template. Do this by hand for each tool. (No shared endstate oracle exists for CWL per-tool loops yet — the iteration set is the tools enumerated in the template.)
+6. **implement-cwl-tool-step** (loop, once per CWL tool/step) — MANUAL — `implement-cwl-tool-step` is not yet cast. It should convert each abstract step into a concrete CWL CommandLineTool + step. Do this by hand for each tool.
+7. **validate-cwl** (loop, once per CWL tool/step) — MANUAL — `validate-cwl` is not yet cast. It should run `cwltool --validate` / schema lint on each implemented tool/step, classify failures, and recommend fixes. Do this by hand for each tool.
+8. **nextflow-test-to-cwl-test-plan** — MANUAL — `nextflow-test-to-cwl-test-plan` is not yet cast. It should translate Nextflow test evidence into a CWL workflow test plan. Do this by hand and confirm before continuing.
+9. **implement-cwl-workflow-test** — MANUAL — `implement-cwl-workflow-test` is not yet cast. It should assemble CWL job file(s) and expected-output assertions. Do this by hand and confirm before continuing.
+10. **validate-cwl** — MANUAL — `validate-cwl` is not yet cast. Run terminal `cwltool --validate` / schema lint over the assembled workflow, classify failures, recommend fixes. Do this by hand.
+11. **run-workflow-test** — invoke the `run-workflow-test` skill. Executes the workflow's tests via Planemo (which runs CWL as well as Galaxy); emits structured pass/fail and outputs.
+12. **debug-cwl-workflow-output** — MANUAL — `debug-cwl-workflow-output` is not yet cast. It should triage failing CWL run outputs, classify failure modes, and propose fixes. Do this by hand if `run-workflow-test` reported failures; otherwise skip.
+
+## Done
+
+Report the final artifacts in `./<run-slug>/` and the phases handled manually (everything except `summarize-nextflow` and `run-workflow-test`, until the CWL Molds are cast).
+
+## Notes
+
+- Do not re-implement any skill's internal logic here; this harness only sequences and routes.
+- CWL per-tool loops (phases 5–7) have no shared `draft-next-step`-style endstate oracle today; iterate over the tools enumerated in the CWL template. This is an open gap to revisit when those Molds are cast.
+- NF brings real test fixtures, so `nextflow-test-to-cwl-test-plan` replaces the `test-data-resolution` chain that paper-sourced pipelines need.
+- Carry unresolved assumptions forward as notes rather than inventing missing inputs.

--- a/casts/claude/skills/pipeline-nextflow-to-cwl/_assembly.json
+++ b/casts/claude/skills/pipeline-nextflow-to-cwl/_assembly.json
@@ -1,0 +1,19 @@
+{
+  "source_pipeline": "nextflow-to-cwl",
+  "source_revision": 2,
+  "harness_name": "pipeline-nextflow-to-cwl",
+  "phases": [
+    { "phase": 1, "kind": "mold", "skill": "summarize-nextflow", "cast_present": true, "loop": false },
+    { "phase": 2, "kind": "mold", "skill": "nextflow-summary-to-cwl-interface", "cast_present": false, "loop": false },
+    { "phase": 3, "kind": "mold", "skill": "nextflow-summary-to-cwl-data-flow", "cast_present": false, "loop": false },
+    { "phase": 4, "kind": "mold", "skill": "summary-to-cwl-template", "cast_present": false, "loop": false },
+    { "phase": 5, "kind": "mold", "skill": "summarize-cwl-tool", "cast_present": false, "loop": true },
+    { "phase": 6, "kind": "mold", "skill": "implement-cwl-tool-step", "cast_present": false, "loop": true },
+    { "phase": 7, "kind": "mold", "skill": "validate-cwl", "cast_present": false, "loop": true },
+    { "phase": 8, "kind": "mold", "skill": "nextflow-test-to-cwl-test-plan", "cast_present": false, "loop": false },
+    { "phase": 9, "kind": "mold", "skill": "implement-cwl-workflow-test", "cast_present": false, "loop": false },
+    { "phase": 10, "kind": "mold", "skill": "validate-cwl", "cast_present": false, "loop": false },
+    { "phase": 11, "kind": "mold", "skill": "run-workflow-test", "cast_present": true, "loop": false },
+    { "phase": 12, "kind": "mold", "skill": "debug-cwl-workflow-output", "cast_present": false, "loop": false }
+  ]
+}

--- a/casts/claude/skills/pipeline-nextflow-to-galaxy/SKILL.md
+++ b/casts/claude/skills/pipeline-nextflow-to-galaxy/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: pipeline-nextflow-to-galaxy
+description: "Direct path from a Nextflow pipeline to a Galaxy gxformat2 workflow — orchestrates the Foundry skills of the NEXTFLOW → GALAXY pipeline in order, in a per-run working directory."
+---
+
+# pipeline-nextflow-to-galaxy
+
+Harness for the **NEXTFLOW → GALAXY** Foundry pipeline. Runs the constituent skills in order inside a single per-run working directory. Assembled from `content/pipelines/nextflow-to-galaxy.md` (revision 3) — regenerate with `/assemble-pipeline nextflow-to-galaxy` if the pipeline changes; do not hand-edit.
+
+## When To Use
+
+- Direct path from a Nextflow pipeline to a Galaxy gxformat2 workflow.
+
+## Working directory (do this first)
+
+Every constituent skill writes fixed filenames to its working directory. To keep one run's artifacts namespaced and avoid clobbering a prior run (foundry#282):
+
+1. Pick a run slug — use the harness argument if given; else ask the user for a short project name up front (the directory must exist before phase 1 writes its first artifact, so don't wait for a source title); else default `nextflow-to-galaxy-run`.
+2. Create `./<run-slug>/` in the current directory. If it exists, suffix `-2`, `-3`, … .
+3. Run **every** skill invocation below with `./<run-slug>/` as its working directory: **prefix every default input and output filename with `./<run-slug>/`** when you invoke the skill. The skills preserve their declared basenames and honor a harness-supplied directory; you supply the prefix on **both reads and writes**, so each phase finds the prior phase's output and nothing lands in the repo root.
+
+Announce the chosen directory before starting.
+
+## Pipeline
+
+Run these phases in order. After each, confirm the expected artifact exists in the run directory before advancing.
+
+1. **summarize-nextflow** — invoke the `summarize-nextflow` skill. Reads the Nextflow pipeline source tree and emits a structured JSON summary for downstream translation.
+2. **nextflow-summary-to-galaxy-reference-data** — MANUAL — `nextflow-summary-to-galaxy-reference-data` is not yet cast. It should decide the Galaxy-side shape of external reference data declared by the Nextflow pipeline. Do this by hand and confirm before continuing.
+3. **nextflow-summary-to-galaxy-interface** — invoke the `nextflow-summary-to-galaxy-interface` skill. Maps the Nextflow summary into a Galaxy workflow interface design brief.
+4. **nextflow-summary-to-galaxy-data-flow** — invoke the `nextflow-summary-to-galaxy-data-flow` skill. Translates the Nextflow summary into a Galaxy data-flow design brief.
+5. **compare-against-iwc-exemplar** — invoke the `compare-against-iwc-exemplar` skill. Surfaces the nearest IWC exemplar(s) and a structural diff to guide template authoring.
+6. **nextflow-summary-to-galaxy-template** — invoke the `nextflow-summary-to-galaxy-template` skill. Emits the gxformat2 skeleton with per-step TODOs (`galaxy-workflow-draft.gxwf.yml`).
+7. **advance-galaxy-draft-step** (loop) — re-invoke the `advance-galaxy-draft-step` skill repeatedly. It owns its own endstate oracle (`gxwf draft-next-step`) and concretizes one drafty step per call; stop when it reports `draft: false` (no remaining drafty steps), then continue.
+8. **nextflow-test-to-galaxy-test-plan** — MANUAL — `nextflow-test-to-galaxy-test-plan` is not yet cast. It should translate Nextflow test evidence into a Galaxy workflow test plan. Do this by hand and confirm before continuing.
+9. **implement-galaxy-workflow-test** — invoke the `implement-galaxy-workflow-test` skill. Assembles the Galaxy workflow test fixtures and assertions.
+10. **validate-galaxy-workflow** — invoke the `validate-galaxy-workflow` skill. Runs terminal gxwf validation on the assembled workflow and classifies failures.
+11. **run-workflow-test** — invoke the `run-workflow-test` skill. Executes the workflow's tests via Planemo; emits structured pass/fail and outputs.
+12. **debug-galaxy-workflow-output** — MANUAL — `debug-galaxy-workflow-output` is not yet cast. It should triage failing Galaxy run outputs, classify failure modes, and propose fixes. Do this by hand if `run-workflow-test` reported failures; otherwise skip.
+
+## Done
+
+Report the final artifacts in `./<run-slug>/` (notably the concretized `galaxy-workflow-draft.gxwf.yml` and the test outputs) and any phases that were handled manually (`nextflow-summary-to-galaxy-reference-data`, `nextflow-test-to-galaxy-test-plan`, `debug-galaxy-workflow-output`).
+
+## Notes
+
+- Do not re-implement any skill's internal logic here; this harness only sequences and routes. Endstate detection for the per-step loop belongs to `advance-galaxy-draft-step`.
+- Carry unresolved assumptions forward as notes rather than inventing missing inputs.
+- Replaces the prior-art hand-authored `nf-to-galaxy` skill — same goal, decomposed into Molds, validation-driven.

--- a/casts/claude/skills/pipeline-nextflow-to-galaxy/_assembly.json
+++ b/casts/claude/skills/pipeline-nextflow-to-galaxy/_assembly.json
@@ -1,0 +1,19 @@
+{
+  "source_pipeline": "nextflow-to-galaxy",
+  "source_revision": 3,
+  "harness_name": "pipeline-nextflow-to-galaxy",
+  "phases": [
+    { "phase": 1, "kind": "mold", "skill": "summarize-nextflow", "cast_present": true, "loop": false },
+    { "phase": 2, "kind": "mold", "skill": "nextflow-summary-to-galaxy-reference-data", "cast_present": false, "loop": false },
+    { "phase": 3, "kind": "mold", "skill": "nextflow-summary-to-galaxy-interface", "cast_present": true, "loop": false },
+    { "phase": 4, "kind": "mold", "skill": "nextflow-summary-to-galaxy-data-flow", "cast_present": true, "loop": false },
+    { "phase": 5, "kind": "mold", "skill": "compare-against-iwc-exemplar", "cast_present": true, "loop": false },
+    { "phase": 6, "kind": "mold", "skill": "nextflow-summary-to-galaxy-template", "cast_present": true, "loop": false },
+    { "phase": 7, "kind": "mold", "skill": "advance-galaxy-draft-step", "cast_present": true, "loop": true },
+    { "phase": 8, "kind": "mold", "skill": "nextflow-test-to-galaxy-test-plan", "cast_present": false, "loop": false },
+    { "phase": 9, "kind": "mold", "skill": "implement-galaxy-workflow-test", "cast_present": true, "loop": false },
+    { "phase": 10, "kind": "mold", "skill": "validate-galaxy-workflow", "cast_present": true, "loop": false },
+    { "phase": 11, "kind": "mold", "skill": "run-workflow-test", "cast_present": true, "loop": false },
+    { "phase": 12, "kind": "mold", "skill": "debug-galaxy-workflow-output", "cast_present": false, "loop": false }
+  ]
+}

--- a/casts/claude/skills/pipeline-paper-to-cwl/SKILL.md
+++ b/casts/claude/skills/pipeline-paper-to-cwl/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: pipeline-paper-to-cwl
+description: "Direct path from a paper to a CWL Workflow + CommandLineTool set — orchestrates the Foundry skills of the PAPER → CWL pipeline in order, in a per-run working directory."
+---
+
+# pipeline-paper-to-cwl
+
+Harness for the **PAPER → CWL** Foundry pipeline. Runs the constituent skills in order inside a single per-run working directory. Assembled from `content/pipelines/paper-to-cwl.md` (revision 2) — regenerate with `/assemble-pipeline paper-to-cwl` if the pipeline changes; do not hand-edit.
+
+Most CWL-targeting Molds are not yet cast, so this harness is mostly manual checkpoints today; it still fixes the phase order, the per-run working directory, and the few real casts. It strengthens as the CWL Molds land.
+
+## When To Use
+
+- Direct path from a paper to a CWL Workflow + CommandLineTool set.
+
+## Working directory (do this first)
+
+Every constituent skill writes fixed filenames to its working directory. To keep one run's artifacts namespaced and avoid clobbering a prior run (foundry#282):
+
+1. Pick a run slug — use the harness argument if given; else ask the user for a short project name up front (the directory must exist before phase 1 writes its first artifact, so don't wait for a source title); else default `paper-to-cwl-run`.
+2. Create `./<run-slug>/` in the current directory. If it exists, suffix `-2`, `-3`, … .
+3. Run **every** skill invocation below with `./<run-slug>/` as its working directory: **prefix every default input and output filename with `./<run-slug>/`** when you invoke the skill. The skills preserve their declared basenames and honor a harness-supplied directory; you supply the prefix on **both reads and writes**, so each phase finds the prior phase's output and nothing lands in the repo root.
+
+Announce the chosen directory before starting.
+
+## Pipeline
+
+Run these phases in order. After each, confirm the expected artifact exists in the run directory before advancing.
+
+1. **summarize-paper** — MANUAL — `summarize-paper` is not yet cast. It should extract methods, tools, sample data, and references from the paper into the shared `freeform-summary` handoff (`freeform-summary.md`). Do this by hand and confirm before continuing.
+2. **freeform-summary-to-cwl-design** — MANUAL — `freeform-summary-to-cwl-design` is not yet cast. It should translate the free-form summary into a CWL workflow design brief. Do this by hand and confirm before continuing.
+3. **summary-to-cwl-template** — MANUAL — `summary-to-cwl-template` is not yet cast. It should emit a CWL Workflow skeleton with per-step TODOs from the source and design handoffs. Do this by hand and confirm before continuing.
+4. **summarize-cwl-tool** (loop, once per CWL tool/step) — MANUAL — `summarize-cwl-tool` is not yet cast. It should derive a CommandLineTool description (container, baseCommand, IO) for each tool/step in the template. Do this by hand for each tool. (No shared endstate oracle exists for CWL per-tool loops yet — the iteration set is the tools enumerated in the template.)
+5. **implement-cwl-tool-step** (loop, once per CWL tool/step) — MANUAL — `implement-cwl-tool-step` is not yet cast. It should convert each abstract step into a concrete CWL CommandLineTool + step; CommandLineTool authoring is built into this step (no separate discover-or-author branch). Do this by hand for each tool.
+6. **validate-cwl** (loop, once per CWL tool/step) — MANUAL — `validate-cwl` is not yet cast. It should run `cwltool --validate` / schema lint on each implemented tool/step, classify failures, and recommend fixes. Do this by hand for each tool.
+7. **test-data-resolution** (branch) — resolve the test-data chain in order; stop at the first that yields acceptable test data:
+   - MANUAL — `paper-to-test-data` is not yet cast. It should derive workflow test inputs and expected outputs from the paper. Do this by hand first.
+   - MANUAL — `find-test-data` is not yet cast. It should search IWC fixtures and public sources for test data matching the data-flow shape. Try this if `paper-to-test-data` yields nothing usable.
+   - `user-supplied` — if neither yields acceptable data, ask the user to provide test data directly.
+8. **implement-cwl-workflow-test** — MANUAL — `implement-cwl-workflow-test` is not yet cast. It should assemble CWL job file(s) and expected-output assertions. Do this by hand and confirm before continuing.
+9. **validate-cwl** — MANUAL — `validate-cwl` is not yet cast. Run terminal `cwltool --validate` / schema lint over the assembled workflow, classify failures, recommend fixes. Do this by hand.
+10. **run-workflow-test** — invoke the `run-workflow-test` skill. Executes the workflow's tests via Planemo (which runs CWL as well as Galaxy); emits structured pass/fail and outputs.
+11. **debug-cwl-workflow-output** — MANUAL — `debug-cwl-workflow-output` is not yet cast. It should triage failing CWL run outputs, classify failure modes, and propose fixes. Do this by hand if `run-workflow-test` reported failures; otherwise skip.
+
+## Done
+
+Report the final artifacts in `./<run-slug>/` and the phases handled manually (everything except `run-workflow-test`, until the CWL Molds are cast).
+
+## Notes
+
+- Do not re-implement any skill's internal logic here; this harness only sequences and routes.
+- CWL per-tool loops (phases 4–6) have no shared `draft-next-step`-style endstate oracle today; iterate over the tools enumerated in the CWL template. This is an open gap to revisit when those Molds are cast.
+- CWL targeting has no `discover-or-author` branch — CommandLineTool authoring is built into `implement-cwl-tool-step`, informed by `summarize-cwl-tool`.
+- Carry unresolved assumptions forward as notes rather than inventing missing inputs.

--- a/casts/claude/skills/pipeline-paper-to-cwl/_assembly.json
+++ b/casts/claude/skills/pipeline-paper-to-cwl/_assembly.json
@@ -1,0 +1,18 @@
+{
+  "source_pipeline": "paper-to-cwl",
+  "source_revision": 2,
+  "harness_name": "pipeline-paper-to-cwl",
+  "phases": [
+    { "phase": 1, "kind": "mold", "skill": "summarize-paper", "cast_present": false, "loop": false },
+    { "phase": 2, "kind": "mold", "skill": "freeform-summary-to-cwl-design", "cast_present": false, "loop": false },
+    { "phase": 3, "kind": "mold", "skill": "summary-to-cwl-template", "cast_present": false, "loop": false },
+    { "phase": 4, "kind": "mold", "skill": "summarize-cwl-tool", "cast_present": false, "loop": true },
+    { "phase": 5, "kind": "mold", "skill": "implement-cwl-tool-step", "cast_present": false, "loop": true },
+    { "phase": 6, "kind": "mold", "skill": "validate-cwl", "cast_present": false, "loop": true },
+    { "phase": 7, "kind": "branch", "pattern": "test-data-resolution", "chain": ["paper-to-test-data", "find-test-data", "user-supplied"], "cast_present": [false, false, null] },
+    { "phase": 8, "kind": "mold", "skill": "implement-cwl-workflow-test", "cast_present": false, "loop": false },
+    { "phase": 9, "kind": "mold", "skill": "validate-cwl", "cast_present": false, "loop": false },
+    { "phase": 10, "kind": "mold", "skill": "run-workflow-test", "cast_present": true, "loop": false },
+    { "phase": 11, "kind": "mold", "skill": "debug-cwl-workflow-output", "cast_present": false, "loop": false }
+  ]
+}

--- a/casts/claude/skills/pipeline-paper-to-galaxy/SKILL.md
+++ b/casts/claude/skills/pipeline-paper-to-galaxy/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: pipeline-paper-to-galaxy
+description: "Direct path from a paper to a Galaxy gxformat2 workflow — orchestrates the Foundry skills of the PAPER → GALAXY pipeline in order, in a per-run working directory."
+---
+
+# pipeline-paper-to-galaxy
+
+Harness for the **PAPER → GALAXY** Foundry pipeline. Runs the constituent skills in order inside a single per-run working directory. Assembled from `content/pipelines/paper-to-galaxy.md` (revision 2) — regenerate with `/assemble-pipeline paper-to-galaxy` if the pipeline changes; do not hand-edit.
+
+## When To Use
+
+- Direct path from a paper to a Galaxy gxformat2 workflow. No CWL intermediate.
+
+## Working directory (do this first)
+
+Every constituent skill writes fixed filenames to its working directory. To keep one run's artifacts namespaced and avoid clobbering a prior run (foundry#282):
+
+1. Pick a run slug — use the harness argument if given; else ask the user for a short project name up front (the directory must exist before phase 1 writes its first artifact, so don't wait for a source title); else default `paper-to-galaxy-run`.
+2. Create `./<run-slug>/` in the current directory. If it exists, suffix `-2`, `-3`, … .
+3. Run **every** skill invocation below with `./<run-slug>/` as its working directory: **prefix every default input and output filename with `./<run-slug>/`** when you invoke the skill. The skills preserve their declared basenames and honor a harness-supplied directory; you supply the prefix on **both reads and writes**, so each phase finds the prior phase's output and nothing lands in the repo root.
+
+Announce the chosen directory before starting.
+
+## Pipeline
+
+Run these phases in order. After each, confirm the expected artifact exists in the run directory before advancing.
+
+1. **summarize-paper** — MANUAL — `summarize-paper` is not yet cast. It should extract methods, tools, sample data, and references from the paper into the shared `freeform-summary` handoff (`freeform-summary.md`). Do this by hand and confirm before continuing.
+2. **freeform-summary-to-galaxy-interface** — invoke the `freeform-summary-to-galaxy-interface` skill. Maps the summary into a Galaxy workflow interface design brief.
+3. **freeform-summary-to-galaxy-data-flow** — invoke the `freeform-summary-to-galaxy-data-flow` skill. Translates the summary into a Galaxy data-flow design brief.
+4. **compare-against-iwc-exemplar** — invoke the `compare-against-iwc-exemplar` skill. Surfaces the nearest IWC exemplar(s) and a structural diff to guide template authoring.
+5. **freeform-summary-to-galaxy-template** — invoke the `freeform-summary-to-galaxy-template` skill. Emits the gxformat2 skeleton with per-step TODOs (`galaxy-workflow-draft.gxwf.yml`).
+6. **advance-galaxy-draft-step** (loop) — re-invoke the `advance-galaxy-draft-step` skill repeatedly. It owns its own endstate oracle (`gxwf draft-next-step`) and concretizes one drafty step per call; stop when it reports `draft: false` (no remaining drafty steps), then continue.
+7. **test-data-resolution** (branch) — resolve the test-data chain in order; stop at the first that yields acceptable test data:
+   - MANUAL — `paper-to-test-data` is not yet cast. It should derive workflow test inputs and expected outputs from the paper. Do this by hand first.
+   - MANUAL — `find-test-data` is not yet cast. It should search IWC fixtures and public sources for test data matching the data-flow shape. Try this if `paper-to-test-data` yields nothing usable.
+   - `user-supplied` — if neither yields acceptable data, ask the user to provide test data directly.
+8. **implement-galaxy-workflow-test** — invoke the `implement-galaxy-workflow-test` skill. Assembles the Galaxy workflow test fixtures and assertions.
+9. **validate-galaxy-workflow** — invoke the `validate-galaxy-workflow` skill. Runs terminal gxwf validation on the assembled workflow and classifies failures.
+10. **run-workflow-test** — invoke the `run-workflow-test` skill. Executes the workflow's tests via Planemo; emits structured pass/fail and outputs.
+11. **debug-galaxy-workflow-output** — MANUAL — `debug-galaxy-workflow-output` is not yet cast. It should triage failing Galaxy run outputs, classify failure modes, and propose fixes. Do this by hand if `run-workflow-test` reported failures; otherwise skip.
+
+## Done
+
+Report the final artifacts in `./<run-slug>/` (notably the concretized `galaxy-workflow-draft.gxwf.yml` and the test outputs) and any phases that were handled manually (`summarize-paper`, the test-data branch, `debug-galaxy-workflow-output`).
+
+## Notes
+
+- Do not re-implement any skill's internal logic here; this harness only sequences and routes. Endstate detection for the per-step loop belongs to `advance-galaxy-draft-step`.
+- Carry unresolved assumptions forward as notes rather than inventing missing inputs.
+- The composed alternative PAPER → CWL → GALAXY is a runtime composition of `pipeline-paper-to-cwl` followed by `pipeline-cwl-to-galaxy`.

--- a/casts/claude/skills/pipeline-paper-to-galaxy/_assembly.json
+++ b/casts/claude/skills/pipeline-paper-to-galaxy/_assembly.json
@@ -1,0 +1,18 @@
+{
+  "source_pipeline": "paper-to-galaxy",
+  "source_revision": 2,
+  "harness_name": "pipeline-paper-to-galaxy",
+  "phases": [
+    { "phase": 1, "kind": "mold", "skill": "summarize-paper", "cast_present": false, "loop": false },
+    { "phase": 2, "kind": "mold", "skill": "freeform-summary-to-galaxy-interface", "cast_present": true, "loop": false },
+    { "phase": 3, "kind": "mold", "skill": "freeform-summary-to-galaxy-data-flow", "cast_present": true, "loop": false },
+    { "phase": 4, "kind": "mold", "skill": "compare-against-iwc-exemplar", "cast_present": true, "loop": false },
+    { "phase": 5, "kind": "mold", "skill": "freeform-summary-to-galaxy-template", "cast_present": true, "loop": false },
+    { "phase": 6, "kind": "mold", "skill": "advance-galaxy-draft-step", "cast_present": true, "loop": true },
+    { "phase": 7, "kind": "branch", "pattern": "test-data-resolution", "chain": ["paper-to-test-data", "find-test-data", "user-supplied"], "cast_present": [false, false, null] },
+    { "phase": 8, "kind": "mold", "skill": "implement-galaxy-workflow-test", "cast_present": true, "loop": false },
+    { "phase": 9, "kind": "mold", "skill": "validate-galaxy-workflow", "cast_present": true, "loop": false },
+    { "phase": 10, "kind": "mold", "skill": "run-workflow-test", "cast_present": true, "loop": false },
+    { "phase": 11, "kind": "mold", "skill": "debug-galaxy-workflow-output", "cast_present": false, "loop": false }
+  ]
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -25,7 +25,7 @@ Foundry-internal (in the `foundry/` repo):
 - **Static site** — Astro renderer over the foundry's content collections, deployed to GitHub Pages.
 
 Consumers (external):
-- **Harnesses** — hand-authored orchestration that consumes generated skills or other cast artifacts. Live in their own repos. The Foundry produces the artifacts they load.
+- **Harnesses** — orchestration that consumes generated skills or other cast artifacts. What a *sophisticated* harness is — stateful, resumable, approval-gated, Archon-style — is an open research question (§15); those live in their own repos and the Foundry produces the artifacts they load. The only in-repo harnesses today are **stop-gaps**: a pipeline assembled into a trivial linear `pipeline-<slug>` skill that runs its phase casts in order. Trivial exercises of the pipeline spine, enough to test-drive the casts end-to-end — not the production harness surface.
 - **Web applications** — consume `web`-target casts.
 
 ## 2. Concepts and vocabulary
@@ -544,12 +544,13 @@ Key decisions reflected in the layout:
 - **`casts/` outside `content/`** — casts are not foundry notes. They have their own provenance shape and target-specific layouts; collapsing them into `content/` would muddy the validator and the site.
 - **`docs/` for Foundry-meta** — long-form design docs (architecture, MOLD_SPEC) live here, not as content notes.
 - **No `content/exemplars/` directory** — IWC is referenced by URL in pattern bodies, not mirrored. See `CORPUS_INGESTION.md`.
-- **No top-level `harnesses/`** — harnesses are downstream consumers, in their own repos. `content/pipelines/` is the Foundry's representation of the journey shape; harnesses (in their own repos) are the executable orchestration that consumes a pipeline + the cast Molds.
+- **No top-level `harnesses/`** — the Foundry doesn't host the production harness surface; sophisticated, stateful orchestration is an open research question (§15) that belongs in downstream repos consuming a pipeline + the cast Molds. `content/pipelines/` is the Foundry's representation of the journey shape. The one in-repo exception is a deliberate **stop-gap**: `/assemble-pipeline` compiles a pipeline into a trivial linear harness skill (`pipeline-<slug>` under `casts/claude/skills/`, namespaced by prefix) that runs its phase casts in order for end-to-end test-drives. A trivial exercise of the pipeline spine — not a commitment to in-repo orchestration, and not a `harnesses/` directory.
 - **`content/pipelines/` as primary IA** — pipelines are the journey surface (subway maps over the KB) and the source of truth for "what Molds compose into a buildable harness." Mold inventory invariant ("Molds = union of pipeline phases") is machine-checked in `validatePipelinePhases`.
 - **Single `package.json`, single `tsconfig.json`** — tooling and site share a dep tree. The wiki-link module under `scripts/lib/` is imported by both sides via path alias.
 
 ## 15. Tracked Follow-Up
 
+- **Harness execution strategy (open research question).** How a pipeline becomes an executable harness spans a spectrum. The current floor is a **stop-gap**: `/assemble-pipeline` compiles a pipeline into a trivial linear `pipeline-<slug>` skill that runs its phase casts in order, defers loop endstate detection to the looped Mold's own oracle (`advance-galaxy-draft-step` → `gxwf draft-next-step`), expands `[branch]` routing inline, and sets up a per-run working directory (foundry#282). The ceiling is heavyweight stateful orchestration — resumption, approval gates, autonomy posture, cross-step rework, routing the harness owns rather than the looped/branching Molds. Unresolved: where sophisticated harnesses live (downstream repos vs. a Foundry-blessed format), how much routing the harness owns vs. the Molds own, and whether the stop-gap assembler graduates into something durable or stays a test-drive convenience. See `docs/HARNESS_PIPELINES.md`.
 - **Composed pipelines (`PAPER -> CWL -> GALAXY`).** Track representation for composed paths in [issue #200](https://github.com/galaxyproject/foundry/issues/200). The Mold inventory already supports the paths; the unresolved question is whether composed journeys get distinct `content/pipelines/*.md` notes or remain harness-level runtime compositions.
 
 ## 16. Resolved Contracts


### PR DESCRIPTION
First crack at https://github.com/galaxyproject/foundry/issues/286 - I had the agent assemble these skills but in retrospect I sort of think that should be programatic. This is all just like quick wrappers to expose the functionality though.

> Posted by Claude (AI assistant) on behalf of @jmchilton — not authored by them personally.

## What

A `/assemble-pipeline <pipeline-slug>` command that compiles a Pipeline note's machine-readable `phases:` spine into a lightweight `pipeline-<slug>` **harness skill**, plus all 6 pipelines assembled.

A harness is **Not a Mold** — it's orchestration glue, not a cast. These in-repo `pipeline-*` skills are deliberate **stop-gaps**: trivial linear exercises of the pipeline spine for test-driving the casts end-to-end. Sophisticated/stateful harnesses remain an open research question that belongs downstream (see ARCHITECTURE §15).

## The command does

- Resolves each Mold wiki-link (top-level + branch inner) to a cast under `casts/claude/skills/`; **un-cast phases become explicit manual checkpoints** with the Mold's one-line intent, not silent skips.
- **Loop** phases defer endstate detection to the looped Mold's own oracle (`advance-galaxy-draft-step` → `gxwf draft-next-step`); harness just re-invokes until done — no re-implementation.
- **Branch** phases expand `test-data-resolution` (chain → first success; `user-supplied` = ask user) and `discover-or-author`.
- **foundry#282**: harness sets up a per-run `./<run-slug>/` and threads it to every phase (prefix on reads + writes), so molds stop dropping fixed filenames in the repo root.
- Writes an `_assembly.json` provenance/drift sidecar per harness.

## Assembled (6)

`interview→galaxy`, `paper→galaxy`, `nextflow→galaxy`, `cwl→galaxy`, `nextflow→cwl`, `paper→cwl`. Each ships `SKILL.md` + `_assembly.json`. The Galaxy paths are mostly wired to real casts; the CWL paths are mostly manual today (CWL Molds uncast) and strengthen as casts land.

## Notes / open questions

- Placement under `casts/claude/skills/` (for `.claude/skills` discovery) is reconciled in ARCHITECTURE §14/§15 as the stop-gap exception, not a `harnesses/` dir.
- CWL per-tool loops (`summarize-cwl-tool`, `implement-cwl-tool-step`, `validate-cwl`) have no shared `draft-next-step`-style oracle yet — flagged inline as an open gap.
- `_assembly.json` is a harness artifact, distinct from cast `_provenance.json`; the cast verifier doesn't touch it.

`npm run validate` clean (0 errors). Generated by the command's own procedure; reviewed by a subagent (directory-binding + run-slug-timing fixes applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)