### PR TITLE
Fix Mold health: refresh eval check, add scenarios item

### DIFF
--- a/site/src/components/HealthPanel.astro
+++ b/site/src/components/HealthPanel.astro
@@ -3,6 +3,9 @@ interface HealthItem {
   label: string;
   state: 'ok' | 'warn' | 'error';
   detail: string;
+  help?: string;
+  href?: string;
+  hrefLabel?: string;
 }
 
 interface Props {
@@ -28,7 +31,9 @@ const maxColumnClass = maxColumns === 3 ? ' health-grid-max-3' : '';
         <span class="health-dot" aria-hidden="true"></span>
         <div>
           <strong>{item.label}</strong>
+          {item.help && <p class="health-help">{item.help}</p>}
           <p>{item.detail}</p>
+          {item.href && <a class="health-link" href={item.href}>{item.hrefLabel ?? 'View artifact'} ↗</a>}
         </div>
       </li>
     ))}
@@ -99,6 +104,15 @@ const maxColumnClass = maxColumns === 3 ? ' health-grid-max-3' : '';
     margin: 0.15rem 0 0;
     font-size: 0.78rem;
     color: var(--color-text-muted);
+  }
+  .health-help {
+    font-style: italic;
+  }
+  .health-link {
+    display: inline-block;
+    margin-top: 0.3rem;
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
   }
   .health-ok .health-dot,
   .health-pill.health-ok {

--- a/site/src/components/MoldHealth.astro
+++ b/site/src/components/MoldHealth.astro
@@ -15,13 +15,24 @@ interface HealthItem {
   label: string;
   state: 'ok' | 'warn' | 'error';
   detail: string;
+  help?: string;
+  href?: string;
+  hrefLabel?: string;
 }
 
 const { entry, linkMap, entryById } = Astro.props;
 const data = entry.data as any;
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const evalPath = fileURLToPath(new URL(`../../../content/${entry.id}/eval.md`, import.meta.url));
 const hasEval = existsSync(evalPath);
+const scenariosPath = fileURLToPath(new URL(`../../../content/${entry.id}/scenarios.md`, import.meta.url));
+const hasScenarios = existsSync(scenariosPath);
 const moldDir = fileURLToPath(new URL(`../../../content/${entry.id}/`, import.meta.url));
+
+const EVAL_HELP = 'Abstract oracle: fixture-independent property checks any run must satisfy.';
+const SCENARIOS_HELP = 'Concrete cases: fixtures bound to expected values, run against the eval properties.';
+const evalHref = `${base}/raw/${entry.id}/eval.md`;
+const scenariosHref = `${base}/raw/${entry.id}/scenarios.md`;
 
 function hasAxisSpecifier(): boolean {
   if (data.axis === 'source-specific') return Boolean(data.source);
@@ -83,14 +94,34 @@ function hasFrontmatter(filePath: string): boolean {
 }
 
 function evalDetail(): HealthItem {
+  const labelled = { label: 'Eval plan', help: EVAL_HELP } as const;
   if (!hasEval) {
-    return { label: 'Eval plan', state: 'warn', detail: 'eval.md not written yet.' };
+    return { ...labelled, state: 'warn', detail: 'eval.md not written yet.' };
   }
+  const item = { ...labelled, href: evalHref, hrefLabel: 'eval.md' };
   const body = readFileSync(evalPath, 'utf8');
+  const hasProperty = /^##\s+Property:/m.test(body);
   const hasCase = /^##\s+Case:/m.test(body);
   const hasCheck = /\b(deterministic|llm-judged)\b/.test(body);
-  if (hasCase && hasCheck) return { label: 'Eval plan', state: 'ok', detail: 'eval.md declares cases and check type.' };
-  return { label: 'Eval plan', state: 'warn', detail: 'eval.md should include a Case section and deterministic or llm-judged check.' };
+  if (hasCase) {
+    return { ...item, state: 'warn', detail: 'eval.md has a Case section — concrete cases belong in scenarios.md.' };
+  }
+  if (hasProperty && hasCheck) return { ...item, state: 'ok', detail: 'eval.md declares properties and check type.' };
+  return { ...item, state: 'warn', detail: 'eval.md should declare a Property section and a deterministic or llm-judged check.' };
+}
+
+function scenariosDetail(): HealthItem {
+  const labelled = { label: 'Scenarios', help: SCENARIOS_HELP } as const;
+  if (!hasScenarios) {
+    return { ...labelled, state: 'warn', detail: 'scenarios.md not written yet.' };
+  }
+  const item = { ...labelled, href: scenariosHref, hrefLabel: 'scenarios.md' };
+  const body = readFileSync(scenariosPath, 'utf8');
+  const hasCase = /^##\s+Case:/m.test(body);
+  const hasFixture = /\bfixture\b/i.test(body);
+  if (hasCase && hasFixture) return { ...item, state: 'ok', detail: 'scenarios.md declares cases bound to fixtures.' };
+  if (hasCase) return { ...item, state: 'warn', detail: 'scenarios.md cases should bind a fixture.' };
+  return { ...item, state: 'warn', detail: 'scenarios.md should declare at least one Case section.' };
 }
 
 const nonIndexFrontmatter = listMarkdownFiles(moldDir)
@@ -109,6 +140,7 @@ const items: HealthItem[] = [
     detail: hasAxisSpecifier() ? `${data.axis} fields are coherent.` : `${data.axis} Mold is missing its required specifier.`,
   },
   evalDetail(),
+  scenariosDetail(),
   ...referenceFindings(),
 ];
 

--- a/site/src/pages/raw/[...slug].md.ts
+++ b/site/src/pages/raw/[...slug].md.ts
@@ -1,17 +1,35 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import type { APIRoute, GetStaticPaths } from 'astro';
 import { getCollection } from 'astro:content';
 
+// Sibling artifacts served alongside a directory note's index.md.
+const SIBLINGS = ['eval', 'scenarios'] as const;
+
 export const getStaticPaths: GetStaticPaths = async () => {
   const entries = await getCollection('content');
-  return entries.map(entry => ({
+  const paths = entries.map(entry => ({
     params: { slug: entry.id },
-    props: { entry },
+    props: { body: entry.body ?? '' },
   }));
+  for (const entry of entries) {
+    const data = entry.data as any;
+    if (data.type !== 'mold' && data.type !== 'pipeline') continue;
+    for (const sib of SIBLINGS) {
+      const sibPath = fileURLToPath(new URL(`../../../../content/${entry.id}/${sib}.md`, import.meta.url));
+      if (!existsSync(sibPath)) continue;
+      paths.push({
+        params: { slug: `${entry.id}/${sib}` },
+        props: { body: readFileSync(sibPath, 'utf8') },
+      });
+    }
+  }
+  return paths;
 };
 
 export const GET: APIRoute = ({ props }) => {
-  const { entry } = props as { entry: { body?: string } };
-  return new Response(entry.body ?? '', {
+  const { body } = props as { body: string };
+  return new Response(body ?? '', {
     headers: { 'Content-Type': 'text/plain; charset=utf-8' },
   });
 };


### PR DESCRIPTION
> Posted by Claude (AI assistant) on behalf of @jmchilton — not authored by them personally.

Closes #302.

## Problem

Two defects in the Mold health display:

1. **Stale eval check** — `MoldHealth.astro`'s `evalDetail()` tested `eval.md` for `## Case:`, but the recent migration moved cases to `scenarios.md` (`eval.md` now uses `## Property:`). Every Mold was showing a false `warn`.
2. **No scenarios item** — `scenarios.md` health was not surfaced at all.

Both displays were also missing any description of what they are or links to the underlying artifacts.

## Changes

- `MoldHealth.astro` — eval check now looks for `## Property:` + a deterministic/llm-judged check, and warns on a stray `## Case:` (mirrors the validator). Added a **Scenarios** item (`## Case:` + fixture binding).
- Both items now carry a one-line description (eval = abstract oracle / property checks; scenarios = concrete fixture-bound cases) and a link to the artifact (`eval.md ↗` / `scenarios.md ↗`).
- `raw/[...slug].md.ts` — extended to serve sibling `eval.md`/`scenarios.md` for molds and pipelines at `/raw/<id>/eval.md`, so the links resolve on any deploy (no branch pinning).
- `HealthPanel.astro` — optional `help`/`href`/`hrefLabel` fields (backward-compatible; PatternHealth unaffected).

## Verification

- `astro build` — 313 pages, raw siblings emitted, eval+scenarios render `ok` with help + links.
- `astro check` — 0 errors.

## Out of scope

The "Source layout" item flags `error` on molds with `refinements/` journal entries + `changes.md` (both carry frontmatter by design) — a pre-existing false-positive in a separate check, left untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)