### PR TITLE
Draft stub Mold bodies: Galaxy pipeline test tail + per-step core

### DIFF
--- a/casts/claude/skills/pipeline-cwl-to-galaxy/SKILL.md
+++ b/casts/claude/skills/pipeline-cwl-to-galaxy/SKILL.md
@@ -67,7 +67,7 @@ Run these phases in order. After each, confirm the expected artifact exists in t
 8. **implement-galaxy-workflow-test** — invoke the `implement-galaxy-workflow-test` skill. Assemble Galaxy workflow test fixtures and assertions.
 9. **validate-galaxy-workflow** — invoke the `validate-galaxy-workflow` skill. Run terminal gxwf validation on an assembled Galaxy workflow and classify workflow-level failures.
 10. **run-workflow-test** — invoke the `run-workflow-test` skill. Execute a workflow's tests via Planemo; emit structured pass/fail and outputs.
-11. **debug-galaxy-workflow-output** — MANUAL — `debug-galaxy-workflow-output` is not yet cast. Triage failing Galaxy run outputs; classify failure modes; propose fixes. Do this by hand and confirm before continuing.
+11. **debug-galaxy-workflow-output** — MANUAL — `debug-galaxy-workflow-output` is not yet cast. Triage failing Galaxy run outputs; classify the failure surface and capture evidence before recommending repairs. Do this by hand and confirm before continuing.
 
 ## Done
 

--- a/casts/claude/skills/pipeline-interview-to-galaxy/SKILL.md
+++ b/casts/claude/skills/pipeline-interview-to-galaxy/SKILL.md
@@ -57,7 +57,7 @@ Run these phases in order. After each, confirm the expected artifact exists in t
 8. **implement-galaxy-workflow-test** — invoke the `implement-galaxy-workflow-test` skill. Assemble Galaxy workflow test fixtures and assertions.
 9. **validate-galaxy-workflow** — invoke the `validate-galaxy-workflow` skill. Run terminal gxwf validation on an assembled Galaxy workflow and classify workflow-level failures.
 10. **run-workflow-test** — invoke the `run-workflow-test` skill. Execute a workflow's tests via Planemo; emit structured pass/fail and outputs.
-11. **debug-galaxy-workflow-output** — MANUAL — `debug-galaxy-workflow-output` is not yet cast. Triage failing Galaxy run outputs; classify failure modes; propose fixes. Do this by hand and confirm before continuing.
+11. **debug-galaxy-workflow-output** — MANUAL — `debug-galaxy-workflow-output` is not yet cast. Triage failing Galaxy run outputs; classify the failure surface and capture evidence before recommending repairs. Do this by hand and confirm before continuing.
 
 ## Done
 

--- a/casts/claude/skills/pipeline-nextflow-to-galaxy/SKILL.md
+++ b/casts/claude/skills/pipeline-nextflow-to-galaxy/SKILL.md
@@ -60,7 +60,7 @@ Run these phases in order. After each, confirm the expected artifact exists in t
 9. **implement-galaxy-workflow-test** — invoke the `implement-galaxy-workflow-test` skill. Assemble Galaxy workflow test fixtures and assertions.
 10. **validate-galaxy-workflow** — invoke the `validate-galaxy-workflow` skill. Run terminal gxwf validation on an assembled Galaxy workflow and classify workflow-level failures.
 11. **run-workflow-test** — invoke the `run-workflow-test` skill. Execute a workflow's tests via Planemo; emit structured pass/fail and outputs.
-12. **debug-galaxy-workflow-output** — MANUAL — `debug-galaxy-workflow-output` is not yet cast. Triage failing Galaxy run outputs; classify failure modes; propose fixes. Do this by hand and confirm before continuing.
+12. **debug-galaxy-workflow-output** — MANUAL — `debug-galaxy-workflow-output` is not yet cast. Triage failing Galaxy run outputs; classify the failure surface and capture evidence before recommending repairs. Do this by hand and confirm before continuing.
 
 ## Done
 

