### PR TITLE
Add missing pipeline casts + eval polish from INTERVIEW→GALAXY run

### DIFF
--- a/casts/claude/skills/_emulated-runs/uc1-mrsa-interview/concrete-subset.gxwf.yml
+++ b/casts/claude/skills/_emulated-runs/uc1-mrsa-interview/concrete-subset.gxwf.yml
@@ -1,0 +1,62 @@
+class: GalaxyWorkflow
+label: MRSA mobile-AMR context across isolates
+doc: |
+  Comparative mobile-AMR analysis across 3-4 MRSA isolate assemblies. For each
+  isolate: call ARGs/plasmids/MLST (staramr) and mobile elements (ISEScan,
+  IntegronFinder), reshape calls to intervals, compute each ARG's nearest mobile
+  element + distance, classify mobile context, and collapse to a per-isolate ARG
+  matrix + heatmap. Topology settled here; wrapper-tier (tool_id/tool_state/port
+  names) deferred to the per-step loop. Nearest IWC exemplar:
+  bacterial_genomics/amr_gene_detection (staramr core reused; mobile-element and
+  interval-distance half has no IWC analog).
+inputs:
+  - id: MRSA isolate assemblies
+    label: MRSA isolate assemblies
+    type: collection
+    collection_type: list
+    optional: false
+    format:
+      - fasta
+    doc: 3-4 complete isolate assemblies (combined chromosome+plasmid FASTA), one per isolate. List element identifier = strain name; carried through every map-over step.
+  - id: StarAMR database
+    label: StarAMR database
+    type: string
+    optional: false
+    doc: staramr database selection (ResFinder/PointFinder/PlasmidFinder). Surfaced as input because AMR calls are DB-version dependent (source constraint).
+  - id: Species for point mutation analysis
+    label: Species for point mutation analysis
+    type: string
+    optional: true
+    doc: PointFinder organism for staramr. Source did not pin a species; for MRSA this is Staphylococcus aureus, left as an explicit input rather than hard-coded.
+  - id: isolate metadata
+    label: isolate metadata
+    type: data
+    optional: true
+    format:
+      - tabular
+    doc: Optional per-isolate metadata TSV (strain/year/source/accessions/genome size). Open question whether workflow input or hand-curated sidecar; modeled optional.
+outputs:
+  - id: integrons
+    label: integrons
+    outputSource: integronfinder/integrons_table
+steps:
+  - id: integronfinder
+    label: integronfinder
+    tool_id: toolshed.g2.bx.psu.edu/repos/iuc/integron_finder/integron_finder/2.0.5+galaxy1
+    tool_version: 2.0.5+galaxy1
+    tool_shed_repository:
+      changeset_revision: 5429646e486d
+      name: integron_finder
+      owner: iuc
+      tool_shed: toolshed.g2.bx.psu.edu
+    doc: Integron detection, mapped over the isolate list.
+    in:
+      - id: sequence
+        source: MRSA isolate assemblies
+    out:
+      - id: integrons_table
+        rename: integrons_table
+    tool_state:
+      sequence:
+        __class__: ConnectedValue
+tags: []

--- a/casts/claude/skills/_emulated-runs/uc1-mrsa-interview/freeform-galaxy-data-flow.md
+++ b/casts/claude/skills/_emulated-runs/uc1-mrsa-interview/freeform-galaxy-data-flow.md
@@ -1,0 +1,100 @@
+# freeform-galaxy-data-flow: MRSA mobile-AMR context across isolates
+
+> Artifact id: `freeform-galaxy-data-flow`. Produced by
+> `freeform-summary-to-galaxy-data-flow` from `freeform-summary.md` +
+> `freeform-galaxy-interface.md`. An **abstract** target-shaped DAG: operations,
+> map/reduce, shape changes, unresolved tool needs. Not gxformat2; does not
+> resolve exact Tool Shed tools.
+
+## Abstract DAG (nodes + edges)
+
+```
+[in] MRSA isolate assemblies (list<fasta>, keyed by isolate)
+[in] isolate metadata (tabular, optional)
+
+ A. staramr           map-over list  → per-isolate {summary, detailed, resfinder, plasmidfinder, mlst}
+ B. ISEScan           map-over list  → per-isolate IS calls (tabular/GFF)
+ C. IntegronFinder    map-over list  → per-isolate integron calls (tabular/GFF)
+ D. Bakta (optional)  map-over list  → per-isolate annotation        [de-scoped enrichment]
+
+ E. ARG→intervals     reshape: resfinder.tsv → BED/interval (ARG coords)   [tabular→interval bridge]
+ F. IS→intervals      reshape: ISEScan → BED/interval
+ G. integron→intervals reshape: IntegronFinder → BED/interval
+       (E,F,G are the "table→interval/GFF3" reshaping the source names without a tool)
+
+ H. sort intervals    coordinate-aware sort on E,F,G                      [precondition for closest]
+ I. nearest-feature   ARG-intervals vs (IS ∪ integron) intervals,
+                       per isolate → ARG + nearest mobile element + DISTANCE
+ J. classify context  label each ARG: plasmid-located | IS-adjacent |
+                       integron-associated | SCCmec-candidate | unclassified  [RULES UNDEFINED]
+
+ K. collapse/pivot     per-isolate ARG calls → wide matrix keyed by isolate  [reduction]
+ L. heatmap            matrix → ARG-by-isolate heatmap image
+ (L') matrix/dotplot   plasmid/mobile-element calls by isolate
+
+[out] staramr_summary, staramr_resfinder, staramr_plasmidfinder,
+      is_elements, integrons, arg_mobile_context (=J), arg_heatmap (=L),
+      mobile_element_matrix (=K/L')
+```
+
+## Collection map / reduce choices
+
+- **Map-over** the `list` collection for A–G and the sort step H: every caller and
+  reshape runs once per isolate, identifier preserved. This is plain `list`
+  map-over — no paired/nested semantics.
+- **Identifier synchronization** is load-bearing: the isolate name must ride
+  through reshape (E–G) and the nearest-feature join (I) so the mobile-context
+  table and the final matrix stay keyed by isolate. Re-attach the identifier after
+  any tabular reshape that drops it.
+- **Reduction** at step K: collapse the per-isolate ARG calls into one
+  isolate-indexed wide table — the `tabular-pivot-collection-to-wide` /
+  Collapse-Collection idiom — feeding the heatmap. The isolate column must survive
+  the reduction.
+
+## Shape-changing placeholder steps
+
+- **E–G tabular→interval bridge** (shape change: tabular → interval/BED). Tool
+  unresolved; source says "existing GTN table-processing patterns". Likely an
+  awk/Text-reformatting projection of coordinate columns into BED.
+- **H coordinate-aware sort** — note: IWC corpus sorts intervals with tabular
+  `sort1`, but interval-algebra closest expects coordinate-sorted BED, so a
+  BED-aware sort precedes I. (Corpus-grounded caveat from the interval patterns.)
+- **I nearest-feature + distance** — this is the **mobile-context computation**.
+  Per the Foundry interval-patterns note this "nearest feature + distance"
+  operation is a **corpus gap**: no IWC exemplar, no recurring pattern page. The
+  natural tool is `bedtools closest` (`-d` for signed/absolute distance) from the
+  `iuc/bedtools` suite. Reach for it directly as an unresolved tool need — don't
+  expect a pattern page to cover it.
+- **J classify** — placeholder. Maps (distance to nearest IS/integron, replicon
+  membership from plasmidfinder, SCCmec locus overlap) → a context class. **The
+  source does not define the rules or cutoffs**; this stays an abstract
+  classification node with undefined thresholds (open question), not a concrete
+  step.
+
+## Unresolved Galaxy tool needs (abstract, with shapes)
+
+| op | in shape | out shape | confidence | note |
+|---|---|---|---|---|
+| ARG/plasmid/MLST call | fasta (map) | tabular collection | high | `staramr` named |
+| IS call | fasta (map) | tabular/GFF | high | `ISEScan` named |
+| integron call | fasta (map) | tabular/GFF | high | `IntegronFinder` named |
+| table→interval reshape | tabular | BED/interval | med | tool unnamed; awk/Text-reformat candidate |
+| coordinate sort | BED | sorted BED | med | BED-aware sort (SortBED-style) |
+| nearest-feature+distance | 2× sorted BED | tabular (ARG, mobile elt, distance) | med | corpus gap → `bedtools closest -d` |
+| context classify | tabular | tabular (+ class col) | low | rules undefined |
+| collapse to matrix | tabular collection | wide tabular | high | pivot-collection-to-wide / Collapse Collection |
+| heatmap | matrix | image | med | plotting tool unresolved (heatmap-style) |
+
+## Confidence / open questions
+
+- High confidence on the call layer (A–C) and the map-over/identifier spine.
+- Medium on the reshape→sort→closest interval chain: the *operations* are clear
+  and corpus-grounded, the exact tools are not pinned (correctly deferred to
+  template/implement).
+- **Low confidence on J (classify):** rules and distance cutoffs are undefined in
+  the source. Carry as the workflow's central open design question, not a decided
+  step. A defensible MVP: emit the nearest-feature+distance table
+  (`arg_mobile_context`) and let "context class" be a downstream/notebook
+  labeling, rather than hard-coding thresholds the source never gave.
+- Bakta (D) and JBrowse remain de-scoped enrichment/figure layers, consistent
+  with the interface brief.

--- a/casts/claude/skills/_emulated-runs/uc1-mrsa-interview/freeform-galaxy-interface.md
+++ b/casts/claude/skills/_emulated-runs/uc1-mrsa-interview/freeform-galaxy-interface.md
@@ -1,0 +1,72 @@
+# freeform-galaxy-interface: MRSA mobile-AMR context across isolates
+
+> Artifact id: `freeform-galaxy-interface`. Produced by
+> `freeform-summary-to-galaxy-interface` from `freeform-summary.md`. A design
+> handoff — Galaxy workflow inputs/outputs/labels — not a gxformat2 skeleton.
+
+## Workflow inputs
+
+| label | Galaxy input type | datatype | notes |
+|---|---|---|---|
+| `MRSA isolate assemblies` | dataset collection, **`list`** | `fasta` | One combined chromosome+plasmid assembly per isolate. List element identifier = isolate/strain name (e.g. `KUN1163`). 3–4 elements. This is the primary scientific input. |
+| `isolate metadata` | dataset (single) | `tabular` (TSV) | strain, year, source, symptom, chromosome accession, plasmid accession(s), genome size. **Confidence: medium** — may be a workflow input or a hand-curated sidecar (open question carried from summary). Modeled as an optional input so the workflow can join metadata into summary tables; not required for the AMR/mobile-element calls. |
+
+Shape rationale: per-isolate granularity with one file each → a `list` collection,
+not `paired`/`list:paired` (assemblies are single FASTA, not read mates). Every
+caller (`staramr`, `ISEScan`, `IntegronFinder`, `Bakta`) maps over the list,
+preserving the isolate identifier downstream — this is what makes the comparison
+addressable per isolate.
+
+## Workflow outputs (stable labels, testable)
+
+Workflow-producible (should carry stable output labels):
+
+| label | from | datatype | role |
+|---|---|---|---|
+| `staramr_summary` | staramr | tabular collection / merged tabular | per-isolate ARG/plasmid/MLST summary; **primary payload** |
+| `staramr_resfinder` | staramr | tabular | ARG hits w/ coordinates; feeds mobile-context join |
+| `staramr_plasmidfinder` | staramr | tabular | replicon calls; feeds plasmid-context |
+| `is_elements` | ISEScan | tabular/GFF | insertion-sequence coordinates |
+| `integrons` | IntegronFinder | tabular/GFF | integron coordinates |
+| `arg_mobile_context` | reshape + classify steps | tabular | the novel deliverable: ARG × nearest-mobile-element/distance/context-class |
+| `arg_heatmap` | plotting step | image (png/pdf) | ARG presence by isolate |
+| `mobile_element_matrix` | plotting/collapse | tabular or image | plasmid/IS/integron calls by isolate |
+
+Figure-/notebook-layer (flagged, **not forced into the workflow interface**):
+
+- **JBrowse locus view** — interactive; better as a notebook figure or a terminal
+  visualization step than a testable workflow output. Flagged, not promoted.
+- Stacked-bar of ARG counts by context, locus diagrams — narrative figures;
+  candidate workflow outputs only if a plotting tool is wired, otherwise notebook.
+
+Checkpoint outputs worth promoting for tests: `staramr_summary` (deterministic
+given pinned DB), `is_elements`, `integrons`, and `arg_mobile_context` — these
+are the data spine a workflow test would assert on.
+
+## Per-isolate identity
+
+The list element identifier (strain name) must survive through every map-over
+step so the final tables and heatmap are keyed by isolate. Any reduction
+(collapse to a single matrix) must retain the isolate column. This is the
+load-bearing interface constraint behind the whole comparative story.
+
+## Source-summary provenance
+
+- Primary input + collection name `MRSA isolate assemblies`: summary §Inputs.
+- Tools and output set: summary §Tools, §Outputs.
+- Bakta and JBrowse: named in source but de-scoped here from the testable
+  interface (Bakta = optional enrichment; JBrowse = figure layer).
+
+## Confidence / open questions (carried, not resolved)
+
+- **Mobile-context classification** is an output the source names but whose rules
+  are undefined. Modeled as an output label (`arg_mobile_context`) with the
+  computation deferred to data-flow/template; thresholds NOT invented here.
+- table→interval/GFF3 **reshaping tool** unspecified — interface names the output
+  shape (intervals/GFF) but not the tool.
+- `isolate metadata` input vs sidecar: unresolved (see table note).
+- Whether `staramr_summary` is best exposed as a per-isolate collection or a
+  single merged table is a data-flow decision; interface exposes both the
+  collection and a mergeable form.
+- Bakta inclusion (all isolates vs subset) deferred; not on the critical
+  interface path.

