### PR TITLE
Survey IWC comment usage; distill how-to guidance; wire into Galaxy templates

### DIFF
--- a/content/molds/cwl-summary-to-galaxy-template/index.md
+++ b/content/molds/cwl-summary-to-galaxy-template/index.md
@@ -135,6 +135,14 @@ references:
     evidence: corpus-observed
     purpose: "Use corpus-grounded genomic-interval pattern guidance for unresolved skeleton steps."
     trigger: "When adding TODO steps for interval overlap, merge, coverage, windowing, masking, or set-algebra on coordinate features."
+  - kind: research
+    ref: "[[galaxy-workflow-comments]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Group the settled step set into titled stage frames (the gxformat2 `comments:` array) so the skeleton carries the analysis-stage narrative IWC authors annotate by hand. Schema-legal and optional."
+    trigger: "After topology is settled and the skeleton can be partitioned into named analysis stages (inputs, per-stage step clusters, parameter-derivation knots, visualization/outputs)."
 related_notes:
   - "[[summary-cwl]]"
   - "[[cwl-summary-to-galaxy-interface]]"
@@ -150,6 +158,8 @@ CWL already carries structured workflow shape, so this Mold should be lighter th
 Topology is this Mold's job to settle. The output must be concrete gxformat2: workflow inputs with their final collection shapes and formats, workflow outputs, the step set, the producer→consumer edge graph, branches, and `when:` guards are all decided here. The upstream interface and data-flow briefs guide those decisions, but if they hedge or leave a topology choice open, this Mold makes the call from source evidence, IWC exemplars, and pattern pages — never emit a topology `TODO`. Wrapper resolution, by contrast, is **evidence-gated, not source-gated**: resolve each tool step to the tier its evidence supports — **Resolved** (fully concrete, no `_plan_*`), **Identity-pinned** (concrete `tool_id`, parameters and changeset left to the per-step Mold), or **Deferred** (`tool_id: TODO`) — as defined in [[galaxy-workflow-draft-format]]. Capture whatever you defer in the `_plan_*` family (`_plan_state`, `_plan_context`, `_plan_in`, `_plan_out`) so the per-step Mold has the source evidence and constraints it needs.
 
 Source tendency: a CWL `CommandLineTool` carries `baseCommand` / `arguments`, `DockerRequirement` / `SoftwareRequirement` hints, and explicit input/output bindings — so identity is often inferable to **Identity-pinned**, and a step reaches **Resolved** when a pattern page or IWC exemplar covers the operation (fill `tool_id`, parameters, and port names from the worked example). A custom-script tool with no Galaxy equivalent stays **Deferred** — pack `_plan_context` with the `baseCommand` / `arguments`, `DockerRequirement` URIs, `SoftwareRequirement` packages, and `EnvVarRequirement` / `ResourceRequirement` constraints the per-step Mold needs to pick a wrapper. Emitting `TODO` over a pattern-covered recipe discards real evidence the per-step Mold cannot recover.
+
+Optionally, once topology is settled, group the step set into titled stage frames via the gxformat2 `comments:` array (one frame per analysis stage, `contains_steps:` populated, color decorative) — see [[galaxy-workflow-comments]] for the convention.
 
 Output shape is gxformat2 with wrapper-tier relaxations and `_plan_state` / `_plan_context` / `_plan_in` / `_plan_out` per tool step — see [[galaxy-workflow-draft-format]]. Refinement open work for those planning fields lives in `refinement.md`.
 

--- a/content/molds/freeform-summary-to-galaxy-template/index.md
+++ b/content/molds/freeform-summary-to-galaxy-template/index.md
@@ -113,6 +113,14 @@ references:
     evidence: corpus-observed
     purpose: "Use corpus-grounded genomic-interval pattern guidance for unresolved skeleton steps."
     trigger: "When adding TODO steps for interval overlap, merge, coverage, windowing, masking, or set-algebra on coordinate features."
+  - kind: research
+    ref: "[[galaxy-workflow-comments]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Group the settled step set into titled stage frames (the gxformat2 `comments:` array) so the skeleton carries the analysis-stage narrative IWC authors annotate by hand. Schema-legal and optional."
+    trigger: "After topology is settled and the skeleton can be partitioned into named analysis stages (inputs, per-stage step clusters, parameter-derivation knots, visualization/outputs)."
 related_notes:
   - "[[freeform-summary-to-galaxy-interface]]"
   - "[[freeform-summary-to-galaxy-data-flow]]"