--- a/casts/claude/skills/pipeline-paper-to-galaxy/SKILL.md
+++ b/casts/claude/skills/pipeline-paper-to-galaxy/SKILL.md
@@ -58,7 +58,7 @@ Run these phases in order. After each, confirm the expected artifact exists in t
 8. **implement-galaxy-workflow-test** — invoke the `implement-galaxy-workflow-test` skill. Assemble Galaxy workflow test fixtures and assertions.
 9. **validate-galaxy-workflow** — invoke the `validate-galaxy-workflow` skill. Run terminal gxwf validation on an assembled Galaxy workflow and classify workflow-level failures.
 10. **run-workflow-test** — invoke the `run-workflow-test` skill. Execute a workflow's tests via Planemo; emit structured pass/fail and outputs.
-11. **debug-galaxy-workflow-output** — MANUAL — `debug-galaxy-workflow-output` is not yet cast. Triage failing Galaxy run outputs; classify failure modes; propose fixes. Do this by hand and confirm before continuing.
+11. **debug-galaxy-workflow-output** — MANUAL — `debug-galaxy-workflow-output` is not yet cast. Triage failing Galaxy run outputs; classify the failure surface and capture evidence before recommending repairs. Do this by hand and confirm before continuing.
 
 ## Done
 

--- a/content/molds/debug-galaxy-workflow-output/eval.md
+++ b/content/molds/debug-galaxy-workflow-output/eval.md
@@ -18,6 +18,12 @@
 - fixture: failed workflow test where the invocation state or invocation messages indicate scheduling, materialization, cancellation, conditional, or output-resolution failure.
 - expectation: records invocation state, structured message reason, affected step, subworkflow path if present, jobs summary, and whether Planemo surfaced or hid the relevant Galaxy API detail.
 
+## Case: collection output mismatch capture
+
+- check: llm-judged
+- fixture: failed workflow test where a collection or mapped output has wrong nesting, missing elements, or mismatched element identifiers.
+- expectation: diagnoses the collection shape / mapping / reduction / element-identifier mismatch as the failure surface — and for a Nextflow-translated workflow, traces it to a possibly-lossy operator translation — rather than relaxing the assertion to make the test pass.
+
 ## Case: reference gap discovery
 
 - check: llm-judged

--- a/content/molds/debug-galaxy-workflow-output/index.md
+++ b/content/molds/debug-galaxy-workflow-output/index.md
@@ -8,10 +8,18 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-05-02
-revision: 3
+revised: 2026-06-12
+revision: 4
 ai_generated: true
-summary: "Triage failing Galaxy run outputs; classify failure modes; propose fixes."
+summary: "Triage failing Galaxy run outputs; classify the failure surface and capture evidence before recommending repairs."
+input_artifacts:
+  - id: workflow-test-result
+    description: "Structured run handoff from run-workflow-test: Planemo result, invocation/job/artifact context, and the observed failure modality."
+output_artifacts:
+  - id: workflow-debug-report
+    kind: markdown
+    default_filename: workflow-debug-report.md
+    description: "Failure-surface classification with captured job/invocation/collection/assertion evidence and a recommended next step or reference-gap follow-up."
 references:
   - kind: research
     ref: "[[planemo-asserts-idioms]]"
@@ -72,4 +80,15 @@ references:
 ---
 # debug-galaxy-workflow-output
 
-Stub. Replace with real Mold content per MOLD_SPEC once first walks are done.
+Triage a failing Galaxy workflow test. Take the structured handoff from [[run-workflow-test]], classify the failure surface before proposing any repair, and capture the reference evidence the surface requires. When the failure cannot be classified from existing references, recommend a focused follow-up rather than converting uncertainty into a guessed fix.
+
+Classify before repairing. The same red output can be a tool/job failure, a workflow invocation failure, a collection-output mismatch, a missing workflow output, or an assertion mismatch — and each routes to a different reference surface and a different fix. Locate where the evidence lives first ([[planemo-workflow-test-architecture]]).
+
+## Sequence
+
+1. **Classify the first failure surface.** From the run's structured result, decide whether the first failure is a tool/job failure, a workflow invocation failure, a collection-output mismatch, a missing workflow output, or an assertion mismatch. Classify before proposing repairs.
+2. **Capture job-failure evidence.** When a job is in `error`/`failed`/`stopped`, record job id, tool id, exit code, job messages, the stdout/stderr distinction, and output dataset state per [[galaxy-tool-job-failure-reference]]; check whether the wrapper's failure semantics already explain it.
+3. **Capture invocation-failure evidence.** When the invocation state or messages indicate scheduling, materialization, cancellation, conditional, or output-resolution failure, record invocation state, the structured message reason, the affected step, any subworkflow path, and the jobs summary per [[galaxy-workflow-invocation-failure-reference]]; note whether Planemo surfaced or hid the relevant Galaxy API detail.
+4. **Trace collection mismatches.** When a failing output is a collection or mapped output, diagnose shape, mapping, reduction, and element-identifier mismatches with [[galaxy-collection-semantics]]; for workflows translated from Nextflow, trace wrong nesting / missing elements / bad joins back to possibly-lossy operator translations via [[nextflow-operators-to-galaxy-collection-recipes]].
+5. **Read assertion failures honestly.** When the failure is an assertion, use [[planemo-asserts-idioms]] to decide whether it is an assertion-choice/tolerance problem or a real output regression. Before weakening an assertion, widening a delta, or switching to an existence check, confirm against [[iwc-shortcuts-anti-patterns]] that the relaxation is an accepted IWC shortcut and not masking a real failure.
+6. **Discover reference gaps.** When the failure cannot be classified confidently from the references above, recommend a focused follow-up — reference documentation, pattern capture, API verification, or eval coverage — rather than emitting a repair recipe built on a guess.