--- a/casts/claude/skills/_emulated-runs/uc1-mrsa-interview/freeform-summary.md
+++ b/casts/claude/skills/_emulated-runs/uc1-mrsa-interview/freeform-summary.md
@@ -1,0 +1,139 @@
+# freeform-summary: MRSA mobile-AMR context across isolates
+
+> Artifact id: `freeform-summary`. Produced by `interview-to-freeform-summary`
+> from the supplied interview result (UC1_MRSA_issue.md, captured from
+> galaxy-brain issue #12). Source evidence with explicit uncertainty — not a
+> fully specified workflow.
+
+## Workflow intent
+
+Build a comparative mobile-AMR analysis across 3–4 related MRSA isolates: for
+each isolate, call antimicrobial-resistance genes (ARGs) and mobile genetic
+elements, then determine **which resistance genes sit in mobile genomic
+contexts** — plasmid-located, insertion-sequence (IS)-adjacent,
+integron-associated, SCCmec-region candidate, or unclassified — and summarize
+how ARG content and mobile context differ between isolates.
+
+The user frames this as an interpretive comparison over already-assembled
+genomes, deliberately *not* a from-reads pipeline.
+
+## Methods / algorithms (in the order the user describes them)
+
+1. Import 3–4 complete isolate assemblies (one combined chromosome+plasmid FASTA
+   per isolate).
+2. Assemble them into a Galaxy dataset collection named `MRSA isolate assemblies`.
+3. Run ARG / plasmid / MLST calling over the collection (`staramr`), collecting
+   `summary.tsv`, `detailed_summary.tsv`, `resfinder.tsv`, `plasmidfinder.tsv`,
+   `mlst.tsv`.
+4. Run whole-genome annotation (`Bakta`) on the isolates, or a representative
+   subset if runtime is prohibitive.
+5. Run mobile-element callers — `ISEScan` (insertion sequences) and
+   `IntegronFinder` (integrons) — on the assemblies.
+6. Reshape the AMR, plasmid, IS, and integron outputs into interval tables or
+   GFF3 (the user points at "existing GTN table-processing patterns" without
+   naming the specific tool).
+7. Classify each ARG's context as plasmid-located, IS-adjacent,
+   integron-associated, SCCmec-region candidate, or unclassified.
+8. Build a JBrowse view for one representative mobile-AMR locus plus one
+   contrasting isolate.
+9. Export summary TSVs and notebook-ready figures.
+
+## Tools
+
+- **`staramr`** — ARG detection + plasmid replicon (PlasmidFinder) + MLST in one
+  call. Named explicitly; load-bearing.
+- **`Bakta`** — whole-genome annotation. Named; flagged as optionally subsetted
+  for runtime.
+- **`ISEScan`** — insertion-sequence detection. Named.
+- **`IntegronFinder`** — integron detection. Named.
+- **`PlasmidFinder`** — replicon typing; listed among anchor tools, but in
+  practice subsumed by `staramr`'s plasmidfinder.tsv output.
+- **table-to-GFF3 / interval reshaping** — operation named, *tool not specified*
+  ("existing GTN table-processing patterns"). Resolve downstream.
+- **JBrowse** — genome-browser locus visualization. Named.
+- ARG context **classification** — described as a rule set the user has not yet
+  defined (see open questions); no tool named.
+
+## Inputs
+
+- 3–4 **complete isolate assemblies**, one combined chromosome+plasmid FASTA per
+  isolate. Per-isolate granularity → a Galaxy dataset **collection** (list of
+  FASTA), named `MRSA isolate assemblies`.
+- A **metadata TSV**: strain, year, source, symptom, chromosome accession,
+  plasmid accession(s), genome size. (Listed as an expected artifact and a
+  fallback input; the user treats it as a sidecar table.)
+
+## Outputs
+
+Expected paper/demo artifacts the user calls out:
+
+- `staramr` outputs: `summary.tsv`, `detailed_summary.tsv`, `resfinder.tsv`,
+  `plasmidfinder.tsv`, `mlst.tsv`.
+- Metadata table (strain/year/source/symptom/accessions/genome size).
+- AMR presence/absence matrix across isolates.
+- Plasmid replicon / mobile-element matrix across isolates.
+- Mobile-context table: isolate, ARG, phenotype, accession, coordinate,
+  replicon/context, nearest IS/integron/plasmid marker, **distance**.
+- ARG-by-isolate **heatmap**.
+- Plasmid/mobile-element-by-isolate dot plot or heatmap.
+- Stacked bar of ARG counts by context category.
+- One or two locus diagrams / JBrowse screenshots.
+
+Outputs that matter most for review/testing: the per-isolate ARG summary
+(staramr) and the ARG heatmap (these are the comparison's payload); the
+mobile-context table is the novel deliverable.
+
+## Parameters
+
+- Isolate count fixed at **3–4** (eight is stretch scope).
+- No explicit numeric thresholds given for ARG calling or classification.
+- AMR calls are **database-version-dependent**; user wants expected-output
+  snapshots pinned where possible.
+- "nearest IS/integron/plasmid marker, distance" implies a nearest-feature /
+  distance computation, but the user does not specify a method or a distance
+  cutoff.
+
+## Data availability
+
+- GTN Zenodo data: https://doi.org/10.5281/zenodo.10572227
+- Assembly Zenodo data: https://doi.org/10.5281/zenodo.10669812
+- Source paper: Hikichi et al. 2019, DOI `10.1128/mra.01212-19`.
+- Comparative source: BioProject `PRJDB8599` (eight MRSA isolates, complete
+  genome/plasmid accessions).
+- Candidate isolate subset (accessions to verify): KUN1163 `AP020324`+`AP020325`;
+  KUH140013 `AP020311`+`AP020312`; KUH140046 `AP020313`+`AP020314`; KUH180129
+  `AP020322`+`AP020323`.
+- Fallback: a small Zenodo bundle with combined chromosome+plasmid FASTA per
+  isolate plus a metadata TSV, if direct INSDC FASTA import is unstable.
+
+Real public data exists, but the exact accession set and download URLs are not
+yet confirmed (see open questions).
+
+## Constraints
+
+- First version limited to 3–4 isolates.
+- Do **not** re-teach read QC, assembly, or raw-read mapping — provenance only.
+- Treat AMR calls as DB-version-dependent; pin output snapshots.
+- Avoid broad pangenomics unless required for one targeted context question.
+- Avoid clinical interpretation beyond published phenotype comparison.
+
+## Confidence and open questions
+
+High-confidence (interview-supported):
+- The four named tools (`staramr`, `Bakta`, `ISEScan`, `IntegronFinder`) and the
+  collection-of-assemblies input shape.
+- The comparative intent and the mobile-context classification *categories*.
+- The headline outputs (ARG heatmap, mobile-context table, per-isolate summaries).
+
+Open questions (carried forward, not invented):
+- Exact isolate accessions and stable FASTA download URLs (user lists candidates
+  "to verify").
+- Strain→plasmid accession mapping (from Hikichi Table 1 / INSDC).
+- **Mobile-context classification rules** — the user has *not* defined them; the
+  distance method and any cutoff for "IS-adjacent" / "integron-associated" are
+  unspecified. Do not fabricate thresholds.
+- Which specific Galaxy tool implements the table→interval/GFF3 reshaping.
+- Whether `Bakta` runs on all isolates or a representative subset (runtime).
+- Whether JBrowse is in-scope for the workflow proper or a downstream notebook
+  figure step.
+- Whether the metadata TSV is a workflow input or hand-curated sidecar.

--- a/casts/claude/skills/_emulated-runs/uc1-mrsa-interview/galaxy-workflow-draft.gxwf.yml
+++ b/casts/claude/skills/_emulated-runs/uc1-mrsa-interview/galaxy-workflow-draft.gxwf.yml
@@ -1,0 +1,284 @@
+class: GalaxyWorkflowDraft
+label: MRSA mobile-AMR context across isolates
+doc: |
+  Comparative mobile-AMR analysis across 3-4 MRSA isolate assemblies. For each
+  isolate: call ARGs/plasmids/MLST (staramr) and mobile elements (ISEScan,
+  IntegronFinder), reshape calls to intervals, compute each ARG's nearest mobile
+  element + distance, classify mobile context, and collapse to a per-isolate ARG
+  matrix + heatmap. Topology settled here; wrapper-tier (tool_id/tool_state/port
+  names) deferred to the per-step loop. Nearest IWC exemplar:
+  bacterial_genomics/amr_gene_detection (staramr core reused; mobile-element and
+  interval-distance half has no IWC analog).
+inputs:
+  - id: MRSA isolate assemblies
+    label: MRSA isolate assemblies
+    type: collection
+    collection_type: list
+    optional: false
+    format:
+      - fasta
+    doc: "3-4 complete isolate assemblies (combined chromosome+plasmid FASTA), one per isolate. List element identifier = strain name; carried through every map-over step."
+  - id: StarAMR database
+    label: StarAMR database
+    type: string
+    optional: false
+    doc: "staramr database selection (ResFinder/PointFinder/PlasmidFinder). Surfaced as input because AMR calls are DB-version dependent (source constraint)."
+  - id: Species for point mutation analysis
+    label: Species for point mutation analysis
+    type: string
+    optional: true
+    doc: "PointFinder organism for staramr. Source did not pin a species; for MRSA this is Staphylococcus aureus, left as an explicit input rather than hard-coded."
+  - id: isolate metadata
+    label: isolate metadata
+    type: data
+    optional: true
+    format:
+      - tabular
+    doc: "Optional per-isolate metadata TSV (strain/year/source/accessions/genome size). Open question whether workflow input or hand-curated sidecar; modeled optional."
+outputs:
+  - id: staramr_summary
+    label: staramr_summary
+    outputSource: staramr/TODO_summary
+    doc: "Per-isolate ARG/plasmid/MLST summary collection. Primary comparison payload."
+  - id: staramr_resfinder
+    label: staramr_resfinder
+    outputSource: staramr/TODO_resfinder
+  - id: staramr_plasmidfinder
+    label: staramr_plasmidfinder
+    outputSource: staramr/TODO_plasmidfinder
+  - id: is_elements
+    label: is_elements
+    outputSource: isescan/TODO_is_table
+  - id: integrons
+    label: integrons
+    outputSource: integronfinder/TODO_integron_table
+  - id: arg_mobile_context
+    label: arg_mobile_context
+    outputSource: classify_context/TODO_classified
+    doc: "Novel deliverable: per ARG, nearest mobile element, distance, and context class."
+  - id: arg_heatmap
+    label: arg_heatmap
+    outputSource: arg_heatmap/TODO_heatmap
+    doc: "ARG presence/abundance by isolate."
+steps:
+  - id: staramr
+    label: staramr
+    tool_id: TODO
+    tool_version: TODO
+    doc: "ARG + plasmid replicon + MLST calls, mapped over the isolate list collection."
+    in:
+      - id: TODO_genomes
+        source: MRSA isolate assemblies
+      - id: TODO_db
+        source: StarAMR database
+      - id: TODO_pointfinder_organism
+        source: Species for point mutation analysis
+    out:
+      - id: TODO_summary
+      - id: TODO_resfinder
+      - id: TODO_plasmidfinder
+      - id: TODO_mlst
+      - id: TODO_detailed_summary
+    _plan_state: |
+      Map over the list collection (one combined assembly per isolate). Database
+      version is the load-bearing parameter (source flags DB-version dependence);
+      bind staramr_db_select from the `StarAMR database` input and
+      pointfinder_organism from the `Species for point mutation analysis` input
+      (Staphylococcus aureus for MRSA). Pin expected-output snapshots.
+    _plan_context: |
+      STRONG corpus evidence: the nearest IWC exemplar
+      (bacterial_genomics/amr_gene_detection) uses
+      tool_id toolshed.g2.bx.psu.edu/repos/iuc/staramr/staramr_search/0.11.0+galaxy3
+      (owner iuc, changeset 6d5c8a6ceea0). Port names there: in `genomes`,
+      `staramr_db_select`, `pointfinder_organism`; out `summary`, `resfinder`,
+      `plasmidfinder`, `mlst`, `detailed_summary`. Discover/confirm this pin in
+      the per-step loop, then map it over the list.
+    _plan_in: |
+      genomes <- isolate list collection (map-over); staramr_db_select <- string
+      input; pointfinder_organism <- string input.
+    _plan_out: |
+      summary + resfinder + plasmidfinder are promoted outputs and feed the
+      reshape + matrix steps; mlst/detailed_summary are secondary.
+  - id: isescan
+    label: isescan
+    tool_id: TODO
+    tool_version: TODO
+    doc: "Insertion-sequence detection, mapped over the isolate list."
+    in:
+      - id: TODO_genome
+        source: MRSA isolate assemblies
+    out:
+      - id: TODO_is_table
+    _plan_state: |
+      Default IS detection per isolate. No non-default parameters given by source.
+      Output must carry coordinates so it can be reshaped to intervals downstream.
+    _plan_context: |
+      Tool named in source: ISEScan. No IWC exemplar contains it (the AMR exemplar
+      lacks mobile-element callers entirely). Discover a Tool Shed wrapper
+      (likely iuc) in the per-step loop; if none acceptable, author one.
+    _plan_in: "genome <- isolate list collection (map-over)."
+    _plan_out: "IS calls with coordinates -> reshaped to mobile-element BED."
+  - id: integronfinder
+    label: integronfinder
+    tool_id: TODO
+    tool_version: TODO
+    doc: "Integron detection, mapped over the isolate list."
+    in:
+      - id: TODO_genome
+        source: MRSA isolate assemblies
+    out:
+      - id: TODO_integron_table
+    _plan_state: "Default integron detection per isolate; no source-specified knobs."
+    _plan_context: |
+      Tool named in source: IntegronFinder. No IWC exemplar. Discover-or-author in
+      per-step loop.
+    _plan_in: "genome <- isolate list collection (map-over)."
+    _plan_out: "integron calls with coordinates -> reshaped to mobile-element BED."
+  - id: arg_to_bed
+    label: arg_to_bed
+    tool_id: TODO
+    tool_version: TODO
+    doc: "Project staramr resfinder hits into a BED/interval table (coordinates) per isolate."
+    in:
+      - id: TODO_arg_table
+        source: staramr/TODO_resfinder
+    out:
+      - id: TODO_arg_bed
+    _plan_state: |
+      Extract contig/start/end/gene columns from resfinder output into BED-like
+      intervals. Source calls this 'existing GTN table-processing patterns' and
+      names no tool; likely awk / Text reformatting (galaxy-tabular-patterns
+      text-processing recipe). Must preserve the isolate identifier.
+    _plan_context: "table->interval bridge; no specific tool pinned by source."
+    _plan_in: "arg_table <- staramr resfinder collection (map-over)."
+    _plan_out: "ARG intervals -> coordinate sort -> nearest-feature."
+  - id: mobile_to_bed
+    label: mobile_to_bed
+    tool_id: TODO
+    tool_version: TODO
+    doc: "Combine ISEScan + IntegronFinder calls into one mobile-element BED per isolate."
+    in:
+      - id: TODO_is_table
+        source: isescan/TODO_is_table
+      - id: TODO_integron_table
+        source: integronfinder/TODO_integron_table
+    out:
+      - id: TODO_mobile_bed
+    _plan_state: |
+      Concatenate IS + integron coordinates into a single mobile-element interval
+      set per isolate, tagging element type (IS vs integron) in a column so the
+      downstream classify step can distinguish IS-adjacent from
+      integron-associated. awk / Text reformatting + concatenate.
+    _plan_context: "tabular concat + projection; no tool pinned by source."
+    _plan_in: "is_table + integron_table (both map-over, same isolate key)."
+    _plan_out: "combined mobile-element BED -> coordinate sort -> nearest-feature."
+  - id: sort_arg_bed
+    label: sort_arg_bed
+    tool_id: TODO
+    tool_version: TODO
+    doc: "BED-aware coordinate sort of ARG intervals (precondition for closest)."
+    in:
+      - id: TODO_bed
+        source: arg_to_bed/TODO_arg_bed
+    out:
+      - id: TODO_sorted_bed
+    _plan_state: "Coordinate sort (chrom, start). bedtools SortBED-style."
+    _plan_context: |
+      Interval-algebra closest expects coordinate-sorted BED. Corpus note: IWC
+      sorts intervals with tabular sort1, but bedtools closest wants BED sort ->
+      use a BED-aware sort (e.g. iuc/bedtools SortBED).
+    _plan_in: "bed <- ARG intervals (map-over)."
+    _plan_out: "sorted ARG BED -> closest."
+  - id: sort_mobile_bed
+    label: sort_mobile_bed
+    tool_id: TODO
+    tool_version: TODO
+    doc: "BED-aware coordinate sort of mobile-element intervals."
+    in:
+      - id: TODO_bed
+        source: mobile_to_bed/TODO_mobile_bed
+    out:
+      - id: TODO_sorted_bed
+    _plan_state: "Coordinate sort (chrom, start). bedtools SortBED-style."
+    _plan_context: "Same as sort_arg_bed; sorted BED required by closest."
+    _plan_in: "bed <- mobile-element intervals (map-over)."
+    _plan_out: "sorted mobile BED -> closest."
+  - id: nearest_feature
+    label: nearest_feature
+    tool_id: TODO
+    tool_version: TODO
+    doc: "Per ARG interval, find nearest mobile-element interval and signed/absolute distance."
+    in:
+      - id: TODO_a
+        source: sort_arg_bed/TODO_sorted_bed
+      - id: TODO_b
+        source: sort_mobile_bed/TODO_sorted_bed
+    out:
+      - id: TODO_arg_with_nearest
+    _plan_state: |
+      Nearest-feature + distance: for each ARG, nearest IS/integron and base-pair
+      distance (-d). This is the mobile-context computation. Distance cutoff for
+      'IS-adjacent'/'integron-associated' is UNDEFINED by source -> do not invent;
+      emit raw distance and let classify (or a downstream/notebook step) threshold.
+    _plan_context: |
+      CORPUS GAP: 'nearest feature + distance' has no IWC exemplar and no Foundry
+      pattern page (interval-patterns note flags it explicitly). Natural tool:
+      iuc/bedtools bedtools_closestbed with -d. Reach for it directly in the
+      per-step loop; do not expect a pattern page.
+    _plan_in: "a <- sorted ARG BED; b <- sorted mobile-element BED (both map-over)."
+    _plan_out: "ARG rows + nearest mobile element + distance -> classify."
+  - id: classify_context
+    label: classify_context
+    tool_id: TODO
+    tool_version: TODO
+    doc: "Label each ARG: plasmid-located / IS-adjacent / integron-associated / SCCmec-candidate / unclassified."
+    in:
+      - id: TODO_arg_with_nearest
+        source: nearest_feature/TODO_arg_with_nearest
+      - id: TODO_plasmidfinder
+        source: staramr/TODO_plasmidfinder
+    out:
+      - id: TODO_classified
+    _plan_state: |
+      OPEN DESIGN QUESTION (low confidence): classification RULES are undefined by
+      the source. Defensible MVP = pass through nearest-element + distance +
+      plasmid-replicon membership as columns and mark context class only where
+      unambiguous (plasmid-located from plasmidfinder overlap); leave distance
+      thresholds for IS-adjacent/integron-associated as a parameter or downstream
+      decision rather than hard-coding. SCCmec-candidate needs a locus reference
+      not provided -> likely 'unclassified' for v1. Surface to user.
+    _plan_context: "No tool/rules in source. Likely awk / Filter+compute or a small tabular tool. Carry the open question forward."
+    _plan_in: "arg_with_nearest <- nearest_feature; plasmidfinder <- staramr (replicon membership)."
+    _plan_out: "classified ARG mobile-context table (promoted output)."
+  - id: collapse_to_matrix
+    label: collapse_to_matrix
+    tool_id: TODO
+    tool_version: TODO
+    doc: "Reduce the per-isolate ARG summary collection into one wide isolate-by-ARG matrix."
+    in:
+      - id: TODO_arg_summary_collection
+        source: staramr/TODO_summary
+    out:
+      - id: TODO_matrix
+    _plan_state: |
+      Reduction (collection -> single table) keyed by isolate identifier; isolate
+      column MUST survive. Pattern: tabular-pivot-collection-to-wide /
+      Collapse Collection.
+    _plan_context: "collection->tabular bridge; pattern-grounded (galaxy-tabular-patterns)."
+    _plan_in: "arg_summary_collection <- staramr summary collection (reduce)."
+    _plan_out: "wide ARG-by-isolate matrix -> heatmap."
+  - id: arg_heatmap
+    label: arg_heatmap
+    tool_id: TODO
+    tool_version: TODO
+    doc: "Render the ARG-by-isolate matrix as a heatmap image."
+    in:
+      - id: TODO_matrix
+        source: collapse_to_matrix/TODO_matrix
+    out:
+      - id: TODO_heatmap
+    _plan_state: "Heatmap of ARG presence/abundance by isolate. heatmap2-style plotting tool."
+    _plan_context: "Plotting tool unresolved; heatmap2 is a candidate (used in the unvalidated target .ga)."
+    _plan_in: "matrix <- collapse_to_matrix."
+    _plan_out: "heatmap image (promoted output)."
+tags: []

--- a/casts/claude/skills/_emulated-runs/uc1-mrsa-interview/galaxy-workflow-draft.iter1.gxwf.yml
+++ b/casts/claude/skills/_emulated-runs/uc1-mrsa-interview/galaxy-workflow-draft.iter1.gxwf.yml
@@ -1,0 +1,287 @@
+class: GalaxyWorkflowDraft
+label: MRSA mobile-AMR context across isolates
+doc: |
+  Comparative mobile-AMR analysis across 3-4 MRSA isolate assemblies. For each
+  isolate: call ARGs/plasmids/MLST (staramr) and mobile elements (ISEScan,
+  IntegronFinder), reshape calls to intervals, compute each ARG's nearest mobile
+  element + distance, classify mobile context, and collapse to a per-isolate ARG
+  matrix + heatmap. Topology settled here; wrapper-tier (tool_id/tool_state/port
+  names) deferred to the per-step loop. Nearest IWC exemplar:
+  bacterial_genomics/amr_gene_detection (staramr core reused; mobile-element and
+  interval-distance half has no IWC analog).
+inputs:
+  - id: MRSA isolate assemblies
+    label: MRSA isolate assemblies
+    type: collection
+    collection_type: list
+    optional: false
+    format:
+      - fasta
+    doc: "3-4 complete isolate assemblies (combined chromosome+plasmid FASTA), one per isolate. List element identifier = strain name; carried through every map-over step."
+  - id: StarAMR database
+    label: StarAMR database
+    type: string
+    optional: false
+    doc: "staramr database selection (ResFinder/PointFinder/PlasmidFinder). Surfaced as input because AMR calls are DB-version dependent (source constraint)."
+  - id: Species for point mutation analysis
+    label: Species for point mutation analysis
+    type: string
+    optional: true
+    doc: "PointFinder organism for staramr. Source did not pin a species; for MRSA this is Staphylococcus aureus, left as an explicit input rather than hard-coded."
+  - id: isolate metadata
+    label: isolate metadata
+    type: data
+    optional: true
+    format:
+      - tabular
+    doc: "Optional per-isolate metadata TSV (strain/year/source/accessions/genome size). Open question whether workflow input or hand-curated sidecar; modeled optional."
+outputs:
+  - id: staramr_summary
+    label: staramr_summary
+    outputSource: staramr/TODO_summary
+    doc: "Per-isolate ARG/plasmid/MLST summary collection. Primary comparison payload."
+  - id: staramr_resfinder
+    label: staramr_resfinder
+    outputSource: staramr/TODO_resfinder
+  - id: staramr_plasmidfinder
+    label: staramr_plasmidfinder
+    outputSource: staramr/TODO_plasmidfinder
+  - id: is_elements
+    label: is_elements
+    outputSource: isescan/TODO_is_table
+  - id: integrons
+    label: integrons
+    outputSource: integronfinder/integrons_table
+  - id: arg_mobile_context
+    label: arg_mobile_context
+    outputSource: classify_context/TODO_classified
+    doc: "Novel deliverable: per ARG, nearest mobile element, distance, and context class."
+  - id: arg_heatmap
+    label: arg_heatmap
+    outputSource: arg_heatmap/TODO_heatmap
+    doc: "ARG presence/abundance by isolate."
+steps:
+  - id: staramr
+    label: staramr
+    tool_id: TODO
+    tool_version: TODO
+    doc: "ARG + plasmid replicon + MLST calls, mapped over the isolate list collection."
+    in:
+      - id: TODO_genomes
+        source: MRSA isolate assemblies
+      - id: TODO_db
+        source: StarAMR database
+      - id: TODO_pointfinder_organism
+        source: Species for point mutation analysis
+    out:
+      - id: TODO_summary
+      - id: TODO_resfinder
+      - id: TODO_plasmidfinder
+      - id: TODO_mlst
+      - id: TODO_detailed_summary
+    _plan_state: |
+      Map over the list collection (one combined assembly per isolate). Database
+      version is the load-bearing parameter (source flags DB-version dependence);
+      bind staramr_db_select from the `StarAMR database` input and
+      pointfinder_organism from the `Species for point mutation analysis` input
+      (Staphylococcus aureus for MRSA). Pin expected-output snapshots.
+    _plan_context: |
+      STRONG corpus evidence: the nearest IWC exemplar
+      (bacterial_genomics/amr_gene_detection) uses
+      tool_id toolshed.g2.bx.psu.edu/repos/iuc/staramr/staramr_search/0.11.0+galaxy3
+      (owner iuc, changeset 6d5c8a6ceea0). Port names there: in `genomes`,
+      `staramr_db_select`, `pointfinder_organism`; out `summary`, `resfinder`,
+      `plasmidfinder`, `mlst`, `detailed_summary`. Discover/confirm this pin in
+      the per-step loop, then map it over the list.
+    _plan_in: |
+      genomes <- isolate list collection (map-over); staramr_db_select <- string
+      input; pointfinder_organism <- string input.
+    _plan_out: |
+      summary + resfinder + plasmidfinder are promoted outputs and feed the
+      reshape + matrix steps; mlst/detailed_summary are secondary.
+  - id: isescan
+    label: isescan
+    tool_id: TODO
+    tool_version: TODO
+    doc: "Insertion-sequence detection, mapped over the isolate list."
+    in:
+      - id: TODO_genome
+        source: MRSA isolate assemblies
+    out:
+      - id: TODO_is_table
+    _plan_state: |
+      Default IS detection per isolate. No non-default parameters given by source.
+      Output must carry coordinates so it can be reshaped to intervals downstream.
+    _plan_context: |
+      Tool named in source: ISEScan. No IWC exemplar contains it (the AMR exemplar
+      lacks mobile-element callers entirely). Discover a Tool Shed wrapper
+      (likely iuc) in the per-step loop; if none acceptable, author one.
+    _plan_in: "genome <- isolate list collection (map-over)."
+    _plan_out: "IS calls with coordinates -> reshaped to mobile-element BED."
+  - id: integronfinder
+    label: integronfinder
+    tool_id: toolshed.g2.bx.psu.edu/repos/iuc/integron_finder/integron_finder/2.0.5+galaxy1
+    tool_version: 2.0.5+galaxy1
+    tool_shed_repository:
+      changeset_revision: 5429646e486d
+      name: integron_finder
+      owner: iuc
+      tool_shed: toolshed.g2.bx.psu.edu
+    doc: "Integron detection, mapped over the isolate list."
+    in:
+      - id: sequence
+        source: MRSA isolate assemblies
+    out:
+      - id: integrons_table
+        rename: integrons_table
+    tool_state:
+      sequence:
+        __class__: ConnectedValue
+  - id: arg_to_bed
+    label: arg_to_bed
+    tool_id: TODO
+    tool_version: TODO
+    doc: "Project staramr resfinder hits into a BED/interval table (coordinates) per isolate."
+    in:
+      - id: TODO_arg_table
+        source: staramr/TODO_resfinder
+    out:
+      - id: TODO_arg_bed
+    _plan_state: |
+      Extract contig/start/end/gene columns from resfinder output into BED-like
+      intervals. Source calls this 'existing GTN table-processing patterns' and
+      names no tool; likely awk / Text reformatting (galaxy-tabular-patterns
+      text-processing recipe). Must preserve the isolate identifier.
+    _plan_context: "table->interval bridge; no specific tool pinned by source."
+    _plan_in: "arg_table <- staramr resfinder collection (map-over)."
+    _plan_out: "ARG intervals -> coordinate sort -> nearest-feature."
+  - id: mobile_to_bed
+    label: mobile_to_bed
+    tool_id: TODO
+    tool_version: TODO
+    doc: "Combine ISEScan + IntegronFinder calls into one mobile-element BED per isolate."
+    in:
+      - id: TODO_is_table
+        source: isescan/TODO_is_table
+      - id: TODO_integron_table
+        source: integronfinder/integrons_table
+    out:
+      - id: TODO_mobile_bed
+    _plan_state: |
+      Concatenate IS + integron coordinates into a single mobile-element interval
+      set per isolate, tagging element type (IS vs integron) in a column so the
+      downstream classify step can distinguish IS-adjacent from
+      integron-associated. awk / Text reformatting + concatenate.
+    _plan_context: "tabular concat + projection; no tool pinned by source."
+    _plan_in: "is_table + integron_table (both map-over, same isolate key)."
+    _plan_out: "combined mobile-element BED -> coordinate sort -> nearest-feature."
+  - id: sort_arg_bed
+    label: sort_arg_bed
+    tool_id: TODO
+    tool_version: TODO
+    doc: "BED-aware coordinate sort of ARG intervals (precondition for closest)."
+    in:
+      - id: TODO_bed
+        source: arg_to_bed/TODO_arg_bed
+    out:
+      - id: TODO_sorted_bed
+    _plan_state: "Coordinate sort (chrom, start). bedtools SortBED-style."
+    _plan_context: |
+      Interval-algebra closest expects coordinate-sorted BED. Corpus note: IWC
+      sorts intervals with tabular sort1, but bedtools closest wants BED sort ->
+      use a BED-aware sort (e.g. iuc/bedtools SortBED).
+    _plan_in: "bed <- ARG intervals (map-over)."
+    _plan_out: "sorted ARG BED -> closest."
+  - id: sort_mobile_bed
+    label: sort_mobile_bed
+    tool_id: TODO
+    tool_version: TODO
+    doc: "BED-aware coordinate sort of mobile-element intervals."
+    in:
+      - id: TODO_bed
+        source: mobile_to_bed/TODO_mobile_bed
+    out:
+      - id: TODO_sorted_bed
+    _plan_state: "Coordinate sort (chrom, start). bedtools SortBED-style."
+    _plan_context: "Same as sort_arg_bed; sorted BED required by closest."
+    _plan_in: "bed <- mobile-element intervals (map-over)."
+    _plan_out: "sorted mobile BED -> closest."
+  - id: nearest_feature
+    label: nearest_feature
+    tool_id: TODO
+    tool_version: TODO
+    doc: "Per ARG interval, find nearest mobile-element interval and signed/absolute distance."
+    in:
+      - id: TODO_a
+        source: sort_arg_bed/TODO_sorted_bed
+      - id: TODO_b
+        source: sort_mobile_bed/TODO_sorted_bed
+    out:
+      - id: TODO_arg_with_nearest
+    _plan_state: |
+      Nearest-feature + distance: for each ARG, nearest IS/integron and base-pair
+      distance (-d). This is the mobile-context computation. Distance cutoff for
+      'IS-adjacent'/'integron-associated' is UNDEFINED by source -> do not invent;
+      emit raw distance and let classify (or a downstream/notebook step) threshold.
+    _plan_context: |
+      CORPUS GAP: 'nearest feature + distance' has no IWC exemplar and no Foundry
+      pattern page (interval-patterns note flags it explicitly). Natural tool:
+      iuc/bedtools bedtools_closestbed with -d. Reach for it directly in the
+      per-step loop; do not expect a pattern page.
+    _plan_in: "a <- sorted ARG BED; b <- sorted mobile-element BED (both map-over)."
+    _plan_out: "ARG rows + nearest mobile element + distance -> classify."
+  - id: classify_context
+    label: classify_context
+    tool_id: TODO
+    tool_version: TODO
+    doc: "Label each ARG: plasmid-located / IS-adjacent / integron-associated / SCCmec-candidate / unclassified."
+    in:
+      - id: TODO_arg_with_nearest
+        source: nearest_feature/TODO_arg_with_nearest
+      - id: TODO_plasmidfinder
+        source: staramr/TODO_plasmidfinder
+    out:
+      - id: TODO_classified
+    _plan_state: |
+      OPEN DESIGN QUESTION (low confidence): classification RULES are undefined by
+      the source. Defensible MVP = pass through nearest-element + distance +
+      plasmid-replicon membership as columns and mark context class only where
+      unambiguous (plasmid-located from plasmidfinder overlap); leave distance
+      thresholds for IS-adjacent/integron-associated as a parameter or downstream
+      decision rather than hard-coding. SCCmec-candidate needs a locus reference
+      not provided -> likely 'unclassified' for v1. Surface to user.
+    _plan_context: "No tool/rules in source. Likely awk / Filter+compute or a small tabular tool. Carry the open question forward."
+    _plan_in: "arg_with_nearest <- nearest_feature; plasmidfinder <- staramr (replicon membership)."
+    _plan_out: "classified ARG mobile-context table (promoted output)."
+  - id: collapse_to_matrix
+    label: collapse_to_matrix
+    tool_id: TODO
+    tool_version: TODO
+    doc: "Reduce the per-isolate ARG summary collection into one wide isolate-by-ARG matrix."
+    in:
+      - id: TODO_arg_summary_collection
+        source: staramr/TODO_summary
+    out:
+      - id: TODO_matrix
+    _plan_state: |
+      Reduction (collection -> single table) keyed by isolate identifier; isolate
+      column MUST survive. Pattern: tabular-pivot-collection-to-wide /
+      Collapse Collection.
+    _plan_context: "collection->tabular bridge; pattern-grounded (galaxy-tabular-patterns)."
+    _plan_in: "arg_summary_collection <- staramr summary collection (reduce)."
+    _plan_out: "wide ARG-by-isolate matrix -> heatmap."
+  - id: arg_heatmap
+    label: arg_heatmap
+    tool_id: TODO
+    tool_version: TODO
+    doc: "Render the ARG-by-isolate matrix as a heatmap image."
+    in:
+      - id: TODO_matrix
+        source: collapse_to_matrix/TODO_matrix
+    out:
+      - id: TODO_heatmap
+    _plan_state: "Heatmap of ARG presence/abundance by isolate. heatmap2-style plotting tool."
+    _plan_context: "Plotting tool unresolved; heatmap2 is a candidate (used in the unvalidated target .ga)."
+    _plan_in: "matrix <- collapse_to_matrix."
+    _plan_out: "heatmap image (promoted output)."
+tags: []

--- a/casts/claude/skills/_emulated-runs/uc1-mrsa-interview/galaxy-workflow-tests.yml
+++ b/casts/claude/skills/_emulated-runs/uc1-mrsa-interview/galaxy-workflow-tests.yml
@@ -1,0 +1,57 @@
+- doc: |
+    MRSA mobile-AMR context across isolates — workflow test skeleton.
+    Test DATA is user-supplied (find-test-data did not resolve real FASTA URLs;
+    see test-data-refs.json). The `location:` values below are placeholders the
+    user must fill with verified isolate-assembly URLs before this test can run.
+    Parameter inputs are pinned. Output assertions are deliberately weak
+    (existence / non-empty) because the workflow is not yet fully concrete and no
+    expected-output snapshots are pinned.
+  job:
+    MRSA isolate assemblies:
+      class: Collection
+      collection_type: list
+      elements:
+        - identifier: KUN1163
+          class: File
+          location: https://USER_SUPPLIED/KUN1163.fasta
+          filetype: fasta
+        - identifier: KUH140013
+          class: File
+          location: https://USER_SUPPLIED/KUH140013.fasta
+          filetype: fasta
+        - identifier: KUH140046
+          class: File
+          location: https://USER_SUPPLIED/KUH140046.fasta
+          filetype: fasta
+    StarAMR database: resfinder_db_USER_PINNED_VERSION
+    Species for point mutation analysis: Staphylococcus aureus
+  outputs:
+    staramr_summary:
+      asserts:
+        has_text_matching:
+          expression: ".+"
+    staramr_resfinder:
+      asserts:
+        has_text_matching:
+          expression: ".+"
+    staramr_plasmidfinder:
+      asserts:
+        has_text_matching:
+          expression: ".+"
+    is_elements:
+      asserts:
+        has_text_matching:
+          expression: ".+"
+    integrons:
+      asserts:
+        has_text_matching:
+          expression: ".+"
+    arg_mobile_context:
+      asserts:
+        has_text_matching:
+          expression: ".+"
+    arg_heatmap:
+      asserts:
+        has_size:
+          value: 1000
+          delta: 1000000

--- a/casts/claude/skills/_emulated-runs/uc1-mrsa-interview/iwc-comparison-notes.md
+++ b/casts/claude/skills/_emulated-runs/uc1-mrsa-interview/iwc-comparison-notes.md
@@ -1,0 +1,121 @@
+# iwc-comparison-notes: MRSA mobile-AMR context across isolates
+
+> Artifact id: `iwc-comparison-notes`. Produced by `compare-against-iwc-exemplar`
+> from `freeform-galaxy-interface.md` + `freeform-galaxy-data-flow.md`. Structural
+> diff guidance for `freeform-summary-to-galaxy-template`. Companion file:
+> `iwc-exemplar.gxwf.yml`.
+
+## Nearest exemplar
+
+**`bacterial_genomics/amr_gene_detection/amr_gene_detection`** — IWC.
+
+Confidence: **Medium.**
+
+| Feature (hierarchy) | UC1 brief | Exemplar | Match |
+|---|---|---|---|
+| 1. Domain/intent | bacterial AMR + mobile-element context | bacterial AMR + virulence detection | **same domain** ✅ |
+| 2. Input topology | `list<fasta>` (3–4 isolates) | single `data` fasta (one genome) | **differs** ⚠ |
+| 3. Primary tool families | staramr, ISEScan, IntegronFinder | staramr, AMRFinderPlus, ABRicate, ToolDistillator, MultiQC | **partial** (staramr exact) |
+| 4. DAG motifs | map-over callers → reshape → nearest-feature → collapse → heatmap | fan-out callers → ToolDistillator merge → MultiQC report | **partial** |
+| 5. Output/report shape | per-isolate matrix + ARG heatmap + mobile-context table | per-output promotion + MultiQC HTML + distillator JSON | **partial** |
+| 6. Test/fixture | not yet specified | single-genome fixture | n/a here |
+
+Why Medium not High: domain and the `staramr` core are an exact hit (the
+source even cites the AMR-gene-detection GTN tutorial this workflow comes from),
+but the **input topology differs** (single genome vs isolate collection) and
+UC1's **mobile-element + interval-distance half has no analog** in the exemplar.
+Per the Feature-Hierarchy rubric a topology divergence + partial-tool/output
+match caps this at Medium.
+
+## Nearest exemplar gxformat2 excerpt
+
+Inline bounded subgraph (the staramr input→step→output slice UC1 reuses), cited
+from `bacterial_genomics/amr_gene_detection/amr_gene_detection`, step label
+`Staramr AMR genes detection`. Fuller view in `iwc-exemplar.gxwf.yml`.
+
+```yaml
+inputs:
+  - id: Input sequence fasta        # single `data` in exemplar; UC1 maps over list<fasta>
+    type: data
+    format: [fasta]
+  - id: StarAMR database
+    type: string
+    restrictOnConnections: true
+steps:
+  - id: Staramr AMR genes detection
+    label: Staramr AMR genes detection
+    tool_id: toolshed.g2.bx.psu.edu/repos/iuc/staramr/staramr_search/0.11.0+galaxy3
+    tool_version: 0.11.0+galaxy3
+    in:
+      - {id: genomes, source: Input sequence fasta}
+      - {id: staramr_db_select, source: StarAMR database}
+    out:
+      - {id: summary, rename: staramr_summary, add_tags: [staramr_summary]}
+      - {id: resfinder, rename: staramr_resfinder_report, add_tags: [staramr_resfinder_report]}
+      - {id: plasmidfinder, rename: staramr_plasmidfinder_report, add_tags: [staramr_plasmidfinder_report]}
+      - {id: mlst, rename: staramr_mlst_report, add_tags: [staramr_mlst_report]}
+```
+
+## Reuse verbatim (high-value idiom transfer)
+
+- **The `staramr` step.** Real pinnable identity: `tool_id`
+  `toolshed.g2.bx.psu.edu/repos/iuc/staramr/staramr_search/0.11.0+galaxy3`,
+  changeset `6d5c8a6ceea0`, owner `iuc`. Input port `genomes` ← fasta; DB
+  selection via `staramr_db_select` + `pointfinder_organism` **string** inputs
+  with `restrictOnConnections: true`. See `iwc-exemplar.gxwf.yml`.
+- **Output-promotion idiom.** The exemplar promotes each staramr output
+  (`summary`, `resfinder`, `plasmidfinder`, `mlst`, `detailed_summary`, …) with
+  `rename:` + `add_tags:`. UC1's interface labels (`staramr_summary`,
+  `staramr_resfinder`, `staramr_plasmidfinder`) map 1:1 onto these — adopt the
+  rename/tag pattern directly.
+- **DB-as-string-input idiom.** staramr's database + species are surfaced as
+  workflow `string` inputs, not hard-coded — UC1 should do the same so AMR-DB
+  version is explicit (the source flagged DB-version dependence).
+
+## Structural divergences the template must handle
+
+> Routing: all **template/data-flow** issues for `freeform-summary-to-galaxy-template`.
+
+1. **Collection map-over (topology).** Exemplar feeds a single `data` fasta;
+   UC1's primary input is a `list<fasta>` of isolates. The template must take the
+   exemplar's staramr step and **map it over the list**, preserving the isolate
+   identifier on every output. Same for ISEScan / IntegronFinder. This is the
+   single most important Galaxy-specific change vs the exemplar.
+2. **Mobile-element callers absent.** ISEScan and IntegronFinder have no node in
+   this exemplar (nor elsewhere in IWC AMR workflows). Template adds them as
+   placeholder map-over steps; exact wrappers → per-step discover/author loop.
+3. **table→interval reshape + nearest-feature distance has NO IWC exemplar.**
+   This confirms the data-flow brief's corpus-gap call: the "nearest feature +
+   distance" operation (`bedtools closest -d`) is absent from IWC. The exemplar
+   offers no idiom to copy here — template emits an explicit placeholder chain
+   (reshape → coordinate-sort → closest → classify) and the per-step loop reaches
+   for `iuc/bedtools` directly. Flag as a candidate **pattern-page gap** if it
+   recurs, but do not block.
+4. **Aggregation idiom differs.** Exemplar aggregates with
+   ToolDistillator→MultiQC into an HTML report. UC1 wants a per-isolate **matrix +
+   heatmap** instead (collapse/pivot-to-wide → heatmap). Do **not** import the
+   ToolDistillator/MultiQC tail; it answers a different output question. Note it
+   only as an alternative report idiom.
+5. **Classification step has no exemplar and undefined rules.** Keep as an
+   explicit placeholder/TODO with the open question carried, not an invented step.
+
+## Anti-pattern / shortcut check
+
+- Promoting every intermediate as a workflow output (as the exemplar does for all
+  staramr outputs) is **accepted in IWC** — fine to mirror for UC1's testable
+  checkpoints. No smell.
+- Do not collapse the isolate collection to an opaque concatenation before the
+  per-isolate calls just to reuse the single-genome exemplar shape — that would
+  lose the comparative axis. Keep the map-over.
+
+## Findings routed forward
+
+| finding | owner surface |
+|---|---|
+| map staramr/ISEScan/IntegronFinder over `list` | template |
+| reuse staramr tool_id + rename/tag output idiom | template (then per-step confirms pin) |
+| reshape→sort→closest→classify placeholder chain | template (data-flow gap) |
+| ISEScan / IntegronFinder / bedtools-closest wrappers | per-step loop (discover-or-author) |
+| nearest-feature+distance as recurring idiom | pattern-page gap (defer, don't author off one case) |
+| matrix+heatmap vs ToolDistillator/MultiQC report | template (keep UC1's outputs) |
+| classification rules undefined | open question → user / per-step decision |

--- a/casts/claude/skills/_emulated-runs/uc1-mrsa-interview/iwc-exemplar.gxwf.yml
+++ b/casts/claude/skills/_emulated-runs/uc1-mrsa-interview/iwc-exemplar.gxwf.yml
@@ -1,0 +1,61 @@
+# Nearest IWC exemplar — relevant subgraph (staramr AMR-calling core)
+# Source: bacterial_genomics/amr_gene_detection/amr_gene_detection (IWC)
+# Bounded to the staramr input→step→output promotion idiom, which is the slice
+# UC1 reuses. The fan-out (AMRFinderPlus/ABRicate) and ToolDistillator/MultiQC
+# aggregation tail are omitted as not-relevant to UC1's mobile-context shape.
+class: GalaxyWorkflow
+label: "AMR Gene Detection (staramr subgraph)"
+inputs:
+  - id: Input sequence fasta        # NOTE: single `data` in exemplar; UC1 needs list<fasta>
+    type: data
+    format: [fasta]
+  - id: StarAMR database
+    type: string
+    restrictOnConnections: true
+  - id: Species for point mutation analysis using PointFinder
+    type: string
+    restrictOnConnections: true
+outputs:
+  - id: staramr_summary
+    outputSource: Staramr AMR genes detection/summary
+  - id: staramr_resfinder_report
+    outputSource: Staramr AMR genes detection/resfinder
+  - id: staramr_plasmidfinder_report
+    outputSource: Staramr AMR genes detection/plasmidfinder
+  - id: staramr_mlst_report
+    outputSource: Staramr AMR genes detection/mlst
+  - id: staramr_detailed_summary
+    outputSource: Staramr AMR genes detection/detailed_summary
+steps:
+  - id: Staramr AMR genes detection
+    label: Staramr AMR genes detection
+    tool_id: toolshed.g2.bx.psu.edu/repos/iuc/staramr/staramr_search/0.11.0+galaxy3
+    tool_version: 0.11.0+galaxy3
+    tool_shed_repository:
+      changeset_revision: 6d5c8a6ceea0
+      name: staramr
+      owner: iuc
+      tool_shed: toolshed.g2.bx.psu.edu
+    in:
+      - id: genomes
+        source: Input sequence fasta
+      - id: pointfinder_organism
+        source: Species for point mutation analysis using PointFinder
+      - id: staramr_db_select
+        source: StarAMR database
+    out:
+      - id: summary
+        rename: staramr_summary
+        add_tags: [staramr_summary]
+      - id: resfinder
+        rename: staramr_resfinder_report
+        add_tags: [staramr_resfinder_report]
+      - id: plasmidfinder
+        rename: staramr_plasmidfinder_report
+        add_tags: [staramr_plasmidfinder_report]
+      - id: mlst
+        rename: staramr_mlst_report
+        add_tags: [staramr_mlst_report]
+      - id: detailed_summary
+        rename: staramr_detailed_summary
+        add_tags: [staramr_detailed_summary]

--- a/casts/claude/skills/_emulated-runs/uc1-mrsa-interview/run-summary.md
+++ b/casts/claude/skills/_emulated-runs/uc1-mrsa-interview/run-summary.md
@@ -1,0 +1,129 @@
+# Run summary — INTERVIEW → GALAXY / "MRSA mobile-AMR context across isolates"
+
+Driven via `/test-pipeline interview-to-galaxy "MRSA mobile-AMR context across isolates"`.
+Scenario = `content/pipelines/interview-to-galaxy/scenarios.md` → *Case: MRSA mobile-AMR context across isolates*.
+
+## Scenario as run
+
+Interview result supplied as the saved issue body `examples/UC1_MRSA_issue.md`
+(galaxy-brain #12). Aspirational (unvalidated) target: `examples/UC1_MRSA_extracted.ga`
+(14-step extracted history). Drove the full 11-phase spine in one run dir.
+
+## Molds exercised (in spine order)
+
+| phase | mold | how run |
+|---|---|---|
+| 1 | interview-to-freeform-summary | emulation (read cast SKILL.md) |
+| 2 | freeform-summary-to-galaxy-interface | emulation |
+| 3 | freeform-summary-to-galaxy-data-flow | emulation |
+| 4 | compare-against-iwc-exemplar | emulation + **real IWC corpus** (local iwc-format2 mirror) |
+| 5 | freeform-summary-to-galaxy-template | emulation + **`gxwf draft-validate` (real)** |
+| 6 | advance-galaxy-draft-step `[loop]` | **real `gxwf draft-next-step`/`draft-extract`/`draft-validate`** + 1 emulated concretization iteration |
+| 7 | `[branch]` test-data-resolution → find-test-data \| user-supplied | emulated from eval contract (**no cast bundle**) → routed `user-supplied` |
+| 8 | implement-galaxy-workflow-test | emulation + **real `gxwf validate-tests` (schema + cross-check)** |
+| 9 | validate-galaxy-workflow | **real `gxwf validate`** on concrete subset |
+| 10 | run-workflow-test | **blocked** — no planemo / Galaxy in env |
+| 11 | debug-galaxy-workflow-output | **N/A** — no failed run to debug; also no cast bundle |
+
+## Inputs consumed
+
+- `content/pipelines/interview-to-galaxy/examples/UC1_MRSA_issue.md` (interview result, binding fixture).
+- IWC corpus: `~/projects/repositories/workflow-fixtures/iwc-format2/bacterial_genomics/amr_gene_detection/` (nearest exemplar).
+- `content/pipelines/interview-to-galaxy/examples/UC1_MRSA_extracted.ga` (compare-and-contrast target + emulated discovery source for tool_ids/ports/changesets).
+
+## Outputs produced (under this run dir)
+
+- `freeform-summary.md`
+- `freeform-galaxy-interface.md`
+- `freeform-galaxy-data-flow.md`
+- `iwc-comparison-notes.md` + `iwc-exemplar.gxwf.yml`
+- `galaxy-workflow-draft.gxwf.yml` (template draft; all 11 steps drafty, topology concrete; `draft valid`)
+- `galaxy-workflow-draft.iter1.gxwf.yml` (loop: integronfinder concretized)
+- `concrete-subset.gxwf.yml` (draft-extract of iter1; terminal-validates OK)
+- `test-data-refs.json` (all inputs `resolved:false` → user-supplied)
+- `galaxy-workflow-tests.yml` (test skeleton; schema + label cross-check OK)
+
+## Eval results
+
+### Per-step composition (member Mold eval.md applied to that step's output)
+
+| phase / mold | property | verdict |
+|---|---|---|
+| 1 interview-to-freeform-summary | handoff fidelity preserves interview facts | ✅ |
+| | no invented specificity | ✅ (reshape tool, classify rules, distance cutoff left open) |
+| | shared shape with summarize-paper | ✅ |
+| 2 interface | primary data surface identified | ✅ (list<fasta> primary; metadata not over-promoted) |
+| | sample-sheet / per-sample metadata preserved | ✅ (list keyed by isolate id) |
+| | output labels testable | ✅ (JBrowse/figures flagged non-workflow) |
+| | uncertainty carried, not invented | ✅ |
+| | downstream data-flow can consume | ✅ |
+| 3 data-flow | preserves source analysis intent | ✅ |
+| | operations classified, not guessed | ✅ (closest=corpus-gap tool need) |
+| | collection shape survives across nodes | ✅ (identifier-sync called load-bearing) |
+| | unresolved tool needs bounded | ✅ (shapes, no Tool Shed IDs) |
+| | template can consume the draft | ✅ |
+| 4 compare-against-iwc-exemplar | nearest exemplar + confidence + citation | ✅ (amr_gene_detection, **Medium**) |
+| | selection domain-aligned, confidence justified | ✅ |
+| | structural diff names real alignments/mismatches | ✅ |
+| | no forced nearest | N/A (exemplar exists) |
+| | generic-tool overlap not high conf | ✅ (staramr is domain-specific) |
+| | gxformat2 view surfaced (sibling + inline excerpt) | ✅ *(initially missed inline excerpt + used "Medium-High"; corrected mid-run)* |
+| | inline excerpt is relevant subgraph | ✅ |
+| | corpus reuses local clone / offline-tolerant | ✅ (used local mirror) |
+| 5 template | *(Mold has **no eval.md/scenarios.md**)* | high-level: ✅ topology fully resolved, only wrapper-tier TODO, `draft valid`, IWC-aligned, open Qs carried |
+| 6 advance-loop | draft-next-step picks deterministically + stable | ✅ (picks `integronfinder`; stable) |
+| | fully concrete terminates loop | ✅ (exemplar → `draft:false`) |
+| | well-formed draft validates clean `--concrete` | ✅ (drafty steps excluded, not malformed) |
+| | extract = maximal concrete prefix | ✅ (all-drafty → inputs only) |
+| | one invocation advances one step | ✅ (integronfinder → next pick `isescan`) |
+| | implemented step leaves no TODO | ✅ (`grep TODO`=0 on step; real port `integrons_table`; downstream repointed) |
+| | round-trips to oracle | N/A (no fixture oracle for this scenario) |
+| | terminates without per-step work on concrete | ✅ |
+| | no shed candidate → authoring | ⚠ design: classify_context (no tool + undefined rules) is the fall-through case; not executed (no live shed) |
+| | `--concrete` failure routes to right surface | ⚠ design: mobile_to_bed 2-input→awk arity mismatch is the routing case; documented, not executed |
+| 7 find-test-data | no fabricated references | ✅ (accessions kept `resolved:false`) |
+| | shape & datatype match | ✅ |
+| | full input coverage | ✅ (every input one entry) |
+| 8 implement-galaxy-workflow-test | tests-format schema gate | ✅ (`OK`) |
+| | workflow/test cross-check gate | ✅ (`OK`, zero missing labels) |
+| | static CLI validation | ✅ |
+| | managed Galaxy runtime green | ❌ N/A — no planemo/Galaxy |
+| 9 validate-galaxy-workflow | terminal validate (concrete) | ✅ concrete subset OK; correctly **rejects** drafty full wf |
+| 10 run-workflow-test | structured Planemo capture / modes / failure handoff | ❌ blocked — no runtime |
+| 11 debug-galaxy-workflow-output | — | N/A (no failed run; no cast) |
+
+### Pipeline-level oracle
+
+No `content/pipelines/interview-to-galaxy/eval.md` exists → oracle = scenario `expect:` + compare-and-contrast.
+
+| scenario `expect:` assertion | verdict |
+|---|---|
+| gxformat2 workflow validates and round-trips | ⚠ **partial** — draft validates; concrete subset terminal-validates; **full concrete validate+roundtrip not reached** (loop incomplete: no Tool Shed/tool cache) |
+| isolate-assembly collection as primary input | ✅ `MRSA isolate assemblies` list<fasta> |
+| staramr + ≥1 mobile-element caller preserved | ✅ staramr + ISEScan + IntegronFinder |
+| mobile-context carried as real step / explicit decision, not dropped | ✅ `nearest_feature` + `classify_context` steps; classification rules carried as explicit open decision |
+| per-isolate ARG summary/heatmap as output | ✅ `staramr_summary` + `arg_heatmap` promoted |
+
+**Compare-and-contrast vs `UC1_MRSA_extracted.ga`:**
+
+- **Closest-feature idiom: reached.** The run independently arrives at the same `bedtools closest -d` idiom the target uses — surfaced by the data-flow brief from the Foundry interval-patterns *corpus-gap* note, then carried through the template. Strong cross-validation.
+- **Richer than the target on the science the issue asked for:** the target feeds **only ISEScan** into the distance computation (IntegronFinder runs but its calls are never used downstream) and has **no classification step** — the differential call is implicit. The run keeps **both** mobile-element callers in the design and adds an explicit `classify_context` step for the 5 context classes the issue enumerates. Per the scenario's "beat the target" framing, this is favorable.
+- **Tools:** the run invents **no** tool beyond the target's set; tool_ids/ports/changesets used in the loop were harvested from the target `.ga` + the IWC exemplar (staramr pinned to the **IWC `iuc/staramr/...0.11.0+galaxy3`** rather than the target's `nml/...0.12.3` — corpus-first authority preferred; nml noted as alternative).
+- **Stretch goals NOT met:** Bakta whole-genome annotation and a JBrowse locus view (the issue's "bonus" the manual build skipped) were **de-scoped** by the interface brief to enrichment/figure layers — the run did *not* pull them in, so it does not exceed the target there.
+- **Template topology issue vs target:** the run's single `mobile_to_bed` step combines IS+integron in one reshape; the target uses separate single-input reshapes. The combined step doesn't map onto a single-input awk → a real arity mismatch the loop must fix (insert a concat).
+
+## Process observations
+
+- No `gxwf` on PATH; used `node_modules/.bin/gxwf`. No planemo, no Galaxy server, no `.venv`.
+- **Cast bundles missing** for `find-test-data` and `debug-galaxy-workflow-output` (both phase members) — emulated phase 7 from eval contract; phase 11 N/A.
+- `freeform-summary-to-galaxy-template` has **no eval.md and no scenarios.md** (all 10 other phase Molds have eval.md).
+- `implement-galaxy-workflow-test` Procedure is a **stub** ("Replace with real skill content per MOLD_SPEC once first walks are done") and declares a `galaxy-test-plan` input with **no producer in the INTERVIEW→GALAXY spine** (only the nextflow/cwl pipelines have a `*-test-to-galaxy-test-plan` phase).
+- `gxwf draft-next-step` has no `--json` flag (uses `--output-format json`); minor doc nit vs intuition.
+- The advance loop could not reach a full concrete endstate in this environment: 8 distinct wrappers need live discover-shed-tool + a Galaxy tool cache for summarize-galaxy-tool/`tool_state` binding; hand-fabricating that state would violate the loop's own no-fabrication property.
+
+## Cross-cutting open questions
+
+- Should INTERVIEW→GALAXY (and PAPER→GALAXY) gain a freeform `*-test-to-galaxy-test-plan` phase, or should `implement-galaxy-workflow-test` make `galaxy-test-plan` formally optional?
+- Should `find-test-data` and `debug-galaxy-workflow-output` be cast (they're live phase members but have no bundles)?
+- Should the pipeline carry a `eval.md` (end-to-end oracle) so `/test-pipeline` has a pipeline layer beyond the scenario `expect:`?
+- Does the template need a guard against emitting a multi-input reshape step that no single-input text tool can realize (the `mobile_to_bed` arity bug)?

--- a/casts/claude/skills/_emulated-runs/uc1-mrsa-interview/test-data-refs.json
+++ b/casts/claude/skills/_emulated-runs/uc1-mrsa-interview/test-data-refs.json
@@ -1,0 +1,40 @@
+{
+  "_note": "Emulated from find-test-data eval/index contract (no cast bundle exists for find-test-data). Branch test-data-resolution chain: find-test-data -> user-supplied. Per the 'no fabricated references' property, the issue's accessions are recorded as UNVERIFIED candidates (resolved:false), so the chain falls through to the 'user-supplied' terminal sentinel.",
+  "branch_outcome": "user-supplied",
+  "inputs": [
+    {
+      "label": "MRSA isolate assemblies",
+      "galaxy_shape": "list",
+      "datatype": "fasta",
+      "resolved": false,
+      "reason": "Source lists candidate isolate accessions only as 'candidate subset to verify', not confirmed direct FASTA download URLs. No stable URL/path can be emitted without fabrication.",
+      "candidate_leads": {
+        "bioproject": "PRJDB8599",
+        "candidate_accessions": ["KUN1163: AP020324+AP020325", "KUH140013: AP020311+AP020312", "KUH140046: AP020313+AP020314", "KUH180129: AP020322+AP020323"],
+        "zenodo": ["https://doi.org/10.5281/zenodo.10572227", "https://doi.org/10.5281/zenodo.10669812"],
+        "fallback": "small Zenodo bundle (combined chromosome+plasmid FASTA per isolate + metadata TSV) if direct INSDC import is unstable"
+      }
+    },
+    {
+      "label": "isolate metadata",
+      "galaxy_shape": "single",
+      "datatype": "tabular",
+      "resolved": false,
+      "reason": "No metadata TSV artifact supplied; source lists it as an expected output/fallback input to be hand-curated. Optional workflow input."
+    },
+    {
+      "label": "StarAMR database",
+      "galaxy_shape": "param",
+      "datatype": "string",
+      "resolved": false,
+      "reason": "Parameter value, not staged test data. Pin a specific staramr DB version at test time (source flags DB-version dependence); not resolvable as a data ref."
+    },
+    {
+      "label": "Species for point mutation analysis",
+      "galaxy_shape": "param",
+      "datatype": "string",
+      "resolved": false,
+      "reason": "Parameter value, not staged test data. For MRSA = Staphylococcus aureus; supply at test time."
+    }
+  ]
+}

--- a/casts/claude/skills/debug-galaxy-workflow-output/SKILL.md
+++ b/casts/claude/skills/debug-galaxy-workflow-output/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: debug-galaxy-workflow-output
+description: "Triage failing Galaxy run outputs; classify the failure surface and capture evidence before recommending repairs."
+---
+
+# debug-galaxy-workflow-output
+
+Follow the procedure below and use the artifact/reference sections as the runtime contract.
+
+## When To Use
+
+- Triage failing Galaxy run outputs; classify the failure surface and capture evidence before recommending repairs.
+
+## Inputs
+
+- Read artifact `workflow-test-result`. Produced by `run-workflow-test`. Structured run handoff from run-workflow-test: Planemo result, invocation/job/artifact context, and the observed failure modality.
+
+## Outputs
+
+- Write artifact `workflow-debug-report` as `workflow-debug-report.md`. Format: `markdown`. Failure-surface classification with captured job/invocation/collection/assertion evidence and a recommended next step or reference-gap follow-up.
+
+## Required Tools
+
+- None declared. Procedure should not assume external CLIs are present.
+
+## Load Upfront
+
+- None declared.
+
+## Load On Demand
+
+- `references/notes/galaxy-collection-semantics.md`: Research note copied verbatim into the bundle. Diagnose collection shape, mapping, reduction, and element-identifier mismatches in failed Galaxy runs. Use when: a failing output is a collection, a mapped output, or an unexpectedly nested/flattened structure.
+- `references/notes/galaxy-collection-semantics.upstream.myst`: Companion file copied verbatim into the bundle. Sibling of `references/notes/galaxy-collection-semantics.md`; read it where that note directs.
+- `references/notes/galaxy-collection-semantics.yml`: Companion file copied verbatim into the bundle. Sibling of `references/notes/galaxy-collection-semantics.md`; read it where that note directs.
+- `references/notes/galaxy-tool-job-failure-reference.md`: Research note copied verbatim into the bundle. Interpret Galaxy job-level failure evidence including stdio rules, exit code, job messages, and output dataset state. Use when: a failed workflow test includes errored jobs, tool stderr/stdout, non-zero exit codes, or red output datasets.
+- `references/notes/galaxy-workflow-invocation-failure-reference.md`: Research note copied verbatim into the bundle. Interpret Galaxy invocation-level failure evidence including invocation state, structured messages, and step job summaries. Use when: a failed workflow test has invocation failure, missing workflow outputs, cancelled/paused steps, subworkflow failures, or collection population errors.
+- `references/notes/iwc-shortcuts-anti-patterns.md`: Research note copied verbatim into the bundle. Decide whether a proposed debug fix aligns with accepted IWC testing shortcuts or masks a real failure. Use when: debugging suggests weakening assertions, widening deltas, switching to existence checks, or changing output labels.
+- `references/notes/nextflow-operators-to-galaxy-collection-recipes.md`: Research note copied verbatim into the bundle. Trace collection output failures back to possibly lossy operator translations. Use when: debugging wrong nesting, missing elements, branch merges, bad joins, or gather/reduction mismatches.
+- `references/notes/planemo-asserts-idioms.md`: Research note copied verbatim into the bundle. Classify whether a failure is an assertion-choice problem, tolerance problem, or real workflow-output regression. Use when: planemo reports output assertion failures or generated tests are too strict/too weak.
+- `references/notes/planemo-workflow-test-architecture.md`: Research note copied verbatim into the bundle. Locate which Planemo artifact or Galaxy API surface preserves the failure evidence. Use when: planemo output is ambiguous, structured test JSON is available, or rerunning can be avoided by inspecting an existing invocation.
+
+## Validation
+
+- None declared.
+
+## Procedure
+
+Triage a failing Galaxy workflow test. Take the structured handoff from run-workflow-test, classify the failure surface before proposing any repair, and capture the reference evidence the surface requires. When the failure cannot be classified from existing references, recommend a focused follow-up rather than converting uncertainty into a guessed fix.
+
+Classify before repairing. The same red output can be a tool/job failure, a workflow invocation failure, a collection-output mismatch, a missing workflow output, or an assertion mismatch — and each routes to a different reference surface and a different fix. Locate where the evidence lives first (planemo-workflow-test-architecture).
+
+### Sequence
+
+1. **Classify the first failure surface.** From the run's structured result, decide whether the first failure is a tool/job failure, a workflow invocation failure, a collection-output mismatch, a missing workflow output, or an assertion mismatch. Classify before proposing repairs.
+2. **Capture job-failure evidence.** When a job is in `error`/`failed`/`stopped`, record job id, tool id, exit code, job messages, the stdout/stderr distinction, and output dataset state per galaxy-tool-job-failure-reference; check whether the wrapper's failure semantics already explain it.
+3. **Capture invocation-failure evidence.** When the invocation state or messages indicate scheduling, materialization, cancellation, conditional, or output-resolution failure, record invocation state, the structured message reason, the affected step, any subworkflow path, and the jobs summary per galaxy-workflow-invocation-failure-reference; note whether Planemo surfaced or hid the relevant Galaxy API detail.
+4. **Trace collection mismatches.** When a failing output is a collection or mapped output, diagnose shape, mapping, reduction, and element-identifier mismatches with galaxy-collection-semantics; for workflows translated from Nextflow, trace wrong nesting / missing elements / bad joins back to possibly-lossy operator translations via nextflow-operators-to-galaxy-collection-recipes.
+5. **Read assertion failures honestly.** When the failure is an assertion, use planemo-asserts-idioms to decide whether it is an assertion-choice/tolerance problem or a real output regression. Before weakening an assertion, widening a delta, or switching to an existence check, confirm against iwc-shortcuts-anti-patterns that the relaxation is an accepted IWC shortcut and not masking a real failure.
+6. **Discover reference gaps.** When the failure cannot be classified confidently from the references above, recommend a focused follow-up — reference documentation, pattern capture, API verification, or eval coverage — rather than emitting a repair recipe built on a guess.
+
+## Runtime Notes
+
+- Do not read Foundry source files at runtime; use only files packaged in this skill bundle and user-supplied artifacts.
+- Preserve declared artifact filenames unless the user or harness supplies explicit paths.
+- Carry unresolved assumptions into the output artifact instead of silently inventing missing source evidence.

--- a/casts/claude/skills/debug-galaxy-workflow-output/_provenance.json
+++ b/casts/claude/skills/debug-galaxy-workflow-output/_provenance.json
@@ -1,0 +1,170 @@
+{
+  "provenance_schema_version": 2,
+  "cast_target": "claude",
+  "mold": {
+    "name": "debug-galaxy-workflow-output",
+    "path": "content/molds/debug-galaxy-workflow-output/index.md",
+    "revision": 4,
+    "content_hash": "9d560d77fe14fb9c2ebee1a67b49370d2d1b080a6821835407c4b89877bf7fd4",
+    "commit": "64a340bb8e24e9949be9cbd6678a51da42d14203"
+  },
+  "cast_at": "2026-06-15T13:53:42.883Z",
+  "refs": [
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[galaxy-collection-semantics]]",
+      "src": "content/research/galaxy-collection-semantics.md",
+      "dst": "references/notes/galaxy-collection-semantics.md",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Diagnose collection shape, mapping, reduction, and element-identifier mismatches in failed Galaxy runs.",
+      "trigger": "When a failing output is a collection, a mapped output, or an unexpectedly nested/flattened structure.",
+      "src_hash": "42d416765af0e91a48509cc37c09cfd69eaf9f724aa06c08e393b014c02b142e",
+      "dst_hash": "42d416765af0e91a48509cc37c09cfd69eaf9f724aa06c08e393b014c02b142e",
+      "source": "deterministic"
+    },
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[galaxy-collection-semantics]]",
+      "src": "content/research/galaxy-collection-semantics.upstream.myst",
+      "dst": "references/notes/galaxy-collection-semantics.upstream.myst",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Diagnose collection shape, mapping, reduction, and element-identifier mismatches in failed Galaxy runs.",
+      "trigger": "When a failing output is a collection, a mapped output, or an unexpectedly nested/flattened structure.",
+      "companion_of": "references/notes/galaxy-collection-semantics.md",
+      "src_hash": "bbc8215b0a6ae8e735042af8353c73fc0d740f4ff8a32d85aba83eae63a2b3a1",
+      "dst_hash": "bbc8215b0a6ae8e735042af8353c73fc0d740f4ff8a32d85aba83eae63a2b3a1",
+      "source": "deterministic"
+    },
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[galaxy-collection-semantics]]",
+      "src": "content/research/galaxy-collection-semantics.yml",
+      "dst": "references/notes/galaxy-collection-semantics.yml",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Diagnose collection shape, mapping, reduction, and element-identifier mismatches in failed Galaxy runs.",
+      "trigger": "When a failing output is a collection, a mapped output, or an unexpectedly nested/flattened structure.",
+      "companion_of": "references/notes/galaxy-collection-semantics.md",
+      "src_hash": "f4e9d0a55459b6080b826e2ae41a920c9404f95fda0e518be8f86bc3d2e73e6e",
+      "dst_hash": "f4e9d0a55459b6080b826e2ae41a920c9404f95fda0e518be8f86bc3d2e73e6e",
+      "source": "deterministic"
+    },
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[galaxy-tool-job-failure-reference]]",
+      "src": "content/research/galaxy-tool-job-failure-reference.md",
+      "dst": "references/notes/galaxy-tool-job-failure-reference.md",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Interpret Galaxy job-level failure evidence including stdio rules, exit code, job messages, and output dataset state.",
+      "trigger": "When a failed workflow test includes errored jobs, tool stderr/stdout, non-zero exit codes, or red output datasets.",
+      "src_hash": "9d5c615b75660e932c0bb1b6f8d13390e735901764aea5989cd39ec500227e1b",
+      "dst_hash": "9d5c615b75660e932c0bb1b6f8d13390e735901764aea5989cd39ec500227e1b",
+      "source": "deterministic"
+    },
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[galaxy-workflow-invocation-failure-reference]]",
+      "src": "content/research/galaxy-workflow-invocation-failure-reference.md",
+      "dst": "references/notes/galaxy-workflow-invocation-failure-reference.md",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Interpret Galaxy invocation-level failure evidence including invocation state, structured messages, and step job summaries.",
+      "trigger": "When a failed workflow test has invocation failure, missing workflow outputs, cancelled/paused steps, subworkflow failures, or collection population errors.",
+      "src_hash": "9c68c90b974111298e089ba2e4193e3fc074836a4d675ddfedf954a2b133337c",
+      "dst_hash": "9c68c90b974111298e089ba2e4193e3fc074836a4d675ddfedf954a2b133337c",
+      "source": "deterministic"
+    },
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[iwc-shortcuts-anti-patterns]]",
+      "src": "content/research/iwc-shortcuts-anti-patterns.md",
+      "dst": "references/notes/iwc-shortcuts-anti-patterns.md",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Decide whether a proposed debug fix aligns with accepted IWC testing shortcuts or masks a real failure.",
+      "trigger": "When debugging suggests weakening assertions, widening deltas, switching to existence checks, or changing output labels.",
+      "src_hash": "69269abd774152694053f0b9922f88dfcd175ba8c3697b2c530d911740c7fcc6",
+      "dst_hash": "69269abd774152694053f0b9922f88dfcd175ba8c3697b2c530d911740c7fcc6",
+      "source": "deterministic"
+    },
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[nextflow-operators-to-galaxy-collection-recipes]]",
+      "src": "content/research/nextflow-operators-to-galaxy-collection-recipes.md",
+      "dst": "references/notes/nextflow-operators-to-galaxy-collection-recipes.md",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Trace collection output failures back to possibly lossy operator translations.",
+      "trigger": "When debugging wrong nesting, missing elements, branch merges, bad joins, or gather/reduction mismatches.",
+      "src_hash": "d583e8f902dd236d021dedad83bd8dff7350cfed5935c0ecd5734c90b98d69f6",
+      "dst_hash": "d583e8f902dd236d021dedad83bd8dff7350cfed5935c0ecd5734c90b98d69f6",
+      "source": "deterministic"
+    },
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[planemo-asserts-idioms]]",
+      "src": "content/research/planemo-asserts-idioms.md",
+      "dst": "references/notes/planemo-asserts-idioms.md",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Classify whether a failure is an assertion-choice problem, tolerance problem, or real workflow-output regression.",
+      "trigger": "When Planemo reports output assertion failures or generated tests are too strict/too weak.",
+      "src_hash": "9d87cd37efcc3f5e3a378011892f3846c8fdecec7a5765193044d71edb746ed9",
+      "dst_hash": "9d87cd37efcc3f5e3a378011892f3846c8fdecec7a5765193044d71edb746ed9",
+      "source": "deterministic"
+    },
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[planemo-workflow-test-architecture]]",
+      "src": "content/research/planemo-workflow-test-architecture.md",
+      "dst": "references/notes/planemo-workflow-test-architecture.md",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Locate which Planemo artifact or Galaxy API surface preserves the failure evidence.",
+      "trigger": "When Planemo output is ambiguous, structured test JSON is available, or rerunning can be avoided by inspecting an existing invocation.",
+      "src_hash": "f66d053cf71c5d5aa4151e0b55719f9b200f5848e7dc69e0200d63d991a9dacf",
+      "dst_hash": "f66d053cf71c5d5aa4151e0b55719f9b200f5848e7dc69e0200d63d991a9dacf",
+      "source": "deterministic"
+    }
+  ],
+  "artifacts": {
+    "produces": [
+      {
+        "id": "workflow-debug-report",
+        "kind": "markdown",
+        "default_filename": "workflow-debug-report.md",
+        "description": "Failure-surface classification with captured job/invocation/collection/assertion evidence and a recommended next step or reference-gap follow-up."
+      }
+    ],
+    "consumes": [
+      {
+        "id": "workflow-test-result",
+        "description": "Structured run handoff from run-workflow-test: Planemo result, invocation/job/artifact context, and the observed failure modality.",
+        "producers": [
+          "run-workflow-test"
+        ]
+      }
+    ]
+  }
+}