@@ -126,5 +134,7 @@ The free-form summary does not have a concrete schema yet; treat it as Markdown.
 Topology is this Mold's job to settle. The output must be concrete gxformat2: workflow inputs with their final collection shapes and formats, workflow outputs, the step set, the producer→consumer edge graph, branches, and `when:` guards are all decided here. The upstream freeform-to-Galaxy interface and data-flow briefs guide those decisions, but if they hedge or leave a topology choice open, this Mold makes the call from source evidence, IWC exemplars, and pattern pages — never emit a topology `TODO`. Wrapper resolution, by contrast, is **evidence-gated, not source-gated**: resolve each tool step to the tier its evidence supports — **Resolved** (fully concrete, no `_plan_*`), **Identity-pinned** (concrete `tool_id`, parameters and changeset left to the per-step Mold), or **Deferred** (`tool_id: TODO`) — as defined in [[galaxy-workflow-draft-format]]. Capture whatever you defer in the `_plan_*` family (`_plan_state`, `_plan_context`, `_plan_in`, `_plan_out`) so the per-step Mold has the source evidence and constraints it needs.
 
 Source tendency: free-form sources rarely name tools, so steps land in **Deferred** more often than nf-core or CWL — but a free-form source that *does* name a specific tool/version with evidence hardens to the matching tier, and a corpus-confirmed utility wrapper (interval/tabular/collection op) is not deferred just because the surrounding prose is informal. When deferring a domain tool, cite the originating paper section, interview answer, figure, or supplementary table in `_plan_context`, and record vague intent in `_plan_state` ("default settings", "stranded reverse if mentioned, else unstranded") so the per-step Mold knows the evidence ceiling.
+
+Optionally, once topology is settled, group the step set into titled stage frames via the gxformat2 `comments:` array (one frame per analysis stage, `contains_steps:` populated, color decorative) — see [[galaxy-workflow-comments]] for the convention.
 
 Output shape is gxformat2 with wrapper-tier relaxations and `_plan_state` / `_plan_context` / `_plan_in` / `_plan_out` per tool step — see [[galaxy-workflow-draft-format]]. Refinement open work for those planning fields lives in `refinement.md`.

--- a/content/molds/nextflow-summary-to-galaxy-template/index.md
+++ b/content/molds/nextflow-summary-to-galaxy-template/index.md
@@ -153,6 +153,14 @@ references:
     evidence: corpus-observed
     purpose: "Resolve reference-asset declarations into gxformat2 inputs with the right datatype, optionality, and rebuild-on-absence wiring; cross-check the upstream brief against the datatypes table and v1 posture when the brief is silent or low-confidence on a specific asset."
     trigger: "When emitting workflow inputs or input-connection wiring for any reference asset flagged in the reference-data brief (FASTA, fai, dict, indexes, dbsnp, known_indels, intervals, PoN, …), or when the source pipeline declares iGenomes-derived params, per-asset reference path params, or any compute-if-missing index-building branch."
+  - kind: research
+    ref: "[[galaxy-workflow-comments]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Group the settled step set into titled stage frames (the gxformat2 `comments:` array) so the skeleton carries the analysis-stage narrative IWC authors annotate by hand. Schema-legal and optional."
+    trigger: "After topology is settled and the skeleton can be partitioned into named analysis stages (inputs, per-stage step clusters, parameter-derivation knots, visualization/outputs)."
 related_notes:
   - "[[summary-nextflow]]"
   - "[[nextflow-summary-to-galaxy-interface]]"