--- a/content/molds/find-test-data/eval.md
+++ b/content/molds/find-test-data/eval.md
@@ -1,0 +1,19 @@
+# find-test-data eval
+
+## Case: no fabricated references
+
+- check: llm-judged
+- fixture: data-flow brief naming several workflow inputs where at least one has no obvious public test dataset.
+- expectation: every emitted `test-data-refs.json` entry points at a real URL/path, or the input is reported with `resolved: false` and a reason. No invented accessions, Zenodo ids, or paths appear as resolved.
+
+## Case: shape and datatype match
+
+- check: llm-judged
+- fixture: data-flow brief with a mix of File, paired, and list:paired collection inputs.
+- expectation: each resolved entry records the Galaxy collection shape and datatype matching the brief's input; a paired-end input does not resolve to a single unpaired file without flagging the mismatch.
+
+## Case: full input coverage
+
+- check: deterministic
+- fixture: a `test-data-refs.json` emitted for an IWC-style workflow such as SARS-CoV-2 variant calling or RNAseq-PE.
+- expectation: every workflow input label has exactly one entry; each entry is either resolved (URL/path + shape + datatype) or marked `resolved: false` with a reason. No input is uncovered and none is silently absent, so [[implement-galaxy-workflow-test]] can stage from the refs without re-deriving input shapes.

--- a/content/molds/find-test-data/index.md
+++ b/content/molds/find-test-data/index.md
@@ -6,8 +6,8 @@ tags:
   - mold
 status: draft
 created: 2026-04-30
-revised: 2026-04-30
-revision: 1
+revised: 2026-06-12
+revision: 2
 ai_generated: true
 summary: "Search IWC fixtures and public sources for test data matching a data-flow shape."
 output_artifacts:
@@ -15,7 +15,38 @@ output_artifacts:
     kind: json
     default_filename: test-data-refs.json
     description: "Test data matched from IWC fixtures or public sources, expressed as URLs/paths plus expected shapes for downstream test authoring."
+references:
+  - kind: research
+    ref: "[[iwc-test-data-conventions]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Match IWC test-data conventions — Zenodo/remote-URL first, SHA-1 integrity, per-input collection layout — when selecting or describing candidate fixtures."
+    trigger: "When choosing where test data should come from or describing the shape a candidate file must have."
+  - kind: research
+    ref: "[[galaxy-workflow-testability-design]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Confirm the collection shapes and labels the resolved data must populate so downstream tests can address them."
+    trigger: "When mapping an input label in the data-flow brief to a concrete file or collection of files."
 ---
 # find-test-data
 
