### PR TITLE
Make interview-to-galaxy scenarios self-contained

### DIFF
--- a/content/pipelines/interview-to-galaxy/examples/UC1_MRSA_extracted.ga
+++ b/content/pipelines/interview-to-galaxy/examples/UC1_MRSA_extracted.ga
@@ -1,0 +1,674 @@
+{
+    "a_galaxy_workflow": "true",
+    "annotation": "",
+    "comments": [],
+    "format-version": "0.1",
+    "name": "MRSA mobile-AMR context (extracted)",
+    "report": {
+        "markdown": "# MRSA mobile-AMR context across isolates\n\nFour complete *Staphylococcus aureus* isolates from Hikichi et al. 2019 (BioProject `PRJDB8599`) were imported as combined chromosome + plasmid FASTA into **one collection** and scanned \u2014 **all steps mapped over that collection** \u2014 with **staramr** (ResFinder + PlasmidFinder + MLST), **ISEScan** + **Integron Finder** for mobile elements, and **bedtools closest** for ARG\u2194IS distances. Rather than re-teaching single-isolate AMR detection, this notebook asks a comparative question: **which resistance genes sit in mobile genomic contexts (plasmids, insertion sequences), and how does that context differ between related isolates?**\n\nBecause every step is a collection map-over and every displayed figure is a real tool output, this whole notebook **extracts to a single reusable workflow**.\n\n## Isolates\n\n| Strain | MLST | Chromosome | Plasmid | Genome (bp) |\n|---|---|---|---|---|\n| KUH140013 | ST8 | AP020311 | AP020312 | 2,837,394 |\n| KUH140046 | ST8 | AP020313 | AP020314 | 2,859,431 |\n| KUH180129 | ST6313 | AP020322 | AP020323 | 2,897,282 |\n| KUN1163 | ST764 | AP020324 | AP020325 | 2,944,787 |\n\nThree distinct sequence types (ST8 \u00d72, ST6313, ST764), so differences below are between *related but non-clonal* backgrounds. The two ST8 isolates are the natural clonal pair to contrast.\n\n```galaxy\nhistory_dataset_collection_display(output=\"staramr on collection 1: mlst.tsv\")\n```\n\n> Note: staramr flags all four genomes as *quality-failed* only because the expected genome-size window (4\u20136 Mb) is set for larger organisms; *S. aureus* genomes are ~2.8\u20132.9 Mb. The ResFinder / PlasmidFinder calls are unaffected.\n\n## AMR gene presence / absence\n\nPer-isolate genotype and predicted phenotype from the staramr summary (one element per isolate):\n\n```galaxy\nhistory_dataset_collection_display(output=\"staramr on collection 1: summary.tsv\")\n```\n\nPresence/absence matrix, annotated with genomic location (**P** = plasmid, **C** = chromosome, count = gene copies):\n\n| Gene | Class | KUH140013 | KUH140046 | KUH180129 | KUN1163 |\n|---|---|---|---|---|---|\n| `mecA` | methicillin (SCC*mec*) | C | C | **\u2013** | C |\n| `blaZ` | \u03b2-lactam | C | C | **P** | \u2013 |\n| `aac(6')-aph(2'')` | aminoglycoside | \u2013 | **P** | C | **P** |\n| `ant(9)-Ia` | spectinomycin | \u2013 | C \u00d73 | C \u00d72 | C \u00d72 |\n| `erm(A)` | MLS_B | \u2013 | C \u00d73 | C \u00d72 | C \u00d72 |\n| `tet(M)` | tetracycline | \u2013 | \u2013 | C | C |\n| `fosD` | fosfomycin | \u2013 | **P** | \u2013 | \u2013 |\n| `aadD` | aminoglycoside | \u2013 | \u2013 | \u2013 | C |\n| `bleO` | bleomycin | \u2013 | \u2013 | \u2013 | C |\n\nThe same data as a heatmap (0 = absent, 1 = chromosome, 2 = plasmid) \u2014 built from the pipeline, not pasted. The teal (plasmid) cells carry the comparative story:\n\n```galaxy\nhistory_dataset_as_image(output=\"heatmap2 on dataset 172\")\n```\n\nTwo findings stand out immediately:\n\n1. **KUH180129 carries no `mecA`** (nor `mecC`) \u2014 genotypically MSSA, an outlier in a set otherwise defined by methicillin resistance. Its \u03b2-lactam resistance rests on `blaZ` alone, and that `blaZ` is plasmid-borne.\n2. **The resistome scales with, but is not explained by, lineage.** The two ST8 isolates are far apart: KUH140013 carries only `blaZ`+`mecA`, while its clonemate KUH140046 adds an aminoglycoside / MLS_B / fosfomycin load. Within one ST, almost the entire difference is mobile-element cargo.\n\n## Plasmid vs chromosome: classify by contig, not by replicon\n\nThe location calls were made data-driven, by contig length, **not** by PlasmidFinder replicon presence \u2014 every isolate carries a chromosomal replicon marker (`rep7c`, `rep22`, or `repUS43`), so replicon presence cannot discriminate:\n\n```galaxy\nhistory_dataset_collection_display(output=\"staramr on collection 1: plasmidfinder.tsv\")\n```\n\nThe robust discriminant is **contig length** (the ~2.8 Mb contig is the chromosome; the ~20\u201335 kb contig is the plasmid). The chromosomal replicon markers are then best read as rep genes resident in integrated elements (SCC / prophage / island remnants) or PlasmidFinder cross-hits. The same length-based rule classifies every contig downstream (see *Pipeline*).\n\n## Mobile context of each ARG\n\nEvery ResFinder hit's contig + coordinates classifies each gene as plasmid- or chromosome-borne:\n\n```galaxy\nhistory_dataset_collection_display(output=\"staramr on collection 1: resfinder.tsv\")\n```\n\n**Plasmid-borne ARGs (the horizontally-mobile pool):**\n\n| Isolate | Gene | Plasmid | Note |\n|---|---|---|---|\n| KUH140046 | `aac(6')-aph(2'')`, `fosD` | AP020314 | aminoglycoside + fosfomycin co-located on one plasmid |\n| KUN1163 | `aac(6')-aph(2'')` | AP020325 | same gene, plasmid context as KUH140046 |\n| KUH180129 | `blaZ` | AP020323 | \u03b2-lactamase on a plasmid, not the chromosome |\n\n**Chromosomal cassettes:** `erm(A)` and `ant(9)-Ia` recur as *adjacent pairs* (~900 bp apart) at repeated chromosomal loci \u2014 the gene content of the **Tn554** transposon (`ermA` + `spc`/`ant(9)`):\n\n| Isolate | erm(A)+ant(9)-Ia pairs | Approx. chromosomal positions |\n|---|---|---|\n| KUH140046 | 3 | ~377 kb, ~1,194 kb, ~2,330 kb |\n| KUH180129 | 2 | ~347 kb, ~2,239 kb |\n| KUN1163 | 2 | ~345 kb, ~2,088 kb |\n\n(KUH140013 carries neither gene.) In KUN1163, `aadD` + `bleO` also sit adjacent (~2,103\u20132,104 kb) near the `mecA` region (~2,098 kb).\n\n## Mobile elements: insertion sequences and integrons\n\n**Integron Finder detected zero integrons in any isolate** (CALIN = complete = In0 = 0) \u2014 expected for *S. aureus*: resistance mobility here is insertion-sequence / transposon / plasmid-driven, not integron-driven.\n\n```galaxy\nhistory_dataset_collection_display(output=\"Integron Finder on collection 1: Summary\")\n```\n\n**ISEScan** (complete elements only, `remove_short_is`) finds insertion sequences everywhere \u2014 and the IS6 family is disproportionately enriched on the plasmids; IS6/IS257 is the family most associated with staphylococcal resistance-plasmid mosaicism:\n\n```galaxy\nhistory_dataset_collection_display(output=\"ISEScan on collection 1: tabular results\")\n```\n\n- **KUH180129's chromosome carries an IS256 expansion** \u2014 far more than any other isolate. IS256 is the basis of Tn4001.\n\n### ARG \u2192 nearest insertion sequence (bedtools closest)\n\nEach isolate's ResFinder hits and ISEScan elements are converted to BED (awk), sorted (bedtools SortBED), and run through **bedtools `closest -d`**, **mapped over the collection** \u2014 so the distance computation is a reusable part of the history graph (see *Pipeline*).\n\n```galaxy\nhistory_dataset_collection_display(output=\"Closest regions from collection 110 and 160\")\n```\n\n| Isolate | Gene | Location | Nearest IS | Distance |\n|---|---|---|---|---|\n| KUN1163 | `aac(6')-aph(2'')` | plasmid AP020325 | **IS6** | **80 bp** |\n| KUH140046 | `fosD` | plasmid AP020314 | IS6 | 81 bp |\n| KUH140046 | `aac(6')-aph(2'')` | plasmid AP020314 | **IS6** | 467 bp |\n| KUH180129 | `aac(6')-aph(2'')` | **chromosome** AP020322 | **IS256** | **84 bp** |\n| KUH180129 | `tet(M)` | chromosome AP020322 | IS256 | 45 bp |\n| KUH180129 | `blaZ` | plasmid AP020323 | *(none on contig)* | \u22121 |\n\n**This is the demo's headline.** The same gene, **`aac(6')-aph(2'')`, sits in a different mobile context depending on location** \u2014 adjacent to an **IS6** element on the plasmids of KUN1163 (80 bp) and KUH140046 (467 bp), but adjacent to an **IS256** element on the chromosome of KUH180129 (84 bp). Same resistance gene, different mobilizing-element family \u2014 the IS6/IS257 plasmid pool vs the IS256/Tn4001 chromosomal route.\n\nCounting every ARG by mobile context (plasmid / chromosomal IS-adjacent <1 kb / chromosomal distal) shows the comparative burden composition \u2014 KUH180129 is entirely IS-adjacent / plasmid, KUN1163 has more distal genes, KUH140013 is minimal:\n\n```galaxy\nhistory_dataset_as_image(output=\"heatmap2 on dataset 171\")\n```\n\nCaution: `bedtools closest` reports the nearest element regardless of biological relationship, and KUH180129's chromosome is IS256-dense, so small distances are partly expected by chance (`tet(M)`'s 45 bp IS256 neighbour is likely incidental \u2014 `tet(M)` is a Tn916-class conjugative-transposon gene, not IS-mobilized). The `aac(6')-aph(2'')` contrast is the firm call: the IS family flips with location across three isolates.\n\n## Pipeline (structured for workflow extraction)\n\nEvery tool step runs **mapped over the `MRSA isolate assemblies` collection**, so the whole analysis extracts as a single reusable workflow, and **both figures are real on-graph tool outputs** (awk-built matrices, not pasted):\n\n```\nassemblies (collection)\n  \u251c\u2500 staramr \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 resfinder.tsv \u2500 awk\u2192BED \u2500 SortBED \u2510\n  \u251c\u2500 ISEScan \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 results.gff \u2500\u2500\u2500 awk\u2192BED \u2500 SortBED \u2534\u2500 bedtools closest -d \u2500\u2510\n  \u2514\u2500 Integron Finder \u2500\u2500\u2500\u2500 (zero integrons)                                          \u2502\n                                                       Collapse Collection \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n                                                         \u251c\u2500 awk \u2192 location matrix \u2192 heatmap2 (Fig 1)\n                                                         \u2514\u2500 awk \u2192 context-count matrix \u2192 heatmap2 (Fig 2)\n```\n\n## Method caveats\n\n- **Adjacency vs mobilization.** The `bedtools closest` distances are descriptive. The firm comparative call (`aac(6')-aph(2'')`'s IS6\u2194IS256 flip) rests on three isolates agreeing; single proximities (e.g. `tet(M)`\u2194IS256) may be incidental in an IS-dense chromosome. *Optional structural confirmation:* annotating each ARG locus with **Bakta** names the flanking transposases (IS6/IS257 vs IS256 = **Tn4001**) and confirms the composite transposons \u2014 a non-mapped enrichment, outside this extractable core.\n- **Single-database, single-version calls.** ResFinder / PlasmidFinder / ISEScan / Integron Finder results are database-version-dependent; treat as a snapshot.\n- **No SCC*mec* typing tool** was run.\n- **PointFinder disabled**, so chromosomal point-mutation resistance was not assessed.\n\n## Where this goes next\n\nThe comparative question is answered from a fully-mapped, fully-extractable pipeline. Remaining: a **JBrowse** view contrasting one representative mobile-AMR locus (KUH140046 plasmid `aac(6')-aph(2'')`+`fosD`+IS6 vs KUH180129 chromosomal `aac(6')-aph(2'')`+IS256), optional **Bakta** structural confirmation, and **extracting the pipeline above into a reusable workflow** (it is already a clean collection map-over).\n",
+        "title": "MRSA mobile-AMR context across isolates"
+    },
+    "steps": {
+        "0": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 0,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "MRSA isolate assemblies"
+                }
+            ],
+            "label": "MRSA isolate assemblies",
+            "name": "Input dataset collection",
+            "outputs": [],
+            "position": {
+                "left": 10,
+                "top": 10
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false, \"tag\": null, \"collection_type\": \"list\", \"fields\": null, \"column_definitions\": null}",
+            "tool_version": null,
+            "type": "data_collection_input",
+            "uuid": "45a22756-fbff-421f-830d-ae2f3fa38f0f",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "1": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/nml/staramr/staramr_search/0.12.3+galaxy0",
+            "errors": null,
+            "id": 1,
+            "input_connections": {
+                "genomes": {
+                    "id": 0,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "staramr",
+            "outputs": [
+                {
+                    "name": "blast_hits",
+                    "type": "input"
+                },
+                {
+                    "name": "mlst",
+                    "type": "tabular"
+                },
+                {
+                    "name": "summary",
+                    "type": "tabular"
+                },
+                {
+                    "name": "detailed_summary",
+                    "type": "tabular"
+                },
+                {
+                    "name": "resfinder",
+                    "type": "tabular"
+                },
+                {
+                    "name": "plasmidfinder",
+                    "type": "tabular"
+                },
+                {
+                    "name": "settings",
+                    "type": "txt"
+                },
+                {
+                    "name": "excel",
+                    "type": "xlsx"
+                }
+            ],
+            "position": {
+                "left": 230,
+                "top": 10
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/nml/staramr/staramr_search/0.12.3+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "15a4fff208e4",
+                "name": "staramr",
+                "owner": "nml",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"__input_ext\": \"input\", \"advanced\": {\"pid_threshold\": \"98.0\", \"plength_resfinder\": \"60.0\", \"plength_pointfinder\": \"95.0\", \"plength_plasmidfinder\": \"60.0\", \"genome_size_lower_bound\": \"4000000\", \"genome_size_upper_bound\": \"6000000\", \"minimum_N50_value\": \"10000\", \"minimum_contig_length\": \"300\", \"unacceptable_number_contigs\": \"1000\", \"report_all_blast\": false, \"exclude_negatives\": false, \"exclude_resistance_phenotypes\": false, \"mlst_scheme\": \"auto\", \"exclude_genes\": {\"exclude_genes_condition\": \"default\", \"__current_case__\": 0}, \"complex_mutations\": {\"complex_mutations_condition\": \"default\", \"__current_case__\": 0}, \"plasmidfinder_type\": \"include_all\"}, \"chromInfo\": \"/Users/jxc755/projects/worktrees/galaxy/branch/history_pages/tool-data/shared/ucsc/chrom/?.len\", \"genomes\": null, \"genomes1|__identifier__\": \"KUH140013\", \"genomes|__identifier__\": \"KUH140013\", \"pointfinder_db\": {\"use_pointfinder\": \"disabled\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "0.12.3+galaxy0",
+            "type": "tool",
+            "uuid": "9cf5502a-c628-47e7-b6c3-476557174467",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "staramr on collection 1: mlst.tsv",
+                    "output_name": "mlst",
+                    "uuid": "e61185ae-2ce4-4202-8e3f-b4e334c77ac5"
+                },
+                {
+                    "label": "staramr on collection 1: summary.tsv",
+                    "output_name": "summary",
+                    "uuid": "5b7894f7-b9b9-45f1-b77b-31627533d640"
+                },
+                {
+                    "label": "staramr on collection 1: resfinder.tsv",
+                    "output_name": "resfinder",
+                    "uuid": "6c621940-e978-414b-8a66-cbf2c1509e6b"
+                },
+                {
+                    "label": "staramr on collection 1: plasmidfinder.tsv",
+                    "output_name": "plasmidfinder",
+                    "uuid": "3df80bef-522c-404b-b61e-c25bd064b8e6"
+                }
+            ]
+        },
+        "2": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/integron_finder/integron_finder/2.0.5+galaxy1",
+            "errors": null,
+            "id": 2,
+            "input_connections": {
+                "sequence": {
+                    "id": 0,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Integron Finder",
+            "outputs": [
+                {
+                    "name": "integron_log",
+                    "type": "txt"
+                },
+                {
+                    "name": "integrons_table",
+                    "type": "tsv"
+                },
+                {
+                    "name": "summary",
+                    "type": "tsv"
+                }
+            ],
+            "position": {
+                "left": 230,
+                "top": 130
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/integron_finder/integron_finder/2.0.5+galaxy1",
+            "tool_shed_repository": {
+                "changeset_revision": "5429646e486d",
+                "name": "integron_finder",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"__input_ext\": \"input\", \"chromInfo\": \"/Users/jxc755/projects/worktrees/galaxy/branch/history_pages/tool-data/shared/ucsc/chrom/?.len\", \"gbk\": false, \"local_max\": false, \"no_logfile\": false, \"pdf\": false, \"promoter_attI\": false, \"sequence\": null, \"sequence|__identifier__\": \"KUH140013\", \"settings\": {\"attc_settings\": {\"dist_thresh\": \"4000\", \"calin_threshold\": \"2\", \"max_attc_size\": \"200\", \"min_attc_size\": \"40\", \"keep_palindromes\": false, \"covar_matrix\": null}, \"protein_settings\": {\"no_proteins\": false, \"union_integrases\": false, \"func_annot\": false}}, \"topology_file\": null, \"type_replicon\": \"--circ\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "2.0.5+galaxy1",
+            "type": "tool",
+            "uuid": "898e0e86-3c05-4600-868a-e6fdaf602c0a",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "Integron Finder on collection 1: Summary",
+                    "output_name": "summary",
+                    "uuid": "328e4e99-dac4-401c-bc44-79fb730d4596"
+                }
+            ]
+        },
+        "3": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/isescan/isescan/1.7.3+galaxy0",
+            "errors": null,
+            "id": 3,
+            "input_connections": {
+                "input_file": {
+                    "id": 0,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "ISEScan",
+            "outputs": [
+                {
+                    "name": "summary",
+                    "type": "tabular"
+                },
+                {
+                    "name": "all_results",
+                    "type": "tabular"
+                },
+                {
+                    "name": "annotation",
+                    "type": "gff"
+                },
+                {
+                    "name": "is_fasta",
+                    "type": "fasta"
+                },
+                {
+                    "name": "orf_fna",
+                    "type": "fasta"
+                },
+                {
+                    "name": "orf_faa",
+                    "type": "fasta"
+                }
+            ],
+            "position": {
+                "left": 230,
+                "top": 250
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/isescan/isescan/1.7.3+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "81539b9ae80a",
+                "name": "isescan",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"__input_ext\": \"input\", \"chromInfo\": \"/Users/jxc755/projects/worktrees/galaxy/branch/history_pages/tool-data/shared/ucsc/chrom/?.len\", \"input_file\": null, \"input_file|__identifier__\": \"KUH140013\", \"log_activate\": false, \"remove_short_is\": true, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "1.7.3+galaxy0",
+            "type": "tool",
+            "uuid": "aab99faa-de04-4529-bb29-bab4ad0b3eae",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "ISEScan on collection 1: tabular results",
+                    "output_name": "all_results",
+                    "uuid": "9371f98c-c580-4b8a-8cc1-f1e7f56d1b0a"
+                }
+            ]
+        },
+        "4": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/9.5+galaxy3",
+            "errors": null,
+            "id": 4,
+            "input_connections": {
+                "infile": {
+                    "id": 1,
+                    "output_name": "resfinder"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Text reformatting",
+            "outputs": [
+                {
+                    "name": "outfile",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 450,
+                "top": 10
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/9.5+galaxy3",
+            "tool_shed_repository": {
+                "changeset_revision": "ab83aa685821",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"__input_ext\": \"input\", \"chromInfo\": \"/Users/jxc755/projects/worktrees/galaxy/branch/history_pages/tool-data/shared/ucsc/chrom/?.len\", \"code\": \"NR>1 { s=$9; e=$10; if (s>e) { t=s; s=e; e=t } print $8\\\"\\\\t\\\"(s-1)\\\"\\\\t\\\"e\\\"\\\\t\\\"$2 }\", \"infile\": null, \"infile|__identifier__\": \"KUH140013\", \"variables\": [], \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "9.5+galaxy3",
+            "type": "tool",
+            "uuid": "f0ab66b4-4b22-46f2-affc-ae60d4da7afc",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "5": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/9.5+galaxy3",
+            "errors": null,
+            "id": 5,
+            "input_connections": {
+                "infile": {
+                    "id": 3,
+                    "output_name": "annotation"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Text reformatting",
+            "outputs": [
+                {
+                    "name": "outfile",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 450,
+                "top": 130
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/9.5+galaxy3",
+            "tool_shed_repository": {
+                "changeset_revision": "ab83aa685821",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"__input_ext\": \"input\", \"chromInfo\": \"/Users/jxc755/projects/worktrees/galaxy/branch/history_pages/tool-data/shared/ucsc/chrom/?.len\", \"code\": \"/family=/ { fam=\\\"IS\\\"; if (match($9, /family=[^;]+/)) fam=substr($9, RSTART+7, RLENGTH-7); print $1\\\"\\t\\\"($4-1)\\\"\\t\\\"$5\\\"\\t\\\"fam }\", \"infile\": null, \"infile|__identifier__\": \"KUH140013\", \"variables\": [], \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "9.5+galaxy3",
+            "type": "tool",
+            "uuid": "443f874e-976d-4ce8-b92a-f457daeb3f8f",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "6": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_sortbed/2.31.1+galaxy0",
+            "errors": null,
+            "id": 6,
+            "input_connections": {
+                "input": {
+                    "id": 4,
+                    "output_name": "outfile"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "bedtools SortBED",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 670,
+                "top": 10
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_sortbed/2.31.1+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "2892111d91f8",
+                "name": "bedtools",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"__input_ext\": \"input\", \"chromInfo\": \"/Users/jxc755/projects/worktrees/galaxy/branch/history_pages/tool-data/shared/ucsc/chrom/?.len\", \"genome_file_opts\": {\"genome_file_opts_selector\": \"loc\", \"__current_case__\": 0, \"genome\": null}, \"input\": null, \"input|__identifier__\": \"KUH140013\", \"option\": \"\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "2.31.1+galaxy0",
+            "type": "tool",
+            "uuid": "40c247ab-1108-406a-b117-c58a87b9e13e",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "7": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_sortbed/2.31.1+galaxy0",
+            "errors": null,
+            "id": 7,
+            "input_connections": {
+                "input": {
+                    "id": 5,
+                    "output_name": "outfile"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "bedtools SortBED",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 670,
+                "top": 130
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_sortbed/2.31.1+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "2892111d91f8",
+                "name": "bedtools",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"__input_ext\": \"input\", \"chromInfo\": \"/Users/jxc755/projects/worktrees/galaxy/branch/history_pages/tool-data/shared/ucsc/chrom/?.len\", \"genome_file_opts\": {\"genome_file_opts_selector\": \"loc\", \"__current_case__\": 0, \"genome\": null}, \"input\": null, \"input|__identifier__\": \"KUH140013\", \"option\": \"\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "2.31.1+galaxy0",
+            "type": "tool",
+            "uuid": "0e196638-c7ba-4754-b5fd-4978016955de",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "8": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_closestbed/2.31.1+galaxy1",
+            "errors": null,
+            "id": 8,
+            "input_connections": {
+                "inputA": {
+                    "id": 6,
+                    "output_name": "output"
+                },
+                "overlap_with|inputB": {
+                    "id": 7,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "bedtools ClosestBed",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 890,
+                "top": 10
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_closestbed/2.31.1+galaxy1",
+            "tool_shed_repository": {
+                "changeset_revision": "2892111d91f8",
+                "name": "bedtools",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"__input_ext\": \"input\", \"addition\": true, \"addition2\": {\"addition2_select\": \"\", \"__current_case__\": 0}, \"chromInfo\": \"/Users/jxc755/projects/worktrees/galaxy/branch/history_pages/tool-data/shared/ucsc/chrom/?.len\", \"inputA\": null, \"inputA|__identifier__\": \"KUH140013\", \"io\": false, \"k\": \"1\", \"mdb\": \"each\", \"overlap_with\": {\"source\": \"history\", \"__current_case__\": 1, \"inputB\": null}, \"overlap_with|inputB1|__identifier__\": \"KUH140013\", \"overlap_with|inputB|__identifier__\": \"KUH140013\", \"strand\": \"\", \"ties\": \"all\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "2.31.1+galaxy1",
+            "type": "tool",
+            "uuid": "d93d3291-0501-455f-be94-07d672bcfc26",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "Closest regions from collection 110 and 160",
+                    "output_name": "output",
+                    "uuid": "a434a24b-38ce-4094-bf56-c799f97520df"
+                }
+            ]
+        },
+        "9": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
+            "errors": null,
+            "id": 9,
+            "input_connections": {
+                "input_list": {
+                    "id": 8,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Collapse Collection",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 1110,
+                "top": 10
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
+            "tool_shed_repository": {
+                "changeset_revision": "90981f86000f",
+                "name": "collapse_collections",
+                "owner": "nml",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"__input_ext\": \"input\", \"chromInfo\": \"/Users/jxc755/projects/worktrees/galaxy/branch/history_pages/tool-data/shared/ucsc/chrom/?.len\", \"filename\": {\"add_name\": true, \"__current_case__\": 0, \"place_name\": \"same_multiple\"}, \"input_list\": null, \"one_header\": false, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "5.1.0",
+            "type": "tool",
+            "uuid": "cb4dde00-cbc3-4a17-8c8f-44f7126aa878",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "10": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/9.5+galaxy3",
+            "errors": null,
+            "id": 10,
+            "input_connections": {
+                "infile": {
+                    "id": 9,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Text reformatting",
+            "outputs": [
+                {
+                    "name": "outfile",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 1330,
+                "top": 10
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/9.5+galaxy3",
+            "tool_shed_repository": {
+                "changeset_revision": "ab83aa685821",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"__input_ext\": \"input\", \"chromInfo\": \"/Users/jxc755/projects/worktrees/galaxy/branch/history_pages/tool-data/shared/ucsc/chrom/?.len\", \"code\": \"BEGIN{FS=OFS=\\\"\\\\t\\\"}\\n{ iso[NR]=$1; con[NR]=$2; di[NR]=$10; n=NR; if($4+0>mx[$2]) mx[$2]=$4+0; isos[$1]=1 }\\nEND{\\n  for(k=1;k<=n;k++){\\n    code=(mx[con[k]]<200000)?2:1;\\n    if(code==2) ctx=\\\"Plasmid-borne\\\";\\n    else if(di[k]+0<1000) ctx=\\\"Chromosomal IS-adjacent (<1kb)\\\";\\n    else ctx=\\\"Chromosomal distal\\\";\\n    M[ctx,iso[k]]++;\\n  }\\n  ni=0; for(s in isos){ni++; A[ni]=s}\\n  for(a=1;a<=ni;a++)for(b=a+1;b<=ni;b++)if(A[b]<A[a]){t=A[a];A[a]=A[b];A[b]=t}\\n  split(\\\"Plasmid-borne|Chromosomal IS-adjacent (<1kb)|Chromosomal distal\\\",CTX,\\\"|\\\");\\n  printf \\\"Context\\\"; for(a=1;a<=ni;a++) printf \\\"%s%s\\\",OFS,A[a]; printf \\\"\\\\n\\\";\\n  for(r=1;r<=3;r++){ printf \\\"%s\\\",CTX[r]; for(a=1;a<=ni;a++) printf \\\"%s%d\\\",OFS,(M[CTX[r],A[a]]+0); printf \\\"\\\\n\\\"; }\\n}\\n\", \"infile\": null, \"variables\": [], \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "9.5+galaxy3",
+            "type": "tool",
+            "uuid": "3cd636ea-4fdc-4a87-a837-a7a8f7060b2b",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "11": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/9.5+galaxy3",
+            "errors": null,
+            "id": 11,
+            "input_connections": {
+                "infile": {
+                    "id": 9,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Text reformatting",
+            "outputs": [
+                {
+                    "name": "outfile",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 1330,
+                "top": 130
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/9.5+galaxy3",
+            "tool_shed_repository": {
+                "changeset_revision": "ab83aa685821",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"__input_ext\": \"input\", \"chromInfo\": \"/Users/jxc755/projects/worktrees/galaxy/branch/history_pages/tool-data/shared/ucsc/chrom/?.len\", \"code\": \"BEGIN{FS=OFS=\\\"\\\\t\\\"}\\n{ iso[NR]=$1; con[NR]=$2; gene[NR]=$5; n=NR; if($4+0>mx[$2]) mx[$2]=$4+0; isos[$1]=1 }\\nEND{\\n  for(k=1;k<=n;k++){\\n    code=(mx[con[k]]<200000)?2:1; g=gene[k]; ix=iso[k];\\n    if(!((g SUBSEP ix) in L) || code==2) L[g,ix]=code; genes[g]=1;\\n  }\\n  ni=0; for(s in isos){ni++; A[ni]=s}\\n  for(a=1;a<=ni;a++)for(b=a+1;b<=ni;b++)if(A[b]<A[a]){t=A[a];A[a]=A[b];A[b]=t}\\n  ng=0; for(g in genes){ng++; GN[ng]=g}\\n  for(a=1;a<=ng;a++)for(b=a+1;b<=ng;b++)if(GN[b]<GN[a]){t=GN[a];GN[a]=GN[b];GN[b]=t}\\n  printf \\\"Gene\\\"; for(a=1;a<=ni;a++) printf \\\"%s%s\\\",OFS,A[a]; printf \\\"\\\\n\\\";\\n  for(r=1;r<=ng;r++){ printf \\\"%s\\\",GN[r]; for(a=1;a<=ni;a++) printf \\\"%s%d\\\",OFS,(L[GN[r],A[a]]+0); printf \\\"\\\\n\\\"; }\\n}\\n\", \"infile\": null, \"variables\": [], \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "9.5+galaxy3",
+            "type": "tool",
+            "uuid": "fe5c55b9-361c-4a79-a4b2-6c0413201ac1",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "12": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/ggplot2_heatmap2/ggplot2_heatmap2/3.3.0+galaxy0",
+            "errors": null,
+            "id": 12,
+            "input_connections": {
+                "input1": {
+                    "id": 10,
+                    "output_name": "outfile"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "heatmap2",
+            "outputs": [
+                {
+                    "name": "output1",
+                    "type": "pdf"
+                }
+            ],
+            "position": {
+                "left": 1550,
+                "top": 130
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ggplot2_heatmap2/ggplot2_heatmap2/3.3.0+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "6a097d09fca3",
+                "name": "ggplot2_heatmap2",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"__input_ext\": \"input\", \"chromInfo\": \"/Users/jxc755/projects/worktrees/galaxy/branch/history_pages/tool-data/shared/ucsc/chrom/?.len\", \"cluster_cond\": {\"cluster\": \"no\", \"__current_case__\": 1}, \"colorchoice\": {\"type\": \"palettes\", \"__current_case__\": 0, \"name\": \"BrBG\"}, \"image_file_format\": \"png\", \"input1\": null, \"key\": null, \"labels\": \"both\", \"title\": \"ARG counts by mobile context\", \"transform\": \"none\", \"zscore_cond\": {\"zscore\": \"none\", \"__current_case__\": 0, \"scale\": \"none\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "3.3.0+galaxy0",
+            "type": "tool",
+            "uuid": "f09d6fde-6104-4986-98aa-70bef30309cb",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "heatmap2 on dataset 171",
+                    "output_name": "output1",
+                    "uuid": "fc62b044-70cc-451b-bac3-b785ebb06dee"
+                }
+            ]
+        },
+        "13": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/ggplot2_heatmap2/ggplot2_heatmap2/3.3.0+galaxy0",
+            "errors": null,
+            "id": 13,
+            "input_connections": {
+                "input1": {
+                    "id": 11,
+                    "output_name": "outfile"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "heatmap2",
+            "outputs": [
+                {
+                    "name": "output1",
+                    "type": "pdf"
+                }
+            ],
+            "position": {
+                "left": 1550,
+                "top": 10
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ggplot2_heatmap2/ggplot2_heatmap2/3.3.0+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "6a097d09fca3",
+                "name": "ggplot2_heatmap2",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"__input_ext\": \"input\", \"chromInfo\": \"/Users/jxc755/projects/worktrees/galaxy/branch/history_pages/tool-data/shared/ucsc/chrom/?.len\", \"cluster_cond\": {\"cluster\": \"no\", \"__current_case__\": 1}, \"colorchoice\": {\"type\": \"palettes\", \"__current_case__\": 0, \"name\": \"BrBG\"}, \"image_file_format\": \"png\", \"input1\": null, \"key\": null, \"labels\": \"both\", \"title\": \"ARG genomic location (0=absent, 1=chromosome, 2=plasmid)\", \"transform\": \"none\", \"zscore_cond\": {\"zscore\": \"none\", \"__current_case__\": 0, \"scale\": \"none\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "3.3.0+galaxy0",
+            "type": "tool",
+            "uuid": "e0afdc50-c598-48ba-a5ab-889fce2121ff",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "heatmap2 on dataset 172",
+                    "output_name": "output1",
+                    "uuid": "a9de0cb7-a70d-43d8-a655-2178b2e1b6db"
+                }
+            ]
+        }
+    },
+    "tags": [],
+    "uuid": "5ae47af0-28d3-49bc-9927-de55694f14a6",
+    "version": 0
+}

--- a/content/pipelines/interview-to-galaxy/examples/UC1_MRSA_issue.md
+++ b/content/pipelines/interview-to-galaxy/examples/UC1_MRSA_issue.md
@@ -1,0 +1,83 @@
+# UC1 / MRSA mobile-AMR context — interview input
+
+> Pulled-down GitHub issue used as the **effective result of the INTERVIEW → GALAXY interview**
+> (the live interview mechanics are harness-owned and precede pipeline phase 1).
+> Source: galaxy-brain issue #12 (captured).
+> Paired aspirational target: `UC1_MRSA_extracted.ga` (extracted from a Galaxy history; **not human-validated**).
+
+---
+
+## Purpose
+
+Develop a Galaxy Notebooks paper/demo vignette using existing Galaxy Training Network material as scaffolding, but with a new analysis shape: comparative mobile-AMR interpretation across related MRSA isolates. This is for the `galaxy-brain` Galaxy Notebooks work, not a proposal to add new GTN training material by default.
+
+## Objective
+
+Show how a Galaxy Notebook can move from existing one-isolate AMR/annotation workflows to a focused comparative question: which resistance genes appear in mobile genomic contexts such as plasmids, insertion sequences, integrons, or isolate-specific loci?
+
+## Why this is a useful demo deviation
+
+The existing training material already covers KUN1163/DRR187559 assembly-derived annotation and AMR detection. The notebook should reuse those available tools and data patterns, but add a more paper-worthy story: compare 3-4 related MRSA isolates and summarize how ARG content and mobile context differ.
+
+This is small enough to avoid new Galaxy plumbing, but significant enough to demonstrate the notebook as an interpretive layer over Galaxy histories rather than a direct tutorial rewrite.
+
+## Existing analysis anchors
+
+- Bacterial annotation tutorial: https://training.galaxyproject.org/training-material/topics/genome-annotation/tutorials/bacterial-genome-annotation/tutorial.html
+- AMR gene detection tutorial: https://training.galaxyproject.org/training-material/topics/genome-annotation/tutorials/amr-gene-detection/tutorial.html
+- MRSA assembly provenance: https://training.galaxyproject.org/training-material/topics/assembly/tutorials/mrsa-illumina/tutorial.html
+- Relevant existing tools/patterns: Bakta, staramr, PlasmidFinder, IntegronFinder, ISEScan, table-to-GFF3 conversion, and JBrowse visualization.
+
+## Public data candidates
+
+- Existing GTN Zenodo data: https://doi.org/10.5281/zenodo.10572227
+- Assembly Zenodo data: https://doi.org/10.5281/zenodo.10669812
+- Same source paper: Hikichi et al. 2019, DOI `10.1128/mra.01212-19`
+- Comparative source candidate: BioProject `PRJDB8599`, with complete genome/plasmid accessions from eight MRSA isolates.
+- Candidate subset to verify: KUN1163 `AP020324` + `AP020325`; KUH140013 `AP020311` + `AP020312`; KUH140046 `AP020313` + `AP020314`; KUH180129 `AP020322` + `AP020323`.
+
+Fallback: create a small Zenodo bundle with combined chromosome+plasmid FASTA per selected isolate plus metadata TSV if direct INSDC FASTA import is unstable.
+
+## Notebook workflow plan
+
+1. Import 3-4 complete isolate FASTA files, one combined assembly per isolate.
+2. Build a Galaxy dataset collection named `MRSA isolate assemblies`.
+3. Run `staramr` over the collection and collect `summary.tsv`, `detailed_summary.tsv`, `resfinder.tsv`, `plasmidfinder.tsv`, and `mlst.tsv`.
+4. Run Bakta on selected isolates, or on a representative subset if runtime is too high.
+5. Run ISEScan and IntegronFinder on selected assemblies.
+6. Convert AMR, plasmid, IS, and integron outputs into interval tables or GFF3 using existing GTN table-processing patterns.
+7. Classify ARG context as plasmid-located, IS-adjacent, integron-associated, SCCmec-region candidate, or unclassified.
+8. Build a JBrowse view for one representative mobile-AMR locus and one contrasting isolate.
+9. Export summary TSVs and notebook-ready figures.
+
+## Expected paper/demo artifacts
+
+- Metadata table: strain, year, source, symptom, chromosome accession, plasmid accession(s), genome size.
+- AMR presence/absence matrix from `staramr`.
+- Plasmid replicon/mobile element matrix.
+- Mobile-context table: isolate, ARG, phenotype, accession, coordinate, replicon/context, nearest IS/integron/plasmid marker, distance.
+- Heatmap of ARGs by isolate.
+- Dot plot or heatmap of plasmid/mobile element calls by isolate.
+- Stacked bar of ARG counts by context category.
+- One or two locus diagrams or JBrowse screenshots.
+
+## Scope and risks
+
+- Keep the first version to 3-4 isolates; all eight isolates are stretch scope.
+- Do not re-teach read QC, assembly, or raw-read mapping except as provenance.
+- Treat AMR calls as database-version-dependent and pin expected output snapshots where possible.
+- Avoid clinical interpretation beyond published phenotype comparison.
+- Avoid adding broad pangenomics unless it is needed for one targeted context question.
+
+## Tasks
+
+- [ ] Confirm selected isolate accessions and direct FASTA download URLs.
+- [ ] Confirm strain-to-plasmid accession mapping from Hikichi Table 1 / INSDC records.
+- [ ] Run `staramr` on selected isolates and snapshot expected outputs.
+- [ ] Run Bakta, ISEScan, and IntegronFinder on the selected subset; benchmark runtime.
+- [ ] Define mobile-context classification rules for ARGs.
+- [ ] Build notebook summary tables and figures.
+- [ ] Create stable demo data inputs, using direct public URLs or a Zenodo snapshot.
+- [ ] Draft the Galaxy Notebook narrative and connect it to the manuscript framing.
+- [ ] Decide whether any outputs should be mirrored into `vault/papers/galaxy-notebooks/` as figures/tables.
+- [ ] Review database drift, runtime, and scope before using this as a paper example.

--- a/content/pipelines/interview-to-galaxy/examples/UC1_NEXT_STEPS.md
+++ b/content/pipelines/interview-to-galaxy/examples/UC1_NEXT_STEPS.md
@@ -1,0 +1,88 @@
+# UC1 Next Steps — bring Bakta annotation + JBrowse locus view into the workflow
+
+**Issue:** `UC1_MRSA_issue.md` (originally galaxy-brain issue #12).
+**For:** the agent that built the clean UC1 history. Handoff to push the
+MRSA mobile-AMR analysis from "great paper figures" to "complete *workflow*."
+
+## Why this handoff
+
+You optimized UC1 for the Galaxy Notebooks paper: a clean collection map-over
+that extracts to a flawless 14-step, sample-agnostic workflow with two on-graph
+heatmaps. That goal was met. For that goal, Bakta was deliberately left out as
+"non-extractable enrichment" and JBrowse was parked as a TODO.
+
+But the **issue's plan (steps 4 and 8) names both**, and at the *workflow*
+level they are load-bearing, not decoration:
+
+- **Bakta** = the gene-context layer. Right now the ARGs are located (plasmid vs
+  chromosome) and given a nearest-IS distance, but nothing annotates the genomic
+  *neighborhood* — what genes flank the mobile-AMR locus. That's the structural
+  confirmation the issue asks for.
+- **JBrowse** = the auditable locus view. The headline (`aac(6')-aph(2'')` is
+  IS6-adjacent on the KUN1163/KUH140046 plasmids but IS256-adjacent on the
+  KUH180129 chromosome) is currently only legible as matrix cells. A JBrowse
+  locus is the issue's intended way to *show* it.
+
+Both tools are already installed on the reference server (`iuc/bakta`,
+`iuc/jbrowse`). Bakta needs its light DB set up first; the known gotchas are
+db-light layout, the amrfinder-db move, `.loc` registration, and serial
+execution on Apple Silicon (to avoid OOM).
+
+## Step A — Bakta whole-genome annotation (mapped over the collection)
+
+- Tool: `toolshed.g2.bx.psu.edu/repos/iuc/bakta/bakta` (Bakta light DB v5.1).
+- Input: the existing `MRSA isolate assemblies` `list` collection (the same input
+  staramr/ISEScan/Integron Finder map over).
+- Run **mapped** over all 4 isolates if runtime allows; on Apple Silicon run
+  **serially** (one isolate at a time) to avoid OOM, or narrow to the two
+  headline isolates (KUN1163, KUH180129).
+- Output to expose: the Bakta **GFF3** annotation collection (and optionally the
+  GBK/summary). This is the new annotation deliverable.
+- Decide the wiring:
+  - **Minimum:** expose Bakta GFF3 as a workflow output (enrichment; doesn't feed
+    downstream). Lowest risk, still closes the issue's "annotate" task.
+  - **Better:** feed the Bakta GFF3 as a track into Step B (JBrowse) so the locus
+    view shows annotated CDS features around the ARG/IS, and/or `bedtools closest`
+    the ARG BED against Bakta CDS features to attach a nearest-gene column to the
+    context table.
+- Extraction check: Bakta is a normal mapped tool — confirm it seeds and extracts
+  with zero dangling like the rest of the spine. If it genuinely can't extract
+  cleanly (it should), keep it as a parallel enrichment branch rather than
+  dropping it.
+
+## Step B — JBrowse locus view for the headline mobile-AMR region
+
+- Tool: `toolshed.g2.bx.psu.edu/repos/iuc/jbrowse/jbrowse`.
+- Issue step 8: "one representative mobile-AMR locus and one contrasting isolate."
+  Use the headline contrast — **KUN1163** (plasmid, IS6-adjacent
+  `aac(6')-aph(2'')`) vs **KUH180129** (chromosome, IS256-adjacent same gene).
+- Reference: the per-isolate assembly FASTA (pull the relevant element from the
+  `MRSA isolate assemblies` collection).
+- Tracks — **reuse intermediate outputs already in the workflow**, so JBrowse is a
+  connected step, not a fresh upload:
+  - ARG sorted BED (the staramr→BED→SortBED output) → ARG features.
+  - IS sorted BED (the ISEScan→BED→SortBED output) → IS features.
+  - the `bedtools closest` output → the ARG↔IS pairing.
+  - optionally the Bakta GFF3 from Step A → gene context.
+- Output to expose: the JBrowse HTML per isolate (or one combined), centered on
+  the `aac(6')-aph(2'')` locus.
+
+## Verification (what "done" looks like)
+
+| Check | Expected |
+|---|---|
+| Workflow step count | grows from 14 → ~16+ (Bakta + JBrowse, plus any closest/annotate glue) |
+| Bakta output | GFF3 annotation collection exposed as a workflow output |
+| JBrowse output | HTML locus view(s) exposed; `aac(6')-aph(2'')` visible beside its IS in both KUN1163 (plasmid/IS6) and KUH180129 (chr/IS256) |
+| Re-extraction | new outputs exposed, **zero dangling** input_connections, report rewritten clean (hold the re-extraction to the same clean standard) |
+| Science unchanged | the existing 14-step headline still reproduces byte-identically (don't perturb the staramr/ISEScan/closest spine; `remove_short_is=true` still required) |
+
+## Scope / risks
+
+- Bakta DB + Apple-Silicon serial execution is the main cost — budget for it;
+  it's a one-time DB setup.
+- Decide map-over-all-4 vs. two-isolate subset for Bakta/JBrowse before building;
+  the headline only needs KUN1163 + KUH180129.
+- Don't regress the clean extractable core to add these — prefer wiring them as
+  additional connected steps/branches that also extract, following the
+  "reference real outputs, don't re-upload" rule.

--- a/content/pipelines/interview-to-galaxy/examples/UC3_ATAC_extracted.ga
+++ b/content/pipelines/interview-to-galaxy/examples/UC3_ATAC_extracted.ga
@@ -1,0 +1,223 @@
+{
+    "a_galaxy_workflow": "true",
+    "annotation": "",
+    "comments": [],
+    "format-version": "0.1",
+    "name": "Differential ATAC-seq (extracted)",
+    "report": {
+        "markdown": "# Differential ATAC-seq accessibility\n\nThe existing Galaxy ATAC-seq tutorial calls peaks in *one* sample. This notebook makes the jump that matters for biology: **count fragments over a shared peak universe across biological replicates, then test which regions change accessibility between two conditions** \u2014 replicate-aware differential accessibility, not peak presence/absence.\n\nIt starts from a **precomputed count matrix** (the issue's preferred MVP): the **Corces et al. 2016 human hematopoiesis ATAC-seq** peak \u00d7 sample count matrix (GSE74912), **genome-wide**, contrasting **Erythroblast vs B-cell** (donors as replicates). Every analysis step is a real Galaxy tool \u2014 the per-sample counts go in as **one collection** with a donor-aware sample sheet, so the whole notebook **extracts to a reusable DESeq2 workflow**, and every figure below is a genuine tool output (no re-uploaded screenshots).\n\n## Design\n\n| | |\n|---|---|\n| Peak universe | **590,650 genome-wide peaks** (Corces union peak set) |\n| Conditions | Erythroblast (4) vs B-cell (4), donors as replicates |\n| Test | DESeq2 (`sample_sheet_contrasts`, `~ condition`, Erythroblast = reference) |\n| Significance | padj < 0.05 and \\|log2FC\\| \u2265 1 |\n\n## Replicate QC \u2014 the conditions separate cleanly\n\nDESeq2's diagnostic plots (PCA on the variance-stabilised counts, sample-distance, dispersion) come straight from the tool. PC1 carries essentially all the variance (**\u2248 98%**) on the Erythroblast\u2013B-cell axis, with each condition's replicates grouped:\n\n```galaxy\nhistory_dataset_as_image(output=\"DESeq2 plots\")\n```\n\nThis is the replicate-QC the issue asks for. Condition dominates PC1; `Eryth_1` is a mild PC2 outlier but does not cross the boundary \u2014 no samples are swapped, the contrast is safe to run.\n\n## Differential accessibility\n\nDESeq2 finds **45,620 significantly differential peaks** (padj < 0.05, \\|log2FC\\| \u2265 1): **34,873 more accessible in B-cell** and **10,747 more accessible in Erythroblast** \u2014 out of ~247,000 *testable* peaks (DESeq2 low-count-filtered the other 343,612 of 590,650 to NA). The volcano is the real `volcanoplot` tool output on the DESeq2 result (after dropping NA-padj rows):\n\n```galaxy\nhistory_dataset_as_image(output=\"Volcano Plot PDF\")\n```\n\n> **Direction:** DESeq2 used Erythroblast as the reference level, so **log2FC > 0 (red, \"Up\") = gained in B-cell** and **log2FC < 0 (blue, \"Down\") = gained in Erythroblast**. (The sign is reference-dependent and easy to flip.)\n\nThe full DESeq2 result table (every peak's log2FC, p-value, padj) is on-graph:\n\n```galaxy\nhistory_dataset_as_table(output=\"DESeq2 result\", title=\"DESeq2 result (peak, baseMean, log2FC, lfcSE, stat, pvalue, padj)\", compact=true)\n```\n\n## The differential map recovers the lineage master regulators\n\nGenome-wide, the test recovers the **master transcription factors that define the erythroid vs B-lymphoid split**, each accessible on exactly the expected side (hg19):\n\n| Direction | Locus | log2FC | padj | Role |\n|---|---|---|---|---|\n| **B-cell-gained** | **EBF1** (chr5) | **+8.0** | 4\u00d710\u207b\u00b9\u00b9 | B-cell master TF |\n| B-cell-gained | **MS4A1 / CD20** (chr11) | +7.3 | 1\u00d710\u207b\u00b9\u00b3 | B-cell surface marker |\n| B-cell-gained | **PAX5** (chr9) | +6.8 | 1\u00d710\u207b\u2077 | B-cell master TF |\n| B-cell-gained | **CD19** (chr16) | +4.0 | 5\u00d710\u207b\u00b3 | B-cell marker |\n| **Erythroblast-gained** | **HBB \u03b2-globin / LCR** (chr11) | **\u22126.6** | 6\u00d710\u207b\u00b3\u00b2 | erythroid globin |\n| Erythroblast-gained | **GATA1** (chrX) | \u22125.5 | 1\u00d710\u207b\u2079 | **erythroid master TF** |\n\n*(Each row is a representative significant peak; for genes with several peaks the most-significant peak may differ slightly in log2FC/padj. EBF1, MS4A1, HBB and GATA1 are unambiguous.)*\n\nThe payoff of going genome-wide: **GATA1** (erythroid master TF, chrX) sits among the strongest Erythroblast-gained peaks, opposite **PAX5/EBF1** (B-cell master TFs), with the surface markers (CD19, CD20) and the \u03b2-globin locus all where lineage biology predicts. The differential-accessibility map **recovers the lineage master-regulator program** \u2014 a chromatin correlate (accessibility is not expression; see caveats).\n\n## Why this extracts cleanly\n\n- **counts collection + sample sheet \u2192 DESeq2 \u2192 awk (NA filter) \u2192 volcanoplot** are all real tool jobs, so the analysis extracts as one reusable workflow with a single collection input.\n- **The displayed figures are the tools' own outputs** \u2014 the DESeq2 diagnostic-plots PDF and the volcanoplot PDF, referenced directly. (These tools emit PDF; the notebook renderer rasterizes the first page for display, so the real outputs can be shown without re-uploading screenshots \u2014 which is what lets extraction walk back from each figure to DESeq2.)\n\n## Method caveats\n\n- **Accessibility \u2260 expression / regulation.** A differential peak marks differential chromatin accessibility, not a proven regulatory change; recovering master-TF loci validates the test but is a correlate of the lineage program.\n- **Shared-donor pseudoreplication.** Two pairs share a donor (B-cell \u00d72 Donor5483; Erythroblast \u00d72 Donor6926), so effective replication is < 4/condition and significance is somewhat inflated. A donor-aware design (`~ donor + condition`) is preferable \u2014 the `donor` column is in the sample sheet. Conclusions are robust to it.\n- **Precomputed matrix, hg19.** Library sizes are imbalanced; DESeq2 estimates median-of-ratios size factors internally and the PCA confirms imbalance did not drive the separation.\n- **Reference-level direction** stated above; flipping the factor reference flips every sign.\n\n## Where this goes next\n\n1. Re-run with a **donor-aware design** (`~ donor + condition`); annotate top peaks to nearest genes (`bedtools closest`, as in the TAL1 use case).\n2. The issue's optional **BAM branch**: build the union peak set, convert to SAF, count with `featureCounts`.\n3. A **pyGenomeTracks/deepTools heatmap** over the top differential peaks (GATA1 vs PAX5 loci).\n",
+        "title": "Differential ATAC-seq accessibility"
+    },
+    "steps": {
+        "0": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 0,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "ATAC sample metadata"
+                }
+            ],
+            "label": "ATAC sample metadata",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "left": 10,
+                "top": 10
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false, \"tag\": null}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "bba7a389-04bd-4d7b-a445-8def86827286",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "1": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 1,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "ATAC counts"
+                }
+            ],
+            "label": "ATAC counts",
+            "name": "Input dataset collection",
+            "outputs": [],
+            "position": {
+                "left": 10,
+                "top": 130
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false, \"tag\": null, \"collection_type\": \"list\", \"fields\": null, \"column_definitions\": null}",
+            "tool_version": null,
+            "type": "data_collection_input",
+            "uuid": "29829486-8301-4629-9328-b5d42164569d",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "2": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/deseq2/deseq2/2.11.40.8+galaxy2",
+            "errors": null,
+            "id": 2,
+            "input_connections": {
+                "select_data|countsFile": {
+                    "id": 1,
+                    "output_name": "output"
+                },
+                "select_data|sample_sheet": {
+                    "id": 0,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "DESeq2",
+            "outputs": [
+                {
+                    "name": "deseq_out",
+                    "type": "tabular"
+                },
+                {
+                    "name": "plots",
+                    "type": "pdf"
+                },
+                {
+                    "name": "counts_out",
+                    "type": "tabular"
+                },
+                {
+                    "name": "vst_out",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "left": 230,
+                "top": 10
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/deseq2/deseq2/2.11.40.8+galaxy2",
+            "tool_shed_repository": {
+                "changeset_revision": "6c363db8c702",
+                "name": "deseq2",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"__input_ext\": \"input\", \"advanced_options\": {\"esf_cond\": {\"esf\": \"\", \"__current_case__\": 0}, \"fit_type\": \"1\", \"outlier_replace_off\": false, \"outlier_filter_off\": false, \"auto_mean_filter_off\": false, \"prefilter_conditional\": {\"prefilter\": \"\", \"__current_case__\": 1}, \"use_beta_priors\": false}, \"batch_factors\": null, \"chromInfo\": \"/Users/jxc755/projects/worktrees/galaxy/branch/history_pages/tool-data/shared/ucsc/chrom/?.len\", \"header\": true, \"output_options\": {\"output_selector\": [\"pdf\", \"normCounts\", \"normVST\"], \"alpha_ma\": \"0.1\"}, \"select_data\": {\"how\": \"sample_sheet_contrasts\", \"__current_case__\": 2, \"countsFile\": null, \"sample_sheet\": null, \"design_formula_mode\": {\"mode\": \"automatic\", \"__current_case__\": 0, \"factor\": [\"2\"], \"reference_level\": \"Erythroblast\", \"target_level\": \"Bcell\"}}, \"tximport\": {\"tximport_selector\": \"count\", \"__current_case__\": 1}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "2.11.40.8+galaxy2",
+            "type": "tool",
+            "uuid": "a3b10ba7-caca-442b-899d-2f2eff2e36b7",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "DESeq2 result",
+                    "output_name": "deseq_out",
+                    "uuid": "c27add69-cb9b-4472-b134-c7e352411098"
+                },
+                {
+                    "label": "DESeq2 plots",
+                    "output_name": "plots",
+                    "uuid": "75f192fb-8abc-4e84-ba10-aa8b1e867585"
+                }
+            ]
+        },
+        "3": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/9.5+galaxy3",
+            "errors": null,
+            "id": 3,
+            "input_connections": {
+                "infile": {
+                    "id": 2,
+                    "output_name": "deseq_out"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Text reformatting",
+            "outputs": [
+                {
+                    "name": "outfile",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 450,
+                "top": 10
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/9.5+galaxy3",
+            "tool_shed_repository": {
+                "changeset_revision": "ab83aa685821",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"__input_ext\": \"input\", \"chromInfo\": \"/Users/jxc755/projects/worktrees/galaxy/branch/history_pages/tool-data/shared/ucsc/chrom/?.len\", \"code\": \"$6!=\\\"NA\\\" && $7!=\\\"NA\\\"{print}\", \"infile\": null, \"variables\": [], \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "9.5+galaxy3",
+            "type": "tool",
+            "uuid": "1c407ea2-00fd-40de-a3b4-f22b3f25293c",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "4": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/volcanoplot/volcanoplot/4.0.3+galaxy0",
+            "errors": null,
+            "id": 4,
+            "input_connections": {
+                "input": {
+                    "id": 3,
+                    "output_name": "outfile"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Volcano Plot",
+            "outputs": [
+                {
+                    "name": "plot",
+                    "type": "pdf"
+                }
+            ],
+            "position": {
+                "left": 670,
+                "top": 10
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/volcanoplot/volcanoplot/4.0.3+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "3d5b9e4df7ba",
+                "name": "volcanoplot",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"__input_ext\": \"input\", \"chromInfo\": \"/Users/jxc755/projects/worktrees/galaxy/branch/history_pages/tool-data/shared/ucsc/chrom/?.len\", \"input\": null, \"labels\": {\"label_select\": \"none\", \"__current_case__\": 2}, \"lfc_thresh\": \"1.0\", \"out_options\": {\"rscript_out\": false}, \"plot_options\": {\"boxes\": false, \"title\": null, \"xlab\": null, \"ylab\": null, \"xmin\": null, \"xmax\": null, \"ymax\": null, \"legend\": null, \"legend_labs\": \"Down,Not Sig,Up\"}, \"shape_or_facet\": null, \"signif_thresh\": \"0.05\", \"with_header\": {\"header\": \"no\", \"__current_case__\": 2, \"fdr_col\": \"7\", \"pval_col\": \"6\", \"lfc_col\": \"3\", \"label_col\": \"1\", \"shape_col\": null}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "4.0.3+galaxy0",
+            "type": "tool",
+            "uuid": "cd7891a9-17fb-41aa-8b4f-5e8eaa04ae62",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "Volcano Plot PDF",
+                    "output_name": "plot",
+                    "uuid": "488eaafb-68c8-47a0-9345-bdd3c8b00b2d"
+                }
+            ]
+        }
+    },
+    "tags": [],
+    "uuid": "40f8a384-4f12-4cc6-8a43-085ec5a9fd63",
+    "version": 0
+}

--- a/content/pipelines/interview-to-galaxy/examples/UC3_ATAC_issue.md
+++ b/content/pipelines/interview-to-galaxy/examples/UC3_ATAC_issue.md
@@ -1,0 +1,86 @@
+# UC3 / Differential ATAC-seq accessibility — interview input
+
+> Pulled-down GitHub issue used as the **effective result of the INTERVIEW → GALAXY interview**
+> (the live interview mechanics are harness-owned and precede pipeline phase 1).
+> Source: galaxy-brain issue #14 (captured).
+> Paired aspirational target: `UC3_ATAC_extracted.ga` (extracted from a Galaxy history; **not human-validated**).
+
+---
+
+## Purpose
+
+Develop a Galaxy Notebooks paper/demo vignette for bulk differential ATAC-seq accessibility. This should use existing Galaxy Training Network ATAC analysis as scaffolding, but the issue belongs to `galaxy-brain` because the deliverable is a paper/demo notebook, not a direct training-material change.
+
+## Objective
+
+Show the conceptual jump from "call peaks in one ATAC-seq sample" to "count reads/fragments over a shared peak universe and test accessibility differences across biological replicates."
+
+## Why this is a useful demo deviation
+
+The existing ATAC-seq tutorial is single-sample GM12878-focused. It covers QC, trimming, Bowtie2 mapping, filtering, duplicate removal, insert-size QC, MACS2 peak calling, TSS/CTCF heatmaps, and pyGenomeTracks visualization. A differential-accessibility notebook can reuse the same tool ecosystem while adding a more paper-worthy analysis story: replicate-aware peak counts, DESeq2-style testing, volcano plots, and interpretation of condition-specific regulatory regions.
+
+## Existing analysis anchors
+
+- Existing ATAC-seq tutorial: https://training.galaxyproject.org/training-material/topics/epigenetics/tutorials/atac-seq/tutorial.html
+- Reuse current patterns for data import, ATAC QC context, BAM filtering, duplicate handling, insert-size QC, MACS2 peak calling, deepTools heatmaps, and pyGenomeTracks visualization.
+- The existing tutorial already notes that a fuller workflow can be compatible with replicates; this notebook fills that gap without re-teaching every preprocessing step.
+
+## Public data candidates
+
+Preferred MVP direction: use small prepared files from a public ENCODE-derived two-condition replicate dataset rather than full raw FASTQ/BAM processing.
+
+Candidate datasets to evaluate:
+
+- ENCODE NK-cell ATAC-seq stimulation contrast with duplicate accessions cited in community training material: untreated `ENCFF398QLV`, `ENCFF363HBZ`; cytokine-stimulated `ENCFF045OAB`, `ENCFF828ZPN`.
+- ENCODE GM12878 vs K562 ATAC-seq as a continuity-friendly cell-type contrast, since the existing tutorial already uses GM12878 context: GM12878 `ENCSR637XSC`; K562 `ENCSR868FGK`.
+
+Fallback: publish a tiny Zenodo bundle containing `union_peaks.bed`, a featureCounts-style count matrix, `sample_metadata.tsv`, optional bigWigs/narrowPeaks, and selected peak annotations. This still teaches real differential accessibility while keeping runtime workshop-feasible.
+
+## Notebook workflow plan
+
+1. Import prepared small datasets: count matrix or per-sample count files, `sample_metadata.tsv`, `union_peaks.bed`, and optional bigWigs/narrowPeaks.
+2. Explain the peak universe: merged/union reproducible peaks across conditions.
+3. Optional BAM-subset branch: create the union peak universe with concatenate/sort/merge interval tools, then convert intervals to SAF-like annotation.
+4. Optional BAM-subset branch: count fragments over union peaks with `featureCounts`.
+5. Run replicate QC using DESeq2 PCA/sample-distance outputs, or `multiBamSummary` plus `plotCorrelation` if BAMs are included.
+6. Run `DESeq2` with factor `condition`.
+7. Filter significant peaks, e.g. `padj < 0.05` and `abs(log2FoldChange) >= 1`.
+8. Create a volcano plot using the Galaxy Volcano Plot tool.
+9. Sort top condition-gained and condition-lost peaks.
+10. Visualize selected differential regions with deepTools heatmaps and optional pyGenomeTracks.
+
+## Expected paper/demo artifacts
+
+- `sample_metadata.tsv`: sample, condition, replicate, accession, source.
+- `union_peaks.bed`: shared peak universe with stable peak IDs.
+- Peak count matrix or featureCounts-style per-sample count tables.
+- DESeq2 result table with peak ID, base mean, log2 fold change, p-value, adjusted p-value.
+- Normalized and VST-normalized count outputs.
+- PCA plot and sample-distance heatmap.
+- Volcano plot of differential accessibility.
+- Table of top gained and top lost accessible regions.
+- Heatmap/profile over top differential peaks.
+- One genome-track figure showing a gained/lost peak near an interpretable gene or regulatory locus.
+
+## Scope and risks
+
+- Do not make learners or reviewers download full ENCODE BAM/FASTQ files for the MVP.
+- Do not introduce new Galaxy wrappers or unsupported ATAC-specific differential tools.
+- Avoid claiming peak presence/absence overlap alone is statistical differential accessibility.
+- Require at least two replicates per condition; state that two is minimal and three is preferable.
+- Keep peak-to-gene annotation light and optional, since regulatory target assignment is not trivial.
+- Keep the first version to one chromosome, selected loci, or a precomputed count matrix.
+- Link back to the existing ATAC analysis instead of re-teaching single-sample preprocessing.
+
+## Tasks
+
+- [ ] Choose primary dataset: ENCODE NK stimulation or GM12878 vs K562.
+- [ ] Generate or locate a small chr14/chr22 processed BAM/count/peak bundle.
+- [ ] Deposit the final demo bundle on Zenodo or otherwise use stable public URLs.
+- [ ] Draft notebook framing with differential-accessibility questions/objectives/key points.
+- [ ] Add a "relationship to existing ATAC-seq tutorial" section in the notebook narrative.
+- [ ] Add import, metadata, DESeq2, filtering, volcano, and visualization steps.
+- [ ] Add expected-output screenshots/figures.
+- [ ] Validate runtime on a standard Galaxy instance.
+- [ ] Keep optional raw/processed-BAM work separate from the count-matrix MVP.
+- [ ] Decide which tables/figures should feed directly into the Galaxy Notebooks manuscript.

--- a/content/pipelines/interview-to-galaxy/examples/UC3_NEXT_STEPS.md
+++ b/content/pipelines/interview-to-galaxy/examples/UC3_NEXT_STEPS.md
@@ -1,0 +1,90 @@
+# UC3 Next Steps — emit the filtered + ranked differential-peaks tables
+
+**Issue:** `UC3_ATAC_issue.md` (originally galaxy-brain issue #14).
+**For:** the agent that built the clean UC3 history. Handoff to push the
+differential-ATAC analysis from "great paper figures" to "complete *workflow*."
+
+## Why this handoff
+
+You optimized UC3 for the Galaxy Notebooks paper: a clean 5-step spine
+(counts collection + sample sheet → DESeq2 → `tp_awk` NA-filter → volcanoplot)
+that extracts with all rows seeded and forced the PDF-renderer contributions.
+That goal was met.
+
+But at the *workflow* level the headline scientific deliverable is missing. The
+issue (steps 7 and 9) calls for **filtering significant peaks** and **ranking
+top gained/lost** — and the current workflow does neither as data:
+
+- The lone `tp_awk` step is `$6!="NA" && $7!="NA"{print}` — an **NA-row strip**,
+  a prerequisite for volcanoplot, *not* the significance filter.
+- The significance thresholds (`padj < 0.05`, `|log2FC| >= 1`) are applied only
+  **inside the volcanoplot's coloring** (`signif_thresh`, `lfc_thresh`). So the
+  45,620 significant peaks exist as colored dots in a PDF, but **no workflow
+  output is the filtered table**, and nothing ranks top B-cell-gained vs
+  Eryth-gained. The actual answer to "which peaks changed" can't be sorted,
+  counted, or fed onward — only looked at.
+
+No new tools needed: `bgruening/text_processing` (`tp_awk`, sort) is already
+installed and in the spine. This is additive — don't disturb the existing
+DESeq2 / NA-filter / volcano path.
+
+## Step A — significance filter → significant-peaks table
+
+- Tool: `toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/9.5+galaxy3`.
+- Input: the **NA-stripped** DESeq2 table (the output of the existing `tp_awk`
+  step). Branch off it **in parallel with volcanoplot** — do *not* replace the
+  volcano's input, or you starve the volcano of the non-significant cloud and
+  it stops being a volcano.
+- Columns (headerless DESeq2 result): 1=peak_id, 2=baseMean, 3=log2FC, 4=lfcSE,
+  5=stat, 6=pvalue, **7=padj**.
+- awk (`padj < 0.05` AND `|log2FC| >= 1`):
+  ```awk
+  $7+0 < 0.05 && ($3+0 >= 1 || $3+0 <= -1) { print }
+  ```
+- Output to expose: **"Significant differential peaks"** — expected **45,620**
+  rows.
+
+## Step B — rank top gained / top lost
+
+Direction reminder (reference_level = Erythroblast): **LFC > 0 = B-cell-gained,
+LFC < 0 = Erythroblast-gained.** Confirm with a marker (MS4A1/CD20 chr11 is LFC>0).
+
+- Sort the significant table by `log2FC` (col 3) numerically. Use the Sort tool
+  (`tp_sort_header_tool`) or `tp_awk` piped through `sort -k3,3g`.
+- Emit two ranked tables (e.g. top 50 each):
+  - **Top B-cell-gained** — largest positive LFC (expect EBF1 +8.0, MS4A1 +7.3,
+    PAX5 +6.8, CD19 +4.0 near the top).
+  - **Top Eryth-gained** — most negative LFC (expect HBB ≈ −6.6, GATA1 ≈ −5.5
+    near the top).
+- Expose both as workflow outputs (issue step 9).
+
+## Step C — nearest-gene annotation (optional / stretch)
+
+Nearest-gene annotation is a possible "next." Keep it **light** per the issue's
+scope note (peak-to-gene assignment is not trivial):
+
+- Convert the top-peaks `peak_id` back to intervals (the Corces peak IDs encode
+  hg19 coordinates; or join against the union-peaks BED if available).
+- `bedtools closest` against an hg19 gene/TSS BED to attach a nearest-gene column.
+- Optional; do not block Steps A/B on it.
+
+## Verification (what "done" looks like)
+
+| Check | Expected |
+|---|---|
+| Workflow step count | grows from 5 → ~7–8 (filter + sort, plus optional annotate) |
+| Significant-peaks table | exposed output, **45,620** rows (padj<0.05, \|LFC\|≥1) |
+| Direction split | 34,873 B-cell-gained (LFC>0) / 10,747 Eryth-gained (LFC<0) |
+| Top-gained table markers | EBF1/MS4A1/PAX5/CD19 among top LFC>0 |
+| Top-lost table markers | HBB/GATA1 among top LFC<0 |
+| Volcano | unchanged — still fed the full non-NA table, not the filtered subset |
+| Re-extraction | new outputs exposed, **zero dangling**, report clean (hold to the same clean re-extraction standard) |
+
+## Scope / risks
+
+- **Preserve the volcano input.** Step A must branch off the NA-stripped table in
+  parallel; the volcano needs the full cloud to render correctly.
+- Verify column indices on your server (`output_selector`/version can shift cols
+  — confirm 3=log2FC, 6=pvalue, 7=padj from the result header).
+- Keep nearest-gene (Step C) optional and light; don't let it expand into a
+  pangenomic annotation project.

--- a/content/pipelines/interview-to-galaxy/scenarios.md
+++ b/content/pipelines/interview-to-galaxy/scenarios.md
@@ -1,0 +1,102 @@
+# INTERVIEW → GALAXY pipeline scenarios
+
+Concrete end-to-end journeys for the INTERVIEW → GALAXY pipeline. A pipeline
+scenario names the journey input **once**; each member Mold's `eval.md` applies
+to its step's output as the journey advances (it does not re-list the per-Mold
+scenarios).
+
+All fixtures for these cases are vendored under `examples/` beside this file, so
+the cases are self-contained — no GitHub fetch or external checkout is required
+to drive a run. Each `examples/*_issue.md` carries a provenance header noting the
+galaxy-brain issue it was captured from, but the captured text is the binding
+fixture.
+
+The live interview is harness-owned and precedes phase 1
+([[interview-to-freeform-summary]]). For these cases the interview result is
+**supplied as a saved issue body** — a real, already-elaborated demo brief that
+stands in for a normalized interview transcript — so the journey can be driven
+from a fixed input.
+
+Each case also names an **aspirational target**: a `.ga` workflow extracted from
+a hand-built Galaxy history. These targets are **not human-validated** and are
+*not* a hard oracle. They are a compare-and-contrast reference: the run may match
+the target, may exceed it (a cleaner or more complete realization), or may not
+reach its shape at all. Divergence is the signal worth inspecting, not an
+automatic failure. Judge the run against the issue's load-bearing scientific
+intent first; treat the `.ga` as one plausible answer to hold the run beside.
+
+These targets are also **known-incomplete, by design-of-the-moment**. Each was
+built by a paper-focused agent optimizing for in-notebook figures and clean
+notebook→workflow extraction, so each drops workflow-level deliverables its issue
+calls for (catalogued per case below, with handoffs to close the gaps in the
+`examples/UC1_NEXT_STEPS.md` / `examples/UC3_NEXT_STEPS.md` notes beside the
+`.ga`). They aren't good enough yet; we will get there. So don't treat target
+parity as the bar — a run that fills the catalogued gaps is *better* than the
+current target.
+
+## Case: MRSA mobile-AMR context across isolates
+
+- fixture: `examples/UC1_MRSA_issue.md` as the interview result (captured from
+  galaxy-brain issue #12). It names a 3–4 isolate complete-assembly FASTA
+  collection ("MRSA isolate assemblies"), `staramr` for ARG/plasmid/MLST calls,
+  ISEScan and IntegronFinder for mobile elements, table→interval/GFF3 reshaping,
+  ARG mobile-context classification (plasmid / IS-adjacent / integron-associated
+  / SCCmec candidate), and per-isolate summary tables plus an ARG heatmap.
+- aspirational target (unvalidated): `examples/UC1_MRSA_extracted.ga` — a 14-step
+  realization: collection input → `staramr` + `Integron Finder` + `ISEScan` →
+  `Text reformatting` (awk) reshaping → `bedtools SortBED` ×2 →
+  `bedtools ClosestBed` (ARG↔mobile-element distance, standing in for the
+  mobile-context classification) → `Collapse Collection` → `heatmap2` ×2.
+- expect: the journey produces a gxformat2 workflow that validates and
+  round-trips, with the isolate-assembly collection as the primary input, the
+  AMR call (`staramr`) and at least one mobile-element caller (ISEScan /
+  IntegronFinder) preserved as steps, and the mobile-context question carried
+  through as a real step or an explicit design decision rather than silently
+  dropped; a per-isolate ARG summary/heatmap surfaces as an output.
+- compare-and-contrast against the target: does the run reach the
+  closest-feature distance idiom the `.ga` uses for mobile context, or solve it
+  another way? Note tools the run invents or drops versus the target.
+- known limitation of the target (bonus points to beat it): the issue calls for
+  `Bakta` whole-genome annotation and a JBrowse locus view, but the hand-built
+  history that produced `UC1_MRSA_extracted.ga` **never reached those stages** —
+  Bakta was deliberately excluded as "non-extractable enrichment" and JBrowse was
+  left as a TODO. Both tools are already installed on the reference server. So a
+  run that pulls `Bakta` and/or a JBrowse locus view in (and validates) is
+  exceeding even the manual attempt, not scope creep — credit it as a stretch
+  goal met. Closing this gap on the manual build is the work in
+  `examples/UC1_NEXT_STEPS.md`.
+
+## Case: differential ATAC-seq accessibility
+
+- fixture: `examples/UC3_ATAC_issue.md` as the interview result (captured from
+  galaxy-brain issue #14). The count-matrix MVP path it describes: import a
+  per-sample count collection plus a `sample_metadata.tsv`, run `DESeq2` with
+  factor `condition`, filter significant peaks (`padj < 0.05`,
+  `abs(log2FoldChange) >= 1`), and draw a volcano plot — with optional union-peak
+  / `featureCounts` and deepTools branches held out of the MVP.
+- aspirational target (unvalidated): `examples/UC3_ATAC_extracted.ga` — a 5-step
+  realization of exactly that MVP: `ATAC sample metadata` input +
+  `ATAC counts` collection input → `DESeq2` → `Text reformatting` (awk filter)
+  → `Volcano Plot`.
+- expect: the journey produces a gxformat2 workflow that validates and
+  round-trips, with the counts collection and sample metadata as inputs, `DESeq2`
+  keyed on the `condition` factor, the significance filter applied with the
+  issue's thresholds (or those thresholds surfaced as a parameter/decision), and
+  a volcano plot as an output. The MVP scope (count-matrix in, no raw-read
+  preprocessing) is honored, not silently widened back to full FASTQ→peak
+  processing.
+- compare-and-contrast against the target: the `.ga` is a tight 5-step MVP — does
+  the run land near that, or pull in the optional union-peak / `featureCounts`
+  and deepTools-QC branches the issue flags as out-of-MVP? Treat extra QC/PCA
+  steps as a deliberate enrichment to weigh, not an automatic win; flag any
+  thresholds or the `condition` factor that get lost between briefs.
+- known limitation of the target (bonus points to beat it): the target's only
+  intermediate step (`Text reformatting`) is an **NA-row strip**, not the
+  significance filter the issue asks for (step 7) — the significance thresholds
+  (`padj < 0.05`, `|log2FoldChange| >= 1`) are applied only *inside* the Volcano
+  Plot's coloring, so the workflow **emits no filtered or ranked
+  differentially-accessible-peaks table** and no top-gained/lost ranking (issue
+  steps 7 + 9). The actual differential call is trapped in a PDF rather than
+  output as data. A run that materializes the filtered/ranked significant-peaks
+  table as a workflow output is *better* than the target. Closing this gap on the
+  manual build is the work in `examples/UC3_NEXT_STEPS.md`.

--- a/packages/build-cli/src/commands/validate.ts
+++ b/packages/build-cli/src/commands/validate.ts
@@ -827,6 +827,8 @@ const PIPELINE_TOP_FILES = new Set([
   "usage.md",
   "README.md",
 ]);
+// Allowlisted subdirectory: local scenario fixtures referenced by scenarios.md.
+const PIPELINE_TOP_DIRS = new Set(["examples"]);
 
 const REFINEMENT_DECISION_VOCAB = new Set([
   "keep",
@@ -995,11 +997,13 @@ function validatePipelineSourceLayout(
     for (const child of readdirSync(pdir).sort()) {
       const childPath = path.join(pdir, child);
       if (statSync(childPath).isDirectory()) {
-        findings.push({
-          path: childPath,
-          severity: "warning",
-          message: `unexpected directory in pipeline source: ${child}`,
-        });
+        if (!PIPELINE_TOP_DIRS.has(child)) {
+          findings.push({
+            path: childPath,
+            severity: "warning",
+            message: `unexpected directory in pipeline source: ${child}`,
+          });
+        }
       } else if (!PIPELINE_TOP_FILES.has(child)) {
         findings.push({
           path: childPath,

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -566,6 +566,22 @@ describe("validateDirectory (cross-file)", () => {
     expect(after.warnings).toBeGreaterThan(before);
   });
 
+  it("does not warn on an examples/ subdir of scenario fixtures in a pipeline directory", () => {
+    writeFm(path.join(dir, "molds/mold-a/index.md"), {
+      ...baseRequired({ type: "mold", tags: ["mold"], name: "mold-a", axis: "generic" }),
+    });
+    writeFm(path.join(dir, "pipelines/p/index.md"), {
+      ...baseRequired({ type: "pipeline", tags: ["pipeline"], title: "P", phases: [{ mold: "[[mold-a]]" }] }),
+    });
+    const before = validateDirectory({ directory: dir, schemaPath: SCHEMA_PATH, tagsPath: TAGS_PATH }).warnings;
+    mkdirSync(path.join(dir, "pipelines/p/examples"), { recursive: true });
+    writeFileSync(path.join(dir, "pipelines/p/examples/UC_issue.md"), "# Interview input\n\nno frontmatter\n");
+    writeFileSync(path.join(dir, "pipelines/p/examples/UC_extracted.ga"), '{"a_galaxy_workflow":"true"}\n');
+    const after = validateDirectory({ directory: dir, schemaPath: SCHEMA_PATH, tagsPath: TAGS_PATH });
+    expect(after.errors).toBe(0);
+    expect(after.warnings).toBe(before);
+  });
+
   it("warns on a flat .md file under content/pipelines/", () => {
     writeFm(path.join(dir, "molds/mold-a/index.md"), {
       ...baseRequired({ type: "mold", tags: ["mold"], name: "mold-a", axis: "generic" }),


### PR DESCRIPTION
Makes `content/pipelines/interview-to-galaxy/scenarios.md` self-contained so a run can be driven without a GitHub fetch or a galaxy-brain checkout on disk.

## What changed

- **Vendored the UC1/UC3 fixtures** into a new `content/pipelines/interview-to-galaxy/examples/`: the two interview-input issue bodies, the two extracted `.ga` aspirational targets, and the two next-steps gap-closing notes.
- **Rewrote `scenarios.md`** to bind those local `examples/` paths instead of `vault/projects/...` laptop paths and `github.com/.../issues/...` URLs. The GitHub origin survives only as a one-line provenance note ("captured from galaxy-brain issue #12/#14"), not a fetch dependency.
- **Trimmed dangling refs** from the vendored next-steps and issue notes — `*_RECIPE.md` section citations, tool-install ymls, Galaxy history/page/workflow IDs, and issue URLs — folding the load-bearing detail (Bakta DB gotchas, expected row counts, column-index caveats) inline rather than pointing at files that aren't in this repo.
- **Validator:** added an `examples/` carve-out for pipeline source dirs (mirrors the existing mold `examples/` allowance) so the vendored fixtures don't trip the "unexpected directory" warning, plus a test for the carve-out.

One `vault/papers/...` mention remains inside `UC1_MRSA_issue.md`'s own `## Tasks` checklist — that's faithful captured issue-body content (the author's TODO), not a resolvable dependency, so it was left intact rather than rewriting the snapshot.

## Verification

- `npm run validate` → 0 errors, warning count unchanged (none on this pipeline)
- `vitest tests/validate.test.ts` → 77/77 pass
- `tsc --noEmit` on `packages/build-cli` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)