@@ -170,5 +178,7 @@ The reference-data, interface, and data-flow briefs guide the skeleton, but they
 Topology is this Mold's job to settle. The output must be concrete gxformat2: workflow inputs with their final collection shapes and formats, workflow outputs, the step set, the producer→consumer edge graph, branches, and `when:` guards are all decided here. The upstream interface and data-flow briefs guide those decisions, but if they hedge or leave a topology choice open, this Mold makes the call from source evidence, IWC exemplars, and pattern pages — never emit a topology `TODO`. Wrapper resolution, by contrast, is **evidence-gated, not source-gated**: resolve each tool step to the tier its evidence supports — **Resolved** (fully concrete, no `_plan_*`), **Identity-pinned** (concrete `tool_id`, parameters and changeset left to the per-step Mold), or **Deferred** (`tool_id: TODO`) — as defined in [[galaxy-workflow-draft-format]]. Capture whatever you defer in the `_plan_*` family (`_plan_state`, `_plan_context`, `_plan_in`, `_plan_out`) so the per-step Mold has the source evidence and constraints it needs.
 
 Source tendency: nf-core modules name their tool, pin a version, and carry the `command:` block, conda packages, and container tags — so steps reach **Resolved** when a pattern page or IWC exemplar covers the operation (fill `tool_id`, parameters, and port names from the worked example), and **Identity-pinned** when the module names the tool but its settings for this context stay open. **Deferred** is for domain-specific scientific tools with no covering pattern (alignment, variant calling, expression quantification, etc.) — pack `_plan_context` with the source command, conda specs, container tags, and pre/post conditions the per-step Mold needs to pick a wrapper. Emitting `TODO` over a pattern-covered recipe discards real evidence the per-step Mold cannot recover.
+
+Optionally, once topology is settled, group the step set into titled stage frames via the gxformat2 `comments:` array (one frame per analysis stage, `contains_steps:` populated, color decorative) — see [[galaxy-workflow-comments]] for the convention.
 
 Output shape is gxformat2 with wrapper-tier relaxations and `_plan_state` / `_plan_context` / `_plan_in` / `_plan_out` per tool step — see [[galaxy-workflow-draft-format]]. Refinement open work for those planning fields lives in `refinement.md`.