-Stub. Replace with real Mold content per MOLD_SPEC once first walks are done.
+Resolve concrete test data for the workflow's inputs. Read the upstream data-flow / interface brief, and for each workflow input search the IWC corpus and public sources for data that matches its Galaxy collection shape and datatype. Emit `test-data-refs.json`: one entry per input, each carrying a URL or path plus the expected shape, ready for [[implement-galaxy-workflow-test]] to stage.
+
+This Mold is the first leg of the harness's `test-data-resolution` branch. It resolves what it can and reports gaps; the harness routes any unresolved input to the `user-supplied` fallthrough. Deciding to ask the user is a harness concern, not this Mold's — its job is an honest, source-backed match.
+
+## Sequence
+
+1. **Read the brief.** From the data-flow / interface brief, enumerate the workflow inputs: label, Galaxy collection shape (File / list / paired / list:paired / record), and datatype.
+2. **Search IWC fixtures first.** Prefer existing IWC test data for the same domain — it already conforms to the conventions in [[iwc-test-data-conventions]] (remote URL, recorded hash, known collection layout). A near-neighbour IWC workflow's `-tests.yml` is the strongest source.
+3. **Fall to public sources.** When no IWC fixture fits, look for small public data (Zenodo, reference data archives) sized for a fast test run, matching the datatype and shape.
+4. **Emit refs.** Write one `test-data-refs.json` entry per input: the URL/path, the expected Galaxy shape, datatype, and integrity hash when known. Per [[galaxy-workflow-testability-design]], make sure each entry maps to an addressable input label.
+5. **Report gaps.** For any input with no acceptable match, emit the input with `resolved: false` and a short reason rather than a guessed URL. These are what the harness hands to `user-supplied`.
+
+## No fabrication
+
+Never invent a URL, accession, or path to make an input look resolved. A wrong-but-plausible fixture reference is worse than an honest gap: it survives static checks and fails only at run time, far from this Mold. Every emitted ref must point at data that exists; everything else is a reported gap.

--- a/content/molds/implement-galaxy-tool-step/index.md
+++ b/content/molds/implement-galaxy-tool-step/index.md
@@ -8,8 +8,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-05-05
-revision: 5
+revised: 2026-06-12
+revision: 6
 ai_generated: true
 summary: "Convert an abstract step into a concrete gxformat2 step using a tool summary."
 input_artifacts:
@@ -106,4 +106,19 @@ references:
 ---
 # implement-galaxy-tool-step
 
-Stub. Replace with real Mold content per MOLD_SPEC once first walks are done.
+Replace one abstract step in the gxformat2 draft with a concrete tool step, using the upstream tool summary. One invocation resolves exactly the chosen step's `TODO_*` / `_plan_*` slots into a concrete `tool_id`, `tool_version`, `tool_state`, and wrapper-determined port names, and returns the mutated draft. This is the "Implement" leaf of the per-step loop owned by [[advance-galaxy-draft-step]].
+
+Single step in scope. This Mold owns the chosen step and the wiring that connects it to ports already in the draft. It does not redesign topology and does not unwind earlier iterations — cross-step rework is the orchestrator's call.
+
+## Sequence
+
+1. **Read the step's plan.** From the [[galaxy-workflow-draft]], take the chosen step's deferred evidence: `_plan_state`, `_plan_context`, `_plan_in`, `_plan_out`, and any `TODO_*` slots the template or data-flow brief left for this phase.
+2. **Bind to the tool summary.** Read the [[galaxy-tool-summary]] manifest: `parsed_tool` gives concrete input/output port names and datatypes; shape the step's `tool_state` against `input_schemas.workflow_step_linked`. Set `tool_version`, and set `tool_id` — confirming or correcting an identity-pinned id rather than re-deriving a good pin from scratch. If `input_schemas` is `null`, consult `warnings[]` for why before binding by hand.
+3. **Wire ports.** Connect the step's inputs to their upstream producers and its outputs to downstream consumers per the `_plan_in` / `_plan_out` intent, using real wrapper port names. Preserve collection mapping and reduction semantics ([[galaxy-collection-semantics]]); for a source-derived shape, check the chosen input/output can actually carry the intended File / list / paired / list:paired shape ([[nextflow-to-galaxy-channel-shape-mapping]]).
+4. **Close shape gaps.** When a direct tool connection cannot express the needed shape, insert a built-in collection-operation step ([[galaxy-collection-tools]]); for identifier-derived reshaping — regex parsing, nesting swaps, paired assignment — use Apply Rules ([[galaxy-apply-rules-dsl]]); for a transform traced to a Nextflow operator (map, join, groupTuple, branch, mix, combine, multiMap), turn it into concrete wiring or a review request via [[nextflow-operators-to-galaxy-collection-recipes]].
+5. **Preserve testability.** Keep output labels and collection element identifiers stable and addressable ([[galaxy-workflow-testability-design]]). Do not rename a labeled output, drop a checkpoint, or make a final output too weakly assertable just to satisfy this step's wiring.
+6. **Validate.** Run [[draft-validate]] `--concrete` over the mutated draft: it checks draft-contract rules and gates the extracted concrete subset — including the step just implemented — against full gxformat2. On green, return the draft for the next loop iteration; on red, route the diagnostic back to whichever decision above it implicates.
+
+## Failure ownership
+
+When the wrapper can't cleanly carry what the plan needs — wrong datatype, missing parameter, unsupported collection shape — record where a later failure should be investigated: tool/job failure, data-flow mistake, template wiring mistake, wrapper mismatch, or test/assertion issue. Consult [[galaxy-tool-job-failure-reference]] when the selected wrapper has explicit failure semantics (exit-code rules, stdio regex, strict-shell, dynamic outputs); implement the step's labels and wiring so that evidence survives to runtime rather than being erased by the concretization.

