### PR TITLE
Template Mold: prod agent to check each step is computable from its wired inputs

### DIFF
--- a/casts/claude/skills/freeform-summary-to-galaxy-template/SKILL.md
+++ b/casts/claude/skills/freeform-summary-to-galaxy-template/SKILL.md
@@ -63,6 +63,17 @@ Topology is this skill's job to settle. The output must be concrete gxformat2: w
 
 Source tendency: free-form sources rarely name tools, so steps land in **Deferred** more often than nf-core or CWL — but a free-form source that *does* name a specific tool/version with evidence hardens to the matching tier, and a corpus-confirmed utility wrapper (interval/tabular/collection op) is not deferred just because the surrounding prose is informal. When deferring a domain tool, cite the originating paper section, interview answer, figure, or supplementary table in `_plan_context`, and record vague intent in `_plan_state` ("default settings", "stranded reverse if mentioned, else unstranded") so the per-step skill knows the evidence ceiling.
 
+Before handing off, sanity-check that each step is computable from what feeds it. Once the step set is settled, re-read it and ask, for each step, whether the operation its intent implies can actually be produced from the inputs you wired. The connection graph only knows that ports connect — not what each port is supposed to *contain* — so an output that needs evidence no input carries will validate fine and still be impossible to implement. Where you spot that gap, don't leave it implicit: wire (or add) the step that supplies the missing input, or record the unmet need plainly in `_plan_state` so the per-step skill or a reviewer can act on it rather than discover it late.
+
+Things worth a second look:
+
+- an output column or field that no wired input carries;
+- an aggregate or summary whose grouping key isn't present upstream;
+- a filter or threshold whose criterion isn't produced by any input;
+- a join whose key doesn't exist on both sides;
+- a step whose `_plan_*` promises more than its `in:` ports can supply;
+- if classification step, is that classification/enumeration possible only from inputs.
+
 Optionally, once topology is settled, group the step set into titled stage frames via the gxformat2 `comments:` array (one frame per analysis stage, `contains_steps:` populated, color decorative) — see galaxy-workflow-comments for the convention.
 
 Output shape is gxformat2 with wrapper-tier relaxations and `_plan_state` / `_plan_context` / `_plan_in` / `_plan_out` per tool step — see galaxy-workflow-draft-format. Refinement open work for those planning fields lives in `refinement.md`.

--- a/casts/claude/skills/freeform-summary-to-galaxy-template/_provenance.json
+++ b/casts/claude/skills/freeform-summary-to-galaxy-template/_provenance.json
@@ -5,10 +5,10 @@
     "name": "freeform-summary-to-galaxy-template",
     "path": "content/molds/freeform-summary-to-galaxy-template/index.md",
     "revision": 4,
-    "content_hash": "f5342381d5d9b488d2ecbc2783920b1bc9d19fddec76376857520283b6c123bd",
-    "commit": "64a340bb8e24e9949be9cbd6678a51da42d14203"
+    "content_hash": "876776be67332be5a85d6e61802ab405f7aab95cf9cc76eb42af12bc6424b159",
+    "commit": "7060006e335027511b29dbf31415f625462a646a"
   },
-  "cast_at": "2026-06-15T15:10:34.266Z",
+  "cast_at": "2026-06-16T11:53:13.017Z",
   "refs": [
     {
       "kind": "cli-command",

--- a/content/molds/freeform-summary-to-galaxy-template/index.md
+++ b/content/molds/freeform-summary-to-galaxy-template/index.md
@@ -135,6 +135,17 @@ Topology is this Mold's job to settle. The output must be concrete gxformat2: wo
 
 Source tendency: free-form sources rarely name tools, so steps land in **Deferred** more often than nf-core or CWL — but a free-form source that *does* name a specific tool/version with evidence hardens to the matching tier, and a corpus-confirmed utility wrapper (interval/tabular/collection op) is not deferred just because the surrounding prose is informal. When deferring a domain tool, cite the originating paper section, interview answer, figure, or supplementary table in `_plan_context`, and record vague intent in `_plan_state` ("default settings", "stranded reverse if mentioned, else unstranded") so the per-step Mold knows the evidence ceiling.
 
+Before handing off, sanity-check that each step is computable from what feeds it. Once the step set is settled, re-read it and ask, for each step, whether the operation its intent implies can actually be produced from the inputs you wired. The connection graph only knows that ports connect — not what each port is supposed to *contain* — so an output that needs evidence no input carries will validate fine and still be impossible to implement. Where you spot that gap, don't leave it implicit: wire (or add) the step that supplies the missing input, or record the unmet need plainly in `_plan_state` so the per-step Mold or a reviewer can act on it rather than discover it late.
+
+Things worth a second look:
+
+- an output column or field that no wired input carries;
+- an aggregate or summary whose grouping key isn't present upstream;
+- a filter or threshold whose criterion isn't produced by any input;
+- a join whose key doesn't exist on both sides;
+- a step whose `_plan_*` promises more than its `in:` ports can supply;
+- if classification step, is that classification/enumeration possible only from inputs.
+
 Optionally, once topology is settled, group the step set into titled stage frames via the gxformat2 `comments:` array (one frame per analysis stage, `contains_steps:` populated, color decorative) — see [[galaxy-workflow-comments]] for the convention.
 
 Output shape is gxformat2 with wrapper-tier relaxations and `_plan_state` / `_plan_context` / `_plan_in` / `_plan_out` per tool step — see [[galaxy-workflow-draft-format]]. Refinement open work for those planning fields lives in `refinement.md`.


### PR DESCRIPTION
## What

Adds a short review-pass paragraph (plus an example checklist) to the `freeform-summary-to-galaxy-template` Mold body, so it lands in the cast `SKILL.md`. After topology is settled, it prods the agent to re-read each step and check that the operation the step's intent implies is actually **computable from the inputs wired to it**.

```
Before handing off, sanity-check that each step is computable from what feeds it. …
The connection graph only knows that ports connect — not what each port is supposed
to *contain* — so an output that needs evidence no input carries will validate fine
and still be impossible to implement. …

Things worth a second look:
- an output column or field that no wired input carries;
- an aggregate or summary whose grouping key isn't present upstream;
- a filter or threshold whose criterion isn't produced by any input;
- a join whose key doesn't exist on both sides;
- a step whose _plan_* promises more than its in: ports can supply;
- if classification step, is that classification/enumeration possible only from inputs.
```

## Why

Surfaced by a `/test-pipeline interview-to-galaxy "MRSA mobile-AMR context across isolates"` run. The template emitted a `classify_context` step whose `_plan_state` declared five output categories (`plasmid-located`, `IS-adjacent`, `integron-associated`, `SCCmec-region candidate`, `unclassified`), but only wired two evidence inputs — and **nothing in the workflow produces SCCmec-region evidence**. The step validates structurally (a 2-in/1-out step is well-formed) yet one declared output category is uncomputable as designed.

The categories lived only in `_plan_state` prose, so no structural check could relate "5 declared categories" to "2 wired inputs." A prose prod in the skill body is the lightweight fix — it nudges the agent to connect those dots at template time (cheap) rather than discovering the gap mid per-step-loop (expensive), without building out evidence-flow modeling.

## Notes

- Cast `SKILL.md` regenerated; `foundry-build cast --check` clean, `cast-skill-verify` clean (13 refs), `npm run validate` 0 errors.
- Companion problem-statement issues from the same run: #311 (loop can't resolve a missing upstream producer), #312 (convergence guardrails if the loop grows the step set). The heavier "model output taxonomies + required inputs" option is deliberately **not** taken here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