--- a/content/research/galaxy-workflow-comments.md
+++ b/content/research/galaxy-workflow-comments.md
@@ -1,0 +1,119 @@
+---
+type: research
+subtype: component
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-06-12
+revised: 2026-06-12
+revision: 1
+ai_generated: true
+related_notes:
+  - "[[iwc-comments-survey]]"
+  - "[[gxformat2-schema]]"
+  - "[[freeform-summary-to-galaxy-template]]"
+  - "[[nextflow-summary-to-galaxy-template]]"
+  - "[[cwl-summary-to-galaxy-template]]"
+summary: "How to annotate a gxformat2 workflow with editor comments: one titled frame per analysis stage, populate contains_steps, color decorative."
+---
+
+# Galaxy workflow comments
+
+Use this note when authoring or translating a Galaxy gxformat2 workflow and
+deciding how to annotate it with editor comments — the top-level `comments:`
+array the workflow editor renders as on-canvas frames and notes. Comments carry
+no execution semantics; they document and visually organize the workflow. This
+is presentation guidance, not a `content/patterns/` operation. Corpus evidence
+behind every rule here lives in [[iwc-comments-survey]].
+
+Comments are optional — roughly one in five IWC workflows use them. Add them when
+the workflow has enough steps that a reader benefits from a stage map; skip them
+on short linear workflows.
+
+## 1. Box each analysis stage in a titled frame
+
+The core move. Once topology is settled, partition the step set into `type:
+frame` comments — one frame per logical stage of the analysis — and give each a
+`title:` and a `contains_steps:` list of the step labels it groups:
+
+```yaml
+comments:
+  - type: frame
+    position: [687.5, 395.8]
+    size: [498.9, 345.5]
+    color: green
+    title: Genome quality evaluation
+    contains_steps:
+      - run BUSCO
+      - summarize BUSCO
+```
+
+`position` and `size` are editor-canvas geometry (floats); set them so the frame
+encloses its steps, or copy them from the nearest IWC exemplar you are adapting.
+
+## 2. Title by stage, not by tool
+
+A frame title names the analysis phase, never the tool that implements it —
+`Annotation with Braker3`, `Final MF assignment`, `Transcripts assembly`, not
+`braker3` or `stringtie`. Three title flavors, all valid:
+
+- **Stage frames** — one per narrative step of the analysis (the common case).
+- **I/O region frames** — `Inputs`, `Data input`, `Visualization` bracket the
+  workflow's entry and exit regions.
+- **Parameter-derivation frames** — box the fiddly utility clusters that compute
+  a parameter (`Map Strandedness parameter`, `Downsample input BAM to get the
+  same number of reads`). This is the highest-value annotation: the frame is
+  often the only place the intent of a non-obvious helper cluster is written
+  down. Always frame these.
+
+Titles are human prose — spaces, mixed case, and punctuation are fine.
+
+## 3. Populate `contains_steps`
+
+Prefer explicit `contains_steps:` (a list of step labels) over relying on canvas
+geometry alone. Both render identically, but a geometry-only frame loses the
+machine-readable step→frame mapping — a consumer can only recover membership by
+intersecting rectangles. List every step the frame covers.
+
+## 4. Color is decorative — do not encode meaning
+
+Pick any editor color: `green`, `yellow`, `turquoise`, `red`, `blue`, `pink`,
+`lime`, `orange`, `black`, or `none` (an unfilled outline). Color carries **no
+semantic convention** — do not use it to signal input vs output vs compute, and
+do not infer role from a frame's color when reading a workflow. When forking a
+workflow, keep each frame's color stable so the lineage stays visually
+recognizable.
+
+## 5. Free-floating notes: `markdown` and `text`
+
+For a labeled region without a box, use a `type: markdown` comment (a `text:`
+field holding a markdown body) or `type: text` (a `text:` field plus
+`text_size:`). Keep these short — they are mostly one-to-three-word region
+headers (`Input files`, `Alpha diversity`). The one place a longer `markdown`
+note earns its keep is **workflow-level adaptation guidance** — e.g. "to retarget
+this nanopore workflow for Illumina, replace Minimap2 with Bowtie2." Reach for
+prose only when a stage title cannot carry the instruction.
+
+## 6. Comments are reusable scaffold
+
+Frames travel with workflow forks and templates: when deriving a workflow from an
+IWC exemplar, carry its frame set and adjust titles rather than starting bare.
+Embedded subworkflows can carry their own `comments:` array, so annotate at the
+scope the reader navigates.
+
+## 7. Schema and validation
+
+`comments:` is a schema-legal top-level workflow field (and a subworkflow field);
+emitted frames pass `gxwf` draft validation. Field shapes:
+
+| `type:` | Fields |
+|---|---|
+| `frame` | `position`, `size`, `color`, `title`, `contains_steps` (recommended) |
+| `markdown` | `position`, `size`, `color`, `text` |
+| `text` | `position`, `size`, `color`, `text`, `text_size` |
+
+## Cross-references
+
+- Corpus evidence and distribution: [[iwc-comments-survey]].
+- gxformat2 field schema: [[gxformat2-schema]].