--- a/content/molds/implement-galaxy-workflow-test/index.md
+++ b/content/molds/implement-galaxy-workflow-test/index.md
@@ -8,8 +8,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-04-30
-revised: 2026-05-11
-revision: 6
+revised: 2026-06-12
+revision: 7
 ai_generated: true
 related_notes:
   - "[[galaxy-workflow-testability-design]]"
@@ -96,6 +96,18 @@ references:
 ---
 # implement-galaxy-workflow-test
 
-Stub. Replace with real Mold content per MOLD_SPEC once first walks are done.
-- **`planemo workflow_test_init --from_invocation <id>`** ([[planemo-workflow_test_init]]) — preferred bootstrap for new test files; reviewer convention. See [[planemo-asserts-idioms]] §7.
-- **`planemo workflow_test_on_invocation <tests.yml> <id>`** ([[planemo-workflow_test_on_invocation]]) — fast assertion-iteration loop without re-running the workflow.
+Assemble a Galaxy workflow test file (`tests-format`) from the test plan, the gxformat2 draft, and the resolved test-data refs. One invocation produces a `*-tests.yml` whose job inputs come from the draft's workflow inputs and whose assertions come from the test plan's snapshots. The output must validate against [[tests-format]] and pass the workflow-label cross-check before any Planemo run.
+
+The draft is the contract: input and output labels in the test file must address real workflow input/output labels. When authoring reveals a missing label, an omitted workflow output, or an unstable collection identifier, treat it as testability pressure on the workflow itself — surface it per [[galaxy-workflow-testability-design]] rather than asserting around it.
+
+## Sequence
+
+1. **Bootstrap.** Prefer generating the test skeleton from a real invocation, not from scratch:
+   - **`planemo workflow_test_init --from_invocation <id>`** ([[planemo-workflow_test_init]]) — preferred bootstrap for new test files; reviewer convention. See [[planemo-asserts-idioms]] §7.
+   - **`planemo workflow_test_on_invocation <tests.yml> <id>`** ([[planemo-workflow_test_on_invocation]]) — fast assertion-iteration loop without re-running the workflow.
+2. **Author job inputs.** Wire each workflow input to a `test-data-refs` entry. Follow [[iwc-test-data-conventions]] for remote-URL-first fixtures, recorded hashes, and per-input collection layout. Inputs must match the draft's collection shapes and datatypes.
+3. **Author assertions.** Translate the test plan's snapshots into output assertions. Choose assertion families and tolerances per [[planemo-asserts-idioms]]; check each shortcut against [[iwc-shortcuts-anti-patterns]] so an existence-only or size-only assertion is a deliberate choice, not an evasion.
+4. **Validate static.** Run [[validate-tests]] for the schema gate, then the workflow-label cross-check (`checkTestsAgainstWorkflow`): zero missing input labels, zero missing output labels, no collection/datatype mismatches. Fix before spending a Planemo run.
+5. **Run green.** Drive [[planemo]] `test` on a managed Galaxy with the staged data and tools. On green, hand off the test file plus enough invocation/job/assertion context for [[run-workflow-test]] and [[debug-galaxy-workflow-output]] to use if a later run fails.
+
+Author tests with stable labels and artifacts that Planemo can connect back to Galaxy invocations, jobs, and outputs ([[planemo-workflow-test-architecture]]) — that traceability is what makes the downstream debug Mold able to locate failure evidence.