--- a/casts/claude/skills/debug-galaxy-workflow-output/_verify.json
+++ b/casts/claude/skills/debug-galaxy-workflow-output/_verify.json
@@ -1,0 +1,4 @@
+{
+  "verify_schema_version": 1,
+  "entries": []
+}

--- a/casts/claude/skills/debug-galaxy-workflow-output/references/notes/galaxy-collection-semantics.md
+++ b/casts/claude/skills/debug-galaxy-workflow-output/references/notes/galaxy-collection-semantics.md
@@ -1,0 +1,42 @@
+---
+type: research
+subtype: component
+title: "Galaxy collection semantics"
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-04-30
+revised: 2026-05-05
+revision: 3
+ai_generated: false
+related_notes:
+  - "[[galaxy-xsd]]"
+  - "[[galaxy-collection-tools]]"
+  - "[[galaxy-apply-rules-dsl]]"
+  - "[[nextflow-to-galaxy-channel-shape-mapping]]"
+  - "[[nextflow-operators-to-galaxy-collection-recipes]]"
+  - "[[galaxy-tool-job-failure-reference]]"
+  - "[[galaxy-workflow-invocation-failure-reference]]"
+  - "[[iwc-transformations-survey]]"
+  - "[[galaxy-discover-datasets]]"
+sources:
+  - "https://github.com/galaxyproject/galaxy/blob/7765fae934fbfdee77e3be5f5b235e43735273ae/lib/galaxy/model/dataset_collections/types/collection_semantics.yml"
+companions:
+  - "galaxy-collection-semantics.yml"
+  - "galaxy-collection-semantics.upstream.myst"
+summary: "Vendored formal spec of Galaxy dataset-collection mapping/reduction semantics, with labeled examples and pinned test references."
+---
+
+> **Vendored from upstream**, pinned at SHA `7765fae`. Two files live next to this note:
+>
+> - `galaxy-collection-semantics.yml` — the structured source. **Agents and casting should consume this.** It carries the `tests:` blocks that pin concrete Galaxy test names; the rendered upstream view drops them.
+> - `galaxy-collection-semantics.upstream.myst` — Galaxy's auto-generated MyST/LaTeX rendering of the YAML, vendored only so the human view below has something to render. Sync is manual.
+>
+> **When to consult:** authoring or reasoning about Molds and patterns that touch `data_collection` inputs, map-over / reduction shape changes, sub-collection mapping, `paired_or_unpaired`, or `sample_sheet`.
+
+```vendored-myst
+file: galaxy-collection-semantics.upstream.myst
+source: https://github.com/galaxyproject/galaxy/blob/7765fae934fbfdee77e3be5f5b235e43735273ae/doc/source/dev/collection_semantics.md
+sha: 7765fae
+```