--- a/content/research/iwc-comments-survey.md
+++ b/content/research/iwc-comments-survey.md
@@ -1,0 +1,218 @@
+---
+type: research
+subtype: component
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-06-12
+revised: 2026-06-12
+revision: 1
+ai_generated: true
+related_notes:
+  - "[[galaxy-workflow-comments]]"
+  - "[[galaxy-native-workflow-schema]]"
+  - "[[gxformat2-schema]]"
+  - "[[iwc-parameter-derivation-survey]]"
+summary: "How IWC uses the gxformat2 `comments:` array: titled stage frames dominate, color is decorative, frames travel with template forks. An authoring convention."
+---
+
+# IWC corpus survey: workflow editor `comments`
+
+Scope: the gxformat2 top-level `comments:` array — the Galaxy workflow editor's
+on-canvas annotation layer (titled colored frames, markdown notes, text notes).
+**Out of scope** (per scoping): the step/workflow `annotation:` documentation
+field, and tool-parameter noise that merely contains the word "comment"
+(`tool_state.comment`, `pass_comments`, `no_file_comments`, `comment_char`).
+
+This is an **authoring-metadata / convention** surface, not an operation family.
+Comments do not move data; they document and visually organize a workflow.
+The `docs/PATTERNS.md` operation/recipe lens mostly does not apply — see
+§7 for the no-pattern-candidate call.
+
+## 1. The comment object
+
+A comment item is one of three `type:` shapes, all sharing `position` and `size`
+(editor canvas geometry) plus `color`:
+
+| `type:` | Distinguishing fields | Role |
+|---|---|---|
+| `frame` | `title:`, optional `contains_steps:` | A titled, colored box grouping a region of steps |
+| `markdown` | `text:` (markdown body) | A free-floating note |
+| `text` | `text:`, `text_size:` | A free-floating plain label |
+
+Distribution across the corpus: **102 frame, 9 markdown, 1 text** — 112 items in
+**25 of 120** workflows (~21% uptake). Frames are ~91% of all comment items; the
+feature is, in practice, "titled step-grouping boxes." Example block:
+`$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-chip-pe.gxwf.yml:772`.
+
+Comments are the workflow tail: where present, the `comments:` key sits at the
+end of the file after `steps:`. They carry no execution semantics — purely
+editor-canvas presentation.
+
+## 2. Frames as pipeline-stage labels (dominant idiom)
+
+The overwhelming use of a frame is to name an analysis *stage* and box the steps
+that implement it. Titles read as phase names, not tool names:
+
+- `$IWC_FORMAT2/genome_annotation/annotation-maker/Genome_annotation_with_maker_short.gxwf.yml:630`
+  — `Inputs`, `Genome quality evaluation`, `Annotation with Maker`,
+  `Evaluation - Predicted proteins from annotation`, `Annotation statistics`,
+  `Improving gene naming`, `Visualization`.
+- `$IWC_FORMAT2/metabolomics/mfassignr/mfassignr.gxwf.yml:361` — `Noise estimation`,
+  `Identify isotope masses`, `Assign MF with CHO`, `Recalibrate mass lists`,
+  `Final MF assignment`.
+
+Three recurring title flavors:
+
+1. **Stage frames** — `Annotation with Braker3`, `Transcripts assembly with
+   StringTie`, `Final MF assignment`. The common case: one frame per logical step
+   of the analysis narrative.
+2. **I/O region frames** — `Inputs`, `Data input`, `Visualization`,
+   `AMR Count table`. Bracket the workflow's entry and exit regions.
+3. **Parameter-derivation frames** — frames that box the fiddly utility clusters
+   the [[iwc-parameter-derivation-survey]] catalogs, documenting *why* a knot of
+   helper steps exists: `Map Strandedness parameter`
+   (`$IWC_FORMAT2/transcriptomics/rnaseq-pe/rnaseq-pe.gxwf.yml:2045`),
+   `Downsample input BAM to get the same number of reads`
+   (`$IWC_FORMAT2/epigenetics/consensus-peaks/consensus-peaks-chip-pe.gxwf.yml:772`).
+   This is the highest-value annotation use: the frame is the only place the
+   intent of a non-obvious step cluster is written down.
+
+## 3. Membership frames vs geometry-only frames
+
+A frame may declare `contains_steps:` (an explicit list of step labels it groups)
+or omit it and rely on canvas geometry (the frame visually overlays whatever
+steps fall inside its `position`/`size` rectangle).
+
+- **Membership is the norm:** 91 of 102 frames carry `contains_steps:`.
+- **Geometry-only is one workflow's habit:**
+  `$IWC_FORMAT2/microbiome/mags-building/MAGs-generation.gxwf.yml:1766` has all
+  **10** of its frames with no `contains_steps:` (+1 stray in
+  `$IWC_FORMAT2/genome_annotation/annotation-braker3/Genome_annotation_with_braker3.gxwf.yml:406`).
+  These render identically in the editor but lose the machine-readable
+  step→frame mapping.
+
+Implication for any consumer reading frames structurally: `contains_steps:` is
+usually present but not guaranteed; a geometry-only frame's membership is only
+recoverable by intersecting canvas rectangles.
+
+## 4. Free-floating notes (markdown / text)
+
+The 9 markdown + 1 text items are nearly all **short region labels** used like a
+frame title without the box — a header floated over a span of the canvas:
+
+- `$IWC_FORMAT2/amplicon/qiime2/qiime2-III-VI-downsteam/QIIME2-VI-diversity-metrics-and-estimations.gxwf.yml:597`
+  — `Input files`, `Alpha diversity`, `Beta diversity`, `Diversity metrics`.
+- `$IWC_FORMAT2/amplicon/amplicon-mgnify/mapseq-to-ampvis2/mapseq-to-ampvis2.gxwf.yml:395`
+  — `tax_table`, `OTU_table`.
+
+The single exception, and the only comment in the corpus carrying real prose, is
+an **adaptation note** telling a reader how to retarget the workflow:
+
+> In this workflow, we recommend nanopore samples since we are using some tools
+> that are specified for nanopore… In order to switch to illumina please remove
+> the nanoplot step, replace porechop and fastp with cutadapt or trimmomatic, and
+> finally replace Minimap2 with Bowtie2.
+
+`$IWC_FORMAT2/microbiome/pathogen-identification/nanopore-pre-processing/Nanopore-Pre-Processing.gxwf.yml:1013`
+(multi-line `text: |-`). This is the one place a comment does documentation work
+that a stage-title cannot. It is an outlier, not a convention.
+
+## 5. Frames travel with template forks
+
+Comments are part of the reusable workflow scaffold, not one-off canvas doodling.
+Two lineages show the same frames copied across forked workflows:
+
+- **genome-annotation family** shares a fixed skeleton across forks: `Inputs`,
+  `Genome quality evaluation`, `Evaluation - Predicted proteins from annotation`,
+  `Annotation with <tool>`, `Visualization` — present in
+  `annotation-maker`, `annotation-helixer`, `annotation-braker3`
+  (`$IWC_FORMAT2/genome_annotation/annotation-helixer/Galaxy-Workflow-annotation_helixer.gxwf.yml:536`).
+- **consensus-peaks family** carries the same three frames — `Get the average
+  coverage`, `Downsample input BAM to get the same number of reads`, `Get a BED
+  with intersection of at least x rep` — across all three of `chip-pe`, `chip-sr`,
+  `atac-cutandrun` (only the array ordering and one frame's color differ —
+  `Downsample input BAM…` is `none` in the chip forks, `blue` in atac).
+
+### Subworkflow-scope comments (edge)
+
+Comments are not strictly top-level. Embedded subworkflows carry their own
+`comments:` arrays:
+`$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/mgnify-amplicon-pipeline-v5-complete.gxwf.yml:5853`
+has four nested `comments:` keys (6-space indent) inside `run:` subworkflow
+blocks. A scan keyed only on column-0 `comments:` misses these.
+
+## 6. Color and title conventions
+
+- **Color is decorative, not semantic.** Corpus-wide color counts (green 22,
+  yellow 18, turquoise 15, red 11, blue 10, pink 9, none 9, lime 8, orange 7,
+  black 3) carry no consistent meaning. Within one workflow, colors vary freely:
+  rnaseq-pe uses lime/`Map Strandedness parameter`, red/`Coverage Files`,
+  yellow/`Additional quantification` — no input/output/compute code.
+- **…but color is stable within a fork lineage.** The `Inputs` frame is yellow in
+  all four genome-annotation forks. Color travels with the copied frame; it is a
+  per-template aesthetic choice, not a corpus-wide legend. A consumer must not
+  infer frame role from color.
+- **`color: none`** (9 items) is a valid, used choice — an outlined frame with no
+  fill.
+- **Titles are human prose with spaces and mixed case** — `Get a BED with
+  intersection of at least x rep`. Same label-style freedom the test corpus shows
+  for output labels (see [[iwc-shortcuts-anti-patterns]] §6); no naming convention
+  is enforced.
+
+## 7. Candidate conventions (keep / drop / merge)
+
+There is **no operation-anchored or recipe-anchored pattern candidate here.** A
+comment frame is not a workflow-construction operation — it produces no data, has
+no tool, and `docs/PATTERNS.md`'s operation/recipe taxonomy does not fit it.
+Forcing an operation name would be miscategorization. The corpus uptake is real
+(25 workflows), so this is *not* a zero-uptake gap either — it is a genuine
+authoring convention that lives outside the pattern surface.
+
+What the corpus does support, if the Foundry wants to act on it, is **authoring
+guidance**, shaped like [[iwc-shortcuts-anti-patterns]] or a testability-design
+note rather than a `content/patterns/` page:
+
+- **Candidate (convention, keep):** "Box each analysis stage in a titled frame."
+  Evidence: §2, the genome-annotation and mfassignr stage skeletons. This is the
+  single clearest convention — a frame per narrative stage, titled by stage not
+  tool, with `contains_steps:` populated.
+- **Candidate (convention, merge into the above):** "Frame parameter-derivation
+  clusters to document intent" (§2.3). Not separate guidance — it is the
+  stage-framing convention applied to utility knots, which is exactly where it
+  earns the most.
+- **Drop:** color guidance. §6 shows color is decorative and fork-local; there is
+  nothing to prescribe. Telling authors to color-code by role would invent a
+  convention the corpus does not have.
+- **Drop:** markdown/text notes as a distinct recommendation. §4 shows they are
+  mostly degenerate frames (a label without a box); the one prose note is an
+  outlier. No convention to extract.
+
+### Disposition
+
+The actionable conventions here were distilled into [[galaxy-workflow-comments]]
+— a concrete how-to-use note. That note is what the three Galaxy-targeting
+template Molds reference ([[freeform-summary-to-galaxy-template]],
+[[nextflow-summary-to-galaxy-template]], [[cwl-summary-to-galaxy-template]]) so
+the template stage can optionally group the settled step set into titled stage
+frames. This survey is the corpus-evidence trail behind that guidance. No
+`content/patterns/` page; no GitHub issue.
+
+## 8. Open questions
+
+1. ~~**Does the Foundry want annotation guidance at all?**~~ **Resolved:** yes —
+   the three Galaxy template Molds now carry an optional "group steps into titled
+   stage frames" beat referencing [[galaxy-workflow-comments]]. `comments:` is
+   schema-legal at the draft workflow level, so emitted frames pass
+   `draft-validate`.
+2. ~~**If guidance is wanted, where does it live?**~~ **Resolved:** in the
+   distilled how-to-use note [[galaxy-workflow-comments]], referenced from the
+   template Molds — not a `content/patterns/` page.
+3. **Should `contains_steps:` be required guidance?** §3 shows 91/102 frames use
+   it and one workflow (MAGs) drops it entirely. Is "always populate
+   `contains_steps:`" a call worth making, given geometry-only frames render the
+   same but lose machine-readable grouping? Needs a user prescriptive decision.
+4. **Subworkflow-scope comments (§5):** worth surfacing to consumers that comments
+   recur inside `run:` blocks, or an ignorable edge? Affects only tooling that
+   parses comments structurally.


