### PR TITLE
Encode --use-subagents/--checkpoint run options into pipeline harnesses (#291)

### DIFF
--- a/casts/claude/skills/pipeline-cwl-to-galaxy/SKILL.md
+++ b/casts/claude/skills/pipeline-cwl-to-galaxy/SKILL.md
@@ -11,12 +11,19 @@ Harness for the **CWL → GALAXY** Foundry pipeline. Runs the constituent skills
 
 - Path from a CWL Workflow to a Galaxy gxformat2 workflow. Lighter upstream extraction.
 
+## Run options
+
+Optional flags, given as leading arguments. Strip any you recognize; treat the remaining positional argument as the run slug. Both default off and compose.
+
+- `--use-subagents` — run each cast phase in its own subagent to keep this orchestrator's context small. For each phase whose skill is cast, spawn a subagent, tell it the run directory and to invoke the named skill with every default filename prefixed by `./<run-slug>/`, and have it return a short report (artifacts written, assumptions, status) rather than its full transcript; carry only that report forward. A cast loop phase runs **one subagent per iteration** — each advances a single step and returns its done-signal, and you inspect that signal to decide whether to spawn the next iteration. Branch phases run their whole fallback chain in one subagent. MANUAL (un-cast) phases are never delegated — including MANUAL loop phases — so handle those yourself regardless of the per-iteration rule above.
+- `--checkpoint` — commit after every phase so the run directory's git history is a per-step record (a data source for workflow-implementation visualizations). When set, `git init ./<run-slug>/` during working-directory setup — this is a standalone per-run repo; do not add it to any surrounding repo you are working inside. Then after each phase's artifact is confirmed run `git -C ./<run-slug>/ add -A && git -C ./<run-slug>/ commit -m "phase <n>: <skill>"`. Loop phases commit **once per iteration** (`phase <n> step <k>: <skill>`); for a MANUAL loop, commit once per by-hand step. With `--use-subagents`, the subagent does the work and returns; you make the commit.
+
 ## Working directory (do this first)
 
 Every constituent skill writes fixed filenames to its working directory. To keep one run's artifacts namespaced and avoid clobbering a prior run (foundry#282):
 
 1. Pick a run slug — use the harness argument if given; else ask the user for a short project name up front (the directory must exist before phase 1 writes its first artifact, so don't wait for a source title); else default `cwl-to-galaxy-run`.
-2. Create `./<run-slug>/` in the current directory. If it exists, suffix `-2`, `-3`, … .
+2. Create `./<run-slug>/` in the current directory. If it exists, suffix `-2`, `-3`, … . If invoked with `--checkpoint`, run `git init ./<run-slug>/` now (see Run options).
 3. Run **every** skill invocation below with `./<run-slug>/` as its working directory: **prefix every default input and output filename with `./<run-slug>/`** when you invoke the skill. The skills preserve their declared basenames and honor a harness-supplied directory; you supply the prefix on **both reads and writes**, so each phase finds the prior phase's output and nothing lands in the repo root.
 
 Announce the chosen directory before starting.

--- a/casts/claude/skills/pipeline-cwl-to-galaxy/_assembly.json
+++ b/casts/claude/skills/pipeline-cwl-to-galaxy/_assembly.json
@@ -2,6 +2,7 @@
   "source_pipeline": "cwl-to-galaxy",
   "source_revision": 2,
   "harness_name": "pipeline-cwl-to-galaxy",
+  "options": ["use-subagents", "checkpoint"],
   "phases": [
     { "phase": 1, "kind": "mold", "skill": "summarize-cwl", "cast_present": true, "loop": false },
     { "phase": 2, "kind": "mold", "skill": "cwl-summary-to-galaxy-interface", "cast_present": true, "loop": false },

--- a/casts/claude/skills/pipeline-interview-to-galaxy/SKILL.md
+++ b/casts/claude/skills/pipeline-interview-to-galaxy/SKILL.md
@@ -11,12 +11,19 @@ Harness for the **INTERVIEW → GALAXY** Foundry pipeline. Runs the constituent 
 
 - Interview-driven path to a Galaxy gxformat2 workflow through the shared freeform-summary handoff.
 
+## Run options
+
+Optional flags, given as leading arguments. Strip any you recognize; treat the remaining positional argument as the run slug. Both default off and compose.
+
+- `--use-subagents` — run each cast phase in its own subagent to keep this orchestrator's context small. For each phase whose skill is cast, spawn a subagent, tell it the run directory and to invoke the named skill with every default filename prefixed by `./<run-slug>/`, and have it return a short report (artifacts written, assumptions, status) rather than its full transcript; carry only that report forward. A cast loop phase runs **one subagent per iteration** — each advances a single step and returns its done-signal, and you inspect that signal to decide whether to spawn the next iteration. Branch phases run their whole fallback chain in one subagent. MANUAL (un-cast) phases are never delegated — including MANUAL loop phases — so handle those yourself regardless of the per-iteration rule above.
+- `--checkpoint` — commit after every phase so the run directory's git history is a per-step record (a data source for workflow-implementation visualizations). When set, `git init ./<run-slug>/` during working-directory setup — this is a standalone per-run repo; do not add it to any surrounding repo you are working inside. Then after each phase's artifact is confirmed run `git -C ./<run-slug>/ add -A && git -C ./<run-slug>/ commit -m "phase <n>: <skill>"`. Loop phases commit **once per iteration** (`phase <n> step <k>: <skill>`); for a MANUAL loop, commit once per by-hand step. With `--use-subagents`, the subagent does the work and returns; you make the commit.
+
 ## Working directory (do this first)
 
 Every constituent skill writes fixed filenames to its working directory. To keep one run's artifacts namespaced and avoid clobbering a prior run (foundry#282):
 
 1. Pick a run slug — use the harness argument if given; else ask the user for a short project name up front (the directory must exist before phase 1 writes its first artifact, so don't wait for a source title); else default `interview-to-galaxy-run`.
-2. Create `./<run-slug>/` in the current directory. If it exists, suffix `-2`, `-3`, … .
+2. Create `./<run-slug>/` in the current directory. If it exists, suffix `-2`, `-3`, … . If invoked with `--checkpoint`, run `git init ./<run-slug>/` now (see Run options).
 3. Run **every** skill invocation below with `./<run-slug>/` as its working directory: **prefix every default input and output filename with `./<run-slug>/`** when you invoke the skill. The skills preserve their declared basenames and honor a harness-supplied directory; you supply the prefix on **both reads and writes**, so each phase finds the prior phase's output and nothing lands in the repo root.
 
 Announce the chosen directory before starting.

--- a/casts/claude/skills/pipeline-interview-to-galaxy/_assembly.json
+++ b/casts/claude/skills/pipeline-interview-to-galaxy/_assembly.json
@@ -2,6 +2,7 @@
   "source_pipeline": "interview-to-galaxy",
   "source_revision": 1,
   "harness_name": "pipeline-interview-to-galaxy",
+  "options": ["use-subagents", "checkpoint"],
   "phases": [
     { "phase": 1, "kind": "mold", "skill": "interview-to-freeform-summary", "cast_present": true, "loop": false },
     { "phase": 2, "kind": "mold", "skill": "freeform-summary-to-galaxy-interface", "cast_present": true, "loop": false },

--- a/casts/claude/skills/pipeline-nextflow-to-cwl/SKILL.md
+++ b/casts/claude/skills/pipeline-nextflow-to-cwl/SKILL.md
@@ -13,12 +13,19 @@ Most of this pipeline's Molds are not yet cast, so this harness is mostly manual
 
 - Direct path from a Nextflow pipeline to a CWL Workflow + CommandLineTool set.
 
+## Run options
+
+Optional flags, given as leading arguments. Strip any you recognize; treat the remaining positional argument as the run slug. Both default off and compose.
+
+- `--use-subagents` — run each cast phase in its own subagent to keep this orchestrator's context small. For each phase whose skill is cast, spawn a subagent, tell it the run directory and to invoke the named skill with every default filename prefixed by `./<run-slug>/`, and have it return a short report (artifacts written, assumptions, status) rather than its full transcript; carry only that report forward. A cast loop phase runs **one subagent per iteration** — each advances a single step and returns its done-signal, and you inspect that signal to decide whether to spawn the next iteration. Branch phases run their whole fallback chain in one subagent. MANUAL (un-cast) phases are never delegated — including MANUAL loop phases — so handle those yourself regardless of the per-iteration rule above.
+- `--checkpoint` — commit after every phase so the run directory's git history is a per-step record (a data source for workflow-implementation visualizations). When set, `git init ./<run-slug>/` during working-directory setup — this is a standalone per-run repo; do not add it to any surrounding repo you are working inside. Then after each phase's artifact is confirmed run `git -C ./<run-slug>/ add -A && git -C ./<run-slug>/ commit -m "phase <n>: <skill>"`. Loop phases commit **once per iteration** (`phase <n> step <k>: <skill>`); for a MANUAL loop, commit once per by-hand step. With `--use-subagents`, the subagent does the work and returns; you make the commit.
+
 ## Working directory (do this first)
 
 Every constituent skill writes fixed filenames to its working directory. To keep one run's artifacts namespaced and avoid clobbering a prior run (foundry#282):
 
 1. Pick a run slug — use the harness argument if given; else ask the user for a short project name up front (the directory must exist before phase 1 writes its first artifact, so don't wait for a source title); else default `nextflow-to-cwl-run`.
-2. Create `./<run-slug>/` in the current directory. If it exists, suffix `-2`, `-3`, … .
+2. Create `./<run-slug>/` in the current directory. If it exists, suffix `-2`, `-3`, … . If invoked with `--checkpoint`, run `git init ./<run-slug>/` now (see Run options).
 3. Run **every** skill invocation below with `./<run-slug>/` as its working directory: **prefix every default input and output filename with `./<run-slug>/`** when you invoke the skill. The skills preserve their declared basenames and honor a harness-supplied directory; you supply the prefix on **both reads and writes**, so each phase finds the prior phase's output and nothing lands in the repo root.
 
 Announce the chosen directory before starting.

--- a/casts/claude/skills/pipeline-nextflow-to-cwl/_assembly.json
+++ b/casts/claude/skills/pipeline-nextflow-to-cwl/_assembly.json
@@ -2,6 +2,7 @@
   "source_pipeline": "nextflow-to-cwl",
   "source_revision": 2,
   "harness_name": "pipeline-nextflow-to-cwl",
+  "options": ["use-subagents", "checkpoint"],
   "phases": [
     { "phase": 1, "kind": "mold", "skill": "summarize-nextflow", "cast_present": true, "loop": false },
     { "phase": 2, "kind": "mold", "skill": "nextflow-summary-to-cwl-interface", "cast_present": false, "loop": false },

--- a/casts/claude/skills/pipeline-nextflow-to-galaxy/SKILL.md
+++ b/casts/claude/skills/pipeline-nextflow-to-galaxy/SKILL.md
@@ -11,12 +11,19 @@ Harness for the **NEXTFLOW → GALAXY** Foundry pipeline. Runs the constituent s
 
 - Direct path from a Nextflow pipeline to a Galaxy gxformat2 workflow.
 
+## Run options
+
+Optional flags, given as leading arguments. Strip any you recognize; treat the remaining positional argument as the run slug. Both default off and compose.
+
+- `--use-subagents` — run each cast phase in its own subagent to keep this orchestrator's context small. For each phase whose skill is cast, spawn a subagent, tell it the run directory and to invoke the named skill with every default filename prefixed by `./<run-slug>/`, and have it return a short report (artifacts written, assumptions, status) rather than its full transcript; carry only that report forward. A cast loop phase runs **one subagent per iteration** — each advances a single step and returns its done-signal, and you inspect that signal to decide whether to spawn the next iteration. Branch phases run their whole fallback chain in one subagent. MANUAL (un-cast) phases are never delegated — including MANUAL loop phases — so handle those yourself regardless of the per-iteration rule above.
+- `--checkpoint` — commit after every phase so the run directory's git history is a per-step record (a data source for workflow-implementation visualizations). When set, `git init ./<run-slug>/` during working-directory setup — this is a standalone per-run repo; do not add it to any surrounding repo you are working inside. Then after each phase's artifact is confirmed run `git -C ./<run-slug>/ add -A && git -C ./<run-slug>/ commit -m "phase <n>: <skill>"`. Loop phases commit **once per iteration** (`phase <n> step <k>: <skill>`); for a MANUAL loop, commit once per by-hand step. With `--use-subagents`, the subagent does the work and returns; you make the commit.
+
 ## Working directory (do this first)
 
 Every constituent skill writes fixed filenames to its working directory. To keep one run's artifacts namespaced and avoid clobbering a prior run (foundry#282):
 
 1. Pick a run slug — use the harness argument if given; else ask the user for a short project name up front (the directory must exist before phase 1 writes its first artifact, so don't wait for a source title); else default `nextflow-to-galaxy-run`.
-2. Create `./<run-slug>/` in the current directory. If it exists, suffix `-2`, `-3`, … .
+2. Create `./<run-slug>/` in the current directory. If it exists, suffix `-2`, `-3`, … . If invoked with `--checkpoint`, run `git init ./<run-slug>/` now (see Run options).
 3. Run **every** skill invocation below with `./<run-slug>/` as its working directory: **prefix every default input and output filename with `./<run-slug>/`** when you invoke the skill. The skills preserve their declared basenames and honor a harness-supplied directory; you supply the prefix on **both reads and writes**, so each phase finds the prior phase's output and nothing lands in the repo root.
 
 Announce the chosen directory before starting.

--- a/casts/claude/skills/pipeline-nextflow-to-galaxy/_assembly.json
+++ b/casts/claude/skills/pipeline-nextflow-to-galaxy/_assembly.json
@@ -2,6 +2,7 @@
   "source_pipeline": "nextflow-to-galaxy",
   "source_revision": 3,
   "harness_name": "pipeline-nextflow-to-galaxy",
+  "options": ["use-subagents", "checkpoint"],
   "phases": [
     { "phase": 1, "kind": "mold", "skill": "summarize-nextflow", "cast_present": true, "loop": false },
     { "phase": 2, "kind": "mold", "skill": "nextflow-summary-to-galaxy-reference-data", "cast_present": false, "loop": false },

--- a/casts/claude/skills/pipeline-paper-to-cwl/SKILL.md
+++ b/casts/claude/skills/pipeline-paper-to-cwl/SKILL.md
@@ -13,12 +13,19 @@ Most of this pipeline's Molds are not yet cast, so this harness is mostly manual
 
 - Direct path from a paper to a CWL Workflow + CommandLineTool set.
 
+## Run options
+
+Optional flags, given as leading arguments. Strip any you recognize; treat the remaining positional argument as the run slug. Both default off and compose.
+
+- `--use-subagents` — run each cast phase in its own subagent to keep this orchestrator's context small. For each phase whose skill is cast, spawn a subagent, tell it the run directory and to invoke the named skill with every default filename prefixed by `./<run-slug>/`, and have it return a short report (artifacts written, assumptions, status) rather than its full transcript; carry only that report forward. A cast loop phase runs **one subagent per iteration** — each advances a single step and returns its done-signal, and you inspect that signal to decide whether to spawn the next iteration. Branch phases run their whole fallback chain in one subagent. MANUAL (un-cast) phases are never delegated — including MANUAL loop phases — so handle those yourself regardless of the per-iteration rule above.
+- `--checkpoint` — commit after every phase so the run directory's git history is a per-step record (a data source for workflow-implementation visualizations). When set, `git init ./<run-slug>/` during working-directory setup — this is a standalone per-run repo; do not add it to any surrounding repo you are working inside. Then after each phase's artifact is confirmed run `git -C ./<run-slug>/ add -A && git -C ./<run-slug>/ commit -m "phase <n>: <skill>"`. Loop phases commit **once per iteration** (`phase <n> step <k>: <skill>`); for a MANUAL loop, commit once per by-hand step. With `--use-subagents`, the subagent does the work and returns; you make the commit.
+
 ## Working directory (do this first)
 
 Every constituent skill writes fixed filenames to its working directory. To keep one run's artifacts namespaced and avoid clobbering a prior run (foundry#282):
 
 1. Pick a run slug — use the harness argument if given; else ask the user for a short project name up front (the directory must exist before phase 1 writes its first artifact, so don't wait for a source title); else default `paper-to-cwl-run`.
-2. Create `./<run-slug>/` in the current directory. If it exists, suffix `-2`, `-3`, … .
+2. Create `./<run-slug>/` in the current directory. If it exists, suffix `-2`, `-3`, … . If invoked with `--checkpoint`, run `git init ./<run-slug>/` now (see Run options).
 3. Run **every** skill invocation below with `./<run-slug>/` as its working directory: **prefix every default input and output filename with `./<run-slug>/`** when you invoke the skill. The skills preserve their declared basenames and honor a harness-supplied directory; you supply the prefix on **both reads and writes**, so each phase finds the prior phase's output and nothing lands in the repo root.
 
 Announce the chosen directory before starting.

--- a/casts/claude/skills/pipeline-paper-to-cwl/_assembly.json
+++ b/casts/claude/skills/pipeline-paper-to-cwl/_assembly.json
@@ -2,6 +2,7 @@
   "source_pipeline": "paper-to-cwl",
   "source_revision": 2,
   "harness_name": "pipeline-paper-to-cwl",
+  "options": ["use-subagents", "checkpoint"],
   "phases": [
     { "phase": 1, "kind": "mold", "skill": "summarize-paper", "cast_present": false, "loop": false },
     { "phase": 2, "kind": "mold", "skill": "freeform-summary-to-cwl-design", "cast_present": false, "loop": false },

--- a/casts/claude/skills/pipeline-paper-to-galaxy/SKILL.md
+++ b/casts/claude/skills/pipeline-paper-to-galaxy/SKILL.md
@@ -11,12 +11,19 @@ Harness for the **PAPER → GALAXY** Foundry pipeline. Runs the constituent skil
 
 - Direct path from a paper to a Galaxy gxformat2 workflow. No CWL intermediate.
 
+## Run options
+
+Optional flags, given as leading arguments. Strip any you recognize; treat the remaining positional argument as the run slug. Both default off and compose.
+
+- `--use-subagents` — run each cast phase in its own subagent to keep this orchestrator's context small. For each phase whose skill is cast, spawn a subagent, tell it the run directory and to invoke the named skill with every default filename prefixed by `./<run-slug>/`, and have it return a short report (artifacts written, assumptions, status) rather than its full transcript; carry only that report forward. A cast loop phase runs **one subagent per iteration** — each advances a single step and returns its done-signal, and you inspect that signal to decide whether to spawn the next iteration. Branch phases run their whole fallback chain in one subagent. MANUAL (un-cast) phases are never delegated — including MANUAL loop phases — so handle those yourself regardless of the per-iteration rule above.
+- `--checkpoint` — commit after every phase so the run directory's git history is a per-step record (a data source for workflow-implementation visualizations). When set, `git init ./<run-slug>/` during working-directory setup — this is a standalone per-run repo; do not add it to any surrounding repo you are working inside. Then after each phase's artifact is confirmed run `git -C ./<run-slug>/ add -A && git -C ./<run-slug>/ commit -m "phase <n>: <skill>"`. Loop phases commit **once per iteration** (`phase <n> step <k>: <skill>`); for a MANUAL loop, commit once per by-hand step. With `--use-subagents`, the subagent does the work and returns; you make the commit.
+
 ## Working directory (do this first)
 
 Every constituent skill writes fixed filenames to its working directory. To keep one run's artifacts namespaced and avoid clobbering a prior run (foundry#282):
 
 1. Pick a run slug — use the harness argument if given; else ask the user for a short project name up front (the directory must exist before phase 1 writes its first artifact, so don't wait for a source title); else default `paper-to-galaxy-run`.
-2. Create `./<run-slug>/` in the current directory. If it exists, suffix `-2`, `-3`, … .
+2. Create `./<run-slug>/` in the current directory. If it exists, suffix `-2`, `-3`, … . If invoked with `--checkpoint`, run `git init ./<run-slug>/` now (see Run options).
 3. Run **every** skill invocation below with `./<run-slug>/` as its working directory: **prefix every default input and output filename with `./<run-slug>/`** when you invoke the skill. The skills preserve their declared basenames and honor a harness-supplied directory; you supply the prefix on **both reads and writes**, so each phase finds the prior phase's output and nothing lands in the repo root.
 
 Announce the chosen directory before starting.

--- a/casts/claude/skills/pipeline-paper-to-galaxy/_assembly.json
+++ b/casts/claude/skills/pipeline-paper-to-galaxy/_assembly.json
@@ -2,6 +2,7 @@
   "source_pipeline": "paper-to-galaxy",
   "source_revision": 2,
   "harness_name": "pipeline-paper-to-galaxy",
+  "options": ["use-subagents", "checkpoint"],
   "phases": [
     { "phase": 1, "kind": "mold", "skill": "summarize-paper", "cast_present": false, "loop": false },
     { "phase": 2, "kind": "mold", "skill": "freeform-summary-to-galaxy-interface", "cast_present": true, "loop": false },

--- a/packages/build-cli/src/commands/assemble-pipeline.ts
+++ b/packages/build-cli/src/commands/assemble-pipeline.ts
@@ -123,6 +123,21 @@ type AssemblyPhase = MoldPhaseEntry | BranchPhaseEntry;
 
 const SUPPORTED_BRANCH_PATTERNS = new Set(["test-data-resolution"]);
 
+// Runtime invocation options every assembled harness honors. Uniform across
+// pipelines (#291): documented as prose in `## Run options` and surfaced in
+// `_assembly.json` for the site / future visualization tooling.
+const HARNESS_OPTIONS = ["use-subagents", "checkpoint"] as const;
+
+const RUN_OPTIONS_SECTION: string[] = [
+  "## Run options",
+  "",
+  "Optional flags, given as leading arguments. Strip any you recognize; treat the remaining positional argument as the run slug. Both default off and compose.",
+  "",
+  "- `--use-subagents` — run each cast phase in its own subagent to keep this orchestrator's context small. For each phase whose skill is cast, spawn a subagent, tell it the run directory and to invoke the named skill with every default filename prefixed by `./<run-slug>/`, and have it return a short report (artifacts written, assumptions, status) rather than its full transcript; carry only that report forward. A cast loop phase runs **one subagent per iteration** — each advances a single step and returns its done-signal, and you inspect that signal to decide whether to spawn the next iteration. Branch phases run their whole fallback chain in one subagent. MANUAL (un-cast) phases are never delegated — including MANUAL loop phases — so handle those yourself regardless of the per-iteration rule above.",
+  "- `--checkpoint` — commit after every phase so the run directory's git history is a per-step record (a data source for workflow-implementation visualizations). When set, `git init ./<run-slug>/` during working-directory setup — this is a standalone per-run repo; do not add it to any surrounding repo you are working inside. Then after each phase's artifact is confirmed run `git -C ./<run-slug>/ add -A && git -C ./<run-slug>/ commit -m \"phase <n>: <skill>\"`. Loop phases commit **once per iteration** (`phase <n> step <k>: <skill>`); for a MANUAL loop, commit once per by-hand step. With `--use-subagents`, the subagent does the work and returns; you make the commit.",
+  "",
+];
+
 interface Assembled {
   skill: string;
   assemblyPhases: AssemblyPhase[];
@@ -310,12 +325,13 @@ function renderSkill(args: {
     "",
     `- ${args.summary}`,
     "",
+    ...RUN_OPTIONS_SECTION,
     "## Working directory (do this first)",
     "",
     "Every constituent skill writes fixed filenames to its working directory. To keep one run's artifacts namespaced and avoid clobbering a prior run (foundry#282):",
     "",
     `1. Pick a run slug — use the harness argument if given; else ask the user for a short project name up front (the directory must exist before phase 1 writes its first artifact, so don't wait for a source title); else default \`${args.slug}-run\`.`,
-    "2. Create `./<run-slug>/` in the current directory. If it exists, suffix `-2`, `-3`, … .",
+    "2. Create `./<run-slug>/` in the current directory. If it exists, suffix `-2`, `-3`, … . If invoked with `--checkpoint`, run `git init ./<run-slug>/` now (see Run options).",
     "3. Run **every** skill invocation below with `./<run-slug>/` as its working directory: **prefix every default input and output filename with `./<run-slug>/`** when you invoke the skill. The skills preserve their declared basenames and honor a harness-supplied directory; you supply the prefix on **both reads and writes**, so each phase finds the prior phase's output and nothing lands in the repo root.",
     "",
     "Announce the chosen directory before starting.",
@@ -361,6 +377,7 @@ function renderAssembly(
     `  "source_pipeline": ${JSON.stringify(slug)},`,
     `  "source_revision": ${revision},`,
     `  "harness_name": ${JSON.stringify(harnessName)},`,
+    `  "options": ${compactValue([...HARNESS_OPTIONS])},`,
     `  "phases": [`,
     ...phases.map((p, i) => `    ${compactValue(p)}${i < phases.length - 1 ? "," : ""}`),
     "  ]",

--- a/site/src/lib/casts.ts
+++ b/site/src/lib/casts.ts
@@ -244,6 +244,8 @@ export interface AssemblyManifest {
   source_pipeline: string;
   source_revision: number;
   harness_name: string;
+  /** Runtime invocation flags the harness honors (e.g. `use-subagents`, `checkpoint`). */
+  options?: string[];
   phases: AssemblyPhase[];
 }
 

--- a/site/src/pages/pipelines/[slug]/harness.astro
+++ b/site/src/pages/pipelines/[slug]/harness.astro
@@ -66,6 +66,15 @@ function branchChain(p: AssemblyPhase): string[] {
       then invoke in a Claude Code session:
     </p>
     <pre class="p-3 rounded bg-(--color-surface-raised) text-sm font-mono overflow-x-auto"><code>/foundry-skills:{assembly.harness_name}</code></pre>
+    {assembly.options && assembly.options.length > 0 && (
+      <p class="text-sm mt-2">
+        Optional flags:
+        {assembly.options.map((o, i) => (
+          <>{i > 0 ? ', ' : ' '}<code class="font-mono">--{o}</code></>
+        ))}
+        <span class="text-(--color-text-muted)"> — see the <code class="font-mono">## Run options</code> section below.</span>
+      </p>
+    )}
   </section>
 
   <StopGapBanner />

--- a/site/src/pages/pipelines/run-a-pipeline.astro
+++ b/site/src/pages/pipelines/run-a-pipeline.astro
@@ -63,6 +63,13 @@ const pipelines = (await getCollection('content'))
         <code class="font-mono">./&lt;run-slug&gt;/</code> working directory, so artifacts stay namespaced
         and a second run won't clobber the first — the harness creates it before phase&nbsp;1. Pick a pipeline below.
       </li>
+      <li>
+        <strong>Optional run flags.</strong> Pass <code class="font-mono">--use-subagents</code> to run each
+        cast phase in its own subagent (one per loop iteration) so the orchestrator's context stays small, and
+        <code class="font-mono">--checkpoint</code> to <code class="font-mono">git init</code> the run directory and
+        commit after every phase — a per-step history for workflow-implementation visualizations. Both default off
+        and compose.
+      </li>
     </ol>
   </section>
 

--- a/tests/assemble-pipeline.test.ts
+++ b/tests/assemble-pipeline.test.ts
@@ -67,6 +67,33 @@ describe("assemble-pipeline (committed harnesses)", () => {
     expect(loop.skill).toBe("advance-galaxy-draft-step");
   });
 
+  it("documents the --use-subagents and --checkpoint run options", () => {
+    const skill = readFileSync(
+      path.join(repoRoot, "casts/claude/skills/pipeline-nextflow-to-galaxy/SKILL.md"),
+      "utf8",
+    );
+    expect(skill).toContain("## Run options");
+    expect(skill).toContain("`--use-subagents`");
+    expect(skill).toContain("one subagent per iteration");
+    expect(skill).toContain("`--checkpoint`");
+    expect(skill).toContain("git init ./<run-slug>/");
+    expect(skill).toContain("once per iteration");
+    // MANUAL precedence over the per-iteration rules (S1).
+    expect(skill).toContain("including MANUAL loop phases");
+    // Standalone per-run repo, not added to a surrounding repo (S2).
+    expect(skill).toContain("standalone per-run repo");
+  });
+
+  it("_assembly.json surfaces the uniform run options", () => {
+    const assembly = JSON.parse(
+      readFileSync(
+        path.join(repoRoot, "casts/claude/skills/pipeline-nextflow-to-galaxy/_assembly.json"),
+        "utf8",
+      ),
+    );
+    expect(assembly.options).toEqual(["use-subagents", "checkpoint"]);
+  });
+
   it("--check catches a tampered SKILL.md", () => {
     const skillPath = path.join(repoRoot, "casts/claude/skills/pipeline-paper-to-galaxy/SKILL.md");
     const original = readFileSync(skillPath, "utf8");
@@ -206,9 +233,12 @@ phases:
       // Un-cast loop phase: MANUAL marker + verbatim summary + loop_endstate prose.
       expect(skill).toContain("**looper** (loop) — MANUAL");
       expect(skill).toContain("Owns its own oracle; re-invoke until done, then continue.");
+      // Run options are uniform — present even on a minimal one-phase pipeline.
+      expect(skill).toContain("## Run options");
       const assembly = JSON.parse(
         readFileSync(path.join(dir, "casts/claude/skills/pipeline-mini/_assembly.json"), "utf8"),
       );
+      expect(assembly.options).toEqual(["use-subagents", "checkpoint"]);
       expect(assembly.phases[0]).toEqual({
         phase: 1,
         kind: "mold",

--- a/tests/assemble-pipeline.test.ts
+++ b/tests/assemble-pipeline.test.ts
@@ -8,6 +8,10 @@ import { describe, expect, it } from "vitest";
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, "..");
 const foundryBuild = path.join(repoRoot, "packages", "build-cli", "src", "bin", "foundry-build.ts");
+// Resolve the repo-local tsx binary by absolute path. Invoking `npx tsx` from a
+// temp-dir cwd can't see local node_modules and auto-installs tsx into the
+// shared npx cache; two such installs racing across test files corrupt it.
+const tsxBin = path.join(repoRoot, "node_modules", ".bin", process.platform === "win32" ? "tsx.cmd" : "tsx");
 
 const PIPELINES = [
   "cwl-to-galaxy",
@@ -24,7 +28,7 @@ function runTsx(
   cwd = repoRoot,
 ): { code: number; stdout: string; stderr: string } {
   try {
-    const stdout = execFileSync("npx", ["tsx", script, ...args], {
+    const stdout = execFileSync(tsxBin, [script, ...args], {
       cwd,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],

--- a/tests/cast-mold.test.ts
+++ b/tests/cast-mold.test.ts
@@ -10,10 +10,14 @@ const repoRoot = path.resolve(here, "..");
 const castMold = path.join(repoRoot, "scripts", "cast-mold.ts");
 const foundryBuild = path.join(repoRoot, "packages", "build-cli", "src", "bin", "foundry-build.ts");
 const castVerify = path.join(repoRoot, "scripts", "cast-skill-verify.ts");
+// Resolve the repo-local tsx binary by absolute path. Invoking `npx tsx` from a
+// temp-dir cwd can't see local node_modules and auto-installs tsx into the
+// shared npx cache; two such installs racing across test files corrupt it.
+const tsxBin = path.join(repoRoot, "node_modules", ".bin", process.platform === "win32" ? "tsx.cmd" : "tsx");
 
 function runTsx(script: string, args: string[]): { code: number; stdout: string; stderr: string } {
   try {
-    const stdout = execFileSync("npx", ["tsx", script, ...args], {
+    const stdout = execFileSync(tsxBin, [script, ...args], {
       cwd: repoRoot,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
@@ -577,7 +581,7 @@ Consume \`bundled-note.spec.yml\` for the structured spec.
 
 function execVerify(cwd: string, mold: string): { code: number; stdout: string; stderr: string } {
   try {
-    const stdout = execFileSync("npx", ["tsx", castVerify, mold, "--target=claude"], {
+    const stdout = execFileSync(tsxBin, [castVerify, mold, "--target=claude"], {
       cwd,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],


### PR DESCRIPTION
Closes #291.

Bakes two runtime invocation options into every assembled `pipeline-*` harness skill, as decided on #291. Both are **uniform across all six pipelines** — pure template constants in the deterministic assembler. No schema change, no pipeline frontmatter, no LLM step; the `--check` byte-drift gate still holds.

## Options

- **`--use-subagents`** — run each cast phase in its own subagent to keep the orchestrator's context small. A cast loop phase runs **one subagent per iteration** (each advances one step and returns its done-signal). Branch phases run their whole fallback chain in one subagent. MANUAL (un-cast) phases — including MANUAL loop phases — are never delegated.
- **`--checkpoint`** *(opt-in)* — `git init` the run-slug directory as a **standalone per-run repo** (not the surrounding checkout) and commit after every phase, **once per loop iteration**. Produces the per-step git history #291 wants as the data source for future workflow-implementation visualizations.

Both default off and compose (under both, the subagent does the work and returns; the orchestrator commits).

## Changes

- `packages/build-cli/src/commands/assemble-pipeline.ts` — `HARNESS_OPTIONS` constant + `## Run options` template section; conditional `git init` in the working-directory step; `"options"` in `_assembly.json`.
- Six regenerated `casts/claude/skills/pipeline-*/{SKILL.md,_assembly.json}`.
- `site/src/lib/casts.ts` — additive optional `options?: string[]` on `AssemblyManifest`.
- `site/src/pages/pipelines/[slug]/harness.astro` + `run-a-pipeline.astro` — surface the two flags.
- `tests/assemble-pipeline.test.ts` — assert the Run-options prose (incl. MANUAL precedence + standalone-repo wording) and the `_assembly.json` options array.

## Out of scope

The visualization tool that consumes the checkpoint commits — this PR produces only the data source.

## Verification

`make check-assemble-pipelines` clean · assemble tests 13/13 · `npm run test` 119/119 · `packages-typecheck` clean · `astro check` 0 errors. (The 3 pre-existing `npm run validate` errors are unrelated gxwf `draft-*` CLI metadata drift.)

A review subagent flagged two interaction gaps that are addressed in the final commit: MANUAL-loop precedence under both flags (all three `nextflow-to-cwl` loops are MANUAL), and the nested-`git init` repo gotcha for an orchestrator running inside a git checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