--- a/content/molds/interview-to-freeform-summary/eval.md
+++ b/content/molds/interview-to-freeform-summary/eval.md
@@ -1,0 +1,19 @@
+# interview-to-freeform-summary eval
+
+## Case: handoff fidelity
+
+- check: llm-judged
+- fixture: an interview transcript that names methods, at least one tool, sample-data location, one non-default parameter, and an explicit point of user uncertainty.
+- expectation: the emitted `freeform-summary.md` surfaces each of those, and the user's uncertainty appears as an open question. No high-confidence interview fact is silently dropped.
+
+## Case: no invented specificity
+
+- check: llm-judged
+- fixture: an interview where the user describes an operation vaguely ("trim the reads somehow") without naming a tool or settings.
+- expectation: the summary records the intent plus an open question; it does not fabricate a specific tool, version, or parameter value to fill the gap.
+
+## Case: shared shape with summarize-paper
+
+- check: deterministic
+- fixture: a `freeform-summary.md` produced from an interview.
+- expectation: the artifact is Markdown carrying the shared freeform-summary sections (methods, tools, inputs, outputs, parameters, open questions) under the `freeform-summary` artifact id — structurally what [[summarize-paper]] emits, with nothing interview-specific that [[freeform-summary-to-galaxy-interface]] would have to special-case.

--- a/content/molds/interview-to-freeform-summary/index.md
+++ b/content/molds/interview-to-freeform-summary/index.md
@@ -8,8 +8,8 @@ tags:
   - source/interview
 status: draft
 created: 2026-05-22
-revised: 2026-05-22
-revision: 1
+revised: 2026-06-12
+revision: 2
 ai_generated: true
 summary: "Normalize a free-form user interview into the shared freeform-summary workflow handoff."
 output_artifacts:
@@ -22,6 +22,24 @@ output_artifacts:
 
 Turn a free-form user interview into the shared `freeform-summary` artifact consumed by downstream freeform-summary Molds.
 
-The harness owns the live interaction style. It may run this Mold inside an interactive Claude/Codex session, feed it a saved transcript, or collect answers through a custom UI. The Mold's job is the normalized handoff: methods, tools or algorithms, inputs, outputs, parameters, data availability, expected outputs, constraints, confidence, and open questions.
+The harness owns the live interaction style. It may run this Mold inside an interactive Claude/Codex session, feed it a saved transcript, or collect answers through a custom UI. The Mold's job is the normalized handoff, not the conversation.
 
-Emit Markdown, not a target workflow schema. Downstream Molds treat this the same way they treat the output of [[summarize-paper]]: useful source evidence with explicit uncertainty, not a fully specified workflow.
+Emit Markdown, not a target workflow schema. Downstream Molds treat this exactly like the output of [[summarize-paper]]: useful source evidence with explicit uncertainty, not a fully specified workflow. Keeping the two producers shape-compatible is what lets paper and interview starts share one design/template tier.
+
+## What to capture
+
+Record what the interview actually supports, and mark the rest as uncertain rather than inventing it:
+
+- **Workflow intent** — what the user is trying to build, in their words.
+- **Methods / algorithms** — the analytical steps, ordered as the user describes them.
+- **Tools** — named tools or versions if given; otherwise the operation to be resolved downstream.
+- **Inputs** — sample data, formats, per-sample structure, paired/grouped shape.
+- **Outputs** — expected results and which ones matter for review or testing.
+- **Parameters** — any non-default settings the user calls out.
+- **Data availability** — whether real or test data exists, and where.
+- **Constraints** — runtime, environment, licensing, or scale limits.
+- **Confidence and open questions** — where the user was unsure, and what still needs answering.
+
+## Don't over-specify
+
+A free-form source carries genuine uncertainty; preserve it. Do not promote a vague answer ("some kind of alignment") into a precise tool or parameter — record it as intent plus an open question. Silent invention here propagates as false confidence through every downstream brief.

--- a/content/molds/run-workflow-test/index.md
+++ b/content/molds/run-workflow-test/index.md
@@ -6,12 +6,17 @@ tags:
   - mold
 status: draft
 created: 2026-04-30
-revised: 2026-05-04
-revision: 3
+revised: 2026-06-12
+revision: 4
 ai_generated: true
 summary: "Execute a workflow's tests via Planemo; emit structured pass/fail and outputs."
 related_notes:
   - "[[tests-format]]"