### PR DESCRIPTION
> Posted by Claude (AI assistant) on jmchilton's behalf.

## What

Surveys how IWC workflows use the gxformat2 `comments:` array (the workflow-editor canvas annotations — frames, markdown, text; **not** the `annotation:` field), distills the actionable conventions into a concrete how-to note, and wires that guidance into the three Galaxy-targeting template Molds.

## Why

The template Molds settle workflow topology but had no guidance on annotating the result. ~1 in 5 IWC workflows group their steps into titled stage frames; giving the templates that convention lets generated skeletons carry the analysis-stage narrative authors otherwise add by hand.

## Changes

- **`content/research/iwc-comments-survey.md`** — corpus survey. 102 frame / 9 markdown / 1 text comment items across 25/120 workflows; titled stage frames dominate (91/102 carry `contains_steps`), color is decorative + fork-stable, frames travel with template forks. Concludes this is an authoring **convention**, not an operation pattern.
- **`content/research/galaxy-workflow-comments.md`** — concrete how-to-use guidance distilled from the survey (one titled frame per stage, populate `contains_steps`, color carries no meaning, markdown/text for floating notes, field-shape table). The survey is its evidence trail, mirroring the `galaxy-workflow-testability-design` → `iwc-workflow-testability-survey` precedent.
- **`{freeform,nextflow,cwl}-summary-to-galaxy-template`** — each gains a `kind: research` reference to `[[galaxy-workflow-comments]]` plus a one-line body beat. `summary-to-cwl-template` left unwired (comments are gxformat2-specific).

## Validation

`npm run validate`: 207 files, 3 errors — all pre-existing `gxwf/draft-*` "absent from upstream CLI metadata", none from this change. `comments:` is schema-legal at the draft workflow level, so emitted frames pass `draft-validate`.

Reviewed by a subagent against the corpus (distribution numbers re-derived to an exact match) and schema: ship-as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)