--- a/casts/claude/skills/debug-galaxy-workflow-output/references/notes/galaxy-collection-semantics.upstream.myst
+++ b/casts/claude/skills/debug-galaxy-workflow-output/references/notes/galaxy-collection-semantics.upstream.myst
@@ -1,0 +1,1120 @@
+# Collection Semantics
+
+This document describes the semantics around working with Galaxy dataset collections.
+In particular it describes how they operate within Galaxy tools and workflows.
+
+:::{admonition} You Probably Don't Need to Read This
+:class: caution
+
+Any significantly sophisticated workflow language will have ways to collect data
+into arrays or vectors or dictionaries and apply operations across this data (mapping)
+or reduce the dimensionality of this data (reductions). Typically, this is explicitly
+annotated with map functions or for loops. Galaxy however is designed to be a point
+and click interface for connecting steps and running tools. It is important that steps
+just connect and just do the most natural thing - and this is what Galaxy does.
+This document just provides a mathematical formalism to that "what should just
+intuitively work" that can be used to document test cases and help with implementation.
+This is reference documentation not user documentation, Galaxy should just work.
+:::
+
+## Mapping
+
+If a tool consumes a simple dataset parameter and produces a simple dataset parameter,
+then any collection type may be "mapped over" the data input to that tool. The result of
+that is the tool being applied to each element of the collection and "implicit collections"
+being created from the outputs that are produced from those operations. Those implicit
+collections have the same element identifiers in the same order as the input collection that is
+mapped over. Each element of the implicit collections correspond to their own job and
+Galaxy very naturally and intuitively parallelizes jobs without extra work from the user
+and without any knowledge of the tool.
+
+
+(BASIC_MAPPING_PAIRED)=
+(BASIC_MAPPING_PAIRED_OR_UNPAIRED_PAIRED)=
+(BASIC_MAPPING_PAIRED_OR_UNPAIRED_UNPAIRED)=
+(BASIC_MAPPING_LIST)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `BASIC_MAPPING_PAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ dataset }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{paired},\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C)) \mapsto \left\{o: \text{collection}<\text{paired},\left\{\text{forward}=tool(i=d_f)[o], \text{reverse}=tool(i=d_r)[o]\right\}>\right\}$$
+
+:::
+
+
+
+:::{admonition} Example: `BASIC_MAPPING_PAIRED_OR_UNPAIRED_PAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ dataset }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{paired\_or\_unpaired},\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C)) \mapsto \left\{o: \text{collection}<\text{paired\_or\_unpaired},\left\{\text{forward}=tool(i=d_f)[o], \text{reverse}=tool(i=d_r)[o]\right\}>\right\}$$
+
+:::
+
+
+
+:::{admonition} Example: `BASIC_MAPPING_PAIRED_OR_UNPAIRED_UNPAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_u $ is a dataset
+* $ tool \text{ is } (i: \text{ dataset }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{paired\_or\_unpaired},\left\{ \text{ unpaired }=d_u \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C)) \mapsto \left\{o: \text{collection}<\text{paired\_or\_unpaired},\left\{\text{unpaired}=tool(i=d_u)[o]\right\}>\right\}$$
+
+:::
+
+
+
+:::{admonition} Example: `BASIC_MAPPING_LIST` 
+:class: note
+
+Assuming,
+
+* $ d_1,...,d_n $ are datasets
+* $ tool \text{ is } (i: \text{ dataset }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list},\left\{ \text{ i1 }=d_1, ..., \text{ in }=d_n \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C)) \mapsto \left\{o: \text{collection}<\text{list},\left\{\text{i1}=tool(i=d_1)[o],...,\text{in}=tool(i=d_n)[o]\right\}>\right\}$$
+
+:::
+
+
+
+</details><br>
+
+
+
+The above description of mapping over inputs works naturally and as expected for
+nested collections.
+
+
+(NESTED_LIST_MAPPING)=
+(BASIC_MAPPING_LIST_PAIRED_OR_UNPAIRED)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `NESTED_LIST_MAPPING` 
+:class: note
+
+Assuming,
+
+* $ d_1,...,d_n $ are datasets
+* $ tool \text{ is } (i: \text{ dataset }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list}:\text{list},\left\{ \text{ o1 }=\left\{ \text{ inner }=d_1 \right\}, ..., \text{ on }=\left\{ \text{ inner }=d_n \right\} \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C)) \mapsto \left\{o: \text{collection}<\text{list}:\text{list},\left\{\text{o1}=\left\{\text{inner}=tool(i=d_1)[o]\right\},...,\text{on}=\left\{\text{inner}=tool(i=d_n)[o]\right\}\right\}>\right\}$$
+
+:::
+
+
+
+:::{admonition} Example: `BASIC_MAPPING_LIST_PAIRED_OR_UNPAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ dataset }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list}:\text{paired\_or\_unpaired},\left\{ \text{ el1 }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C)) \mapsto \left\{o: \text{collection}<\text{list}:\text{paired\_or\_unpaired},\left\{\text{el1}=\left\{\text{forward}=tool(i=d_f)[o], \text{reverse}=tool(i=d_r)[o]\right\}\right\}>\right\}$$
+
+:::
+
+
+
+</details><br>
+
+
+
+
+For tools with multiple data inputs, the tool can be executed with individual
+datasets for the non-mapped over input and each tool execution will just be executed
+with that dataset. The dataset not mapped over serves as the input for each execution.
+
+
+(BASIC_MAPPING_INCLUDING_SINGLE_DATASET)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `BASIC_MAPPING_INCLUDING_SINGLE_DATASET` 
+:class: note
+
+Assuming,
+
+* $ d_1,...,d_n $, $ d_o $ are datasets
+* $ tool \text{ is } (i: \text{ dataset }, i2: \text{ dataset }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list},\left\{ \text{ i1 }=d_1, ..., \text{ in }=d_n \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C), i2=d_o) \mapsto \left\{o: \text{collection}<\text{list},\left\{\text{i1}=tool(i=d_1, i2=d_o)[o],...,\text{in}=tool(i=d_n, i2=d_o)[o]\right\}>\right\}$$
+
+:::
+
+
+
+</details><br>
+
+
+
+If a tool consumes two input datasets and produces one output dataset, you can map two
+collections with identical structure (same element identifiers in the same order) over
+the respective inputs and the result is an implicit collection with the same structure
+as the inputs and where each output in the implicit collection corresponds to the tool
+being executed with the two inputs corresponding to that position in the input
+collections.
+
+The default behavior here is the collections are linked and the act of mapping over
+inputs to the tool are sort of a flat map or a dot product. No extra dimensionality
+in the resulting collections.
+
+From a user perspective this means if you start with a collection and apply a bunch
+of map over operations on tools - the results will all continue to match and work together
+very naturally - again without extra work by the user and without extra knowledge
+by the tool author.
+
+
+(BASIC_MAPPING_TWO_INPUTS_WITH_IDENTICAL_STRUCTURE)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `BASIC_MAPPING_TWO_INPUTS_WITH_IDENTICAL_STRUCTURE` 
+:class: note
+
+Assuming,
+
+* $ d1_1,...,d1_n $, $ d2_1,...,d2_n $ are datasets
+* $ tool \text{ is } (i: \text{ dataset }, i2: \text{ dataset }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C1 $ is $ \text{CollectionInstance<}\text{list},\left\{ \text{ i1 }=d1_1, ..., \text{ in }=d1_n \right\}\text{>} $
+* $ C2 $ is $ \text{CollectionInstance<}\text{list},\left\{ \text{ i1 }=d2_1, ..., \text{ in }=d2_n \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C1), i2=\text{mapOver}(C2)) \mapsto \left\{o: \text{collection}<\text{list},\left\{\text{i1}=tool(i=d1_1, i2=d2_1)[o],...,\text{in}=tool(i=d1_n, i2=d2_n)[o]\right\}>\right\}$$
+
+:::
+
+
+
+</details><br>
+
+
+
+## Reduction
+
+Not all tool executions result in implicit collections and mapping
+over inputs. Tool inputs of ``type`` ``data_collection`` can consume
+collections directly and do not necessarily result in mapping over.
+
+Tools that consume collections and output datasets effectively
+reduce the dimension of the Galaxy data structure. When used at runtime
+this is often referred to as a "reduction" in the code.
+
+
+(COLLECTION_INPUT_PAIRED)=
+(COLLECTION_INPUT_LIST)=
+(COLLECTION_INPUT_PAIRED_OR_UNPAIRED)=
+(COLLECTION_INPUT_LIST_PAIRED_OR_UNPAIRED)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `COLLECTION_INPUT_PAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<paired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{paired},\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\}\text{>} $
+
+
+then
+
+$$tool(i=C) \rightarrow \left\{o: \text{dataset}\right\}$$
+
+:::
+
+
+
+:::{admonition} Example: `COLLECTION_INPUT_LIST` 
+:class: note
+
+Assuming,
+
+* $ d_1,...,d_n $ are datasets
+* $ tool \text{ is } (i: \text{ collection<list> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list},\left\{ \text{ el1 }=d_1, ..., \text{ eln }=d_n \right\}\text{>} $
+
+
+then
+
+$$tool(i=C) \rightarrow \left\{o: \text{dataset}\right\}$$
+
+:::
+
+
+
+:::{admonition} Example: `COLLECTION_INPUT_PAIRED_OR_UNPAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<paired\_or\_unpaired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{paired\_or\_unpaired},\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\}\text{>} $
+
+
+then
+
+$$tool(i=C) \rightarrow \left\{o: \text{dataset}\right\}$$
+
+:::
+
+
+
+:::{admonition} Example: `COLLECTION_INPUT_LIST_PAIRED_OR_UNPAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<list:paired\_or\_unpaired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list}:\text{paired\_or\_unpaired},\left\{ \text{ el1 }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\}\text{>} $
+
+
+then
+
+$$tool(i=C) \rightarrow \left\{o: \text{dataset}\right\}$$
+
+:::
+
+
+
+</details><br>
+
+
+
+For nested collections where each rank is a ``list`` or a ``paired`` collection,
+then collection inputs must match every part of the collection type input definition.
+
+
+(COLLECTION_INPUT_LIST_NOT_CONSUMES_PAIRS)=
+(COLLECTION_INPUT_PAIRED_NOT_CONSUMES_LIST)=
+(COLLECTION_INPUT_LIST_PAIRED_NOT_CONSUMES_PAIRED_PAIRED)=
+(COLLECTION_INPUT_LIST_PAIRED_OR_NOT_PAIRED_NOT_CONSUMES_PAIRED_PAIRED)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `COLLECTION_INPUT_LIST_NOT_CONSUMES_PAIRS` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<list> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{paired},\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\}\text{>} $
+
+
+then
+
+$$tool(i=C)\text{ is invalid}$$
+
+:::
+
+
+
+:::{admonition} Example: `COLLECTION_INPUT_PAIRED_NOT_CONSUMES_LIST` 
+:class: note
+
+Assuming,
+
+* $ d_1,...,d_n $ are datasets
+* $ tool \text{ is } (i: \text{ collection<paired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list},\left\{ \text{ i1 }=d_1, ..., \text{ in }=d_n \right\}\text{>} $
+
+
+then
+
+$$tool(i=C)\text{ is invalid}$$
+
+:::
+
+
+
+:::{admonition} Example: `COLLECTION_INPUT_LIST_PAIRED_NOT_CONSUMES_PAIRED_PAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<list:paired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{paired}:\text{paired},\left\{ \text{ forward }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\}, \text{ reverse }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\}\text{>} $
+
+
+then
+
+$$tool(i=C)\text{ is invalid}$$
+
+:::
+
+
+
+:::{admonition} Example: `COLLECTION_INPUT_LIST_PAIRED_OR_NOT_PAIRED_NOT_CONSUMES_PAIRED_PAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<list:paired\_or\_unpaired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{paired}:\text{paired},\left\{ \text{ forward }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\}, \text{ reverse }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\}\text{>} $
+
+
+then
+
+$$tool(i=C)\text{ is invalid}$$
+
+:::
+
+
+
+</details><br>
+
+
+
+In addition to explicit collection inputs, tool inputs of ``type`` ``data``
+where ``multiple="true"`` can consume lists directly. This is likewise a
+"reduction" and does not result in implicit collection creation.
+
+
+(LIST_REDUCTION)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `LIST_REDUCTION` 
+:class: note
+
+Assuming,
+
+* $ d_1,...,d_n $ are datasets
+* $ tool \text{ is } (i: \text{ dataset<multiple=true> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list},\left\{ \text{ i1 }=d_1, ..., \text{ in }=d_n \right\}\text{>} $
+
+
+then
+
+$$tool(i=C) == tool(i=[d_1,...,d_n])$$
+
+:::
+
+
+
+</details><br>
+
+
+
+Paired collections cannot be reduced this way. ``paired`` is not meant
+to represent a list/array/vector data structure - it is more like a tuple.
+
+
+(PAIRED_REDUCTION_INVALID)=
+(PAIRED_OR_UNPAIRED_REDUCTION_INVALID)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `PAIRED_REDUCTION_INVALID` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ dataset<multiple=true> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{paired},\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\}\text{>} $
+
+
+then
+
+$$tool(i=C)\text{ is invalid}$$
+
+:::
+
+
+
+:::{admonition} Example: `PAIRED_OR_UNPAIRED_REDUCTION_INVALID` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ dataset<multiple=true> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{paired\_or\_unpaired},\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\}\text{>} $
+
+
+then
+
+$$tool(i=C)\text{ is invalid}$$
+
+:::
+
+
+
+</details><br>
+
+
+
+## Sub-collection Mapping
+
+![](https://planemo.readthedocs.io/en/master/_images/subcollection_mapping_identifiers.svg)
+
+
+(MAPPING_LIST_PAIRED_OVER_PAIRED)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `MAPPING_LIST_PAIRED_OVER_PAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<paired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list}:\text{paired},\left\{ \text{ el1 }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\}\text{>} $
+* $ C\_PAIRED $ is $ \text{CollectionInstance<}\text{paired},\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C, '\text{paired}')) \mapsto \left\{o: \text{collection}<\text{list},\left\{\text{el1}=tool(i=C\_PAIRED)[o]\right\}>\right\}$$
+
+:::
+
+
+
+</details><br>
+
+
+
+The natural extension of multiple data input parameters consuming list collections as described
+above when discussing reductions is that nested lists of lists (``list:list``) can be mapped
+over a multiple data input parameter. Each nested list will be reduced by this operation but the
+results will be mapped over. The result will be a list with the same structure as the outer list
+of the input collection.
+
+
+(NESTED_LIST_REDUCTION)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `NESTED_LIST_REDUCTION` 
+:class: note
+
+Assuming,
+
+* $ d_1,...,d_n $ are datasets
+* $ tool \text{ is } (i: \text{ dataset<multiple=true> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list}:\text{list},\left\{ \text{ o1 }=\left\{ \text{ inner }=d_1 \right\}, ..., \text{ on }=\left\{ \text{ inner }=d_n \right\} \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C, '\text{list}')) \mapsto \left\{o: \text{collection}<\text{list},\left\{\text{o1}=tool(i=[d_1])[o],...,\text{on}=tool(i=[d_n])[o]\right\}>\right\}$$
+
+:::
+
+
+
+</details><br>
+
+
+
+Just as a paired collection won't be reduced by a multiple data input, any sort of nested
+collection ending in a paired collection cannot be mapped over such an input. So a multiple
+data input parameter cannot be mapped over by a list of pairs (``list:paired``) for instance.
+
+
+(LIST_PAIRED_REDUCTION_INVALID)=
+(LIST_PAIRED_OR_UNPAIRED_REDUCTION_INVALID)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `LIST_PAIRED_REDUCTION_INVALID` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ dataset<multiple=true> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list}:\text{paired},\left\{ \text{ el1 }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C, '\text{paired}'))\text{ is invalid}$$
+
+:::
+
+
+
+:::{admonition} Example: `LIST_PAIRED_OR_UNPAIRED_REDUCTION_INVALID` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ dataset<multiple=true> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list}:\text{paired\_or\_unpaired},\left\{ \text{ el1 }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C, '\text{paired\_or\_unpaired}'))\text{ is invalid}$$
+
+:::
+
+
+
+</details><br>
+
+
+
+## paired_or_unpaired Collections
+
+The collection type ``paired_or_unpaired`` is meant to serve as a stand-in for
+an entity that can be either a single dataset or what is effectively a ``paired``
+dataset collection. These collections either have one element with identifier
+``unpaired`` or two elements with identifiers ``forward`` and ``reverse``.
+
+Tools can declare a data_collection input with collection type ``paired_or_unpaired``
+and that input will consume either an explicit ``paired_or_unpaired`` collection
+normally or can consume a ``paired`` input.
+
+
+(PAIRED_OR_UNPAIRED_CONSUMES_PAIRED)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `PAIRED_OR_UNPAIRED_CONSUMES_PAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<paired\_or\_unpaired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{paired},\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\}\text{>} $
+* $ C_AS_MIXED = CollectionInstance<\text{paired\_or\_unpaired}, \left\{\text{forward}: d_f, \text{reverse}: d_r\right\}> $
+
+
+then
+
+$$tool(i=C) == tool(i=C_AS_MIXED)$$
+
+:::
+
+
+
+</details><br>
+
+
+
+
+The inverse of this doesn't work intentionally. In some ways a ``paired`` collection
+acts as a ``paired_or_unpaired`` collection but a ``paired_or_unpaired`` is not a paired
+collection. This makes a lot of sense in terms of tools - a tool consuming a ``paired``
+dataset expects to find both a ``forward`` and ``reverse`` element but these may not exist
+in ``paired_or_unpaired`` collection.
+
+
+(PAIRED_OR_UNPAIRED_NOT_CONSUMED_BY_PAIRED)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `PAIRED_OR_UNPAIRED_NOT_CONSUMED_BY_PAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<paired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{paired\_or\_unpaired},\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\}\text{>} $
+
+
+then
+
+$$tool(i=C)\text{ is invalid}$$
+
+:::
+
+
+
+</details><br>
+
+
+
+
+The same logic holds for mapping, lists of paired datasets (``list:paired``) can be mapped over these
+``paired_or_unpaired`` inputs and mixed lists of pairs (``list:paired_or_unpaired``) cannot
+be mapped over a ``paired`` input. Following the same logic, ``list:paired_or_unpaired`` cannot
+be mapped over a ``list`` input or multiple data input.
+
+
+(MAPPING_LIST_PAIRED_OVER_PAIRED_OR_UNPAIRED)=
+(PAIRED_OR_UNPAIRED_NOT_CONSUMED_BY_PAIRED_WHEN_MAPPING)=
+(PAIRED_OR_UNPAIRED_NOT_CONSUMED_BY_LIST_WHEN_MAPPING)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `MAPPING_LIST_PAIRED_OVER_PAIRED_OR_UNPAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<paired\_or\_unpaired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list}:\text{paired},\left\{ \text{ el }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\}\text{>} $
+* $ C_AS_MIXED $ is $ \text{CollectionInstance<}\text{list}:\text{paired\_or\_unpaired},\left\{ \text{ el }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C)) == tool(i=\text{mapOver}(C_AS_MIXED))$$
+
+:::
+
+
+
+:::{admonition} Example: `PAIRED_OR_UNPAIRED_NOT_CONSUMED_BY_PAIRED_WHEN_MAPPING` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<paired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list}:\text{paired\_or\_unpaired},\left\{ \text{ el }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C))\text{ is invalid}$$
+
+:::
+
+
+
+:::{admonition} Example: `PAIRED_OR_UNPAIRED_NOT_CONSUMED_BY_LIST_WHEN_MAPPING` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<list> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list}:\text{paired\_or\_unpaired},\left\{ \text{ el }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C))\text{ is invalid}$$
+
+:::
+
+
+
+</details><br>
+
+
+
+This logic extends naturally into higher dimensional collections. A ``list:list:paired``
+can be mapped over either a ``paired_or_unpaired`` input to produce a nested list (``list:list``)
+or a ``list:paired_or_unpaired`` input to produce a flat list (``list``).
+
+
+(MAPPING_LIST_LIST_PAIRED_OVER_PAIRED_OR_UNPAIRED)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `MAPPING_LIST_LIST_PAIRED_OVER_PAIRED_OR_UNPAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<paired\_or\_unpaired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list}:\text{list}:\text{paired},\left\{ \text{ o1 }=\left\{ \text{ el1 }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\} \right\}\text{>} $
+* $ C_AS_MIXED $ is $ \text{CollectionInstance<}\text{list}:\text{list}:\text{paired\_or\_unpaired},\left\{ \text{ o1 }=\left\{ \text{ el1 }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\} \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C)) == tool(i=\text{mapOver}(C_AS_MIXED))$$
+
+:::
+
+
+
+</details><br>
+
+
+
+
+In order for ``paired_or_unpaired`` collections to also act as a single dataset,
+a flat list can be mapped over a such an input with a special sub collection mapping
+type of 'single_datasets'.
+
+
+(MAPPING_LIST_OVER_PAIRED_OR_UNPAIRED)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `MAPPING_LIST_OVER_PAIRED_OR_UNPAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_1,...,d_n $ are datasets
+* $ tool \text{ is } (i: \text{ collection<paired\_or\_unpaired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list},\left\{ \text{ i1 }=d_1, ..., \text{ in }=d_n \right\}\text{>} $
+* $ C_AS_UNPAIRED_i = CollectionInstance<\text{paired\_or\_unpaired},\left\{\text{unpaired}=di\right\}> for i from 1...n $
+
+
+then
+
+$$tool(i=\text{mapOver}(C, '\text{single\_datasets}')) \mapsto \left\{o: \text{collection}<\text{list},\left\{\text{i1}=tool(i=C_AS_UNPAIRED_1)[o],...,\text{in}=tool(i=C_AS_UNPAIRED_n)[o]\right\}>\right\}$$
+
+:::
+
+
+
+</details><br>
+
+
+
+This treatment of lists without pairing extends to nested structures naturally.
+For instance, a list of list of datasets (``list:list``) can be mapped over a
+``paired_or_unpaired`` input to produce a nested list of lists (``list:list``)
+with a structure matching the input. Likewise, the nested list can be mapped over
+a ``list:paired_or_unpaired`` input to produce a flat list with the same structure
+as the outer list of the input.
+
+
+(MAPPING_LIST_LIST_OVER_PAIRED_OR_UNPAIRED)=
+(MAPPING_LIST_LIST_OVER_LIST_PAIRED_OR_UNPAIRED)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `MAPPING_LIST_LIST_OVER_PAIRED_OR_UNPAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_1,...,d_n $ are datasets
+* $ tool \text{ is } (i: \text{ collection<paired\_or\_unpaired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list}:\text{list},\left\{ \text{ o1 }=\left\{ \text{ inner }=d_1 \right\}, ..., \text{ on }=\left\{ \text{ inner }=d_n \right\} \right\}\text{>} $
+* $ C_AS_UNPAIRED_j = CollectionInstance<\text{paired\_or\_unpaired},\left\{\text{unpaired}=dj\right\}> for each \text{dataset} dj in C $
+
+
+then
+
+$$tool(i=\text{mapOver}(C, '\text{single\_datasets}')) \mapsto \left\{o: \text{collection}<\text{list}:\text{list},\left\{\text{o1}=\left\{\text{inner}=tool(i=C_AS_UNPAIRED_1)[o]\right\},...,\text{on}=\left\{\text{inner}=tool(i=C_AS_UNPAIRED_n)[o]\right\}\right\}>\right\}$$
+
+:::
+
+
+
+:::{admonition} Example: `MAPPING_LIST_LIST_OVER_LIST_PAIRED_OR_UNPAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_1,...,d_n $ are datasets
+* $ tool \text{ is } (i: \text{ collection<list:paired\_or\_unpaired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list}:\text{list},\left\{ \text{ o1 }=\left\{ \text{ inner }=d_1 \right\}, ..., \text{ on }=\left\{ \text{ inner }=d_n \right\} \right\}\text{>} $
+* $ C_AS_LPU_i = \text{inner} \text{list} of C at position i, treated as \text{list}:\text{paired\_or\_unpaired} via \text{single\_datasets} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C, '\text{list}:\text{paired\_or\_unpaired}')) \mapsto \left\{o: \text{collection}<\text{list},\left\{\text{o1}=tool(i=C_AS_LPU_1)[o],...,\text{on}=tool(i=C_AS_LPU_n)[o]\right\}>\right\}$$
+
+:::
+
+
+
+</details><br>
+
+
+
+Due only to implementation time, the special casing of allowing paired_or_unpaired
+act as both datasets and paired collections only works when it is the deepest
+collection type. So while list:paired can be consumed by a list:paired_or_unpaired
+input, a paired:list cannot be consumed by a paired_or_unpaired:list input though
+it should be able to for consistency. We have focused our time on data structures
+more likely to be used in actual Galaxy analyses given current and guessed future
+usage.
+
+
+## sample_sheet Collections
+
+The collection type ``sample_sheet`` attaches typed, columnar metadata to each
+element of a dataset collection. For mapping and type matching purposes,
+``sample_sheet`` behaves identically to ``list`` - it can be mapped over tool
+inputs, matched against ``list`` collection inputs, and composed with inner types
+(``sample_sheet:paired``, ``sample_sheet:paired_or_unpaired``). The key asymmetry
+is that while a ``sample_sheet`` output can satisfy a ``list`` input, a ``list``
+output cannot satisfy a ``sample_sheet`` input - sample sheets carry metadata
+that plain lists do not.
+
+
+(SAMPLE_SHEET_MAPPING)=
+(SAMPLE_SHEET_MATCHES_LIST)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `SAMPLE_SHEET_MAPPING` 
+:class: note
+
+Assuming,
+
+* $ d_1,...,d_n $ are datasets
+* $ tool \text{ is } (i: \text{ dataset }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{sample\_sheet},\left\{ \text{ i1 }=d_1, ..., \text{ in }=d_n \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C)) \mapsto \left\{o: \text{collection}<\text{sample\_sheet},\left\{\text{i1}=tool(i=d_1)[o],...,\text{in}=tool(i=d_n)[o]\right\}>\right\}$$
+
+:::
+
+
+
+:::{admonition} Example: `SAMPLE_SHEET_MATCHES_LIST` 
+:class: note
+
+Assuming,
+
+* $ d_1,...,d_n $ are datasets
+* $ tool \text{ is } (i: \text{ collection<list> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{sample\_sheet},\left\{ \text{ i1 }=d_1, ..., \text{ in }=d_n \right\}\text{>} $
+
+
+then
+
+$$tool(i=C) \rightarrow \left\{o: \text{dataset}\right\}$$
+
+:::
+
+
+
+</details><br>
+
+
+
+Sub-collection mapping works the same as for ``list`` composites. A
+``sample_sheet:paired`` can be mapped over a ``paired`` collection input,
+extracting each inner pair and producing a ``sample_sheet`` implicit output.
+
+
+(SAMPLE_SHEET_PAIRED_MAPPING_OVER_PAIRED)=
+(SAMPLE_SHEET_PAIRED_MATCHES_LIST_PAIRED)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `SAMPLE_SHEET_PAIRED_MAPPING_OVER_PAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<paired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{sample\_sheet}:\text{paired},\left\{ \text{ el1 }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\}\text{>} $
+* $ C\_PAIRED $ is $ \text{CollectionInstance<}\text{paired},\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C, '\text{paired}')) \mapsto \left\{o: \text{collection}<\text{sample\_sheet},\left\{\text{el1}=tool(i=C\_PAIRED)[o]\right\}>\right\}$$
+
+:::
+
+
+
+:::{admonition} Example: `SAMPLE_SHEET_PAIRED_MATCHES_LIST_PAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<list:paired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{sample\_sheet}:\text{paired},\left\{ \text{ el1 }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\}\text{>} $
+
+
+then
+
+$$tool(i=C) \rightarrow \left\{o: \text{dataset}\right\}$$
+
+:::
+
+
+
+</details><br>
+
+
+
+The ``paired_or_unpaired`` integration rules carry over from ``list`` to
+``sample_sheet``. A flat ``sample_sheet`` can be mapped over a
+``paired_or_unpaired`` input via ``single_datasets`` sub-collection mapping,
+and ``sample_sheet:paired`` can be mapped over ``paired_or_unpaired`` just as
+``list:paired`` can.
+
+
+(SAMPLE_SHEET_MAPPING_OVER_PAIRED_OR_UNPAIRED)=
+(SAMPLE_SHEET_PAIRED_MAPPING_OVER_PAIRED_OR_UNPAIRED)=
+(SAMPLE_SHEET_PAIRED_OR_UNPAIRED_MATCHES_LIST_PAIRED_OR_UNPAIRED)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `SAMPLE_SHEET_MAPPING_OVER_PAIRED_OR_UNPAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_1,...,d_n $ are datasets
+* $ tool \text{ is } (i: \text{ collection<paired\_or\_unpaired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{sample\_sheet},\left\{ \text{ i1 }=d_1, ..., \text{ in }=d_n \right\}\text{>} $
+* $ C_AS_UNPAIRED_i = CollectionInstance<\text{paired\_or\_unpaired},\left\{\text{unpaired}=di\right\}> for i from 1...n $
+
+
+then
+
+$$tool(i=\text{mapOver}(C, '\text{single\_datasets}')) \mapsto \left\{o: \text{collection}<\text{sample\_sheet},\left\{\text{i1}=tool(i=C_AS_UNPAIRED_1)[o],...,\text{in}=tool(i=C_AS_UNPAIRED_n)[o]\right\}>\right\}$$
+
+:::
+
+
+
+:::{admonition} Example: `SAMPLE_SHEET_PAIRED_MAPPING_OVER_PAIRED_OR_UNPAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<paired\_or\_unpaired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{sample\_sheet}:\text{paired},\left\{ \text{ el1 }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\}\text{>} $
+* $ C_AS_MIXED $ is $ \text{CollectionInstance<}\text{sample\_sheet}:\text{paired\_or\_unpaired},\left\{ \text{ el1 }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C)) == tool(i=\text{mapOver}(C_AS_MIXED))$$
+
+:::
+
+
+
+:::{admonition} Example: `SAMPLE_SHEET_PAIRED_OR_UNPAIRED_MATCHES_LIST_PAIRED_OR_UNPAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<list:paired\_or\_unpaired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{sample\_sheet}:\text{paired\_or\_unpaired},\left\{ \text{ el1 }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\}\text{>} $
+
+
+then
+
+$$tool(i=C) \rightarrow \left\{o: \text{dataset}\right\}$$
+
+:::
+
+
+
+</details><br>
+
+
+
+The type matching is asymmetric: a ``sample_sheet`` output can satisfy a ``list``
+input because sample sheets carry all the structural information lists have (plus
+metadata). However, a ``list`` output cannot satisfy a ``sample_sheet`` input because
+lists lack the ``column_definitions`` and per-element ``columns`` metadata that
+sample sheet consumers expect.
+
+
+(LIST_NOT_MATCHES_SAMPLE_SHEET)=
+(LIST_PAIRED_NOT_MATCHES_SAMPLE_SHEET_PAIRED)=
+(SAMPLE_SHEET_MATCHES_SAMPLE_SHEET)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `LIST_NOT_MATCHES_SAMPLE_SHEET` 
+:class: note
+
+Assuming,
+
+* $ d_1,...,d_n $ are datasets
+* $ tool \text{ is } (i: \text{ collection<sample\_sheet> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list},\left\{ \text{ i1 }=d_1, ..., \text{ in }=d_n \right\}\text{>} $
+
+
+then
+
+$$tool(i=C)\text{ is invalid}$$
+
+:::
+
+
+
+:::{admonition} Example: `LIST_PAIRED_NOT_MATCHES_SAMPLE_SHEET_PAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<sample\_sheet:paired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list}:\text{paired},\left\{ \text{ el1 }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\}\text{>} $
+
+
+then
+
+$$tool(i=C)\text{ is invalid}$$
+
+:::
+
+
+
+:::{admonition} Example: `SAMPLE_SHEET_MATCHES_SAMPLE_SHEET` 
+:class: note
+
+Assuming,
+
+* $ d_1,...,d_n $ are datasets
+* $ tool \text{ is } (i: \text{ collection<sample\_sheet> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{sample\_sheet},\left\{ \text{ i1 }=d_1, ..., \text{ in }=d_n \right\}\text{>} $
+
+
+then
+
+$$tool(i=C) \rightarrow \left\{o: \text{dataset}\right\}$$
+
+:::
+
+
+
+</details><br>
+
+
+

--- a/casts/claude/skills/debug-galaxy-workflow-output/references/notes/galaxy-collection-semantics.yml
+++ b/casts/claude/skills/debug-galaxy-workflow-output/references/notes/galaxy-collection-semantics.yml
@@ -1,0 +1,1250 @@
+- doc: |
+    # Collection Semantics
+
+    This document describes the semantics around working with Galaxy dataset collections.
+    In particular it describes how they operate within Galaxy tools and workflows.
+
+    :::{admonition} You Probably Don't Need to Read This
+    :class: caution
+
+    Any significantly sophisticated workflow language will have ways to collect data
+    into arrays or vectors or dictionaries and apply operations across this data (mapping)
+    or reduce the dimensionality of this data (reductions). Typically, this is explicitly
+    annotated with map functions or for loops. Galaxy however is designed to be a point
+    and click interface for connecting steps and running tools. It is important that steps
+    just connect and just do the most natural thing - and this is what Galaxy does.
+    This document just provides a mathematical formalism to that "what should just
+    intuitively work" that can be used to document test cases and help with implementation.
+    This is reference documentation not user documentation, Galaxy should just work.
+    :::
+
+    ## Mapping
+
+    If a tool consumes a simple dataset parameter and produces a simple dataset parameter,
+    then any collection type may be "mapped over" the data input to that tool. The result of
+    that is the tool being applied to each element of the collection and "implicit collections"
+    being created from the outputs that are produced from those operations. Those implicit
+    collections have the same element identifiers in the same order as the input collection that is
+    mapped over. Each element of the implicit collections correspond to their own job and
+    Galaxy very naturally and intuitively parallelizes jobs without extra work from the user
+    and without any knowledge of the tool.
+
+- example:
+    label: BASIC_MAPPING_PAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: dataset}
+        out: {o: dataset}
+    - collections:
+        C: [paired, {forward: d_f, reverse: d_r}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C}
+        produces:
+            o:
+                type: collection
+                collection_type: paired
+                elements:
+                    forward:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d_f}}}
+                        output: o
+                    reverse:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d_r}}}
+                        output: o
+    tests:
+        tool_runtime:
+            api_test: "test_tool_execute.py::test_map_over_collection"
+        workflow_runtime:
+            framework_test: "collection_semantics_cat_0"
+        workflow_editor: "accepts paired data -> data connection"
+
+- example:
+    label: BASIC_MAPPING_PAIRED_OR_UNPAIRED_PAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: dataset}
+        out: {o: dataset}
+    - collections:
+        C: [paired_or_unpaired, {forward: d_f, reverse: d_r}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C}
+        produces:
+            o:
+                type: collection
+                collection_type: paired_or_unpaired
+                elements:
+                    forward:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d_f}}}
+                        output: o
+                    reverse:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d_r}}}
+                        output: o
+    tests:
+        tool_runtime:
+            api_test: "test_tool_execute.py::test_map_over_data_with_paired_or_unpaired_paired"
+        workflow_runtime:
+            framework_test: "collection_semantics_cat_1"
+        workflow_editor: "accepts paired_or_unpaired data -> data connection"
+
+- example:
+    label: BASIC_MAPPING_PAIRED_OR_UNPAIRED_UNPAIRED
+    assumptions:
+    - datasets: [d_u]
+    - tool:
+        in: {i: dataset}
+        out: {o: dataset}
+    - collections:
+        C: [paired_or_unpaired, {unpaired: d_u}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C}
+        produces:
+            o:
+                type: collection
+                collection_type: paired_or_unpaired
+                elements:
+                    unpaired:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d_u}}}
+                        output: o
+    tests:
+        tool_runtime:
+            api_test: "test_tool_execute.py::test_map_over_data_with_paired_or_unpaired_unpaired"
+        workflow_runtime:
+            framework_test: "collection_semantics_cat_2"
+        workflow_editor: "accepts paired_or_unpaired data -> data connection"
+
+- example:
+    label: BASIC_MAPPING_LIST
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: dataset}
+        out: {o: dataset}
+    - collections:
+        C: [list, {i1: "d_1", ..., in: "d_n"}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C}
+        produces:
+            o:
+                type: collection
+                collection_type: list
+                elements:
+                    i1:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d_1}}}
+                        output: o
+                    "...": {type: ellipsis}
+                    in:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d_n}}}
+                        output: o
+    tests:
+        workflow_editor: "accepts collection data -> data connection"
+
+- doc: |
+    The above description of mapping over inputs works naturally and as expected for
+    nested collections.
+
+- example:
+    label: NESTED_LIST_MAPPING
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: dataset}
+        out: {o: dataset}
+    - collections:
+        C: ["list:list", {o1: {inner: d_1}, ..., "on": {inner: d_n}}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C}
+        produces:
+            o:
+                type: collection
+                collection_type: "list:list"
+                elements:
+                    o1:
+                        type: nested_elements
+                        elements:
+                            inner:
+                                type: tool_output_ref
+                                invocation: {inputs: {i: {type: dataset, ref: d_1}}}
+                                output: o
+                    "...": {type: ellipsis}
+                    "on":
+                        type: nested_elements
+                        elements:
+                            inner:
+                                type: tool_output_ref
+                                invocation: {inputs: {i: {type: dataset, ref: d_n}}}
+                                output: o
+    tests:
+        tool_runtime:
+            api_test: "test_tools.py::TestToolsApi::test_map_over_nested_collections"
+        workflow_editor: "accepts list:list data -> data connection"
+
+- example:
+    label: BASIC_MAPPING_LIST_PAIRED_OR_UNPAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: dataset}
+        out: {o: dataset}
+    - collections:
+        C: ["list:paired_or_unpaired", {el1: {forward: d_f, reverse: d_r}}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C}
+        produces:
+            o:
+                type: collection
+                collection_type: "list:paired_or_unpaired"
+                elements:
+                    el1:
+                        type: nested_elements
+                        elements:
+                            forward:
+                                type: tool_output_ref
+                                invocation: {inputs: {i: {type: dataset, ref: d_f}}}
+                                output: o
+                            reverse:
+                                type: tool_output_ref
+                                invocation: {inputs: {i: {type: dataset, ref: d_r}}}
+                                output: o
+    tests:
+        tool_runtime:
+            api_test: "test_tool_execute.py::test_map_over_data_with_list_paired_or_unpaired"
+        workflow_runtime:
+            framework_test: "collection_semantics_cat_3"
+        workflow_editor: "accepts list:paired_or_unpaired data -> data connection"
+
+- doc: |
+
+    For tools with multiple data inputs, the tool can be executed with individual
+    datasets for the non-mapped over input and each tool execution will just be executed
+    with that dataset. The dataset not mapped over serves as the input for each execution.
+
+- example:
+    label: BASIC_MAPPING_INCLUDING_SINGLE_DATASET
+    assumptions:
+    - datasets: ["d_1,...,d_n", "d_o"]
+    - tool:
+        in: {i: dataset, i2: dataset}
+        out: {o: dataset}
+    - collections:
+        C: ["list", {i1: d_1, ..., in: d_n}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C}
+                i2: {type: dataset, ref: d_o}
+        produces:
+            o:
+                type: collection
+                collection_type: list
+                elements:
+                    i1:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d_1}, i2: {type: dataset, ref: d_o}}}
+                        output: o
+                    "...": {type: ellipsis}
+                    in:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d_n}, i2: {type: dataset, ref: d_o}}}
+                        output: o
+    tests:
+        tool_runtime:
+            api_test: "test_tools.py::TestToolsApi::test_map_over_collected_and_individual_datasets"
+        workflow_runtime:
+            framework_test: "collection_semantics_cat_two_inputs_0"
+
+- doc: |
+    If a tool consumes two input datasets and produces one output dataset, you can map two
+    collections with identical structure (same element identifiers in the same order) over
+    the respective inputs and the result is an implicit collection with the same structure
+    as the inputs and where each output in the implicit collection corresponds to the tool
+    being executed with the two inputs corresponding to that position in the input
+    collections.
+
+    The default behavior here is the collections are linked and the act of mapping over
+    inputs to the tool are sort of a flat map or a dot product. No extra dimensionality
+    in the resulting collections.
+
+    From a user perspective this means if you start with a collection and apply a bunch
+    of map over operations on tools - the results will all continue to match and work together
+    very naturally - again without extra work by the user and without extra knowledge
+    by the tool author.
+
+- example:
+    label: BASIC_MAPPING_TWO_INPUTS_WITH_IDENTICAL_STRUCTURE
+    assumptions:
+    - datasets: ["d1_1,...,d1_n", "d2_1,...,d2_n"]
+    - tool:
+        in: {i: dataset, i2: dataset}
+        out: {o: dataset}
+    - collections:
+        C1: ["list", {i1: d1_1, ..., in: d1_n}]
+        C2: ["list", {i1: d2_1, ..., in: d2_n}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C1}
+                i2: {type: map_over, collection: C2}
+        produces:
+            o:
+                type: collection
+                collection_type: list
+                elements:
+                    i1:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d1_1}, i2: {type: dataset, ref: d2_1}}}
+                        output: o
+                    "...": {type: ellipsis}
+                    in:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d1_n}, i2: {type: dataset, ref: d2_n}}}
+                        output: o
+    tests:
+        tool_runtime:
+            api_test: test_tools.py::TestToolsApi::test_map_over_two_collections
+        workflow_runtime:
+            framework_test: "collection_semantics_cat_two_inputs_1"
+
+- doc: "## Reduction"
+- doc: |
+    Not all tool executions result in implicit collections and mapping
+    over inputs. Tool inputs of ``type`` ``data_collection`` can consume
+    collections directly and do not necessarily result in mapping over.
+
+    Tools that consume collections and output datasets effectively
+    reduce the dimension of the Galaxy data structure. When used at runtime
+    this is often referred to as a "reduction" in the code.
+
+- example:
+    label: COLLECTION_INPUT_PAIRED
+    assumptions:
+    - datasets: ["d_f", "d_r"]
+    - tool:
+        in: {i: "collection<paired>"}
+        out: {o: dataset}
+    - collections:
+        C: [paired, {forward: d_f, reverse: d_r}]
+    then:
+        type: reduction
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+        produces:
+            o: {type: dataset}
+    tests:
+        tool_runtime:
+            tool: collection_paired_test
+        workflow_editor: "accepts paired -> paired connection"
+
+- example:
+    label: COLLECTION_INPUT_LIST
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: "collection<list>"}
+        out: {o: dataset}
+    - collections:
+        C: [list, {el1: d_1, ..., eln: d_n}]
+    then:
+        type: reduction
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+        produces:
+            o: {type: dataset}
+    tests:
+        workflow_runtime:
+            framework_test: "collection_semantics_cat_collection_0"
+        workflow_editor: "accepts list -> list connection"
+
+- example:
+    label: COLLECTION_INPUT_PAIRED_OR_UNPAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: [paired_or_unpaired, {forward: d_f, reverse: d_r}]
+    then:
+        type: reduction
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+        produces:
+            o: {type: dataset}
+    tests:
+        tool_runtime:
+            tool: collection_paired_or_unpaired
+        workflow_runtime:
+            framework_test: "collection_semantics_paired_or_unpaired_0"
+        workflow_editor: "accepts paired_or_unpaired data -> paired_or_unpaired connection"
+
+- example:
+    label: COLLECTION_INPUT_LIST_PAIRED_OR_UNPAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<list:paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:paired_or_unpaired", {el1: {forward: d_f, reverse: d_r}}]
+    then:
+        type: reduction
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+        produces:
+            o: {type: dataset}
+    tests:
+        tool_runtime:
+            tool: collection_list_paired_or_unpaired
+        workflow_runtime:
+            framework_test: "collection_semantics_list_paired_or_unpaired_0"
+        workflow_editor: "accepts list:paired_or_unpaired data -> list:paired_or_unpaired connection"
+
+- doc: |
+    For nested collections where each rank is a ``list`` or a ``paired`` collection,
+    then collection inputs must match every part of the collection type input definition.
+
+- example:
+    label: COLLECTION_INPUT_LIST_NOT_CONSUMES_PAIRS
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<list>"}
+        out: {o: dataset}
+    - collections:
+        C: [paired, {forward: d_f, reverse: d_r}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects connecting paired -> list"
+
+- example:
+    label: COLLECTION_INPUT_PAIRED_NOT_CONSUMES_LIST
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: "collection<paired>"}
+        out: {o: dataset}
+    - collections:
+        C: [list, {i1: d_1, ..., in: d_n}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects connecting list -> paired"
+
+- example:
+    label: COLLECTION_INPUT_LIST_PAIRED_NOT_CONSUMES_PAIRED_PAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<list:paired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["paired:paired", {forward: {forward: d_f, reverse: d_r}, reverse: {forward: d_f, reverse: d_r}}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects paired:paired -> list:paired connection"
+
+- example:
+    label: COLLECTION_INPUT_LIST_PAIRED_OR_NOT_PAIRED_NOT_CONSUMES_PAIRED_PAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<list:paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["paired:paired", {forward: {forward: d_f, reverse: d_r}, reverse: {forward: d_f, reverse: d_r}}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects paired:paired -> list:paired_or_unpaired connection"
+
+- doc: |
+    In addition to explicit collection inputs, tool inputs of ``type`` ``data``
+    where ``multiple="true"`` can consume lists directly. This is likewise a
+    "reduction" and does not result in implicit collection creation.
+
+- example:
+    label: LIST_REDUCTION
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: "dataset<multiple=true>"}
+        out: {o: dataset}
+    - collections:
+        C: [list, {i1: d_1, ..., in: d_n}]
+    then:
+        type: equivalence
+        left:
+            inputs:
+                i: {type: collection, ref: C}
+        right:
+            inputs:
+                i: {type: dataset_list, refs: ["d_1", "...", "d_n"]}
+    tests:
+        tool_runtime:
+            api_test: "test_tools.py::TestToolsApi::test_reduce_collections"
+        workflow_runtime:
+            framework_test: "collection_semantics_multi_data_optional_0"
+        workflow_editor: "treats multi data input as list input"
+
+- doc: |
+    Paired collections cannot be reduced this way. ``paired`` is not meant
+    to represent a list/array/vector data structure - it is more like a tuple.
+
+- example:
+    label: PAIRED_REDUCTION_INVALID
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "dataset<multiple=true>"}
+        out: {o: dataset}
+    - collections:
+        C: [paired, {forward: d_f, reverse: d_r}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects paired input on multi-data input"
+
+- example:
+    label: PAIRED_OR_UNPAIRED_REDUCTION_INVALID
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "dataset<multiple=true>"}
+        out: {o: dataset}
+    - collections:
+        C: [paired_or_unpaired, {forward: d_f, reverse: d_r}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects paired_or_unpaired input on multi-data input"
+
+- doc: "## Sub-collection Mapping"
+- doc: |
+    ![](https://planemo.readthedocs.io/en/master/_images/subcollection_mapping_identifiers.svg)
+
+- example:
+    label: MAPPING_LIST_PAIRED_OVER_PAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<paired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:paired", {el1: {forward: d_f, reverse: d_r}}]
+        "C\\_PAIRED": [paired, {forward: d_f,reverse: d_r}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C, sub_collection_type: paired}
+        produces:
+            o:
+                type: collection
+                collection_type: list
+                elements:
+                    el1:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: collection, ref: "C\\_PAIRED"}}}
+                        output: o
+    tests:
+        tool_runtime:
+            api_test: "test_tool_execute.py::test_simple_subcollection_mapping"
+        workflow_editor: "accepts list:paired -> paired connection"
+
+- doc: |
+    The natural extension of multiple data input parameters consuming list collections as described
+    above when discussing reductions is that nested lists of lists (``list:list``) can be mapped
+    over a multiple data input parameter. Each nested list will be reduced by this operation but the
+    results will be mapped over. The result will be a list with the same structure as the outer list
+    of the input collection.
+
+- example:
+    label: NESTED_LIST_REDUCTION
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: "dataset<multiple=true>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:list", {o1: {inner: d_1}, ..., "on": {inner: d_n}}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C, sub_collection_type: list}
+        produces:
+            o:
+                type: collection
+                collection_type: list
+                elements:
+                    o1:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset_list, refs: ["d_1"]}}}
+                        output: o
+                    "...": {type: ellipsis}
+                    "on":
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset_list, refs: ["d_n"]}}}
+                        output: o
+    tests:
+        workflow_editor: "maps list:list over multi data input"
+
+- doc: |
+    Just as a paired collection won't be reduced by a multiple data input, any sort of nested
+    collection ending in a paired collection cannot be mapped over such an input. So a multiple
+    data input parameter cannot be mapped over by a list of pairs (``list:paired``) for instance.
+
+- example:
+    label: LIST_PAIRED_REDUCTION_INVALID
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "dataset<multiple=true>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:paired", {el1: {forward: d_f, reverse: d_r}}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C, sub_collection_type: paired}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects list:paired input on multi-data input"
+
+- example:
+    label: LIST_PAIRED_OR_UNPAIRED_REDUCTION_INVALID
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "dataset<multiple=true>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:paired_or_unpaired", {el1: {forward: d_f, reverse: d_r}}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C, sub_collection_type: paired_or_unpaired}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects list:paired_or_unpaired input on multi-data input"
+
+- doc: "## paired_or_unpaired Collections"
+- doc: |
+    The collection type ``paired_or_unpaired`` is meant to serve as a stand-in for
+    an entity that can be either a single dataset or what is effectively a ``paired``
+    dataset collection. These collections either have one element with identifier
+    ``unpaired`` or two elements with identifiers ``forward`` and ``reverse``.
+
+    Tools can declare a data_collection input with collection type ``paired_or_unpaired``
+    and that input will consume either an explicit ``paired_or_unpaired`` collection
+    normally or can consume a ``paired`` input.
+
+- example:
+    label: PAIRED_OR_UNPAIRED_CONSUMES_PAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: [paired, {forward: d_f, reverse: d_r}]
+    - "C_AS_MIXED = CollectionInstance<paired_or_unpaired, {forward: d_f, reverse: d_r}>"
+    then:
+        type: equivalence
+        left:
+            inputs:
+                i: {type: collection, ref: C}
+        right:
+            inputs:
+                i: {type: collection, ref: C_AS_MIXED}
+    tests:
+        tool_runtime:
+            tool: collection_paired_or_unpaired
+        workflow_runtime:
+            framework_test: "collection_semantics_paired_or_unpaired_1"
+        workflow_editor: "accepts paired -> paired_or_unpaired connection"
+
+- doc: |
+
+    The inverse of this doesn't work intentionally. In some ways a ``paired`` collection
+    acts as a ``paired_or_unpaired`` collection but a ``paired_or_unpaired`` is not a paired
+    collection. This makes a lot of sense in terms of tools - a tool consuming a ``paired``
+    dataset expects to find both a ``forward`` and ``reverse`` element but these may not exist
+    in ``paired_or_unpaired`` collection.
+
+- example:
+    label: PAIRED_OR_UNPAIRED_NOT_CONSUMED_BY_PAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<paired>"}
+        out: {o: dataset}
+    - collections:
+        C: [paired_or_unpaired, {forward: d_f, reverse: d_r}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects paired_or_unpaired -> paired connection"
+
+- doc: |
+
+    The same logic holds for mapping, lists of paired datasets (``list:paired``) can be mapped over these
+    ``paired_or_unpaired`` inputs and mixed lists of pairs (``list:paired_or_unpaired``) cannot
+    be mapped over a ``paired`` input. Following the same logic, ``list:paired_or_unpaired`` cannot
+    be mapped over a ``list`` input or multiple data input.
+
+- example:
+    label: MAPPING_LIST_PAIRED_OVER_PAIRED_OR_UNPAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:paired", {el: {forward: d_f, reverse: d_r}}]
+        C_AS_MIXED: ["list:paired_or_unpaired", {el: {forward: d_f, reverse: d_r}}]
+    then:
+        type: equivalence
+        left:
+            inputs:
+                i: {type: map_over, collection: C}
+        right:
+            inputs:
+                i: {type: map_over, collection: C_AS_MIXED}
+    tests:
+        workflow_runtime:
+            framework_test: "collection_semantics_paired_or_unpaired_2"
+        workflow_editor: "accepts list:paired -> paired_or_unpaired connection"
+
+- example:
+    label: PAIRED_OR_UNPAIRED_NOT_CONSUMED_BY_PAIRED_WHEN_MAPPING
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<paired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:paired_or_unpaired", {el: {forward: d_f, reverse: d_r}}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C}
+    is_valid: false
+    tests:
+        tool_runtime:
+            api_test: "test_tool_execute.py::test_paired_or_unpaired_not_consumed_by_paired_when_mapping"
+        workflow_editor: "rejects list:paired_or_unpaired -> paired connection"
+
+- example:
+    label: PAIRED_OR_UNPAIRED_NOT_CONSUMED_BY_LIST_WHEN_MAPPING
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<list>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:paired_or_unpaired", {el: {forward: d_f, reverse: d_r}}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects list:paired_or_unpaired -> list connection"
+
+- doc: |
+    This logic extends naturally into higher dimensional collections. A ``list:list:paired``
+    can be mapped over either a ``paired_or_unpaired`` input to produce a nested list (``list:list``)
+    or a ``list:paired_or_unpaired`` input to produce a flat list (``list``).
+
+- example:
+    label: MAPPING_LIST_LIST_PAIRED_OVER_PAIRED_OR_UNPAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:list:paired", {o1: {el1: {forward: d_f, reverse: d_r}}}]
+        C_AS_MIXED: ["list:list:paired_or_unpaired", {o1: {el1: {forward: d_f, reverse: d_r}}}]
+    then:
+        type: equivalence
+        left:
+            inputs:
+                i: {type: map_over, collection: C}
+        right:
+            inputs:
+                i: {type: map_over, collection: C_AS_MIXED}
+    tests:
+        workflow_runtime:
+            framework_test: "collection_semantics_paired_or_unpaired_3"
+        workflow_editor: "accepts list:list:paired -> paired_or_unpaired connection"
+
+- doc: |
+
+    In order for ``paired_or_unpaired`` collections to also act as a single dataset,
+    a flat list can be mapped over a such an input with a special sub collection mapping
+    type of 'single_datasets'.
+
+- example:
+    label: MAPPING_LIST_OVER_PAIRED_OR_UNPAIRED
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: "collection<paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: [list, {i1: d_1, ..., in: d_n}]
+    - "C_AS_UNPAIRED_i = CollectionInstance<paired_or_unpaired,{unpaired=di}> for i from 1...n"
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C, sub_collection_type: single_datasets}
+        produces:
+            o:
+                type: collection
+                collection_type: list
+                elements:
+                    i1:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: collection, ref: C_AS_UNPAIRED_1}}}
+                        output: o
+                    "...": {type: ellipsis}
+                    in:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: collection, ref: C_AS_UNPAIRED_n}}}
+                        output: o
+    tests:
+        tool_runtime:
+            api_test: "test_tool_execute.py::test_map_over_paired_or_unpaired_with_list"
+        workflow_runtime:
+            framework_test: "collection_semantics_paired_or_unpaired_7"
+        workflow_editor: "accepts list -> paired_or_unpaired connection"
+
+- doc: |
+    This treatment of lists without pairing extends to nested structures naturally.
+    For instance, a list of list of datasets (``list:list``) can be mapped over a
+    ``paired_or_unpaired`` input to produce a nested list of lists (``list:list``)
+    with a structure matching the input. Likewise, the nested list can be mapped over
+    a ``list:paired_or_unpaired`` input to produce a flat list with the same structure
+    as the outer list of the input.
+
+- example:
+    label: MAPPING_LIST_LIST_OVER_PAIRED_OR_UNPAIRED
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: "collection<paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:list", {o1: {inner: d_1}, ..., "on": {inner: d_n}}]
+    - "C_AS_UNPAIRED_j = CollectionInstance<paired_or_unpaired,{unpaired=dj}> for each dataset dj in C"
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C, sub_collection_type: single_datasets}
+        produces:
+            o:
+                type: collection
+                collection_type: "list:list"
+                elements:
+                    o1:
+                        type: nested_elements
+                        elements:
+                            inner:
+                                type: tool_output_ref
+                                invocation: {inputs: {i: {type: collection, ref: C_AS_UNPAIRED_1}}}
+                                output: o
+                    "...": {type: ellipsis}
+                    "on":
+                        type: nested_elements
+                        elements:
+                            inner:
+                                type: tool_output_ref
+                                invocation: {inputs: {i: {type: collection, ref: C_AS_UNPAIRED_n}}}
+                                output: o
+    tests:
+        workflow_editor: "accepts list:list -> paired_or_unpaired connection"
+
+- example:
+    label: MAPPING_LIST_LIST_OVER_LIST_PAIRED_OR_UNPAIRED
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: "collection<list:paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:list", {o1: {inner: d_1}, ..., "on": {inner: d_n}}]
+    - "C_AS_LPU_i = inner list of C at position i, treated as list:paired_or_unpaired via single_datasets"
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C, sub_collection_type: "list:paired_or_unpaired"}
+        produces:
+            o:
+                type: collection
+                collection_type: list
+                elements:
+                    o1:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: collection, ref: C_AS_LPU_1}}}
+                        output: o
+                    "...": {type: ellipsis}
+                    "on":
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: collection, ref: C_AS_LPU_n}}}
+                        output: o
+    tests:
+        tool_runtime:
+            api_test: "test_tool_execute.py::test_map_over_list_paired_or_unpaired_with_list_of_lists"
+        workflow_runtime:
+            framework_test: "collection_semantics_list_paired_or_unpaired_2"
+        workflow_editor: "accepts list:list -> list:paired_or_unpaired connection"
+
+- doc: |
+    Due only to implementation time, the special casing of allowing paired_or_unpaired
+    act as both datasets and paired collections only works when it is the deepest
+    collection type. So while list:paired can be consumed by a list:paired_or_unpaired
+    input, a paired:list cannot be consumed by a paired_or_unpaired:list input though
+    it should be able to for consistency. We have focused our time on data structures
+    more likely to be used in actual Galaxy analyses given current and guessed future
+    usage.
+
+- doc: "## sample_sheet Collections"
+- doc: |
+    The collection type ``sample_sheet`` attaches typed, columnar metadata to each
+    element of a dataset collection. For mapping and type matching purposes,
+    ``sample_sheet`` behaves identically to ``list`` - it can be mapped over tool
+    inputs, matched against ``list`` collection inputs, and composed with inner types
+    (``sample_sheet:paired``, ``sample_sheet:paired_or_unpaired``). The key asymmetry
+    is that while a ``sample_sheet`` output can satisfy a ``list`` input, a ``list``
+    output cannot satisfy a ``sample_sheet`` input - sample sheets carry metadata
+    that plain lists do not.
+
+- example:
+    label: SAMPLE_SHEET_MAPPING
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: dataset}
+        out: {o: dataset}
+    - collections:
+        C: [sample_sheet, {i1: "d_1", ..., in: "d_n"}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C}
+        produces:
+            o:
+                type: collection
+                collection_type: sample_sheet
+                elements:
+                    i1:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d_1}}}
+                        output: o
+                    "...": {type: ellipsis}
+                    in:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d_n}}}
+                        output: o
+    tests:
+        workflow_runtime:
+            framework_test: "collection_semantics_cat_4"
+        workflow_editor: "accepts sample_sheet data -> data connection (maps like list)"
+
+- example:
+    label: SAMPLE_SHEET_MATCHES_LIST
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: "collection<list>"}
+        out: {o: dataset}
+    - collections:
+        C: [sample_sheet, {i1: d_1, ..., in: d_n}]
+    then:
+        type: reduction
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+        produces:
+            o: {type: dataset}
+    tests:
+        workflow_runtime:
+            framework_test: "collection_semantics_cat_collection_1"
+        workflow_editor: "accepts sample_sheet -> list connection (canMatch)"
+
+- doc: |
+    Sub-collection mapping works the same as for ``list`` composites. A
+    ``sample_sheet:paired`` can be mapped over a ``paired`` collection input,
+    extracting each inner pair and producing a ``sample_sheet`` implicit output.
+
+- example:
+    label: SAMPLE_SHEET_PAIRED_MAPPING_OVER_PAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<paired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["sample_sheet:paired", {el1: {forward: d_f, reverse: d_r}}]
+        "C\\_PAIRED": [paired, {forward: d_f, reverse: d_r}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C, sub_collection_type: paired}
+        produces:
+            o:
+                type: collection
+                collection_type: sample_sheet
+                elements:
+                    el1:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: collection, ref: "C\\_PAIRED"}}}
+                        output: o
+    tests:
+        workflow_runtime:
+            framework_test: "collection_semantics_paired_or_unpaired_5"
+        workflow_editor: "accepts sample_sheet:paired -> paired connection (maps over like list:paired)"
+
+- example:
+    label: SAMPLE_SHEET_PAIRED_MATCHES_LIST_PAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<list:paired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["sample_sheet:paired", {el1: {forward: d_f, reverse: d_r}}]
+    then:
+        type: reduction
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+        produces:
+            o: {type: dataset}
+    tests:
+        workflow_runtime:
+            framework_test: "collection_semantics_list_paired_0"
+        workflow_editor: "accepts sample_sheet:paired -> list:paired connection (canMatch)"
+
+- doc: |
+    The ``paired_or_unpaired`` integration rules carry over from ``list`` to
+    ``sample_sheet``. A flat ``sample_sheet`` can be mapped over a
+    ``paired_or_unpaired`` input via ``single_datasets`` sub-collection mapping,
+    and ``sample_sheet:paired`` can be mapped over ``paired_or_unpaired`` just as
+    ``list:paired`` can.
+
+- example:
+    label: SAMPLE_SHEET_MAPPING_OVER_PAIRED_OR_UNPAIRED
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: "collection<paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: [sample_sheet, {i1: d_1, ..., in: d_n}]
+    - "C_AS_UNPAIRED_i = CollectionInstance<paired_or_unpaired,{unpaired=di}> for i from 1...n"
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C, sub_collection_type: single_datasets}
+        produces:
+            o:
+                type: collection
+                collection_type: sample_sheet
+                elements:
+                    i1:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: collection, ref: C_AS_UNPAIRED_1}}}
+                        output: o
+                    "...": {type: ellipsis}
+                    in:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: collection, ref: C_AS_UNPAIRED_n}}}
+                        output: o
+    tests:
+        tool_runtime:
+            api_test: "test_tool_execute.py::test_map_over_paired_or_unpaired_with_sample_sheet"
+        workflow_runtime:
+            framework_test: "collection_semantics_paired_or_unpaired_8"
+        workflow_editor: "accepts sample_sheet -> paired_or_unpaired connection"
+
+- example:
+    label: SAMPLE_SHEET_PAIRED_MAPPING_OVER_PAIRED_OR_UNPAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["sample_sheet:paired", {el1: {forward: d_f, reverse: d_r}}]
+        C_AS_MIXED: ["sample_sheet:paired_or_unpaired", {el1: {forward: d_f, reverse: d_r}}]
+    then:
+        type: equivalence
+        left:
+            inputs:
+                i: {type: map_over, collection: C}
+        right:
+            inputs:
+                i: {type: map_over, collection: C_AS_MIXED}
+    tests:
+        workflow_runtime:
+            framework_test: "collection_semantics_paired_or_unpaired_6"
+        workflow_editor: "accepts sample_sheet:paired -> paired_or_unpaired connection"
+
+- example:
+    label: SAMPLE_SHEET_PAIRED_OR_UNPAIRED_MATCHES_LIST_PAIRED_OR_UNPAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<list:paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["sample_sheet:paired_or_unpaired", {el1: {forward: d_f, reverse: d_r}}]
+    then:
+        type: reduction
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+        produces:
+            o: {type: dataset}
+    tests:
+        workflow_runtime:
+            framework_test: "collection_semantics_list_paired_or_unpaired_1"
+        workflow_editor: "accepts sample_sheet:paired_or_unpaired -> list:paired_or_unpaired connection (canMatch)"
+
+- doc: |
+    The type matching is asymmetric: a ``sample_sheet`` output can satisfy a ``list``
+    input because sample sheets carry all the structural information lists have (plus
+    metadata). However, a ``list`` output cannot satisfy a ``sample_sheet`` input because
+    lists lack the ``column_definitions`` and per-element ``columns`` metadata that
+    sample sheet consumers expect.
+
+- example:
+    label: LIST_NOT_MATCHES_SAMPLE_SHEET
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: "collection<sample_sheet>"}
+        out: {o: dataset}
+    - collections:
+        C: [list, {i1: d_1, ..., in: d_n}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects list -> sample_sheet connection (asymmetry)"
+
+- example:
+    label: LIST_PAIRED_NOT_MATCHES_SAMPLE_SHEET_PAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<sample_sheet:paired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:paired", {el1: {forward: d_f, reverse: d_r}}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects list:paired -> sample_sheet:paired connection (asymmetry)"
+
+- example:
+    label: SAMPLE_SHEET_MATCHES_SAMPLE_SHEET
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: "collection<sample_sheet>"}
+        out: {o: dataset}
+    - collections:
+        C: [sample_sheet, {i1: d_1, ..., in: d_n}]
+    then:
+        type: reduction
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+        produces:
+            o: {type: dataset}
+    tests:
+        workflow_runtime:
+            framework_test: "collection_semantics_cat_sample_sheet_0"
+        workflow_editor: "accepts sample_sheet -> sample_sheet connection"

--- a/casts/claude/skills/debug-galaxy-workflow-output/references/notes/galaxy-tool-job-failure-reference.md
+++ b/casts/claude/skills/debug-galaxy-workflow-output/references/notes/galaxy-tool-job-failure-reference.md
@@ -1,0 +1,140 @@
+---
+type: research
+subtype: component
+title: "Galaxy tool and job failure reference"
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+related_notes:
+  - "[[galaxy-workflow-invocation-failure-reference]]"
+  - "[[planemo-workflow-test-architecture]]"
+  - "[[galaxy-collection-semantics]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+  - "[[debug-galaxy-workflow-output]]"
+sources:
+  - "~/projects/repositories/galaxy/lib/galaxy/tools/__init__.py"
+  - "~/projects/repositories/galaxy/lib/galaxy/tool_util/parser/xml.py"
+  - "~/projects/repositories/galaxy/lib/galaxy/tool_util/output_checker.py"
+  - "~/projects/repositories/galaxy/lib/galaxy/jobs"
+  - "~/projects/repositories/galaxy/lib/galaxy/webapps/galaxy/api/jobs.py"
+summary: "Reference for Galaxy tool stdio rules, job failure detection, job states, and job API failure surfaces."
+---
+
+# Galaxy Tool And Job Failure Reference
+
+This is reference material, not a debug recipe. Use it to understand what Galaxy can know about a failed tool job and which API surfaces preserve that evidence.
+
+## Model
+
+Galaxy tool failure handling is layered:
+
+- The tool wrapper defines expected failure semantics through `detect_errors`, `<stdio>`, exit-code checks, regex checks, and command strictness.
+- The job runner executes the command and captures exit code plus tool/job stdout and stderr streams.
+- Galaxy evaluates configured failure rules and records structured `job_messages`.
+- The job reaches a terminal state, output datasets may become `error`, and dependent jobs may pause or fail later.
+- Workflow invocation APIs summarize those jobs, but job APIs preserve the most detailed tool-level evidence.
+
+## Tool Wrapper Failure Controls
+
+Important wrapper controls:
+
+| Control | Meaning |
+|---|---|
+| `detect_errors="default"` | For non-legacy XML tools without explicit `<stdio>`, Galaxy defaults to non-zero exit-code failure detection. |
+| `detect_errors="exit_code"` | Adds fatal checks for non-zero exit codes, plus optional OOM exit-code handling. |
+| `detect_errors="aggressive"` | Adds non-zero exit-code checks plus broad stdout/stderr regexes for OOM and generic error text. |
+| `<stdio><exit_code ... /></stdio>` | Adds explicit exit-code ranges or values with levels such as `fatal`, `warning`, or `fatal_oom`. |
+| `<stdio><regex ... /></stdio>` | Adds case-insensitive stdout/stderr regex checks. |
+| `<command strict="...">` | Controls shell strictness; newer tool profiles default to `set -e` behavior. |
+
+Current Galaxy source parses these rules while loading the tool, then stores exit-code and regex rules on the tool object. XML parser behavior lives under `~/projects/repositories/galaxy/lib/galaxy/tool_util/parser/xml.py`; concrete stdio presets live under `~/projects/repositories/galaxy/lib/galaxy/tool_util/parser/stdio.py`.
+
+## Rule Ordering And Levels
+
+Galaxy evaluates explicit and preset rules in a defined order:
+
+- Exit-code rules are evaluated before regex rules.
+- Regexes search stdout and/or stderr case-insensitively.
+- A fatal rule stops later checks.
+- Warnings, log messages, and QC messages can produce `job_messages` without failing the job.
+
+Useful levels:
+
+| Level | Effect |
+|---|---|
+| `log` | Records informational message; does not fail the job. |
+| `qc` | Records QC message; does not fail the job. |
+| `warning` | Records warning; does not fail the job. |
+| `fatal` | Fails the job as a generic tool error. |
+| `fatal_oom` | Fails as out-of-memory; runner behavior can use this for OOM handling/resubmission. |
+
+Low-confidence caveat: OOM resubmission behavior is runner/destination configuration dependent. The wrapper and output checker can classify OOM, but retry policy is not solely a wrapper property.
+
+## Job And Dataset States
+
+Job states relevant to workflow tests include:
+
+- In progress or queued: `new`, `queued`, `running`, `waiting`, `upload`, `resubmitted`.
+- Success: `ok`.
+- Failure or terminal problem: `error`, `failed`, `paused`, `stopped`, `deleted`, `skipped` depending context.
+
+Dataset states relevant to downstream failures include `ok`, `error`, `paused`, `failed_metadata`, `deferred`, and `discarded`.
+
+For workflow debugging, do not collapse job state and dataset state. A job can fail, its outputs can become error datasets, and a downstream workflow step can later fail because it consumes those datasets.
+
+## Stream And Message Fields
+
+Galaxy distinguishes tool streams from job/runner streams:
+
+| Field | Meaning |
+|---|---|
+| `tool_stdout` | stdout from the executed tool command. |
+| `tool_stderr` | stderr from the executed tool command. |
+| `job_stdout` | stdout from job wrapper/runner context. |
+| `job_stderr` | stderr from job wrapper/runner context. |
+| `stdout` | Combined stdout compatibility view. |
+| `stderr` | Combined stderr compatibility view. |
+| `job_messages` | Structured failure/warning messages produced by stdio and output checking. |
+| `exit_code` | Process exit code observed by the runner. |
+
+Prefer `job_messages` plus separate streams for reference-quality failure interpretation. Combined `stdout` and `stderr` are useful for humans but lose provenance.
+
+## API Surfaces
+
+Useful job APIs from Galaxy source under `~/projects/repositories/galaxy/lib/galaxy/webapps/galaxy/api/jobs.py`:
+
+| API | Use |
+|---|---|
+| `GET /api/jobs` | Filter jobs by state, tool id, workflow id, invocation id, history id, etc. |
+| `GET /api/jobs/{job_id}` | Basic job detail. |
+| `GET /api/jobs/{job_id}?full=true` | Full job detail, including streams and `job_messages`. |
+| `GET /api/jobs/{job_id}/stdout` | Combined stdout as plain text. |
+| `GET /api/jobs/{job_id}/stderr` | Combined stderr as plain text. |
+| `GET /api/jobs/{job_id}/console_output` | Live or stored tool stdout/stderr, useful while a job is running. |
+| `GET /api/jobs/{job_id}/inputs` | Input datasets for the job. |
+| `GET /api/jobs/{job_id}/outputs` | Output datasets and output collections. |
+| `GET /api/jobs/{job_id}/metrics` | Job metrics, if available. |
+| `GET /api/jobs/{job_id}/common_problems` | Known simple problems such as empty or duplicate inputs. |
+
+Admin-only or admin-enriched fields can include command line, traceback, destination, runner, handler, external id, and destination parameters. Do not assume a normal workflow-testing API key can retrieve everything.
+
+## Durable Reference Use
+
+This note should inform generated skills when they need to preserve or inspect tool-level failure evidence:
+
+- A concrete workflow step should preserve tool id, version, input labels, output labels, datatype and collection shape so a later job failure can be traced back to the authoring decision.
+- A runtime failure should not be classified from stderr alone if `job_messages`, exit code, and wrapper stdio rules are available.
+- A workflow invocation failure may be caused by an upstream job, but invocation APIs are not a substitute for full job detail.
+
+## Low-Confidence Or Version-Sensitive Points
+
+- Tool profile defaults changed over time. Prefer current Galaxy source and wrapper profile over old generic rules.
+- Some docs describe failure messages as stream text; current code preserves structured `job_messages` separately.
+- OOM handling depends on job runner and destination configuration.
+- Planemo may print or summarize job detail differently from raw Galaxy APIs; see [[planemo-workflow-test-architecture]].

--- a/casts/claude/skills/debug-galaxy-workflow-output/references/notes/galaxy-workflow-invocation-failure-reference.md
+++ b/casts/claude/skills/debug-galaxy-workflow-output/references/notes/galaxy-workflow-invocation-failure-reference.md
@@ -1,0 +1,141 @@
+---
+type: research
+subtype: component
+title: "Galaxy workflow invocation failure reference"
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+related_notes:
+  - "[[galaxy-tool-job-failure-reference]]"
+  - "[[planemo-workflow-test-architecture]]"
+  - "[[galaxy-collection-semantics]]"
+related_molds:
+  - "[[run-workflow-test]]"
+  - "[[debug-galaxy-workflow-output]]"
+  - "[[validate-galaxy-workflow]]"
+sources:
+  - "~/projects/repositories/galaxy/lib/galaxy/schema/invocation.py"
+  - "~/projects/repositories/galaxy/lib/galaxy/workflow/run.py"
+  - "~/projects/repositories/galaxy/lib/galaxy/workflow/modules.py"
+  - "~/projects/repositories/galaxy/lib/galaxy/webapps/galaxy/api/workflows.py"
+summary: "Reference for Galaxy workflow invocation states, messages, failure reasons, and invocation API surfaces."
+---
+
+# Galaxy Workflow Invocation Failure Reference
+
+This note describes workflow-level failure surfaces in Galaxy. It is separate from [[galaxy-tool-job-failure-reference]] because invocation state answers whether Galaxy could schedule and drive the workflow, while job state answers whether individual tool jobs succeeded.
+
+## Invocation Versus Job Failure
+
+Important distinction:
+
+- Invocation state says whether Galaxy scheduled, cancelled, failed, or completed the workflow invocation.
+- Job state says whether jobs produced by invocation steps succeeded or failed.
+- Invocation messages explain scheduler/evaluation/cancellation problems.
+- Step states usually describe scheduling progress, not actual job success, unless a legacy serialization mode substitutes job state.
+
+A robust workflow test reference should inspect both invocation APIs and job APIs.
+
+## Invocation States
+
+Galaxy invocation states are defined in `~/projects/repositories/galaxy/lib/galaxy/schema/invocation.py` and related model code.
+
+| State | Meaning |
+|---|---|
+| `new` | Newly created invocation. |
+| `requires_materialization` | Deferred or undeferred inputs must materialize before scheduling can continue. |
+| `ready` | Ready for another scheduler iteration. |
+| `scheduled` | Workflow has been scheduled. Older clients may treat this as successful terminal state. |
+| `cancelling` | Scheduler will cancel jobs and subworkflow invocations. |
+| `cancelled` | Cancellation terminal state. |
+| `failed` | Scheduler/evaluation/materialization failure terminal state. |
+| `completed` | Newer completion state after all jobs reach terminal states. |
+
+Version caveat: `completed` may not be uniformly available across all Galaxy/Planemo combinations. Planemo accounts for both `scheduled` and `completed` as success-like invocation states.
+
+## Invocation Message Reasons
+
+Structured invocation messages are the main durable surface for workflow-level failures.
+
+| Reason | Typical meaning |
+|---|---|
+| `dataset_failed` | Dataset input or upstream dataset was failed/unusable. |
+| `collection_failed` | Collection was failed, incompletely populated, or unusable. |
+| `job_failed` | Upstream dependent job failed. |
+| `output_not_found` | Expected step/subworkflow output could not be resolved. |
+| `expression_evaluation_failed` | Workflow expression or condition evaluation failed. |
+| `when_not_boolean` | Conditional `when` expression did not return a boolean. |
+| `unexpected_failure` | Scheduler or evaluation failure without a more specific safe reason. |
+| `workflow_parameter_invalid` | Workflow parameter validation failed. |
+| `step_input_deleted` | Step input dataset/collection was deleted. |
+| `history_deleted` | Invocation history was deleted, causing cancellation. |
+| `user_request` | User/API cancellation. |
+| `cancelled_on_review` | Pause/review step rejected continuation. |
+| `workflow_output_not_found` | Warning: declared workflow output was not found. |
+
+Message records can include affected workflow step id, dependent step id, job id, HDA/HDCA ids, output name, and nested workflow step index path. These fields matter more than free-text messages for reference-quality diagnosis.
+
+## Common Workflow-Level Failure Surfaces
+
+| Surface | Reference signal |
+|---|---|
+| Request-time validation | API returns an error before useful invocation state exists. |
+| Input materialization | Invocation enters `requires_materialization`, then may fail with `dataset_failed`. |
+| Conditional evaluation | Invocation messages include `expression_evaluation_failed` or `when_not_boolean`. |
+| Missing output graph edge | Invocation messages include `output_not_found`. |
+| Deleted/purged inputs | Invocation messages include `step_input_deleted` or `dataset_failed`. |
+| Upstream job failure | Invocation messages or summaries point to `job_failed`; job API has details. |
+| Collection population failure | Invocation messages include `collection_failed`; inspect HDCA and mapped jobs. |
+| Pause/review rejection | Cancellation reason `cancelled_on_review`. |
+| User/history cancellation | Cancellation messages `user_request` or `history_deleted`. |
+| Warning-only missing output | `workflow_output_not_found` warning; may later become Planemo assertion failure. |
+
+## API Surfaces
+
+Useful invocation APIs from `~/projects/repositories/galaxy/lib/galaxy/webapps/galaxy/api/workflows.py`:
+
+| API | Use |
+|---|---|
+| `GET /api/invocations/{invocation_id}` | Invocation state, messages, inputs, outputs, and steps. |
+| `GET /api/invocations/{invocation_id}?step_details=true` | Richer step detail, jobs, outputs, and output collections. |
+| `GET /api/invocations/steps/{step_id}` | Detail for one invocation step. |
+| `GET /api/invocations/{invocation_id}/steps/{step_id}` | Step detail scoped to invocation. |
+| `GET /api/invocations/{invocation_id}/jobs_summary` | Job state summary across the invocation. |
+| `GET /api/invocations/{invocation_id}/step_jobs_summary` | Job state summary per workflow invocation step. |
+| `GET /api/invocations/{invocation_id}/completion` | Completion record, if available. |
+| `DELETE /api/invocations/{invocation_id}` | Cancel invocation. |
+| `PUT /api/invocations/{invocation_id}/steps/{step_id}` | Continue or cancel pause/review step. |
+| `GET /api/invocations/{invocation_id}/report` | Invocation report surface. |
+
+Workflow aliases under `/api/workflows/{workflow_id}/invocations/...` also exist.
+
+## Planemo Caveats
+
+Planemo polls invocation and job state, but its user-facing output may not expose all structured invocation messages. Treat Planemo terminal output as a summary; use raw invocation and job APIs when the failure class matters.
+
+Likely noisy boundaries:
+
+- Planemo may show failed job details but omit structured invocation messages.
+- `step_jobs_summary` is useful in Galaxy but not necessarily surfaced directly by Planemo output.
+- Subworkflow paths can be represented in Galaxy message fields but may not be displayed by Planemo.
+- A workflow can be `completed` or `scheduled` while one or more jobs failed; job summaries must still be inspected.
+
+## Durable Reference Use
+
+Use this note when a workflow run fails before or around job scheduling, when outputs are missing without an obvious tool stderr cause, or when Planemo only reports a generic invocation failure.
+
+The goal is not to prescribe a single repair loop. The goal is to preserve which Galaxy API surface proves the failure mode so later Molds can decide whether the defect belongs to data-flow, template, concrete step implementation, workflow test assertions, or runtime environment.
+
+## Verification Gaps
+
+Actual runs should verify:
+
+- Whether Planemo surfaces invocation `messages` for each reason.
+- Whether `completed` and `/completion` are populated in the target Galaxy used by tests.
+- How mapped collections and subworkflow failures appear in `step_jobs_summary`.
+- How warning-only `workflow_output_not_found` interacts with Planemo assertions.

--- a/casts/claude/skills/debug-galaxy-workflow-output/references/notes/iwc-shortcuts-anti-patterns.md
+++ b/casts/claude/skills/debug-galaxy-workflow-output/references/notes/iwc-shortcuts-anti-patterns.md
@@ -1,0 +1,360 @@
+---
+type: research
+subtype: component
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-04-30
+revised: 2026-05-03
+revision: 2
+ai_generated: true
+related_notes:
+  - "[[galaxy-workflow-testability-design]]"
+  - "[[iwc-test-data-conventions]]"
+  - "[[planemo-asserts-idioms]]"
+  - "[[implement-galaxy-workflow-test]]"
+  - "[[tests-format]]"
+  - "[[iwc-conditionals-survey]]"
+  - "[[iwc-map-over-lifecycle-survey]]"
+  - "[[iwc-tabular-operations-survey]]"
+  - "[[iwc-transformations-survey]]"
+summary: "What IWC test suites cut corners on (accepted) vs what's a code smell — existence-only probes, sim_size deltas, image dim checks, label coupling."
+---
+
+# IWC test-suite shortcuts and anti-patterns
+
+## Purpose
+
+When an agent translates or authors a Galaxy workflow for IWC submission, the test suite it writes will be reviewed against IWC's *de facto* style — not against an idealized assertion ladder. That style routinely tolerates assertions that look weak in isolation. This note distinguishes the corner-cutting that is **normal and accepted** in the corpus from the patterns that an agent should treat as **smells** worth flagging.
+
+This note owns accepted-vs-smell calls. For positive workflow-structure guidance behind label stability, checkpoint promotion, and collection identifier design, use [[galaxy-workflow-testability-design]].
+
+Grounding: 115 `*-tests.yml` files under `workflow-fixtures/iwc-src/workflows/` (mirror of `galaxyproject/iwc`), prior synthesis in `galaxy-brain/vault/projects/workflow_state/skills/COMPONENT_GALAXY_WORKFLOW_TESTING.md`. Path citations below are relative to `iwc-src/workflows/` unless absolute.
+
+## TL;DR rules of thumb
+
+1. **Default to tolerant assertions.** `compare: sim_size` + `delta:`, `has_image_*` + `delta:`, `has_text` substring, `has_h5_keys`, `has_n_lines` + `delta:` are *the IWC vocabulary*. Strict `compare: diff` or exact-`file:` is the exception, used only when the upstream tool is fully deterministic on fixed inputs.
+2. **No negative tests.** `expect_failure:` does not appear in the corpus. Don't author one.
+3. **No checksums.** `md5:` / `checksum:` do not appear on outputs in the corpus. SHA-1 hashes are used on **inputs** (integrity of remote fetch), never on output assertions.
+4. **Preserve labels.** Inputs and outputs are referenced by label. Renaming silently breaks tests; treat label changes as breaking changes that require a sibling `-tests.yml` update.
+5. **Big data goes to Zenodo.** In-repo `test-data/` is for toy fixtures and expected outputs only.
+
+---
+
+## 1. Existence-only content probes
+
+### Accepted
+
+The HyPhy test files reduce JSON output validation to "starts with `{`":
+
+- `comparative_genomics/hyphy/hyphy-core-tests.yml:32-71` — four output collections (`meme_output`, `prime_output`, `busted_output`, `fel_output`), each gene element asserts `has_text: text: "{"` and nothing else.
+- `comparative_genomics/hyphy/hyphy-compare-tests.yml`, `capheine-core-and-compare-tests.yml` — same pattern across the rest of the family.
+
+This is **accepted** because:
+- HyPhy's MEME/PRIME/BUSTED/FEL/CFEL/RELAX statistical outputs embed run-dependent floats throughout (likelihoods, AIC, posterior probabilities). Substring assertions on numeric fields would fail intermittently.
+- Selecting any specific gene name or category in the JSON would couple the test to internal HyPhy keying that the wrapper has changed across versions.
+- The assertion does verify "the tool ran, produced JSON, did not crash, and the collection structure matches expected element identifiers" — which is genuinely useful given HyPhy's history of opaque failures.
+
+A quick scan finds **298 lines** matching the existence-style `has_text:` pattern across the corpus (`grep "has_text:\s*$\|text: \"{\"$"` yields 298 hits across many files). It is widespread, not a HyPhy quirk.
+
+Other variants in the same accepted-shortcut family:
+
+- **First-line-of-header probes**: `amplicon/amplicon-mgnify/.../mgnify-amplicon-pipeline-v5-rrna-prediction-tests.yml:46-49` asserts `has_text: "# mapseq v1.2.6 (Jan 20 2023)"` — version banner only.
+- **`has_n_columns` schema probes**: same file lines 50-52, 67-69 — "the table has 15 columns" / "4 columns" with no row-content check.
+- **`has_h5_keys` structure probes**: `scRNAseq/scanpy-clustering/.../Preprocessing-...-Scanpy-tests.yml:27-32, 159-166` — confirms AnnData has `obs/louvain`, `var/highly_variable`, `uns/rank_genes_groups`, etc., but says nothing about cluster labels or values. Also `imaging/tissue-microarray-analysis/multiplex-tissue-microarray-analysis/multiplex-tma-tests.yml` for Merged anndata.
+
+### Smell
+
+Existence probes on **deterministic** outputs. If the underlying tool is deterministic on fixed inputs (alignment, simple QC stats, well-defined transformations), reducing to `has_text: "{"` is laziness — agent should at least pull a known stable substring from the expected JSON.
+
+Heuristic for an agent: **if the source workflow's tool is on the "stochastic / floating-point heavy / version-fragile" list (HyPhy, RepeatModeler, scanpy plots, MCMC samplers, ML inference), existence probes are accepted. Otherwise, prefer `has_text` against a stable token from a real output.**
+
+---
+
+## 2. Size-only comparisons (`compare: sim_size` + `delta:`)
+
+### Accepted
+
+Canonical example: `repeatmasking/RepeatMasking-Workflow-tests.yml:11-46` — every output is `compare: sim_size` with `delta: 30000` (30 KB) on small outputs and `delta: 90000000` (90 MB!) on the Stockholm seed-alignment file. RepeatModeler's discovered repeat families differ run-to-run; only output magnitude is reproducible.
+
+`grep "compare: sim_size"` returns 9 files using this pattern:
+- `repeatmasking/RepeatMasking-Workflow-tests.yml`, `repeatmasking/Repeat-masking-with-RepeatModeler-and-RepeatMasker-tests.yml` (RepeatModeler — large delta band)
+- `epigenetics/hic-hicup-cooler/chic-fastq-to-cool-hicup-cooler-tests.yml`, `epigenetics/hic-hicup-cooler/hic-fastq-to-cool-hicup-cooler-tests.yml` (HiC matrices)
+- `genome_annotation/functional-annotation/functional-annotation-of-sequences/Functional_annotation_of_sequences-tests.yml`
+- `VGP-assembly-v2/kmer-profiling-hifi-trio-VGP2/kmer-profiling-hifi-trio-VGP2-tests.yml`
+- `genome-assembly/polish-with-long-reads/Assembly-polishing-with-long-reads-tests.yml`
+- `scRNAseq/baredsc/baredSC-1d-logNorm-tests.yml`, `scRNAseq/baredsc/baredSC-2d-logNorm-tests.yml` (Bayesian sampling — uses `delta_frac:` here)
+
+### Delta-magnitude survey
+
+From `grep "delta: [0-9]+"` distribution across the corpus:
+
+| Delta band | Count | Typical use |
+|---|---|---|
+| 4–100 (tiny) | ~20 | image pixel dimensions, line counts |
+| 1K–10K | ~40 | small text/tabular outputs, plot PNGs |
+| 25K–100K | ~25 | mid-size reports, multi-page plots |
+| 200K–1M | ~10 | report HTML, BAM stats |
+| 1M–10M | ~10 | medium BAM/BCF/cool files |
+| 10M+ (up to 90M) | ~7 | RepeatModeler libraries, large alignments |
+
+The 90 MB delta on `RepeatMasking-Workflow-tests.yml:20` is at the extreme. It says "this output is somewhere between zero bytes and 180 MB" — effectively only catches the empty-output failure mode. Accepted because RepeatModeler's seed alignments are known to vary by tens of MB across runs.
+
+### `delta_frac:`
+
+Used in 3 files (`scRNAseq/baredsc/*`, `genome-assembly/polish-with-long-reads/*`). Preferred over absolute `delta:` when the expected output size scales with input. An agent translating a workflow whose output size depends on input volume should consider `delta_frac:` over `delta:`.
+
+### Smell
+
+`compare: sim_size` on outputs from a **deterministic** tool. If the tool is bwa/bowtie2/samtools-sort with fixed seeds and pinned versions, there's no excuse for size-only — `compare: diff` (with modest `lines_diff:`) or content assertions are appropriate.
+
+Also a smell: stacking size + `has_image_*` checks on a PNG without any content assertion when the workflow's claim is *about the data shown* (e.g., a clustering plot). The corpus does this routinely (Scanpy file below) — accepted, but a translated workflow that has a more deterministic plotter should do better.
+
+---
+
+## 3. Image plot assertions
+
+### Accepted
+
+`scRNAseq/scanpy-clustering/.../Preprocessing-...-Scanpy-tests.yml:33-205` is the dense example. ~15 PNG outputs each get the same triple:
+
+```yaml
+UMAP of louvain:
+  has_size:
+    size: 68416
+    delta: 6000
+  has_image_width:
+    width: 601
+    delta: 30
+  has_image_height:
+    height: 429
+    delta: 25
+```
+
+What this catches:
+- Plot was rendered (non-zero size).
+- Render dimensions are stable (matplotlib defaults didn't drift, theme didn't change).
+- Approximate file size hasn't shifted by an order of magnitude (no catastrophic content change like all-white or all-noise).
+
+What this **misses**: cluster assignments wrong, axes mislabeled, points in wrong positions, colors swapped, the wrong subset plotted, NaN handling regression. Two visually different UMAPs can have identical width/height/size-within-10%.
+
+Other observed image-assertion users (`grep "has_image"`):
+- `imaging/tissue-microarray-analysis/tissue-microarray-analysis/tissue-micro-array-analysis-tests.yml`
+- `imaging/tissue-microarray-analysis/multiplex-tissue-microarray-analysis/multiplex-tma-tests.yml`
+
+The TMA tests use a friendlier shorthand: `has_size: size: 181K, delta: 50K` (human-readable units).
+
+### Smell
+
+Asserting `has_image_width`/`has_image_height` with **zero delta** on a tool that re-encodes (PNG round-trips through matplotlib) is brittle. The corpus uses 5–10% deltas; an agent emitting `delta: 0` should be flagged unless the renderer is byte-stable.
+
+Note `has_image_channels`, `has_image_center_of_mass` are documented (galaxy XSD) but **not observed** in the sampled corpus. An agent with a deterministic mask/segmentation output could use `has_image_center_of_mass` to actually verify spatial correctness — this would be an *upgrade* over the current corpus norm, not a smell.
+
+---
+
+## 4. Happy-path-only culture (`expect_failure:`)
+
+`grep -r "expect_failure"` over all 115 tests files returns **zero hits**. The IWC corpus has no negative tests. Period.
+
+This is a structural property of IWC: the workflows are published artifacts intended to *succeed* on canonical inputs. Adversarial / error-path testing happens in tool wrappers, not in workflow tests.
+
+**Implication for an agent:** Do not author `expect_failure:` cases when translating a workflow. If the source pipeline (e.g., nf-core) had a "fail on bad reference" test, drop it — it doesn't belong in IWC. If the validation logic is important, it should be in a wrapper-level tool test, not a workflow test.
+
+---
+
+## 5. `md5:` / `checksum:` rarity
+
+`grep -r "md5:\|checksum:"` over `*-tests.yml`: **zero hits**.
+
+SHA-1 `hashes:` blocks are pervasive — but exclusively on **inputs** (`hash_function: SHA-1` paired with a remote `location:`), to guard against silent corruption of the fetched fixture. Output assertions never use them.
+
+Accepted. The reason is empirical: outputs of real bioinformatics tools (BAM with PG headers and timestamps, VCFs with command-line provenance, JSON with run dates) are almost never byte-stable across runs. A `checksum:` would fail intermittently.
+
+**Smell:** an agent emitting `checksum:` or `md5:` on a workflow output. Even for "fully deterministic" tools, embedded provenance breaks checksums. Use `compare: diff` + `lines_diff:` instead, or content assertions.
+
+---
+
+## 6. Output label coupling
+
+Test files key outputs by **workflow label**, with spaces, capitals, punctuation preserved verbatim. Examples:
+
+- `scanpy-clustering/.../Preprocessing-...-Scanpy-tests.yml:27` — `Anndata with Celltype Annotation:` (spaces, mixed case)
+- `scanpy-clustering/.../Preprocessing-...-Scanpy-tests.yml:33` — `UMAP of louvain and top ranked genes:`
+- `imaging/tissue-microarray-analysis/multiplex-tissue-microarray-analysis/multiplex-tma-tests.yml` — `Merged anndata:`, `Spatial Scatterplot Montage:`
+- `consensus-from-variation-tests.yml:30` — `multisample_consensus_fasta:` (snake-case style)
+
+**Both styles coexist.** Snake-case (older / SARS-CoV-2 family) and natural-language-with-spaces (newer / scanpy / TMA) are equally valid. Reviewers do not enforce a single convention.
+
+### Coupling consequences
+
+Renaming an output label in the `.ga` without updating the sibling `-tests.yml` is a silent breakage:
+- Test references the old label → key not present in invocation outputs → assertion mismatch surfaces as an opaque "output not found" error in planemo.
+- `planemo workflow_lint --iwc` enforces that workflow outputs are *labeled*, not that test labels match.
+
+**Discipline observed:** every output a test asserts on is a labeled workflow output. The corpus does not assert on positional / unlabeled outputs.
+
+**Smell:** a translated workflow with unlabeled outputs that later need test coverage. Agent should label every output it intends to assert on, before writing assertions.
+
+Positive design guidance now lives in [[galaxy-workflow-testability-design]]: pick stable labels before test authoring and treat renames as test-breaking API changes.
+
+---
+
+## 7. Intermediate-step output gap
+
+`-tests.yml` can only assert on workflow-level **outputs** (entries in the `.ga`'s top-level outputs). Intermediate step results are inaccessible to assertions.
+
+Observed workaround across the corpus: **promote the intermediate to a workflow output**. This is visible indirectly — many workflows expose what would naturally be intermediates as labeled outputs solely for testability:
+
+- `scanpy-clustering` exposes `Initial Anndata General Info`, `Anndata with raw attribute`, `Plot highly variable`, `Elbow plot of PCs and variance` — these are mid-pipeline checkpoints surfaced specifically to be assertable. Compare counts: 22 outputs asserted vs the 7-or-so "user-meaningful" final artifacts.
+- `MAGs-generation-tests.yml` exposes a `Full MultiQC Report` even though MultiQC is logically intermediate to MAG annotation.
+
+**Cost:** "test-only" outputs clutter the workflow's user-facing output list. Reviewers tolerate this in exchange for testability.
+
+**Accepted shortcut:** promoting an intermediate to a workflow output for test purposes. Not a smell.
+
+**Smell:** asserting on a step output via some side-channel (e.g., relying on Galaxy collection ordering, indexing into `tool_state`). The corpus does not do this and an agent should not invent it.
+
+Positive design guidance now lives in [[galaxy-workflow-testability-design]]: promote assertable checkpoints deliberately, especially when final reports or plots can only support weak smoke tests.
+
+---
+
+## 8. Remote-data fragility
+
+### Pattern
+
+Overwhelming preference for **Zenodo** as the input store. Every remote `location:` is paired with a SHA-1 `hashes:` block. Examples already cited in nearly every snippet above.
+
+Non-Zenodo remote sources observed (from `grep "ftp.sra.ebi\|ftp://\|figshare\|github.com"`):
+- `virology/pox-virus-amplicon/pox-virus-half-genome-tests.yml:27,34,48,55` — `ftp://ftp.sra.ebi.ac.uk/...` SRA fastqs
+- `amplicon/amplicon-mgnify/.../mgnify-amplicon-pipeline-v5-rrna-prediction-tests.yml:21` — `ftp://ftp.ebi.ac.uk/...` reference DB
+- `data-fetching/parallel-accession-download/parallel-accession-download-tests.yml`, `VGP-assembly-v2/Plot-Nx-Size/...` — accession-driven
+- `variant-calling/generic-variant-calling-wgs-pe/Generic-variation-analysis-on-WGS-PE-data-tests.yml` — github raw URLs
+
+### The fragility
+
+- **Zenodo is a single point of failure across CI.** A Zenodo outage breaks every IWC PR concurrently. SHA-1 hashes guard against silent corruption but provide no mitigation for outages or HTTP 503s.
+- **EBI/SRA FTP is even less reliable** — observed flake-prone in the broader Galaxy CI history.
+- No retry / backoff configured at the test-format level; planemo-ci-action's defaults handle transient failures only via re-running the chunk job manually.
+
+### Accepted
+
+This is just life in the IWC. Don't try to "fix" it in a translated workflow by inlining large data — reviewers will push back (see §10).
+
+### Smell
+
+Inputs hosted on a contributor's personal endpoint, S3 bucket, or Dropbox. Reviewers ask for migration to Zenodo before merge.
+
+---
+
+## 9. `compare: diff` on timestamped outputs
+
+`compare: diff` usage from `grep`:
+
+- `sars-cov-2-variant-calling/sars-cov-2-ont-artic-variant-calling/ont-artic-variation-tests.yml:32` — `compare: diff, lines_diff: 6` on annotated VCF
+- `sars-cov-2-variant-calling/sars-cov-2-pe-illumina-wgs-variant-calling/pe-wgs-variation-tests.yml:35` — same
+- `imaging/fluorescence-nuclei-segmentation-and-counting/segmentation-and-counting-tests.yml:16` — `lines_diff: 0`
+- `variant-calling/variation-reporting/Generic-variation-analysis-reporting-tests.yml:21,25,29,33` — `lines_diff: 6`
+- `variant-calling/generic-variant-calling-wgs-pe/Generic-variation-analysis-on-WGS-PE-data-tests.yml:39,45,55` — `lines_diff: 6`
+
+The `lines_diff: 6` constant is suspicious — 6 lines is the typical VCF header preamble that embeds `##fileDate=...` and `##source=...`. The use is **defensible**: tolerance window matches the known mutable header lines, content lines are diffed strictly.
+
+### Smell
+
+- `compare: diff` with `lines_diff: 0` on a file that contains *any* timestamp, command-line capture, version banner, or random tie-break (hash-ordered dictionaries in Python output, etc.). The single observed `lines_diff: 0` case (`segmentation-and-counting-tests.yml:16`) appears to be on a numeric tabular output where it's defensible — verify content type before flagging.
+- `compare: diff` on a BAM. BAM headers include `@PG` lines with full command lines and Galaxy job IDs. Use `has_size` + content extracts via `has_archive_member` or `samtools view`-piped XML asserts — not byte-level diff.
+
+**Recommended replacement** when timestamps appear:
+- For VCF: `compare: diff, lines_diff: <header-line-count>` (corpus convention is 6).
+- For tabular reports: `has_text` against stable column headers + `has_n_columns`.
+- For HTML reports (MultiQC etc.): `has_text` substring on stable section names — example `short-read-qc-trimming/short-read-quality-control-and-trimming-tests.yml:25-28` asserts `"Filtered Reads"` substring on the MultiQC HTML report rather than diffing.
+
+---
+
+## 10. Reviewer-feedback recurring asks
+
+Synthesized from the COMPONENT_GALAXY_WORKFLOW_TESTING.md analysis (sections 9 and the "Common PR-review feedback" subsection) plus structural observation of what every accepted workflow has and rejected drafts apparently lack:
+
+| Reviewer ask | Where it bites | Source |
+|---|---|---|
+| **Creator `identifier:` must be a full ORCID URI** (`https://orcid.org/...`), not bare ID. | `.ga` frontmatter `creator:` block. Most common lint failure. | planemo PR #1458; `consensus-from-variation.ga:4-10` shows the conformant shape. |
+| **Move large inputs to Zenodo.** Inline `path: test-data/big.bam` for >1 MB inputs gets pushback. | `-tests.yml` job inputs. | `iwc/workflows/README.md` (per prior analysis). |
+| **Bump `release` + add CHANGELOG.md entry in the same PR.** | `.ga` `release:` and sibling `CHANGELOG.md`. Enforced by `bump_version.py`. | `iwc/workflows/README.md:217-247`. |
+| **Generate tests via `planemo workflow_test_init --from_invocation <id>`**, not by hand. Reviewers push back on hand-authored job blocks. | Any new test contribution. | help.galaxyproject.org thread 13903. |
+| **Don't use `compare: diff` on outputs that embed timestamps.** Switch to `has_text`/`has_n_lines` with `delta:`. | See §9. | Recurring review comment. |
+| **Add labeled outputs for any output you assert on.** Unlabeled outputs caught by `planemo workflow_lint --iwc`. | `.ga` outputs. | §6 above. |
+| **Hashes on every remote `location:`.** SHA-1 block paired with the URL. Reviewers spot-check. | `-tests.yml` job inputs. | Universal in the corpus; missing hashes get flagged. |
+
+### Smell to flag for an agent submission
+
+- Bare ORCID ID (`0000-0002-...`) in `creator:` instead of full URL.
+- Test job referencing >1 MB local fixture instead of a Zenodo URL.
+- PR that bumps a workflow without CHANGELOG / `release:` bump.
+- Hand-authored `-tests.yml` that reads "too clean" — reviewers know `--from_invocation` output has a recognizable fingerprint.
+
+---
+
+## Summary cheatsheet for the implement-galaxy-workflow-test mold
+
+**Use these freely (accepted shortcuts):**
+- `has_text: text: "{"` for stochastic JSON outputs.
+- `compare: sim_size, delta:` for non-deterministic file outputs; pick delta from §2 distribution by tool family.
+- `has_image_width/height/has_size` triple with 5–10% delta for matplotlib plots.
+- `has_h5_keys` for AnnData/HDF5 — assert structure not values.
+- Promoting intermediates to workflow outputs to make them assertable.
+- Labels with spaces, mixed case, punctuation as the output key.
+- SHA-1 hashes on every input `location:`.
+
+**Avoid (smells reviewers or future-you will catch):**
+- `expect_failure:` — not an IWC pattern.
+- `md5:` / `checksum:` on outputs.
+- `compare: diff, lines_diff: 0` on anything containing timestamps, BAM `@PG` lines, or Python dict ordering.
+- `has_image_*` with zero delta.
+- Existence-only `has_text: "{"` on outputs from a deterministic tool.
+- Asserting on positional/unlabeled outputs.
+- Inlining >1 MB binary fixtures in `test-data/`.
+- Bare ORCID identifier in `.ga` frontmatter.
+
+**Review-time checklist before submission:**
+1. Every output asserted on has a label in the `.ga`.
+2. Every remote `location:` has a `hashes: SHA-1` block.
+3. Inputs >1 MB live on Zenodo, not in `test-data/`.
+4. `release:` bumped and `CHANGELOG.md` updated if `.ga` changed.
+5. `creator.identifier:` is a full `https://orcid.org/...` URL.
+6. Test was generated by `planemo workflow_test_init --from_invocation`, not hand-written.
+
+---
+
+## Sources
+
+- Positive workflow-structure guidance: [[galaxy-workflow-testability-design]].
+- Prior synthesis: `/Users/jxc755/projects/repositories/galaxy-brain/vault/projects/workflow_state/skills/COMPONENT_GALAXY_WORKFLOW_TESTING.md` (sections 2c, 2d, 2e, 9).
+- Corpus root: `/Users/jxc755/projects/repositories/workflow-fixtures/iwc-src/workflows/` (115 `*-tests.yml` files across 22 categories).
+- Specific files cited:
+  - `comparative_genomics/hyphy/hyphy-core-tests.yml`, `hyphy-compare-tests.yml`, `capheine-core-and-compare-tests.yml`
+  - `repeatmasking/RepeatMasking-Workflow-tests.yml`, `Repeat-masking-with-RepeatModeler-and-RepeatMasker-tests.yml`
+  - `scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml`
+  - `read-preprocessing/short-read-qc-trimming/short-read-quality-control-and-trimming-tests.yml`
+  - `virology/pox-virus-amplicon/pox-virus-half-genome-tests.yml`
+  - `metabolomics/lcms-preprocessing/Mass_spectrometry__LC-MS_preprocessing_with_XCMS-tests.yml`
+  - `sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation-tests.yml`
+  - `sars-cov-2-variant-calling/sars-cov-2-pe-illumina-wgs-variant-calling/pe-wgs-variation-tests.yml`
+  - `sars-cov-2-variant-calling/sars-cov-2-ont-artic-variant-calling/ont-artic-variation-tests.yml`
+  - `variant-calling/variation-reporting/Generic-variation-analysis-reporting-tests.yml`
+  - `variant-calling/generic-variant-calling-wgs-pe/Generic-variation-analysis-on-WGS-PE-data-tests.yml`
+  - `imaging/fluorescence-nuclei-segmentation-and-counting/segmentation-and-counting-tests.yml`
+  - `imaging/tissue-microarray-analysis/multiplex-tissue-microarray-analysis/multiplex-tma-tests.yml`
+  - `amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction-tests.yml`
+  - `epigenetics/atacseq/atacseq-tests.yml`
+  - `epigenetics/hic-hicup-cooler/chic-fastq-to-cool-hicup-cooler-tests.yml`, `hic-fastq-to-cool-hicup-cooler-tests.yml`
+  - `microbiome/mags-building/MAGs-generation-tests.yml`
+  - `genome-assembly/polish-with-long-reads/Assembly-polishing-with-long-reads-tests.yml`
+  - `scRNAseq/baredsc/baredSC-1d-logNorm-tests.yml`, `baredSC-2d-logNorm-tests.yml`
+- Corpus-wide grep tallies:
+  - `expect_failure`: 0 hits.
+  - `md5:|checksum:` on outputs: 0 hits.
+  - `compare: sim_size`: 9 files.
+  - `compare: diff`: 5 files (variant-calling and imaging).
+  - `has_image_*`: 3 files.
+  - Existence-style `has_text:` patterns: ~298 line matches.
+  - `delta_frac:`: 3 files.

--- a/casts/claude/skills/debug-galaxy-workflow-output/references/notes/nextflow-operators-to-galaxy-collection-recipes.md
+++ b/casts/claude/skills/debug-galaxy-workflow-output/references/notes/nextflow-operators-to-galaxy-collection-recipes.md
@@ -1,0 +1,101 @@
+---
+type: research
+subtype: component
+title: "Nextflow operators to Galaxy collection recipes"
+tags:
+  - research/component
+  - source/nextflow
+  - target/galaxy
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+related_notes:
+  - "[[nextflow-to-galaxy-channel-shape-mapping]]"
+  - "[[galaxy-collection-semantics]]"
+  - "[[galaxy-collection-tools]]"
+  - "[[galaxy-apply-rules-dsl]]"
+  - "[[iwc-transformations-survey]]"
+  - "[[iwc-tabular-operations-survey]]"
+  - "[[galaxy-data-flow-draft-contract]]"
+  - "[[iwc-map-over-lifecycle-survey]]"
+  - "[[nextflow-patterns]]"
+related_molds:
+  - "[[nextflow-summary-to-galaxy-data-flow]]"
+  - "[[implement-galaxy-tool-step]]"
+  - "[[debug-galaxy-workflow-output]]"
+sources:
+  - "https://github.com/galaxyproject/foundry/issues/53"
+summary: "Classifies common Nextflow operators as Galaxy wiring, collection semantics, explicit steps, or review triggers."
+---
+
+# Nextflow Operators To Galaxy Collection Recipes
+
+Most Nextflow operators are not Galaxy tools. Translate them first as source-side data-flow intent, then decide whether the Galaxy representation is simple wiring, collection semantics, an explicit Galaxy step, or a user-review checkpoint.
+
+## Decision Vocabulary
+
+| Label | Meaning |
+|---|---|
+| `channel-only rewiring` | The operator disappears into Galaxy connections, labels, branch wiring, or output selection. |
+| `Galaxy collection semantics` | Translation relies on collection identifiers, collection type, map-over, reduction, or nesting behavior. |
+| `explicit Galaxy step` | Add a collection-operation, tabular, text-processing, or domain tool step. |
+| `user review` | Translation is likely lossy or semantically ambiguous. |
+
+## Operator Recipes
+
+| Nextflow operator | Galaxy recipe | Class | Confidence |
+|---|---|---|---|
+| `map` | Treat metadata-only projection as wiring. Use Apply Rules only when materialized identifiers or collection shape must change. Use an explicit tool if file contents or table rows change. | Usually channel-only; sometimes collection semantics or explicit step | High for metadata-only, medium for identifier parsing |
+| `join` | If two Galaxy collections have matching identifiers and structure, use normal multi-input map-over. Otherwise add synchronization by extracting, sorting, filtering, or relabeling identifiers. Use tabular joins for row-key joins. | Collection semantics or explicit step | High for file/index pairing, medium for loose joins |
+| `groupTuple` | If grouping represents nested collection structure, model collection nesting or Apply Rules. If grouping is scatter/gather for a domain operation, implement the downstream merge/reduce tool. | Collection semantics plus explicit reduction | High for interval gather, medium for arbitrary grouping |
+| `branch` | Use branch wiring only for static workflow-level classes. Per-element conditional routing usually needs explicit filters/classifiers or user review. | Channel-only, explicit step, or review | Medium |
+| `mix` | Keep report/version aggregation as wiring. Use `__MERGE_COLLECTION__` or `__BUILD_LIST__` only when a materialized collection is required. | Usually channel-only; explicit collection assembly when materialized | High for report/version aggregation |
+| `combine` | With `by:`, treat like keyed pairing. Without `by`, treat as Cartesian expansion and require review unless a specific Galaxy cross-product recipe is intended. | Collection semantics or review | Medium-low for unkeyed combine |
+| `multiMap` | Usually split one tuple into separate synchronized Galaxy inputs. Preserve enough edge notes to rejoin later if needed. | Usually channel-only | Medium |
+
+## User-Review Triggers
+
+- `branch` has non-trivial predicates, an `unknown`/default branch, or discarded branch data.
+- `join` uses optional/remainder behavior, duplicate keys, non-metadata keys, or mismatch-tolerant settings.
+- `combine` lacks `by:` and may imply all-vs-all expansion.
+- `groupTuple` uses explicit size, sort, or `groupKey` behavior.
+- `map` mutates metadata, parses identifiers with regex, returns variable arity, or hides content-level computation.
+- `mix` combines branches with overlapping identifiers or unclear ordering.
+- Any Groovy closure transforms file bytes or table rows.
+
+## Evidence
+
+Pinned Nextflow fixtures provide direct examples of all covered operators except some edge cases of `combine` and arbitrary `map` closures:
+
+- `workflow-fixtures/pipelines/nf-core__taxprofiler/main.nf` for `map`, `branch`, `mix`, and collection split/merge behavior.
+- `workflow-fixtures/pipelines/nf-core__taxprofiler/subworkflows/local/visualization_krona/main.nf` for keyed `combine` plus `multiMap`.
+- `workflow-fixtures/pipelines/nf-core__sarek/subworkflows/local/*/main.nf` for `join`, interval `groupTuple`, and scatter/gather patterns.
+- `workflow-fixtures/pipelines/nf-core__fetchngs/workflows/sra/main.nf` for accession/data-fetching branches and reductions.
+
+Galaxy-side evidence:
+
+- [[galaxy-collection-semantics]] for map-over and reduction behavior.
+- [[iwc-transformations-survey]] for cleanup-after-fanout, identifier synchronization, collection flattening, and corpus-observed collection recipes.
+- [[galaxy-collection-tools]] for built-in collection operations.
+- [[galaxy-apply-rules-dsl]] for identifier-derived collection reshaping.
+- [[iwc-tabular-operations-survey]] for cases where operator translation leaves collection-land and becomes tabular/text transformation.
+
+## Low-Confidence Areas
+
+- Unkeyed `combine` can be represented by Galaxy cross-product collection tools, but the IWC survey found little or no corpus uptake. Prefer review.
+- `branch` cleanup via null filtering is possible but weakly attested; avoid claiming it as the default pattern.
+- Arbitrary `map` closures cannot be safely translated from syntax alone. Summarization should classify closure intent when possible.
+
+## Mold Use
+
+- [[nextflow-summary-to-galaxy-data-flow]] should use this as the primary operator-translation reference.
+- [[implement-galaxy-tool-step]] should use this when operator decisions become concrete Galaxy collection or tabular steps.
+- [[debug-galaxy-workflow-output]] should use this when wrong nesting, missing elements, branch merges, or gather outputs indicate a bad operator translation.
+
+## TODOs
+
+- Decide whether `summary-nextflow.schema.json` should record operator parameters such as `by`, `remainder`, `failOnMismatch`, `size`, and `sort`.
+- Consider a dedicated pattern for Nextflow per-element `branch` to Galaxy conditionals/filtering.
+- Decide whether unkeyed `combine` always requires review.

--- a/casts/claude/skills/debug-galaxy-workflow-output/references/notes/planemo-asserts-idioms.md
+++ b/casts/claude/skills/debug-galaxy-workflow-output/references/notes/planemo-asserts-idioms.md
@@ -1,0 +1,249 @@
+---
+type: research
+subtype: component
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-04-30
+revised: 2026-05-11
+revision: 6
+ai_generated: true
+related_notes:
+  - "[[galaxy-workflow-testability-design]]"
+  - "[[iwc-test-data-conventions]]"
+  - "[[iwc-shortcuts-anti-patterns]]"
+  - "[[implement-galaxy-workflow-test]]"
+  - "[[tests-format]]"
+  - "[[planemo-workflow-test-architecture]]"
+  - "[[validate-tests]]"
+  - "[[iwc-tabular-operations-survey]]"
+  - "[[galaxy-discover-datasets]]"
+summary: "Decision and idiom guide for picking planemo workflow-test assertions: which family per output type, how to size tolerances, when to validate."
+---
+
+# Planemo asserts: idiom and decision guide
+
+Companion to [[iwc-test-data-conventions]] (input shapes), [[galaxy-workflow-testability-design]] (workflow structure before test YAML exists), and [[iwc-shortcuts-anti-patterns]] (what's accepted vs smell). This note is forward-looking: when authoring a new `<workflow>-tests.yml`, which assertion family fits which output, and what the recommended tolerances and operators are.
+
+The **vocabulary itself is not restated here** — every assertion's parameter list, types, defaults, required fields, and Python docstring is rendered from the test-format JSON Schema at [[tests-format]]. Assertion names below deep-link into that page (e.g. [[tests-format#has_text_model|has_text]] jumps straight to that `$def`).
+
+## 1. Choose by output type
+
+The single most useful decision table. Pick the row that matches the file format the workflow emits; default to the recommended assertion family.
+
+| Output type | Default assertion family | Why | Fallback |
+|---|---|---|---|
+| **Plain text reports / logs** (FastQC summary, MultiQC text section) | [[tests-format#has_text_model|has_text]] (substring on a known stable token) + [[tests-format#has_n_lines_model|has_n_lines]] with `delta:` | Substring is robust across versions; line count catches truncation | [[tests-format#has_text_matching_model|has_text_matching]] (regex) when token text changes per run |
+| **HTML reports** (MultiQC HTML, custom dashboards) | [[tests-format#has_text_model|has_text]] against stable section names | HTML embeds timestamps and asset hashes; byte-diff is hopeless | [[tests-format#has_size_model|has_size]] + large `delta` as last resort |
+| **Tabular** (TSV, CSV, BED-like) | [[tests-format#has_n_columns_model|has_n_columns]] + [[tests-format#has_text_model|has_text]] for headers + [[tests-format#has_n_lines_model|has_n_lines]] with `delta:` | Schema-shape + content probes; tolerant to row reordering | [[tests-format#has_line_matching_model|has_line_matching]] for a known canonical row |
+| **VCF** | `compare: diff` with `lines_diff: 6` | The `lines_diff: 6` constant matches the typical VCF header preamble that embeds `##fileDate=` and `##source=` | [[tests-format#has_text_matching_model|has_text_matching]] for known variants |
+| **BAM** | [[tests-format#has_size_model|has_size]] + [[tests-format#has_archive_member_model|has_archive_member]] (BAM is a gzipped block format) | Headers contain `@PG` lines with command lines and Galaxy job IDs; never byte-diff | Convert to SAM in a downstream step and assert on text |
+| **FASTA** (deterministic — assemblies, consensus) | `file:` exact comparison or [[tests-format#has_text_model|has_text]] for known sequence | Output is byte-stable when the upstream tool is deterministic | [[tests-format#has_n_lines_model|has_n_lines]] if line wrapping varies |
+| **FASTA** (non-deterministic — RepeatModeler libraries) | `compare: sim_size` with large `delta:` | Family content varies run-to-run | [[tests-format#has_n_lines_model|has_n_lines]] with `delta:` |
+| **FASTQ** (rare as workflow output) | [[tests-format#has_n_lines_model|has_n_lines]] (must be multiple of 4) | Quality scores are read-id-dependent | `compare: sim_size` |
+| **JSON** (deterministic — config dumps, params) | [[tests-format#has_json_property_with_value_model|has_json_property_with_value]] / [[tests-format#has_json_property_with_text_model|has_json_property_with_text]] | Surgical: assert on the property you care about, ignore the rest | `compare: diff` if the JSON is fully canonical |
+| **JSON** (stochastic — HyPhy stats, MCMC results) | `has_text: text: "{"` (existence-only) | Embedded floats break any structural assertion; see [[iwc-shortcuts-anti-patterns]] §1 | [[tests-format#has_h5_keys_model|has_h5_keys]]-equivalent for top-level structural keys |
+| **HDF5 / AnnData** | [[tests-format#has_h5_keys_model|has_h5_keys]] + [[tests-format#has_h5_attribute_model|has_h5_attribute]] for known structure | Asserts shape, not values — values are float-noisy | [[tests-format#has_size_model|has_size]] with `delta:` |
+| **XML** | [[tests-format#is_valid_xml_model|is_valid_xml]] + [[tests-format#has_element_with_path_model|has_element_with_path]] + `element_text_is`/`element_text_matches` | Surgical structural probes; byte-diff fails on whitespace/attribute-order | [[tests-format#has_n_elements_with_path_model|has_n_elements_with_path]] for cardinality |
+| **PNG / image plots** | [[tests-format#has_image_width_model|has_image_width]] + [[tests-format#has_image_height_model|has_image_height]] + [[tests-format#has_size_model|has_size]] with `delta:` (5–10%) | Catches "rendered something with the right dimensions"; corpus norm | [[tests-format#has_image_center_of_mass_model|has_image_center_of_mass]] if mask/segmentation outputs are deterministic |
+| **TIFF / multipage images** | [[tests-format#has_image_frames_model|has_image_frames]] + [[tests-format#has_image_channels_model|has_image_channels]] + [[tests-format#has_size_model|has_size]] with `delta:` | Same logic, channel/frame structure matters | — |
+| **Archives** (zip, tar.gz) | `has_archive_member: path: "regex"` with nested `asserts:` | Asserts on a specific member; archive timestamps never byte-stable | [[tests-format#has_size_model|has_size]] with `delta:` |
+| **GFF / GTF** | [[tests-format#has_n_lines_model|has_n_lines]] with `delta:` + [[tests-format#has_text_model|has_text]] for known feature | Tools reorder freely; hard to byte-diff | `has_n_columns: 9` (GFF spec) |
+| **Cool / HiC matrices** | `compare: sim_size` with multi-MB `delta:` | Binary, run-to-run variance | [[tests-format#has_archive_member_model|has_archive_member]] for HDF5 component |
+
+When in doubt: start with [[tests-format#has_size_model|has_size]] + `delta_frac: 0.1`. It catches the catastrophic failure mode (empty / 10x bigger output). Then add a content probe.
+
+### 1a. If the assertion is too weak, revisit the workflow output
+
+Assertion choice sometimes reveals a workflow-design problem. If the only available output can support only a size check or image-dimension smoke test, check whether the workflow should expose a stronger checkpoint before settling for the weak assertion.
+
+- Scanpy's plot outputs use size and image-dimension assertions, but the same workflow also exposes AnnData HDF5 checkpoints and a cluster-count table (`$IWC/workflows/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml:33-205`).
+- RNA-seq paired-end uses coarse size bands for coverage/mapped-read outputs, but expression/count tables get stronger regex and exact-line checks (`$IWC/workflows/transcriptomics/rnaseq-pe/rnaseq-pe-tests.yml:48-97`).
+
+Rule: if a translated workflow exposes only weakly assertable final reports, consult [[galaxy-workflow-testability-design]] and consider promoting a table/text/HDF5 checkpoint before writing the final assertions.
+
+## 2. The `compare:` operators
+
+Top-level on a `file:` output assertion. Vocabulary, in decreasing strictness:
+
+- **`diff`** (default). Byte-for-byte equality with optional `lines_diff:` tolerance for a fixed number of header lines. Use only when the upstream tool is deterministic on fixed inputs *and* the output has no embedded timestamps, command lines, version banners, or hash-ordered Python-dict-style keys.
+- **`re_match` / `re_match_multiline`**. Each line of the expected fixture is a regex that must match the corresponding output line. Useful when a few fields per row are timestamped but the rest is canonical. Rare in the corpus.
+- **`contains`**. The expected fixture is a substring of the output. Cheap; weak. Prefer `asserts: has_text` for new code unless you genuinely have a multi-line block to assert as a whole.
+- **`sim_size`**. Output file size matches the fixture's size within `delta:` (bytes) or `delta_frac:` (fraction). Use when the output is necessarily non-deterministic but its rough size is reproducible (RepeatModeler libraries, HiC matrices, Bayesian sampler outputs).
+
+Picking `lines_diff:`: count the mutable header lines in the output format. VCF: ~6 (`##fileformat`, `##fileDate`, `##source`, `##reference`, contig/info lines vary). SAM/text headers: count `@HD`/`@PG`/`@CO` lines. Set `lines_diff:` to the count exactly — looser values mask real diffs.
+
+## 3. Tolerance picking
+
+**`delta:`** is bytes (for [[tests-format#has_size_model|has_size]] and `compare: sim_size`) or absolute count (for [[tests-format#has_n_lines_model|has_n_lines]], [[tests-format#has_n_columns_model|has_n_columns]], [[tests-format#has_image_width_model|has_image_width]], etc.). Suffix multipliers documented in the schema — `1K`, `1M`, `1G` work.
+
+**`delta_frac:`** is a fraction (0.1 = 10%). Use when expected size scales with input volume. Three IWC tests use it (`scRNAseq/baredsc/*`, `genome-assembly/polish-with-long-reads/*`); the rest use absolute `delta:`.
+
+**Picking magnitudes** (from corpus survey in [[iwc-shortcuts-anti-patterns]] §2):
+
+- Image dimensions: `delta: 25–30` pixels (5% of typical matplotlib defaults).
+- Image file size: `delta: 5K–60K` (5–10% of file size).
+- Small text reports: `delta: 1K–10K`.
+- HTML reports: `delta: 25K–100K`.
+- BAM files: `delta: 1M–10M`.
+- RepeatModeler / Bayesian sampler outputs: `delta: 30K–90M` (extreme, but justified by the underlying nondeterminism).
+
+**Heuristic for new outputs:** `delta_frac: 0.1` is a defensible default. Tighten if the output proves more deterministic than expected.
+
+## 4. Text family — [[tests-format#has_text_model|has_text]] vs [[tests-format#has_text_matching_model|has_text_matching]] vs [[tests-format#has_line_model|has_line]] vs [[tests-format#has_line_matching_model|has_line_matching]] vs [[tests-format#has_n_lines_model|has_n_lines]]
+
+All five are common; choose by what you're verifying.
+
+- **[[tests-format#has_text_model|has_text]]** — output contains the substring `text:`. Anywhere in the output, any number of times. Add `n:` / `min:` / `max:` to constrain occurrence count. Add `delta:` to allow slack on the count.
+- **[[tests-format#has_text_matching_model|has_text_matching]]** — output matches the regex `expression:`. Use sparingly; prefer literal [[tests-format#has_text_model|has_text]] when you can.
+- **[[tests-format#has_line_model|has_line]]** — output has at least one *line* matching `line:` exactly. Use when line boundaries matter (e.g. asserting on a specific row in a table).
+- **[[tests-format#has_line_matching_model|has_line_matching]]** — same but with regex.
+- **[[tests-format#has_n_lines_model|has_n_lines]]** — assert the line count is `n:` ± `delta:`.
+
+A common combination in IWC: `has_n_lines: n: 100, delta: 5` + `has_text: text: "expected_token"` — line-count sanity-check plus a content marker. This catches both truncation and content drift in one assertion pair.
+
+`negate: true` is supported on every assertion. Used for the "this output should NOT contain X" case.
+
+## 5. Collection output assertions (`element_tests:`)
+
+For Galaxy collection outputs, the test format keys element assertions by element identifier:
+
+```yaml
+my_collection_output:
+  element_tests:
+    sample_1:
+      asserts:
+        has_text:
+          text: "expected"
+    sample_2:
+      file: test-data/expected_sample_2.txt
+```
+
+Optional `attributes:` at the collection level can assert on the produced collection shape:
+
+```yaml
+my_collection_output:
+  attributes: {collection_type: list:list}
+  element_tests:
+    ...
+```
+
+Nested collections: outer `element_tests:` keyed by outer identifier; inner uses `elements:` (note plural, no `_tests` suffix on the inner). See [[iwc-test-data-conventions]] §2f for the live example.
+
+For a list-of-files where every element should pass the same minimal check, the existence-probe pattern (`has_text: "{"` for JSON; `has_size: min: 100` for any non-empty binary) is widely used and accepted in IWC.
+
+## 6. The validate-against-workflow inner loop
+
+A `-tests.yml` file can be **structurally invalid** in two distinct ways:
+
+1. **Schema-invalid** — wrong field names, wrong nesting, wrong types. Caught by the test-format JSON Schema.
+2. **Workflow-incoherent** — schema-valid YAML, but the input/output labels don't match the actual workflow. Renaming an output in the `.ga` and forgetting to update its sibling `-tests.yml` produces this case. Planemo will surface it as an "output not found" error at test-runtime, but only after a full workflow run.
+
+The `@galaxy-tool-util/schema` npm package ships **two** validators that catch both cases statically — no Galaxy or Planemo invocation needed:
+
+- **`validateTestsFile(yaml)`** — runs the file against `tests.schema.json` (AJV). Reports schema violations with paths.
+- **`checkTestsAgainstWorkflow(workflow, tests)`** — cross-checks a `.ga` / format2 workflow against a tests file: missing input labels, missing output labels, type incompatibilities (e.g. test supplies a `File` for a parameter typed `int`).
+
+Both are pure-JS, take milliseconds, and have no Galaxy dependency. Wire them into the inner authoring loop:
+
+```
+edit -tests.yml
+  → validateTestsFile()                    # schema gate
+  → checkTestsAgainstWorkflow(.ga, tests)  # coherence gate
+  → planemo workflow_test_on_invocation    # assertion gate (no full re-run)
+  → planemo test                           # full integration (slow)
+```
+
+The first two gates short-circuit cheap mistakes before a slow planemo run. They are the static-validation equivalent of `gxwf` for tests, and the `implement-galaxy-workflow-test` mold should reference them as its primary inner-loop tooling. Source: galaxy-tool-util-ts package, `src/test-format/index.ts` exports.
+
+## 7. Authoring loop — generation, then refinement
+
+Reviewer convention is to **generate** the initial `-tests.yml` rather than hand-write it. Two planemo subcommands cover this:
+
+- **`planemo workflow_test_init --from_invocation <invocation_id>`** ([[planemo-workflow_test_init]]) — given a successful Galaxy invocation ID, emit a `-tests.yml` with a `job:` block that captures all inputs (with SHA-1 hashes) and an `outputs:` block with `file:` references to the actual outputs (downloaded into `test-data/`). Hand-tighten the assertions afterward.
+- **`planemo workflow_test_on_invocation <tests.yml> <invocation_id>`** ([[planemo-workflow_test_on_invocation]]) — re-evaluate an edited `-tests.yml` against a saved invocation without re-running the workflow. The fast inner loop for assertion iteration; complements the static gates in §6.
+
+Together these cut the assertion-iteration cost dramatically. An agent should:
+
+1. Run the workflow once on usegalaxy.* (or local) to get a known-good invocation.
+2. `--from_invocation` to bootstrap the test file.
+3. Replace the autogenerated `file:` exact-comparison assertions with assertion-family-appropriate alternatives per §1.
+4. [[planemo-workflow_test_on_invocation]] after each edit; full [[planemo-test]] at the end.
+
+## 8. What the schema gives you for free
+
+When the test-format schema lands as a Foundry-rendered note, the agent can consult any assertion's `$def` directly for: parameter types, defaults, required fields, the `that` discriminator constant, and the original Python docstring (carried through as `description`). This note does **not** restate that vocabulary — it complements it with the corpus-grounded *which-and-when*.
+
+What's still missing from the schema and worth keeping in research notes:
+
+- This decision table (§1) — output-type → assertion family.
+- Tolerance magnitudes (§3) — corpus-derived defaults.
+- The `validateTestsFile` / `checkTestsAgainstWorkflow` integration story (§6).
+- Anti-pattern flags — see [[iwc-shortcuts-anti-patterns]].
+
+## 9. Common combinations (recipes)
+
+Six recipes worth memorizing.
+
+**Stable text report (FastQC summary, simple stats).**
+```yaml
+my_report:
+  asserts:
+    has_n_lines: { n: 12, delta: 2 }
+    has_text: { text: "Total Sequences" }
+```
+
+**MultiQC HTML report.**
+```yaml
+multiqc_report:
+  asserts:
+    has_text: { text: "Filtered Reads" }
+    has_text: { text: "FastQC" }
+```
+
+**VCF (pinned tool, fixed reference).**
+```yaml
+called_variants:
+  file: test-data/expected.vcf
+  compare: diff
+  lines_diff: 6
+```
+
+**Stochastic JSON (HyPhy-style).**
+```yaml
+hyphy_meme:
+  element_tests:
+    geneA: { asserts: { has_text: { text: "{" } } }
+    geneB: { asserts: { has_text: { text: "{" } } }
+```
+
+**Matplotlib plot.**
+```yaml
+umap_plot:
+  asserts:
+    has_size: { size: 68416, delta: 6000 }
+    has_image_width: { width: 601, delta: 30 }
+    has_image_height: { height: 429, delta: 25 }
+```
+
+**AnnData (HDF5).**
+```yaml
+clustered_anndata:
+  asserts:
+    has_h5_keys: { keys: "obs/louvain" }
+    has_h5_keys: { keys: "var/highly_variable" }
+    has_h5_keys: { keys: "uns/rank_genes_groups" }
+    has_size: { size: 12000000, delta: 1500000 }
+```
+
+## 10. Cross-references
+
+- [[galaxy-workflow-testability-design]] — decide which workflow outputs and checkpoints to expose before choosing assertions.
+- [[iwc-test-data-conventions]] — input-side conventions (job inputs, collection shapes, `hashes:`, CVMFS).
+- [[iwc-shortcuts-anti-patterns]] — accepted-vs-smell catalog and corpus prevalence; this note's mirror image.
+- Test-format schema (`@galaxy-tool-util/schema` npm package) — authoritative vocabulary; will be vendored into a Foundry-rendered schema note. See `docs/COMPILATION_PIPELINE.md` for the casting story.
+- Planemo test-format spec: [planemo.readthedocs.io/en/latest/test_format.html](https://planemo.readthedocs.io/en/latest/test_format.html).
+- [[galaxy-xsd]] — Galaxy XSD assertion source of truth, vendored from upstream.
+- Tightening of the schema and Pydantic source: [galaxyproject/galaxy#22566](https://github.com/galaxyproject/galaxy/pull/22566).
+- TS schema sync into npm: [jmchilton/galaxy-tool-util-ts#75](https://github.com/jmchilton/galaxy-tool-util-ts/pull/75).

--- a/casts/claude/skills/debug-galaxy-workflow-output/references/notes/planemo-workflow-test-architecture.md
+++ b/casts/claude/skills/debug-galaxy-workflow-output/references/notes/planemo-workflow-test-architecture.md
@@ -1,0 +1,153 @@
+---
+type: research
+subtype: component
+title: "Planemo workflow-test architecture"
+tags:
+  - research/component
+  - tool/planemo
+  - target/galaxy
+status: draft
+created: 2026-05-02
+revised: 2026-05-11
+revision: 3
+ai_generated: true
+related_notes:
+  - "[[galaxy-workflow-testability-design]]"
+  - "[[galaxy-tool-job-failure-reference]]"
+  - "[[galaxy-workflow-invocation-failure-reference]]"
+  - "[[planemo-asserts-idioms]]"
+related_molds:
+  - "[[run-workflow-test]]"
+  - "[[debug-galaxy-workflow-output]]"
+  - "[[implement-galaxy-workflow-test]]"
+sources:
+  - "~/projects/repositories/planemo/planemo/commands/cmd_test.py"
+  - "~/projects/repositories/planemo/planemo/commands/cmd_run.py"
+  - "~/projects/repositories/planemo/planemo/galaxy/activity.py"
+  - "~/projects/repositories/planemo/planemo/galaxy/invocations"
+  - "~/projects/repositories/planemo/planemo/galaxy/config.py"
+summary: "Reference for Planemo workflow test/run architecture, Galaxy modes, API polling, and noisy failure boundaries."
+---
+
+# Planemo Workflow-Test Architecture
+
+This note describes Planemo architecture relevant to workflow tests and workflow runs. It is reference material for Molds that need to run tests or interpret Planemo artifacts, not a command-selection recipe.
+
+## Main Commands
+
+| User action | Command | Core behavior |
+|---|---|---|
+| Full workflow test | `planemo test <workflow>` ([[planemo-test]]) | Finds test definitions, starts or targets Galaxy, stages inputs, invokes workflow, checks assertions, writes reports. |
+| Direct run | `planemo run <workflow> <job.yml>` | Runs one workflow/job pair and can download outputs without assertion checks. |
+| Recheck assertions | `planemo workflow_test_on_invocation <tests.yml> <invocation_id>` ([[planemo-workflow_test_on_invocation]]) | Runs test assertions against an existing invocation without rerunning the workflow. |
+| Track invocation | `planemo workflow_track <invocation_id>` | Polls an existing invocation and displays progress. |
+| Generate test from invocation | `planemo workflow_test_init --from_invocation <id>` ([[planemo-workflow_test_init]]) | Builds a test template from a completed invocation and its outputs. |
+| Generate job template | `planemo workflow_job_init <workflow>` | Creates a job-input template for a workflow. |
+
+Observed code paths live under `~/projects/repositories/planemo/planemo/commands/`, `planemo/engine/`, and `planemo/galaxy/`.
+
+## Engine Selection
+
+Planemo chooses between engines early:
+
+- CWL runnables can use CWL-specific engines.
+- Supplying `--galaxy_url` implies an external running Galaxy unless an engine is explicitly selected.
+- Default Galaxy workflow testing uses a managed local Galaxy engine.
+- `--engine docker_galaxy` uses a managed Dockerized Galaxy.
+- `--engine external_galaxy` uses an existing running Galaxy.
+
+“Existing Galaxy” can mean two different things:
+
+- Existing local Galaxy source tree, still managed by Planemo for this run.
+- Existing running Galaxy server, addressed through URL and API keys.
+
+Mold output and eval logs should record which meaning applies.
+
+## Managed Galaxy Configuration
+
+For managed Galaxy, Planemo builds a temporary configuration directory and generated Galaxy config. It can configure tool config, shed tool config, job config, file sources, object store paths, dependency config, SQLite database by default, admin users, API keys, and environment overrides.
+
+Important managed-mode behavior:
+
+- Planemo may find a local Galaxy root or install/use a cached Galaxy source tree.
+- Managed Galaxy defaults are convenient but may not match production Galaxy behavior.
+- Planemo can install workflow tool dependencies through Tool Shed metadata when configured.
+- Test histories are created automatically unless a history id is supplied.
+
+## External Galaxy Configuration
+
+For external Galaxy, Planemo uses supplied Galaxy URL and API keys. A user key runs workflows; an admin key may be needed for installing missing repositories or creating a user key.
+
+External Galaxy mode is useful when the target environment matters, but failure surfaces can include server configuration, installed tools, permissions, and existing history state. Eval logs should preserve URL/key mode without storing secrets.
+
+## API Interaction
+
+Planemo primarily talks to Galaxy through BioBlend-backed clients.
+
+Important operations:
+
+- Import workflows into Galaxy.
+- Stage datasets and collections into histories.
+- Invoke workflows by input names.
+- Poll invocations and jobs.
+- Fetch job details with full detail when needed.
+- Download outputs and output collections.
+- Run assertion checks and write structured reports.
+
+For workflows, Planemo invokes Galaxy using input labels/names. Stable generated labels are therefore important for both test execution and debugging.
+
+Workflow testability design guidance lives in [[galaxy-workflow-testability-design]]. This architecture note only records why Planemo makes labels and workflow-level outputs operationally important.
+
+## Structured Artifacts
+
+Useful Planemo artifacts and fields:
+
+| Artifact or field | Use |
+|---|---|
+| `tool_test_output.json` | Primary structured result artifact for tests. |
+| invocation id | Key for Galaxy invocation API follow-up. |
+| history id | Key for history contents and output inspection. |
+| workflow id | Key for workflow invocation aliases and reruns. |
+| output problems | Assertion and missing-output failures. |
+| execution problem | Staging, invocation, API, or other execution-level failure. |
+| invocation details | Step/job/output details Planemo collected from Galaxy. |
+| job details | Tool id, state, exit code, command, stdout/stderr when collected. |
+
+Terminal output is not enough for durable failure analysis. Preserve structured output whenever possible.
+
+## Noisy Boundaries
+
+Planemo transforms and summarizes Galaxy failure information. These are likely information-loss boundaries:
+
+- Exceptions during execution can become stringified `ErrorRunResponse` values.
+- Polling may summarize “at least one job is in error” while detailed job evidence is printed elsewhere or stored separately.
+- Missing outputs become assertion/output problems, which can conflate label mismatch, workflow output omission, optional output absence, failed invocation, or output download issue.
+- Output download failures may be logged but not always propagated as the most specific failure.
+- External Galaxy without an admin key may defer missing-tool problems until runtime.
+- `allow_tool_state_corrections=True` can let Galaxy adjust tool state during invocation, which is useful but can mask definition drift.
+- `--no_wait` is not suitable for debug conclusions because invocation creation can succeed before jobs fail.
+
+## Reference Use For Molds
+
+For [[run-workflow-test]]:
+
+- Preserve structured Planemo result output, invocation id, history id, workflow id, and Galaxy mode.
+- Record whether the run used managed local Galaxy, Docker Galaxy, or external Galaxy.
+- Do not treat terminal output as the primary failure artifact.
+
+For [[debug-galaxy-workflow-output]]:
+
+- Start from structured Planemo output.
+- For missing-output failures, check label drift and omitted workflow-level outputs before assuming tool failure.
+- If the failure is job-level, inspect Galaxy job APIs described in [[galaxy-tool-job-failure-reference]].
+- If the failure is invocation-level, inspect Galaxy invocation APIs described in [[galaxy-workflow-invocation-failure-reference]].
+- If only assertions failed, use [[planemo-asserts-idioms]] before deciding to rerun.
+
+## Verification Gaps
+
+Actual runs should verify:
+
+- Which invocation messages Planemo exposes directly.
+- Whether target Planemo/Galaxy versions populate `completed`, `/completion`, and step job summaries.
+- How `workflow_test_on_invocation` behaves for failed, warning-only, mapped collection, and subworkflow invocations.
+- Whether generated test cases from invocation preserve nested output collection structure correctly.

--- a/casts/claude/skills/find-test-data/SKILL.md
+++ b/casts/claude/skills/find-test-data/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: find-test-data
+description: "Search IWC fixtures and public sources for test data matching a data-flow shape."
+---
+
+# find-test-data
+
+Follow the procedure below and use the artifact/reference sections as the runtime contract.
+
+## When To Use
+
+- Search IWC fixtures and public sources for test data matching a data-flow shape.
+
+## Inputs
+
+- No upstream artifact inputs declared. See the procedure for user-supplied runtime inputs.
+
+## Outputs
+
+- Write artifact `test-data-refs` as `test-data-refs.json`. Format: `json`. Test data matched from IWC fixtures or public sources, expressed as URLs/paths plus expected shapes for downstream test authoring.
+
+## Required Tools
+
+- None declared. Procedure should not assume external CLIs are present.
+
+## Load Upfront
+
+- None declared.
+
+## Load On Demand
+
+- `references/notes/galaxy-workflow-testability-design.md`: Research note copied verbatim into the bundle. Confirm the collection shapes and labels the resolved data must populate so downstream tests can address them. Use when: mapping an input label in the data-flow brief to a concrete file or collection of files.
+- `references/notes/iwc-test-data-conventions.md`: Research note copied verbatim into the bundle. Match IWC test-data conventions — Zenodo/remote-URL first, SHA-1 integrity, per-input collection layout — when selecting or describing candidate fixtures. Use when: choosing where test data should come from or describing the shape a candidate file must have.
+
+## Validation
+
+- None declared.
+
+## Procedure
+
+Resolve concrete test data for the workflow's inputs. Read the upstream data-flow / interface brief, and for each workflow input search the IWC corpus and public sources for data that matches its Galaxy collection shape and datatype. Emit `test-data-refs.json`: one entry per input, each carrying a URL or path plus the expected shape, ready for implement-galaxy-workflow-test to stage.
+
+This skill is the first leg of the harness's `test-data-resolution` branch. It resolves what it can and reports gaps; the harness routes any unresolved input to the `user-supplied` fallthrough. Deciding to ask the user is a harness concern, not this skill's — its job is an honest, source-backed match.
+
+### Sequence
+
+1. **Read the brief.** From the data-flow / interface brief, enumerate the workflow inputs: label, Galaxy collection shape (File / list / paired / list:paired / record), and datatype.
+2. **Search IWC fixtures first.** Prefer existing IWC test data for the same domain — it already conforms to the conventions in iwc-test-data-conventions (remote URL, recorded hash, known collection layout). A near-neighbour IWC workflow's `-tests.yml` is the strongest source.
+3. **Fall to public sources.** When no IWC fixture fits, look for small public data (Zenodo, reference data archives) sized for a fast test run, matching the datatype and shape.
+4. **Emit refs.** Write one `test-data-refs.json` entry per input: the URL/path, the expected Galaxy shape, datatype, and integrity hash when known. Per galaxy-workflow-testability-design, make sure each entry maps to an addressable input label.
+5. **Report gaps.** For any input with no acceptable match, emit the input with `resolved: false` and a short reason rather than a guessed URL. These are what the harness hands to `user-supplied`.
+
+### No fabrication
+
+Never invent a URL, accession, or path to make an input look resolved. A wrong-but-plausible fixture reference is worse than an honest gap: it survives static checks and fails only at run time, far from this skill. Every emitted ref must point at data that exists; everything else is a reported gap.
+
+## Runtime Notes
+
+- Do not read Foundry source files at runtime; use only files packaged in this skill bundle and user-supplied artifacts.
+- Preserve declared artifact filenames unless the user or harness supplies explicit paths.
+- Carry unresolved assumptions into the output artifact instead of silently inventing missing source evidence.

--- a/casts/claude/skills/find-test-data/_provenance.json
+++ b/casts/claude/skills/find-test-data/_provenance.json
@@ -1,0 +1,55 @@
+{
+  "provenance_schema_version": 2,
+  "cast_target": "claude",
+  "mold": {
+    "name": "find-test-data",
+    "path": "content/molds/find-test-data/index.md",
+    "revision": 2,
+    "content_hash": "607db69e32896890701577c9f156be662cce1371ac915cbfeb7244c602836e75",
+    "commit": "64a340bb8e24e9949be9cbd6678a51da42d14203"
+  },
+  "cast_at": "2026-06-15T13:53:32.337Z",
+  "refs": [
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[galaxy-workflow-testability-design]]",
+      "src": "content/research/galaxy-workflow-testability-design.md",
+      "dst": "references/notes/galaxy-workflow-testability-design.md",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Confirm the collection shapes and labels the resolved data must populate so downstream tests can address them.",
+      "trigger": "When mapping an input label in the data-flow brief to a concrete file or collection of files.",
+      "src_hash": "e4d5991a5085e0f9ad52b8e6856f64179362334bd51b77a3302faeb96732f980",
+      "dst_hash": "e4d5991a5085e0f9ad52b8e6856f64179362334bd51b77a3302faeb96732f980",
+      "source": "deterministic"
+    },
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[iwc-test-data-conventions]]",
+      "src": "content/research/iwc-test-data-conventions.md",
+      "dst": "references/notes/iwc-test-data-conventions.md",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Match IWC test-data conventions — Zenodo/remote-URL first, SHA-1 integrity, per-input collection layout — when selecting or describing candidate fixtures.",
+      "trigger": "When choosing where test data should come from or describing the shape a candidate file must have.",
+      "src_hash": "2c7ef6a674b84f434ed973fe5c93156a6b368fc774a432e828257ddbde5d4993",
+      "dst_hash": "2c7ef6a674b84f434ed973fe5c93156a6b368fc774a432e828257ddbde5d4993",
+      "source": "deterministic"
+    }
+  ],
+  "artifacts": {
+    "produces": [
+      {
+        "id": "test-data-refs",
+        "kind": "json",
+        "default_filename": "test-data-refs.json",
+        "description": "Test data matched from IWC fixtures or public sources, expressed as URLs/paths plus expected shapes for downstream test authoring."
+      }
+    ],
+    "consumes": []
+  }
+}

--- a/casts/claude/skills/find-test-data/_verify.json
+++ b/casts/claude/skills/find-test-data/_verify.json
@@ -1,0 +1,4 @@
+{
+  "verify_schema_version": 1,
+  "entries": []
+}

--- a/casts/claude/skills/find-test-data/references/notes/galaxy-workflow-testability-design.md
+++ b/casts/claude/skills/find-test-data/references/notes/galaxy-workflow-testability-design.md
@@ -1,0 +1,139 @@
+---
+type: research
+subtype: component
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-05-03
+revised: 2026-05-06
+revision: 2
+ai_generated: true
+related_notes:
+  - "[[iwc-workflow-testability-survey]]"
+  - "[[iwc-test-data-conventions]]"
+  - "[[planemo-asserts-idioms]]"
+  - "[[iwc-shortcuts-anti-patterns]]"
+  - "[[planemo-workflow-test-architecture]]"
+  - "[[implement-galaxy-workflow-test]]"
+  - "[[gxformat2-schema]]"
+  - "[[gxformat2-workflow-inputs]]"
+  - "[[galaxy-datatypes-conf]]"
+summary: "Design guidance for Galaxy workflow inputs, outputs, and checkpoints that make IWC-style workflow tests possible."
+---
+
+# Galaxy workflow testability design
+
+Use this note when authoring or translating a Galaxy workflow **before** the `-tests.yml` file exists. It covers workflow structure choices that make later IWC-style tests meaningful: labels, promoted checkpoints, collection identifiers, and fixture-compatible inputs.
+
+This is not a `content/patterns/` page. It is cross-cutting design guidance for Molds that need testable Galaxy workflows. Assertion syntax lives in [[planemo-asserts-idioms]]. Test YAML fixture shapes live in [[iwc-test-data-conventions]]. Accepted shortcut vs smell calls live in [[iwc-shortcuts-anti-patterns]]. Corpus evidence trail lives in [[iwc-workflow-testability-survey]].
+
+## 1. Treat labels as API
+
+Workflow input and output labels are not cosmetic. Planemo and IWC tests address workflow inputs and outputs by label, and the survey found exact label matches for every asserted output across 114 matched workflow/test pairs. A generated workflow should therefore pick stable, descriptive labels before test authoring starts.
+
+Rules:
+
+- Label every output that may need a test assertion.
+- Treat input/output renames as breaking changes requiring sibling `-tests.yml` updates.
+- Prefer stable domain names over tool-step defaults or positional names.
+- Do not rely on unlabeled or positional outputs for tests.
+
+Evidence:
+
+- Scanpy exposes outputs such as `Initial Anndata General Info`, `UMAP of louvain`, `Ranked genes with Wilcoxon test`, and `Dotplot of top genes on clusters` (`$IWC_FORMAT2/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy.gxwf.yml:105-147`). The sibling test keys assertions by those exact labels (`$IWC/workflows/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml:27-205`).
+- VGP scaffolding uses punctuation-heavy labels such as `Hi-C duplication stats on scaffolds: Raw`, `Hi-C duplication stats on scaffolds: MultiQc`, and `Merged Alignment stats` (`$IWC_FORMAT2/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8.gxwf.yml:170-196`). The test asserts those exact labels (`$IWC/workflows/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8-tests.yml:218-245`).
+
+## 2. Promote assertable checkpoints
+
+IWC workflow tests assert workflow-level outputs. Intermediate step results are invisible unless promoted to top-level workflow outputs. When final reports are weakly assertable, expose intermediate checkpoints that carry deterministic content or structure.
+
+Rules:
+
+- Promote intermediate outputs when they are the best deterministic or structural checkpoint.
+- Prefer a checkpoint table/text/HDF5 object that can prove content over a final plot/report that can only prove existence.
+- Accept some output-list clutter when it buys meaningful tests.
+- Do not promote every intermediate by default; expose checkpoints that map to concrete assertion intent.
+
+Evidence:
+
+- Scanpy exposes 21 workflow outputs and the sibling test asserts all 21. These include initial AnnData summaries, intermediate plots, ranked-gene tables, final AnnData, cluster-count tables, and final plots (`$IWC_FORMAT2/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy.gxwf.yml:105-147`; `$IWC/workflows/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml:27-205`).
+- RNA-seq paired-end exposes mapped reads, stranded/unstranded coverage, abundance estimates, expression tables, counts tables, and MultiQC reports (`$IWC_FORMAT2/transcriptomics/rnaseq-pe/rnaseq-pe.gxwf.yml:90-112`). The sibling test asserts sizes for coverage/read outputs and stronger regex/line checks for expression/count outputs (`$IWC/workflows/transcriptomics/rnaseq-pe/rnaseq-pe-tests.yml:48-97`).
+- MGnify complete exposes 83 workflow outputs; 38 are asserted in the sibling test, including MultiQC reports, FASTA collections, taxonomic classifications, OTU tables, and HDF5/JSON outputs (`$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/mgnify-amplicon-pipeline-v5-complete.gxwf.yml:163-329`; `$IWC/workflows/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/mgnify-amplicon-pipeline-v5-complete-tests.yml:15-120`).
+
+## 3. Stabilize collection output identifiers
+
+Collection tests key assertions by element identifier. If a workflow emits collections with unstable or opaque identifiers, the test cannot target elements cleanly.
+
+Rules:
+
+- Preserve biologically or sample-meaningful identifiers through map-over and collection reshaping.
+- When generating or relabeling collections, make the identifier derivation deterministic and visible in workflow structure.
+- For nested collections, ensure each axis has predictable identifiers.
+- Quote special identifiers in tests when YAML requires it, but do not simplify identifiers merely for YAML convenience.
+
+Evidence:
+
+- 59 of 115 IWC test files use `element_tests:`, with 227 `element_tests:` blocks in the corpus survey.
+- 10x CellPlex tests nested collection outputs by `subsample`, then inner `matrix`, `barcodes`, and `genes` elements (`$IWC/workflows/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:82-128`). The workflow exposes the corresponding collection outputs (`$IWC_FORMAT2/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex.gxwf.yml:73-91`).
+- HyPhy collection outputs are tested by generated gene identifiers such as `NC_001477.1|capsid_protein_C|95-394_DENV1` (`$IWC/workflows/comparative_genomics/hyphy/hyphy-core-tests.yml:31-71`). The workflow exposes collection outputs for MEME, PRIME, BUSTED, and FEL (`$IWC_FORMAT2/comparative_genomics/hyphy/hyphy-core.gxwf.yml:26-38`).
+
+## 4. Choose checkpoints by assertion strength
+
+Assertion choice is not only a test-file decision. It should feed back into workflow output design. If the only exposed output is a stochastic plot or binary file, the best possible test may be a weak size check. Exposing a sibling table, report, HDF5 structure, or summary line can make the same workflow much more testable.
+
+Rules:
+
+- For image-heavy workflows, expose data or summary outputs behind the plot when possible.
+- For stochastic statistical outputs, expose structural checkpoints and stable summary tokens.
+- For binary outputs, expose a text/table report or stats file when the tool can produce one.
+- Use [[planemo-asserts-idioms]] to select the assertion family after choosing the checkpoint.
+
+Evidence:
+
+- Scanpy image outputs are mostly smoke-tested with `has_size`, `has_image_width`, and `has_image_height`, but the same workflow also exposes AnnData HDF5 keys and cluster-count table checks (`$IWC/workflows/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml:33-205`).
+- RNA-seq paired-end pairs coarse size checks for coverage/mapped-read outputs with stronger regex and exact-line checks for expression/count tables (`$IWC/workflows/transcriptomics/rnaseq-pe/rnaseq-pe-tests.yml:48-97`).
+- VGP scaffolding tests combine stable text checks for scaffold/report stats with size checks for map/alignment artifacts (`$IWC/workflows/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8-tests.yml:173-245`).
+
+## 5. Design inputs with fixtures in mind
+
+Workflow input labels and types constrain the eventual `job:` block. Fixture planning is not only a test-file activity: it should influence whether the workflow exposes a file input, a collection input, a string data-table input, or a typed parameter.
+
+Rules:
+
+- Choose input labels that will be readable as test `job:` keys.
+- Match workflow input collection types to realistic fixture shapes.
+- Decide early whether reference data should be a portable remote file or a CVMFS/data-table string.
+- Keep typed parameters explicit when tests need to set them (`int`, `boolean`, `string`) rather than burying them in step defaults.
+
+Evidence:
+
+- 10x CellPlex job inputs include `fastq PE collection GEX`, `reference genome`, `gtf`, `cellranger_barcodes_3M-february-2018.txt`, `fastq PE collection CMO`, `sample name and CMO sequence collection`, and `Number of expected cells` (`$IWC/workflows/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:2-75`). The workflow declares matching collection, data, string, boolean, and int inputs (`$IWC_FORMAT2/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex.gxwf.yml:4-72`).
+- HyPhy accepts a `list` collection of unaligned sequences and preserves accession-like fixture identifiers through to output element assertions (`$IWC/workflows/comparative_genomics/hyphy/hyphy-core-tests.yml:7-30`; `$IWC_FORMAT2/comparative_genomics/hyphy/hyphy-core.gxwf.yml:14-25`).
+
+## 6. Know what a gxformat2 output entry contains
+
+Top-level gxformat2 `outputs:` is the public workflow-output surface. It is separate from per-step `out:` declarations and from step post-job actions such as `change_datatype` or `rename`.
+
+Authoring rules:
+
+- Use `label` as the stable public name tests and users will address.
+- Use `outputSource` to point at the producing step output; do not rely on positional output order.
+- Use `doc` for short user-facing context when the label is not self-explanatory.
+- Keep `type` aligned with the exposed value (`data`, `collection`, or scalar vocabulary from [[gxformat2-workflow-inputs]]) when the schema needs it.
+- Apply `change_datatype` at the producing step output when Galaxy needs a stronger datatype than the tool reports; choose values from [[galaxy-datatypes-conf]].
+- Use `rename` only for generated dataset names inside Galaxy histories. It is not a substitute for stable workflow-output `label`.
+- Treat `add_tags` and `remove_tags` as metadata helpers, not as the test API. IWC tests key by labels and collection element identifiers, not tags.
+- Avoid `hide` or `delete_intermediate_datasets` on outputs that are promoted as test checkpoints.
+
+Design inference: a workflow-output promotion decision should pick both the public `outputs:` entry and any producer-side post-job action needed to make that output useful. For example, a synthesized BED checkpoint needs a stable output `label` plus a producer-side `change_datatype: bed`; one without the other is incomplete for a testable workflow.
+
+## Cross-references
+
+- [[iwc-workflow-testability-survey]] — corpus survey and distribution rationale.
+- [[iwc-test-data-conventions]] — job/input YAML shapes, remote fixtures, hashes, collection fixture syntax.
+- [[planemo-asserts-idioms]] — assertion-family choice after an output is exposed.
+- [[iwc-shortcuts-anti-patterns]] — accepted shortcut vs smell calls for weak assertions and label coupling.
+- [[planemo-workflow-test-architecture]] — Planemo execution, output-problem ambiguity, and structured artifacts.
+- [[gxformat2-schema]] — structural vocabulary for top-level workflow outputs and step post-job actions.
+- [[galaxy-datatypes-conf]] — valid Galaxy datatype extensions for `format` and `change_datatype` choices.

--- a/casts/claude/skills/find-test-data/references/notes/iwc-test-data-conventions.md
+++ b/casts/claude/skills/find-test-data/references/notes/iwc-test-data-conventions.md
@@ -1,0 +1,311 @@
+---
+type: research
+subtype: component
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-04-30
+revised: 2026-05-03
+revision: 3
+ai_generated: true
+related_notes:
+  - "[[galaxy-workflow-testability-design]]"
+  - "[[iwc-shortcuts-anti-patterns]]"
+  - "[[planemo-asserts-idioms]]"
+  - "[[implement-galaxy-workflow-test]]"
+  - "[[tests-format]]"
+  - "[[iwc-tabular-operations-survey]]"
+summary: "How IWC workflows organize and reference test data — Zenodo-first, SHA-1 integrity, collection shapes, CVMFS gotchas."
+---
+
+# IWC test data conventions
+
+Reference for an agent implementing or editing a `<workflow>-tests.yml` in IWC style. All evidence cited from `/Users/jxc755/projects/repositories/workflow-fixtures/iwc-src/workflows/` (raw IWC clone) and `workflows/README.md`. Authoritative spec: [planemo.readthedocs.io/en/latest/test_format.html](https://planemo.readthedocs.io/en/latest/test_format.html). The companion analysis at `/Users/jxc755/projects/repositories/galaxy-brain/vault/projects/workflow_state/skills/COMPONENT_GALAXY_WORKFLOW_TESTING.md` is the synthesized source for several normative claims here.
+
+This note owns **test YAML fixture shapes**. For workflow-structure choices that make those fixtures possible before the test file exists, use [[galaxy-workflow-testability-design]].
+
+## 1. Where does test data live? Remote vs in-repo
+
+Two storage patterns. They mix freely inside one job.
+
+**Remote `location:` (default for any non-trivial input).** Strongly preferred for anything bigger than a toy fixture. Order of preference, observed in the corpus:
+
+- **Zenodo** — overwhelming default, persistent DOI-backed URL.
+  - `read-preprocessing/short-read-qc-trimming/short-read-quality-control-and-trimming-tests.yml:13,17` — `https://zenodo.org/records/11484215/files/paired_r1.fastq.gz` (note the modern `/records/` plural form; older entries use `/record/`).
+  - `metabolomics/lcms-preprocessing/Mass_spectrometry__LC-MS_preprocessing_with_XCMS-tests.yml:6,17,24,...` — 11+ mzML files all hosted at `zenodo.org/record/10130758/files/...`.
+  - `sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation-tests.yml:5` — `https://zenodo.org/record/4555735/files/NC_045512.2_reference.fasta?download=1`.
+  - `repeatmasking/RepeatMasking-Workflow-tests.yml:5` — `https://zenodo.org/record/8364146/files/eco.fasta?download=1`. The `?download=1` query suffix is acceptable but optional; both forms appear.
+- **EBI/ENA REST** — for canonical reference sequences.
+  - `virology/pox-virus-amplicon/pox-virus-half-genome-tests.yml:5` — `https://www.ebi.ac.uk/ena/browser/api/fasta/AF325528.1?download=true`.
+- **SRA / ENA FTP** — for raw read accessions where re-uploading to Zenodo is wasteful.
+  - `pox-virus-half-genome-tests.yml:27,34,49,56` — `ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR151/076/SRR15145276/SRR15145276_1.fastq.gz`.
+
+**In-repo `path: test-data/...` (toy fixtures + small expected outputs only).** Used when:
+
+- File is small enough to commit (rule of thumb from corpus: low single-digit MB or smaller).
+- File is a hand-crafted toy or trimmed reference (e.g. a 5-element FASTA for HyPhy).
+- File is the *expected output* baseline for a `file:` exact-comparison assertion: `consensus-from-variation-tests.yml:31` — `file: test-data/masked_consensus.fa`.
+
+`workflows/README.md:67` makes the contract explicit: "try to generate a toy dataset … and then publish it to zenodo to have a permanent URL." `workflows/README.md:98`: "if some outputs are large, it is better to use assertions than storing the whole output file to the iwc repository."
+
+Subdirectory layout inside `test-data/` is free-form and used to organize related fixtures, e.g. `comparative_genomics/hyphy/test-data/unaligned_seqs/`, `test-data/codon_alignments/`, `test-data/iqtree_trees/` (referenced from `hyphy-core-tests.yml:13,17,21,...`).
+
+**Decision rule for an agent:**
+
+1. Expected-output baseline that's small — commit to `test-data/`.
+2. Toy/trimmed input < ~5 MB — commit to `test-data/`.
+3. Anything else — Zenodo (or EBI/SRA for canonical accessions). Add `hashes:` SHA-1.
+4. If the input is a reference index resolvable from CVMFS (`hg38`, `dm6`, `mm10`, …), use the plain string form. See section 5.
+
+## 2. The `class: File` block — exact YAML shapes
+
+All snippets verbatim from the IWC corpus.
+
+### 2a. Single remote file (with integrity hash)
+
+`virology/pox-virus-amplicon/pox-virus-half-genome-tests.yml:3-9`:
+
+```yaml
+Reference FASTA:
+  class: File
+  location: "https://www.ebi.ac.uk/ena/browser/api/fasta/AF325528.1?download=true"
+  filetype: fasta
+  hashes:
+  - hash_function: SHA-1
+    hash_value: 927d0d00b7db6ad60524bb9e50d3ab41c4ac5ecf
+```
+
+Field order is conventional but not enforced. `filetype:` is the Galaxy datatype name (`fasta`, `fastqsanger.gz`, `mzml`, `bed`, `tabular`, `csv`, `gtf`, `vcf`, …). `location:` URLs may be quoted or bare; both forms occur.
+
+### 2b. Single local file
+
+`comparative_genomics/hyphy/hyphy-core-tests.yml:3-6`:
+
+```yaml
+reference cds:
+  class: File
+  path: test-data/denv1_ref_cds.fasta
+  filetype: fasta
+```
+
+`path:` is relative to the workflow directory (the directory containing the `-tests.yml`). Hashes are usually omitted on local files — the file is in-tree, so integrity is implicit. They are nonetheless added in some workflows: `consensus-from-variation-tests.yml:15-18` shows `path: test-data/aligned_reads_for_coverage.bam` paired with a SHA-1 hash. The pattern appears to be: hashes added when the `-tests.yml` was generated by `planemo workflow_test_init --from_invocation`, which mints them automatically.
+
+A dataset attribute can be set on a single file to force a `dbkey`, e.g. `epigenetics/consensus-peaks/consensus-peaks-chip-pe-tests.yml:7-10`:
+
+```yaml
+- class: File
+  identifier: rep1
+  path: test-data/rep1.bam
+  dbkey: mm10
+```
+
+`dbkey:` and `decompress: true` (`scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:30`) are documented per-file attributes that ride alongside `class: File`.
+
+### 2c. List collection
+
+`hyphy-core-tests.yml:7-30`:
+
+```yaml
+unaligned sequences:
+  class: Collection
+  collection_type: list
+  elements:
+  - identifier: AB178040.1|2002
+    class: File
+    path: test-data/unaligned_seqs/AB178040.1|2002.fasta
+    filetype: fasta
+  - identifier: AB195673.1|2003
+    class: File
+    path: test-data/unaligned_seqs/AB195673.1|2003.fasta
+    filetype: fasta
+  ...
+```
+
+Each element is a single-file dict with an `identifier:`. A larger remote-only example with hashes per element: `metabolomics/lcms-preprocessing/Mass_spectrometry__LC-MS_preprocessing_with_XCMS-tests.yml:11-22`:
+
+```yaml
+Mass-spectrometry Dataset Collection:
+  class: Collection
+  collection_type: list
+  elements:
+  - class: File
+    identifier: Blanc05.mzML
+    location: https://zenodo.org/record/10130758/files/Blanc05.mzML
+    filetype: mzml
+    hashes:
+    - hash_function: SHA-1
+      hash_value: e98d5a4cd8849a145a032bdc31c348ad97cb59c3
+```
+
+### 2d. Paired collection (single pair)
+
+A `paired` collection is a Collection whose two elements have identifiers `forward` and `reverse`. In IWC it is rarely used at top level — it is almost always wrapped as a single-element `list:paired` (see 2e). When it appears bare, the shape is the inner block of 2e without the outer `list:paired` wrapper.
+
+### 2e. `list:paired` collection
+
+`read-preprocessing/short-read-qc-trimming/short-read-quality-control-and-trimming-tests.yml:3-18`:
+
+```yaml
+Raw reads:
+  class: Collection
+  collection_type: list:paired
+  elements:
+  - class: Collection
+    type: paired
+    identifier: pair
+    elements:
+    - class: File
+      identifier: forward
+      location: https://zenodo.org/records/11484215/files/paired_r1.fastq.gz
+      filetype: fastqsanger.gz
+    - class: File
+      identifier: reverse
+      location: https://zenodo.org/records/11484215/files/paired_r2.fastq.gz
+      filetype: fastqsanger.gz
+```
+
+Note: outer `collection_type: list:paired`, inner `type: paired` (not `collection_type:`). Inner element identifiers are the literal strings `forward` and `reverse` — these are reserved.
+
+A multi-pair list:paired with full hashes: `virology/pox-virus-amplicon/pox-virus-half-genome-tests.yml:17-38` or `scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:3-24`.
+
+### 2f. `list:list:paired` and deeper
+
+Not directly observed in sampled IWC inputs. The shape is recursive — wrap a `list:paired` element list inside another `class: Collection, collection_type: list:list:paired`, where each outer element is `class: Collection, type: list:paired` (analogous to the `list:paired` → `paired` nesting in 2e). For deeply-nested collections planemo's [`_writing_collections.rst`](https://github.com/galaxyproject/planemo/blob/master/docs/_writing_collections.rst) is the de-facto reference.
+
+Output side: nested-collection assertions DO exist in the corpus. `scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:82-98`:
+
+```yaml
+Seurat input for gene expression (filtered):
+  attributes: {collection_type: list:list}
+  element_tests:
+    subsample:
+      elements:
+        matrix:
+          asserts:
+            has_line:
+              line: "23932 3 1171"
+        barcodes:
+          asserts:
+            has_line:
+              line: "CACATGATCATAAGGA"
+```
+
+Pattern: outer `element_tests:` keyed by outer identifier; inner `elements:` (note plural, not `element_tests:` here) keyed by inner identifier. Optional `attributes: {collection_type: ...}` asserts the shape of the produced collection.
+
+### 2g. `composite_data:`
+
+**Not observed** in the sampled IWC corpus (`grep -rln "composite\|imzml\|primary_file\|extra_files" workflows/ --include="*-tests.yml"` returns nothing). Per the planemo spec the shape is a `composite_data:` mapping listing each component file path, but an agent emitting one in IWC style has no in-corpus reference and should treat it as unproven territory — fall back to the planemo docs and verify against `galaxy.tool_util.parser.yaml`.
+
+### 2h. CWL-style shorthand (list of File dicts without identifiers)
+
+Documented in planemo; not observed in sampled IWC. IWC always supplies explicit identifiers.
+
+### 2i. `tags:` on elements (Galaxy 20.09+)
+
+Documented in planemo; not surfaced in sampled IWC `-tests.yml` files (`grep "  tags:" --include="*-tests.yml"` empty across the sampled set). Practical absence — IWC tests rely on identifier matching, not tags.
+
+## 3. SHA-1 integrity hashes — when, when not, why
+
+**Format.** Always a list under `hashes:`, even for one entry. Each entry is `{hash_function: SHA-1, hash_value: <40-hex>}`. Verbatim from `pox-virus-half-genome-tests.yml:7-9`:
+
+```yaml
+hashes:
+- hash_function: SHA-1
+  hash_value: 927d0d00b7db6ad60524bb9e50d3ab41c4ac5ecf
+```
+
+Only `SHA-1` observed in the IWC corpus. The planemo spec also accepts `MD5`, `SHA-256`, `SHA-512` as `hash_function:` values; IWC does not exercise these.
+
+**When present:**
+
+- Every remote `location:`-fetched input in the sampled corpus carries a SHA-1 (Zenodo, EBI REST, SRA FTP). The hash guards against silent upstream corruption — Zenodo records are immutable but bit-rot and CDN-edge errors do happen; ENA FASTA endpoints can quietly change line-wrap.
+- Many local `path:`-loaded inputs also carry a SHA-1. This is `--from_invocation` autogeneration leaking through (planemo emits hashes for every input it captured).
+- `consensus-from-variation-tests.yml:6-8,17-18,27-28` — every input in the test, local and remote, has a hash.
+
+**When omitted:**
+
+- Hand-written local-file fixtures often skip hashes — `hyphy-core-tests.yml:3-30` has zero `hashes:` blocks across six local-file inputs.
+- Output assertions: `file:`-comparison outputs and `location:`-comparison outputs (`RepeatMasking-Workflow-tests.yml:13`) **do not** carry `hashes:`. The integrity story for outputs is handled by `compare:` / `asserts:` instead.
+
+**Why bother on local files.** Catches accidental corruption when collaborators hand-edit `test-data/` fixtures.
+
+## 4. Element identifier conventions
+
+Identifiers are arbitrary strings, used both as the YAML key (`element_tests:`) and as the produced Galaxy collection element name. Conventions surfaced from the corpus:
+
+- **Pipes are legal** and survive YAML round-trip without quoting on the input side: `hyphy-core-tests.yml:11` — `identifier: AB178040.1|2002`. On the *output* side they're quoted because they appear as YAML mapping keys: `hyphy-core-tests.yml:34` — `"NC_001477.1|capsid_protein_C|95-394_DENV1":`. Quote when the identifier contains characters that would otherwise start a YAML flow node (`{`, `[`, `&`, `*`, `!`, `|`, `>`, `'`, `"`, `%`, `@`, `` ` ``) or look like a number/bool.
+- **Dots, hyphens, underscores** — common, no quoting needed: `Blanc05.mzML`, `HU_neg_048.mzML`, `SRR11578257`, `Rep1`, `subsample`, `pair`.
+- **Reserved inside `paired` collections:** `forward` and `reverse` (lowercase). Never use these names for outer identifiers in `list:paired`.
+- **Inline comments after identifier** are legal and used for provenance: `pox-virus-half-genome-tests.yml:23` — `identifier: 20L70   # SRR15145276`.
+- **Whitespace and special chars in workflow input *labels*** survive too — they are job-mapping keys, not collection identifiers, but the same YAML quoting rules apply. Example from the analysis doc: `Manually annotate celltypes?: true` as a job key in `Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml:23`.
+
+### 4a. Workflow-interface implications
+
+Fixture shape should feed back into workflow input design. Tests supply job inputs by workflow input label, and collection fixtures must match the workflow's declared collection type.
+
+- The 10x CellPlex test uses `fastq PE collection GEX`, `fastq PE collection CMO`, and `sample name and CMO sequence collection` as job keys with `list:paired` and `list` collection fixtures; the workflow declares matching collection inputs at `$IWC_FORMAT2/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex.gxwf.yml:4-72`.
+- CVMFS/data-table shortcuts like `reference genome: dm6` are workflow-interface choices as much as test YAML choices: they require the workflow input to be a string/data-table-backed parameter, not a file input.
+- If a fixture needs stable sample names, decide whether those names should enter through collection element identifiers, a mapping file, or a workflow parameter before writing assertions.
+
+Rule for an agent: when a new workflow input is being designed and the test fixture is already known, check [[galaxy-workflow-testability-design]] before locking the input label/type.
+
+## 5. CVMFS / `.loc` / built-in-index references
+
+When a workflow input is a Galaxy data-table-backed reference (built-in genome index, dbsnp file, kraken DB, …), the input takes a **plain string** matching the `value` column of a `.loc` file. No `class: File`, no `location:`. Examples:
+
+- `scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:25` — `reference genome: dm6 # To test on usegalaxy.eu dm6full`
+- `epigenetics/cutandrun/cutandrun-tests.yml:27` — `reference_genome: 'hg38canon'`
+- `epigenetics/atacseq/atacseq-tests.yml:25` — `reference_genome: hg19`
+- `microbiome/host-contamination-removal/host-contamination-removal-short-reads/host-or-contamination-removal-on-short-reads-tests.yml:19` — `Host/Contaminant Reference Genome: hg38`
+- `microbiome/pathogen-identification/nanopore-pre-processing/Nanopore-Pre-Processing-tests.yml:22` — `host_reference_genome: apiMel3`
+- `transcriptomics/goseq/goseq-go-kegg-enrichment-analsis-tests.yml:24` — `Select genome to use: mm10`
+
+The string is the first column of the `.loc` entry. `workflows/README.md:169-182` shows the lookup procedure: browse `http://datacache.galaxyproject.org/indexes/location/<table>.loc`, find the `.loc` row, take the value column (which column varies by tool — check the matching `tool_data_table_conf.xml.sample`).
+
+**Portability implication:** these tests **only** run on a Galaxy with CVMFS mounted at `/cvmfs/data.galaxyproject.org`. IWC CI mounts CVMFS in-runner (`setup-cvmfs: true` in `.github/workflows/test_workflows.yml`). On a plain developer laptop running `planemo test`, CVMFS-string inputs fail unresolved. An agent generating tests should either:
+
+1. Stay URL-driven: replace the CVMFS string with a `class: File` + `location:` to a Zenodo-hosted reference (portable, slower CI, larger inputs).
+2. Use the CVMFS string and document "CI-only" — the user cannot reproduce locally without a CVMFS mount.
+
+There is no `.loc`-resolution shorthand in the YAML — it is just a bare string parameter. Agents must not invent `class: DataTable` or similar.
+
+## 6. Reviewer-feedback patterns (PR-review)
+
+Recurring asks from IWC reviewers, distilled from the contribution README and community help threads:
+
+- **Move large data to Zenodo before merge.** Anything bigger than a toy fixture committed in `test-data/` will be flagged. `workflows/README.md:67`.
+- **Use assertions, not exact-file comparison, for large outputs.** `workflows/README.md:98` — "if some outputs are large, it is better to use assertions than storing the whole output file."
+- **Generate tests with `planemo workflow_test_init --from_invocation`, don't hand-write.** `workflows/README.md:88-94`. The autogenerated test will mint correct hashes, correct labels, and a working `test-data/` snapshot.
+- **Set creator `identifier:` to a full ORCID URL** (e.g. `https://orcid.org/0000-0002-1825-0097`) — `workflows/README.md:53`. The most common lint failure; enforced in [planemo#1458](https://github.com/galaxyproject/planemo/pull/1458).
+- **Don't use `compare: diff` on outputs that embed timestamps or non-deterministic ordering.** Switch to `has_text` / `has_n_lines` (with `delta:`) or `compare: sim_size`+`delta:`.
+- **Bump `release:` in the `.ga` and add a `CHANGELOG.md` entry** in the same PR — enforced by the IWC PR template; reviewers verify via `bump_version.py`.
+- **Lower-case + `-` only** in directory names — `workflows/README.md:11,72`.
+- **Element identifiers must round-trip** — quote in YAML when they contain pipes/colons/whitespace.
+
+## 7. What is *not* covered by current convention
+
+Gaps an agent should be aware of:
+
+- **`composite_data:` is unrepresented in the IWC corpus.** No working examples to imitate for imzml+ibd or other multi-file datatypes. Treat as off-trail; cite planemo docs and verify by parser.
+- **`tags:` on elements unused.** Galaxy 20.09+ supports them; IWC does not exercise them.
+- **CWL-style shorthand File lists unused.** IWC always names elements.
+- **No negative tests.** Zero `expect_failure:` across the sampled corpus. There is no IWC convention for asserting a workflow *should* fail on bad input.
+- **No checksum-based output assertion in the wild.** `checksum: "sha1$..."` is documented and used at the input side as `hashes:`, but output-side `checksum:` was not surfaced in sampled tests. The corpus prefers `file:` (exact), `compare: sim_size`+`delta:` (size only), or `asserts:` (content probes).
+- **No data-cache layer beyond pip/planemo.** Every test re-pulls remote inputs from Zenodo / EBI / SRA on every CI run. A Zenodo outage breaks many PRs simultaneously. There is no IWC-side mirror or cache.
+- **No per-test timeout / retry convention.** A hung tool blocks the whole chunk until the GitHub Actions 6-hour limit.
+- **No portable story for CVMFS-only tests.** The same `-tests.yml` either works locally (URL-driven) or works in CI (CVMFS-string-driven), not both. There is no documented switch.
+- **Hash function is de-facto SHA-1.** The spec accepts SHA-256/SHA-512/MD5; IWC does not use them. Agents that emit a stronger hash will pass planemo but break corpus convention.
+- **Local-file `hashes:` are inconsistently present.** `--from_invocation`-generated tests have them, hand-written tests usually don't. Either is accepted; don't expect uniformity.
+- **`decompress: true` and `dbkey:` are file-level attributes** but undocumented at the planemo test_format page in the same place as `class:`/`location:`/`hashes:`. Cross-reference against the `gxformat2` Schema-Salad bindings if unsure.
+- **`?download=1` query string on Zenodo URLs** is optional. Both forms appear (`/record/4555735/files/X?download=1` vs `/records/11484215/files/Y`). The newer `/records/` plural is the modern Zenodo URL form; both work.
+
+## Cross-references
+
+- [[galaxy-workflow-testability-design]] — workflow input/output structure choices that make these fixture shapes testable.
+- `/Users/jxc755/projects/repositories/galaxy-brain/vault/projects/workflow_state/skills/COMPONENT_GALAXY_WORKFLOW_TESTING.md` — full synthesis with assertion-vocabulary table, CI internals, and tooling rundown. Sections 2b, 3, 4, 5, 9 are the direct upstream of this note.
+- planemo test format spec: [planemo.readthedocs.io/en/latest/test_format.html](https://planemo.readthedocs.io/en/latest/test_format.html).
+- planemo best practices: [planemo.readthedocs.io/en/latest/best_practices_workflows.html](https://planemo.readthedocs.io/en/latest/best_practices_workflows.html).
+- planemo collections reference: [github.com/galaxyproject/planemo/blob/master/docs/_writing_collections.rst](https://github.com/galaxyproject/planemo/blob/master/docs/_writing_collections.rst).
+- IWC contribution contract: `workflows/README.md` in [github.com/galaxyproject/iwc](https://github.com/galaxyproject/iwc).
+- Galaxy datacache (CVMFS `.loc` browsing): [datacache.galaxyproject.org/indexes/location/](http://datacache.galaxyproject.org/indexes/location/).

--- a/casts/claude/skills/implement-galaxy-workflow-test/SKILL.md
+++ b/casts/claude/skills/implement-galaxy-workflow-test/SKILL.md
@@ -53,9 +53,21 @@ Follow the procedure below and use the artifact/reference sections as the runtim
 
 ## Procedure
 
-Stub. Replace with real skill content per MOLD_SPEC once first walks are done.
-- **`planemo workflow_test_init --from_invocation <id>`** (planemo-workflow_test_init) — preferred bootstrap for new test files; reviewer convention. See planemo-asserts-idioms §7.
-- **`planemo workflow_test_on_invocation <tests.yml> <id>`** (planemo-workflow_test_on_invocation) — fast assertion-iteration loop without re-running the workflow.
+Assemble a Galaxy workflow test file (`tests-format`) from the test plan, the gxformat2 draft, and the resolved test-data refs. One invocation produces a `*-tests.yml` whose job inputs come from the draft's workflow inputs and whose assertions come from the test plan's snapshots. The output must validate against tests-format and pass the workflow-label cross-check before any Planemo run.
+
+The draft is the contract: input and output labels in the test file must address real workflow input/output labels. When authoring reveals a missing label, an omitted workflow output, or an unstable collection identifier, treat it as testability pressure on the workflow itself — surface it per galaxy-workflow-testability-design rather than asserting around it.
+
+### Sequence
+
+1. **Bootstrap.** Prefer generating the test skeleton from a real invocation, not from scratch:
+   - **`planemo workflow_test_init --from_invocation <id>`** (planemo-workflow_test_init) — preferred bootstrap for new test files; reviewer convention. See planemo-asserts-idioms §7.
+   - **`planemo workflow_test_on_invocation <tests.yml> <id>`** (planemo-workflow_test_on_invocation) — fast assertion-iteration loop without re-running the workflow.
+2. **Author job inputs.** Wire each workflow input to a `test-data-refs` entry. Follow iwc-test-data-conventions for remote-URL-first fixtures, recorded hashes, and per-input collection layout. Inputs must match the draft's collection shapes and datatypes.
+3. **Author assertions.** Translate the test plan's snapshots into output assertions. Choose assertion families and tolerances per planemo-asserts-idioms; check each shortcut against iwc-shortcuts-anti-patterns so an existence-only or size-only assertion is a deliberate choice, not an evasion.
+4. **Validate static.** Run validate-tests for the schema gate, then the workflow-label cross-check (`checkTestsAgainstWorkflow`): zero missing input labels, zero missing output labels, no collection/datatype mismatches. Fix before spending a Planemo run.
+5. **Run green.** Drive planemo `test` on a managed Galaxy with the staged data and tools. On green, hand off the test file plus enough invocation/job/assertion context for run-workflow-test and debug-galaxy-workflow-output to use if a later run fails.
+
+Author tests with stable labels and artifacts that Planemo can connect back to Galaxy invocations, jobs, and outputs (planemo-workflow-test-architecture) — that traceability is what makes the downstream debug skill able to locate failure evidence.
 
 ## Runtime Notes
 

--- a/casts/claude/skills/implement-galaxy-workflow-test/_provenance.json
+++ b/casts/claude/skills/implement-galaxy-workflow-test/_provenance.json
@@ -4,11 +4,11 @@
   "mold": {
     "name": "implement-galaxy-workflow-test",
     "path": "content/molds/implement-galaxy-workflow-test/index.md",
-    "revision": 6,
-    "content_hash": "ca679f3ad95639672de9499283b117e71b94c4a07aa700fa79f1df0f05541807",
-    "commit": "e966a94f2a384913d0105082e8ccacd514e4937f"
+    "revision": 7,
+    "content_hash": "51a2ee6dc4e56436d02a398bf4d2779ab702afa4dc9db77634079d3ab9577876",
+    "commit": "64a340bb8e24e9949be9cbd6678a51da42d14203"
   },
-  "cast_at": "2026-06-11T22:20:45.235Z",
+  "cast_at": "2026-06-15T15:21:57.384Z",
   "refs": [
     {
       "kind": "cli-command",

--- a/casts/claude/skills/pipeline-cwl-to-galaxy/SKILL.md
+++ b/casts/claude/skills/pipeline-cwl-to-galaxy/SKILL.md
@@ -67,7 +67,7 @@ Run these phases in order. After each, confirm the expected artifact exists in t
 8. **implement-galaxy-workflow-test** — invoke the `implement-galaxy-workflow-test` skill. Assemble Galaxy workflow test fixtures and assertions.
 9. **validate-galaxy-workflow** — invoke the `validate-galaxy-workflow` skill. Run terminal gxwf validation on an assembled Galaxy workflow and classify workflow-level failures.
 10. **run-workflow-test** — invoke the `run-workflow-test` skill. Execute a workflow's tests via Planemo; emit structured pass/fail and outputs.
-11. **debug-galaxy-workflow-output** — MANUAL — `debug-galaxy-workflow-output` is not yet cast. Triage failing Galaxy run outputs; classify the failure surface and capture evidence before recommending repairs. Do this by hand and confirm before continuing.
+11. **debug-galaxy-workflow-output** — invoke the `debug-galaxy-workflow-output` skill. Triage failing Galaxy run outputs; classify the failure surface and capture evidence before recommending repairs.
 
 ## Done
 

--- a/casts/claude/skills/pipeline-cwl-to-galaxy/_assembly.json
+++ b/casts/claude/skills/pipeline-cwl-to-galaxy/_assembly.json
@@ -21,6 +21,6 @@
     { "phase": 8, "kind": "mold", "skill": "implement-galaxy-workflow-test", "cast_present": true, "loop": false },
     { "phase": 9, "kind": "mold", "skill": "validate-galaxy-workflow", "cast_present": true, "loop": false },
     { "phase": 10, "kind": "mold", "skill": "run-workflow-test", "cast_present": true, "loop": false },
-    { "phase": 11, "kind": "mold", "skill": "debug-galaxy-workflow-output", "cast_present": false, "loop": false }
+    { "phase": 11, "kind": "mold", "skill": "debug-galaxy-workflow-output", "cast_present": true, "loop": false }
   ]
 }

--- a/casts/claude/skills/pipeline-interview-to-galaxy/SKILL.md
+++ b/casts/claude/skills/pipeline-interview-to-galaxy/SKILL.md
@@ -52,12 +52,12 @@ Run these phases in order. After each, confirm the expected artifact exists in t
 5. **freeform-summary-to-galaxy-template** — invoke the `freeform-summary-to-galaxy-template` skill. gxformat2 skeleton with per-step TODOs from a free-form summary and Galaxy design brief.
 6. **advance-galaxy-draft-step** (loop) — invoke the `advance-galaxy-draft-step` skill, once per step. It owns its own endstate oracle (`gxwf draft-next-step`) and concretizes one drafty step per call; re-invoke until it reports `draft: false`, then continue.
 7. **test-data-resolution** (branch) — resolve in order; stop at the first that yields acceptable output:
-   - Try `find-test-data` (MANUAL — not yet cast). Search IWC fixtures and public sources for test data matching a data-flow shape. Do this by hand.
+   - Try `find-test-data` — Search IWC fixtures and public sources for test data matching a data-flow shape.
    - **user-supplied** — if nothing above yields acceptable output, ask the user to supply it directly.
 8. **implement-galaxy-workflow-test** — invoke the `implement-galaxy-workflow-test` skill. Assemble Galaxy workflow test fixtures and assertions.
 9. **validate-galaxy-workflow** — invoke the `validate-galaxy-workflow` skill. Run terminal gxwf validation on an assembled Galaxy workflow and classify workflow-level failures.
 10. **run-workflow-test** — invoke the `run-workflow-test` skill. Execute a workflow's tests via Planemo; emit structured pass/fail and outputs.
-11. **debug-galaxy-workflow-output** — MANUAL — `debug-galaxy-workflow-output` is not yet cast. Triage failing Galaxy run outputs; classify the failure surface and capture evidence before recommending repairs. Do this by hand and confirm before continuing.
+11. **debug-galaxy-workflow-output** — invoke the `debug-galaxy-workflow-output` skill. Triage failing Galaxy run outputs; classify the failure surface and capture evidence before recommending repairs.
 
 ## Done
 

--- a/casts/claude/skills/pipeline-interview-to-galaxy/_assembly.json
+++ b/casts/claude/skills/pipeline-interview-to-galaxy/_assembly.json
@@ -14,10 +14,10 @@
     { "phase": 4, "kind": "mold", "skill": "compare-against-iwc-exemplar", "cast_present": true, "loop": false },
     { "phase": 5, "kind": "mold", "skill": "freeform-summary-to-galaxy-template", "cast_present": true, "loop": false },
     { "phase": 6, "kind": "mold", "skill": "advance-galaxy-draft-step", "cast_present": true, "loop": true },
-    { "phase": 7, "kind": "branch", "pattern": "test-data-resolution", "chain": ["find-test-data", "user-supplied"], "cast_present": [false, null] },
+    { "phase": 7, "kind": "branch", "pattern": "test-data-resolution", "chain": ["find-test-data", "user-supplied"], "cast_present": [true, null] },
     { "phase": 8, "kind": "mold", "skill": "implement-galaxy-workflow-test", "cast_present": true, "loop": false },
     { "phase": 9, "kind": "mold", "skill": "validate-galaxy-workflow", "cast_present": true, "loop": false },
     { "phase": 10, "kind": "mold", "skill": "run-workflow-test", "cast_present": true, "loop": false },
-    { "phase": 11, "kind": "mold", "skill": "debug-galaxy-workflow-output", "cast_present": false, "loop": false }
+    { "phase": 11, "kind": "mold", "skill": "debug-galaxy-workflow-output", "cast_present": true, "loop": false }
   ]
 }

--- a/casts/claude/skills/pipeline-nextflow-to-galaxy/SKILL.md
+++ b/casts/claude/skills/pipeline-nextflow-to-galaxy/SKILL.md
@@ -60,7 +60,7 @@ Run these phases in order. After each, confirm the expected artifact exists in t
 9. **implement-galaxy-workflow-test** — invoke the `implement-galaxy-workflow-test` skill. Assemble Galaxy workflow test fixtures and assertions.
 10. **validate-galaxy-workflow** — invoke the `validate-galaxy-workflow` skill. Run terminal gxwf validation on an assembled Galaxy workflow and classify workflow-level failures.
 11. **run-workflow-test** — invoke the `run-workflow-test` skill. Execute a workflow's tests via Planemo; emit structured pass/fail and outputs.
-12. **debug-galaxy-workflow-output** — MANUAL — `debug-galaxy-workflow-output` is not yet cast. Triage failing Galaxy run outputs; classify the failure surface and capture evidence before recommending repairs. Do this by hand and confirm before continuing.
+12. **debug-galaxy-workflow-output** — invoke the `debug-galaxy-workflow-output` skill. Triage failing Galaxy run outputs; classify the failure surface and capture evidence before recommending repairs.
 
 ## Done
 

--- a/casts/claude/skills/pipeline-nextflow-to-galaxy/_assembly.json
+++ b/casts/claude/skills/pipeline-nextflow-to-galaxy/_assembly.json
@@ -20,6 +20,6 @@
     { "phase": 9, "kind": "mold", "skill": "implement-galaxy-workflow-test", "cast_present": true, "loop": false },
     { "phase": 10, "kind": "mold", "skill": "validate-galaxy-workflow", "cast_present": true, "loop": false },
     { "phase": 11, "kind": "mold", "skill": "run-workflow-test", "cast_present": true, "loop": false },
-    { "phase": 12, "kind": "mold", "skill": "debug-galaxy-workflow-output", "cast_present": false, "loop": false }
+    { "phase": 12, "kind": "mold", "skill": "debug-galaxy-workflow-output", "cast_present": true, "loop": false }
   ]
 }

--- a/casts/claude/skills/pipeline-paper-to-cwl/SKILL.md
+++ b/casts/claude/skills/pipeline-paper-to-cwl/SKILL.md
@@ -55,7 +55,7 @@ Run these phases in order. After each, confirm the expected artifact exists in t
 6. **validate-cwl** (loop) — MANUAL — `validate-cwl` is not yet cast. Run cwltool --validate / schema lint, classify failures, recommend fixes. No shared endstate oracle yet; iterate over the tools enumerated in the CWL template, doing each by hand.
 7. **test-data-resolution** (branch) — resolve in order; stop at the first that yields acceptable output:
    - Try `paper-to-test-data` (MANUAL — not yet cast). Derive workflow test inputs and expected outputs from a paper. Do this by hand.
-   - Otherwise try `find-test-data` (MANUAL — not yet cast). Search IWC fixtures and public sources for test data matching a data-flow shape. Do this by hand.
+   - Otherwise try `find-test-data` — Search IWC fixtures and public sources for test data matching a data-flow shape.
    - **user-supplied** — if nothing above yields acceptable output, ask the user to supply it directly.
 8. **implement-cwl-workflow-test** — MANUAL — `implement-cwl-workflow-test` is not yet cast. Assemble CWL job file(s) and expected-output assertions. Do this by hand and confirm before continuing.
 9. **validate-cwl** — MANUAL — `validate-cwl` is not yet cast. Run cwltool --validate / schema lint, classify failures, recommend fixes. Do this by hand and confirm before continuing.

--- a/casts/claude/skills/pipeline-paper-to-cwl/_assembly.json
+++ b/casts/claude/skills/pipeline-paper-to-cwl/_assembly.json
@@ -14,7 +14,7 @@
     { "phase": 4, "kind": "mold", "skill": "summarize-cwl-tool", "cast_present": false, "loop": true },
     { "phase": 5, "kind": "mold", "skill": "implement-cwl-tool-step", "cast_present": false, "loop": true },
     { "phase": 6, "kind": "mold", "skill": "validate-cwl", "cast_present": false, "loop": true },
-    { "phase": 7, "kind": "branch", "pattern": "test-data-resolution", "chain": ["paper-to-test-data", "find-test-data", "user-supplied"], "cast_present": [false, false, null] },
+    { "phase": 7, "kind": "branch", "pattern": "test-data-resolution", "chain": ["paper-to-test-data", "find-test-data", "user-supplied"], "cast_present": [false, true, null] },
     { "phase": 8, "kind": "mold", "skill": "implement-cwl-workflow-test", "cast_present": false, "loop": false },
     { "phase": 9, "kind": "mold", "skill": "validate-cwl", "cast_present": false, "loop": false },
     { "phase": 10, "kind": "mold", "skill": "run-workflow-test", "cast_present": true, "loop": false },

--- a/casts/claude/skills/pipeline-paper-to-galaxy/SKILL.md
+++ b/casts/claude/skills/pipeline-paper-to-galaxy/SKILL.md
@@ -53,12 +53,12 @@ Run these phases in order. After each, confirm the expected artifact exists in t
 6. **advance-galaxy-draft-step** (loop) — invoke the `advance-galaxy-draft-step` skill, once per step. It owns its own endstate oracle (`gxwf draft-next-step`) and concretizes one drafty step per call; re-invoke until it reports `draft: false`, then continue.
 7. **test-data-resolution** (branch) — resolve in order; stop at the first that yields acceptable output:
    - Try `paper-to-test-data` (MANUAL — not yet cast). Derive workflow test inputs and expected outputs from a paper. Do this by hand.
-   - Otherwise try `find-test-data` (MANUAL — not yet cast). Search IWC fixtures and public sources for test data matching a data-flow shape. Do this by hand.
+   - Otherwise try `find-test-data` — Search IWC fixtures and public sources for test data matching a data-flow shape.
    - **user-supplied** — if nothing above yields acceptable output, ask the user to supply it directly.
 8. **implement-galaxy-workflow-test** — invoke the `implement-galaxy-workflow-test` skill. Assemble Galaxy workflow test fixtures and assertions.
 9. **validate-galaxy-workflow** — invoke the `validate-galaxy-workflow` skill. Run terminal gxwf validation on an assembled Galaxy workflow and classify workflow-level failures.
 10. **run-workflow-test** — invoke the `run-workflow-test` skill. Execute a workflow's tests via Planemo; emit structured pass/fail and outputs.
-11. **debug-galaxy-workflow-output** — MANUAL — `debug-galaxy-workflow-output` is not yet cast. Triage failing Galaxy run outputs; classify the failure surface and capture evidence before recommending repairs. Do this by hand and confirm before continuing.
+11. **debug-galaxy-workflow-output** — invoke the `debug-galaxy-workflow-output` skill. Triage failing Galaxy run outputs; classify the failure surface and capture evidence before recommending repairs.
 
 ## Done
 

--- a/casts/claude/skills/pipeline-paper-to-galaxy/_assembly.json
+++ b/casts/claude/skills/pipeline-paper-to-galaxy/_assembly.json
@@ -14,10 +14,10 @@
     { "phase": 4, "kind": "mold", "skill": "compare-against-iwc-exemplar", "cast_present": true, "loop": false },
     { "phase": 5, "kind": "mold", "skill": "freeform-summary-to-galaxy-template", "cast_present": true, "loop": false },
     { "phase": 6, "kind": "mold", "skill": "advance-galaxy-draft-step", "cast_present": true, "loop": true },
-    { "phase": 7, "kind": "branch", "pattern": "test-data-resolution", "chain": ["paper-to-test-data", "find-test-data", "user-supplied"], "cast_present": [false, false, null] },
+    { "phase": 7, "kind": "branch", "pattern": "test-data-resolution", "chain": ["paper-to-test-data", "find-test-data", "user-supplied"], "cast_present": [false, true, null] },
     { "phase": 8, "kind": "mold", "skill": "implement-galaxy-workflow-test", "cast_present": true, "loop": false },
     { "phase": 9, "kind": "mold", "skill": "validate-galaxy-workflow", "cast_present": true, "loop": false },
     { "phase": 10, "kind": "mold", "skill": "run-workflow-test", "cast_present": true, "loop": false },
-    { "phase": 11, "kind": "mold", "skill": "debug-galaxy-workflow-output", "cast_present": false, "loop": false }
+    { "phase": 11, "kind": "mold", "skill": "debug-galaxy-workflow-output", "cast_present": true, "loop": false }
   ]
 }

--- a/content/molds/freeform-summary-to-galaxy-template/eval.md
+++ b/content/molds/freeform-summary-to-galaxy-template/eval.md
@@ -1,0 +1,54 @@
+# freeform-summary-to-galaxy-template eval
+
+Evaluation plan for the `freeform-summary-to-galaxy-template` Mold. This file is
+the **abstract oracle**: properties any emitted `galaxy-workflow-draft` must
+satisfy, independent of fixture. Properties are tagged by bucket:
+
+- **fidelity** — does the draft preserve source/data-flow intent without
+  inventing or discarding evidence?
+- **utility** — is the draft a well-formed gxformat2 draft with topology settled?
+- **handoff** — can the per-step loop consume it?
+
+## Property: topology is fully resolved
+
+- bucket: utility
+- check: llm-judged
+- assertion: workflow inputs (with collection shapes and formats), workflow
+  outputs, the full step set, and the producer→consumer edge graph are concrete
+  gxformat2. No step, edge, input shape, or output is left as a TODO; only
+  wrapper-tier fields (`tool_id` / `tool_version` / `tool_shed_repository` /
+  `tool_state` and wrapper-determined `in:`/`out:` port names) may be deferred.
+
+## Property: draft validates against the draft contract
+
+- bucket: utility
+- check: deterministic
+- assertion: `gxwf draft-validate` exits clean (`draft valid`). `TODO` / `TODO_*`
+  sentinels and `_plan_*` fields appear only on unresolved tool steps — never on
+  workflow inputs, outputs, or the connection graph.
+
+## Property: deferral is wrapper-tier only, evidence not discarded
+
+- bucket: fidelity
+- check: llm-judged
+- assertion: every `TODO` / `_plan_*` is wrapper-tier. A step whose recipe a
+  Foundry pattern page or the IWC exemplar fully determines is filled in
+  concretely (tool_id, ports, parameters) rather than left TODO; resolved
+  evidence the per-step Mold could not recover is not thrown away.
+
+## Property: source intent and open questions survive
+
+- bucket: fidelity
+- check: llm-judged
+- assertion: the step set and connections reflect the data-flow brief's
+  operations and their order; under-specified operations are carried as explicit
+  placeholder steps with `_plan_*` context (or surfaced open questions) rather
+  than silently dropped or resolved into invented tools/parameters.
+
+## Property: the per-step loop can consume the draft
+
+- bucket: handoff
+- check: llm-judged
+- assertion: `advance-galaxy-draft-step` / `implement-galaxy-tool-step` can pick
+  each drafty step and resolve a wrapper from its `_plan_*` context without
+  re-deriving topology from the source summary.

--- a/tests/assemble-pipeline.test.ts
+++ b/tests/assemble-pipeline.test.ts
@@ -66,7 +66,7 @@ describe("assemble-pipeline (committed harnesses)", () => {
     const branch = assembly.phases.find((p: { kind: string }) => p.kind === "branch");
     expect(branch.pattern).toBe("test-data-resolution");
     expect(branch.chain).toEqual(["paper-to-test-data", "find-test-data", "user-supplied"]);
-    expect(branch.cast_present).toEqual([false, false, null]);
+    expect(branch.cast_present).toEqual([false, true, null]);
     const loop = assembly.phases.find((p: { loop?: boolean }) => p.loop === true);
     expect(loop.skill).toBe("advance-galaxy-draft-step");
   });


### PR DESCRIPTION
_Opened by Claude (AI assistant) on behalf of @jmchilton._

Catch-up artifacts from a real `/test-pipeline interview-to-galaxy` eval run. The source Molds already merged; their generated casts and source companions never got committed alongside.

## Changes

- **Regen `implement-galaxy-workflow-test` cast** — Mold went to revision 7 in already-merged `64a340b`, but the cast was still the revision-6 stub. This catches it up (Stub → real procedure body). `cast --check` + verifier clean.
- **Add `debug-galaxy-workflow-output` + `find-test-data` casts** — both Molds are committed and referenced by 4 pipeline notes, but their casts were never committed. Drift-check + verifier clean.
- **Add `freeform-summary-to-galaxy-template/eval.md`** — abstract oracle conforming to MOLD_SPEC; clears the prior `validate` WARN for the missing eval.
- **Add `_emulated-runs/uc1-mrsa-interview/`** — run record, consistent with the existing tracked emulated-run convention.

## Verification

- `foundry-build cast --check` clean (no drift) on all three casts
- `cast-skill-verify` clean
- `npm run validate` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)