+output_artifacts:
+  - id: workflow-test-result
+    kind: json
+    default_filename: workflow-test-result.json
+    description: "Structured pass/fail plus captured evidence — Planemo result, invocation/history/workflow ids, artifact paths, Galaxy mode, and (on failure) the observed modality and next reference surface — for debug-galaxy-workflow-output."
 references:
   - kind: schema
     ref: "[[tests-format]]"
@@ -62,4 +67,14 @@ references:
 ---
 # run-workflow-test
 
-Stub. Replace with real Mold content per MOLD_SPEC once first walks are done.
+Execute an assembled workflow's test file via [[planemo]] and emit a structured pass/fail with the artifacts a debug pass needs. One invocation runs the test once, captures the evidence, and — on failure — classifies the failure modality and names the next reference surface to inspect. It does not repair anything; that is [[debug-galaxy-workflow-output]]'s job.
+
+## Sequence
+
+1. **Validate before running.** When a test file is present, run [[validate-tests]] for the static schema and workflow-label checks first. A run is expensive; do not spend one on a test file that fails static validation.
+2. **Pick the Galaxy mode.** Run against a Planemo-managed Galaxy or an existing/external Galaxy. Record which mode was used, how tools, workflows, and test data were staged, and the URLs or API credentials a follow-up inspection would need. The choice and its consequences are guided by [[planemo-workflow-test-architecture]].
+3. **Run and capture.** Drive `planemo test` with structured output enabled. Preserve the invocation id, history id, workflow id, the Planemo structured result, and any test-output artifact paths — these are the inputs the debug Mold consumes.
+4. **Classify on failure.** When the run exits non-zero or reports failed assertions, failed jobs, a failed invocation, missing outputs, or upload/staging problems, identify the observed failure modality and the single next reference surface to open: Planemo result, Galaxy job API, Galaxy invocation API, history contents, or the test assertion report. Use [[planemo-asserts-idioms]] to read assertion failures and [[galaxy-workflow-invocation-failure-reference]] to preserve invocation identifiers and state.
+5. **Hand off.** Emit the structured summary — green, or red with modality + captured artifacts + the named next surface — for [[debug-galaxy-workflow-output]].
+
+Keep this Mold's output a faithful record of what happened, not a diagnosis. Mislabeling a staging failure as an assertion failure here sends the debug pass to the wrong reference surface.


### PR DESCRIPTION
Fills placeholder bodies for Molds whose `references:` manifests and `eval.md` cases were already authored but whose procedural body (the part cast into `SKILL.md`) was still the `Stub. Replace with real Mold content…` sentinel. These were the Molds tripping the validator's *"stub body but declares N reference(s)"* warning.

## INTERVIEW → GALAXY test/execution tail
- **find-test-data** — was a total stub; added references manifest (`iwc-test-data-conventions`, `galaxy-workflow-testability-design`), a 5-step body, and `eval.md`.
- **implement-galaxy-workflow-test** — wrote the body (bootstrap → job inputs → assertions → static gate → green run); folded pre-existing bullets into the bootstrap step.
- **run-workflow-test** — body mapping to its 3 eval cases (capture → classify → handoff); declared `workflow-test-result` output artifact.
- **debug-galaxy-workflow-output** — triage body (classify failure surface *before* repairing); added the missing collection-mismatch eval case; aligned the drifted `summary`; wired the `run → debug` artifact pair.
- **interview-to-freeform-summary** — fleshed the thin body into a capture checklist + "don't over-specify" guard; added `eval.md`.

## Per-step authoring core
- **implement-galaxy-tool-step** — the "Implement" leaf of the `advance-galaxy-draft-step` loop, exercised by all four Galaxy pipelines (nextflow / paper / cwl / interview → galaxy). Wrote a body weaving all 10 declared references and satisfying both eval cases.

## Notes
- Regenerated the 4 Galaxy pipeline harnesses (`make assemble-pipelines`) — the only projected change is `debug-galaxy-workflow-output`'s summary line.
- These are **rough drafts**: structurally complete and validated, not yet test-driven against an IWC fixture.
- One earlier round was reviewed by a subagent; legitimate findings applied (eval-check reclassifications, missing collection eval, summary drift, artifact wiring). One flagged "phantom producer" was verified a false alarm (`paper-to-test-data` is a real Mold).
- Still stubbed (out of scope): `summarize-paper`, and the CWL-side Molds.

**Verification:** `npm run validate` → 0 errors · `npm run test` → 125/125 · `make check-assemble-pipelines` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)