### PR TITLE
Add draft-topology repair escalation + open-requirements ledger

### DIFF
--- a/content/Dashboard.md
+++ b/content/Dashboard.md
@@ -18,6 +18,7 @@ Generated from `dashboard_sections.json` and content frontmatter. Do not edit by
 | Name | Summary | Status | Revised | Rev |
 | --- | --- | --- | --- | --- |
 | [[freeform-summary-to-galaxy-test-plan]] | Synthesize a Galaxy workflow test plan from a free-form summary and the Galaxy design briefs. | draft | 2026-06-16 | 1 |
+| [[repair-galaxy-draft-topology]] | Re-wire a Galaxy draft region when a step's declared output can't be computed from its wired inputs. | draft | 2026-06-16 | 1 |
 | [[summarize-galaxy-tool]] | Pull JSON schema, container, source, inputs/outputs for a Galaxy tool. | draft | 2026-06-16 | 6 |
 | [[debug-galaxy-workflow-output]] | Triage failing Galaxy run outputs; classify the failure surface and capture evidence before recommending repairs. | draft | 2026-06-12 | 4 |
 | [[find-test-data]] | Search IWC fixtures and public sources for test data matching a data-flow shape. | draft | 2026-06-12 | 2 |

--- a/content/Index.md
+++ b/content/Index.md
@@ -44,6 +44,7 @@ Generated from content frontmatter. Do not edit by hand.
 - [[nextflow-test-to-cwl-test-plan]] — Translate Nextflow test evidence into a CWL workflow test plan.
 - [[nextflow-test-to-galaxy-test-plan]] — Translate Nextflow test evidence into a Galaxy workflow test plan.
 - [[paper-to-test-data]] — Derive workflow test inputs and expected outputs from a paper.
+- [[repair-galaxy-draft-topology]] — Re-wire a Galaxy draft region when a step's declared output can't be computed from its wired inputs.
 - [[run-workflow-test]] — Execute a workflow's tests via Planemo; emit structured pass/fail and outputs.
 - [[summarize-cwl]] — Validate and normalize a CWL Workflow tree, then emit a lightweight structured summary for downstream Galaxy translation.
 - [[summarize-cwl-tool]] — Derive a CommandLineTool description (container, baseCommand, IO) for a CWL target.
@@ -234,6 +235,7 @@ Generated from content frontmatter. Do not edit by hand.
 - [[galaxy-data-flow-draft-contract]] — Defines the proposed boundary between Galaxy data-flow drafts, gxformat2 templates, and concrete step implementation.
 - [[galaxy-tool-summary-input-source]] — Decides that summarize-galaxy-tool reads cached ParsedTool JSON as its v1 input source.
 - [[galaxy-workflow-draft-format]] — gxformat2 draft superset: wrapper-tier TODOs (tool_id, tool_state, port names) plus _plan_state / _plan_context / _plan_in / _plan_out per tool step.
+- [[open-requirements-ledger]] — Carried unresolved-requirements artifact the source→Galaxy pipeline discharges or explicitly surrenders, autonomously.
 
 ## Cli Tool
 

--- a/content/glossary.md
+++ b/content/glossary.md
@@ -62,6 +62,8 @@ Alphabetical.
 
 **Not a Mold** — explicit boundary marker for things that are *not* cast from the Foundry. Includes harnesses, harness-level concerns (state, resumption, autonomy posture), Pipelines themselves, non-Mold phase kinds (`[branch]`, future `[gate]` — these reference Molds via embedded wiki-links but are not Molds), and pure reference content (pattern pages, CLI manual pages, IO schemas — these are *referenced by* Molds, not Molds themselves). Wrapping a CLI is *not* a disqualifier: see `discover-shed-tool`, `run-workflow-test`, `validate-galaxy-workflow`.
 
+**Open-requirements ledger** — a carried artifact (`open-requirements-ledger`) threaded through the source→Galaxy pipeline recording obligations the pipeline has taken on but not met: a declared output with no producer, an unpinned parameter, a tool with no corpus exemplar. Molds **append**, **mark resolved**, or **surrender** entries; framed for autonomous runs (consumers are Molds and the loop's convergence gate, not a human). In the per-step loop it is the countable substrate for the topology-repair convergence invariant. See `content/research/open-requirements-ledger.md`. Reframes issue #281's "open-questions ledger" away from human-answered questions.
+
 **Pattern page** — a Foundry reference page describing a Galaxy workflow construction pattern (collection manipulation, tabular manipulation, conditional handling, custom-tool authoring, …). Wiki-linked from action Molds; pulled into cast artifacts via casting's pattern-kind dispatch (LLM-condensed, mixed verbatim and summarization). Different from a Mold: a pattern page is reference, a Mold is action. Some patterns have a companion action Mold (e.g., custom-tool-authoring pattern + `author-galaxy-tool-wrapper` Mold).
 
 **Phase** — one atomic unit of a Pipeline's ordered `phases` array. Either Mold-shaped (`mold: [[...]]`, optionally `loop: true`) or a non-Mold annotation kind: `[branch]` today, future `[gate]` when needed. Open set — new phase kinds are coined when first surfaced inline rather than pre-enumerated. Validator resolves embedded wiki-links per kind (Mold-shaped phases must resolve to `type: mold`; `[branch]` inner items resolve to Molds or are terminal sentinels like `user-supplied`).
@@ -89,6 +91,8 @@ Alphabetical.
 **Target-specific** *(Mold axis)* — a Mold whose content depends on the output target. Examples: `summary-to-cwl-template`, `summarize-galaxy-tool`, `validate-cwl`.
 
 **Tool-specific** *(Mold axis)* — a provisional Mold axis for actions whose behavior depends on one external tool. Whole-CLI reference surfaces are reference content, not Molds.
+
+**Topology repair** — bounded re-wiring of a settled draft by `repair-galaxy-draft-topology`, the escalation target the per-step loop reaches when implementation proves a declared step output can't be computed from its wired inputs. Distinct from **settling** (the template Mold decides topology from the design briefs): repair is narrow (one named region), reactive (only a detected computability gap triggers it), bounded (decreasing open-blocker count under a hard escalation cap), and never decided *by* the loop — the loop escalates the decision back to the template tier. New steps land at draft tier and are realized by the existing discover-or-author → implement machinery. See `repair-galaxy-draft-topology` and the [[Open-requirements ledger]].
 
 **Generic** *(Mold axis)* — a Mold whose content depends on neither source nor target nor a single tool. Rare in the current inventory.
 

--- a/content/molds/advance-galaxy-draft-step/index.md
+++ b/content/molds/advance-galaxy-draft-step/index.md
@@ -16,12 +16,18 @@ loop_endstate: "It owns its own endstate oracle (`gxwf draft-next-step`) and con
 input_artifacts:
   - id: galaxy-workflow-draft
     description: "gxformat2 draft (see [[galaxy-workflow-draft-format]]) mutated in-place across iterations; topology is fully concrete, individual tool steps may still carry `TODO_*` sentinels and `_plan_*` planning fields."
+  - id: open-requirements-ledger
+    description: "Carried obligations ledger [[open-requirements-ledger]]: after implementing the chosen step, read it for a new `open` blocking entry [[implement-galaxy-tool-step]] appended (the step's declared output can't be computed from its wired inputs), and count open blocking entries for the escalation convergence gate."
 output_artifacts:
   - id: galaxy-workflow-draft
     kind: yaml
     default_filename: galaxy-workflow-draft.gxwf.yml
     schema: "[[galaxy-workflow-draft]]"
     description: "Same draft with one additional step concretized (one loop iteration). Once every step is concrete, [[draft-next-step]] reports `draft: false` and the harness exits the loop."
+  - id: open-requirements-ledger
+    kind: yaml
+    default_filename: open-requirements.ledger.yml
+    description: "Same ledger carried through the iteration: a blocking entry [[implement-galaxy-tool-step]] appended is routed to [[repair-galaxy-draft-topology]] and returns marked `resolved` or `surrendered`."
 references:
   - kind: schema
     ref: "[[galaxy-workflow-draft]]"
@@ -64,15 +70,25 @@ references:
     evidence: corpus-observed
     purpose: "Classify [[draft-validate]] diagnostics against wrapper-defined runtime failure semantics so the iteration routes back to the right authoring surface (implementation vs. wrapper choice)."
     trigger: "When draft-validate fails after a step has been implemented, or when a selected wrapper has explicit failure semantics that may surface at runtime."
+  - kind: research
+    ref: "[[open-requirements-ledger]]"
+    used_at: runtime
+    load: upfront
+    mode: verbatim
+    evidence: hypothesis
+    purpose: "Recognize the blocking entry [[implement-galaxy-tool-step]] appends (its shape and `open | resolved | surrendered` status) so the orchestrator can detect the raised computability gap, count open blocking entries for the convergence gate, and escalate to [[repair-galaxy-draft-topology]]."
+    verification: "Promote after a run where a blocking entry appended by implement is detected here and drives an escalation that strictly reduces the open count."
 related_molds:
   - "[[discover-shed-tool]]"
   - "[[author-galaxy-tool-wrapper]]"
   - "[[summarize-galaxy-tool]]"
   - "[[implement-galaxy-tool-step]]"
+  - "[[repair-galaxy-draft-topology]]"
   - "[[validate-galaxy-workflow]]"
 related_notes:
   - "[[galaxy-workflow-draft-format]]"
   - "[[galaxy-data-flow-draft-contract]]"
+  - "[[open-requirements-ledger]]"
 ---
 
 # advance-galaxy-draft-step
@@ -91,7 +107,8 @@ This Mold is **single-entry, single-exit**: it owns the loop oracle ([[draft-nex
    Either way, if no acceptable shed candidate emerges, fall through to [[author-galaxy-tool-wrapper]].
 3. **Summarize the wrapper.** Invoke [[summarize-galaxy-tool]] on the resolved wrapper to produce a [[galaxy-tool-summary]] for the next phase.
 4. **Implement.** Invoke [[implement-galaxy-tool-step]] with the summary and the draft; it resolves the chosen step's remaining `TODO_*` / `_plan_*` slots into a concrete `tool_id` (confirming or correcting any pinned identity), `tool_version`, `tool_state`, and wrapper-determined port names.
-5. **Validate.** Run [[draft-validate]] `--concrete` over the mutated draft. On green, return; the next iteration starts at step 1. On red, route per the failure-routing rules below.
+5. **Check computability.** Inspect the [[open-requirements-ledger]] for a new `open` blocking entry [[implement-galaxy-tool-step]] appended against this step — a declared output that can't be computed from its wired inputs. [[draft-validate]] cannot catch this: the connection graph knows ports connect, not what they carry, so the draft validates green even though the step can't run. If such an entry is present, escalate to [[repair-galaxy-draft-topology]] for a bounded repair (insert a producer/sub-path or honestly narrow the output); it marks the entry `resolved`, or `surrendered` when no producer is reachable. Each escalation must strictly reduce the open blocking-entry count, under a hard escalation cap; track both in the ledger's `topology_repair` block (increment `escalations`, append the post-repair open count to `open_history`, surrender once `escalations` reaches `cap`). A surrendered entry stays open and is written into the final draft as a labelled gap rather than fabricated. Then return — the next iteration resumes the loop, realizing any draft-tier steps the repair inserted. With no new blocking entry, continue to validation.
+6. **Validate.** Run [[draft-validate]] `--concrete` over the mutated draft. On green, return; the next iteration starts at step 1. On red, route per the failure-routing rules below.
 
 ## Failure routing
 
@@ -100,6 +117,8 @@ This Mold is **single-entry, single-exit**: it owns the loop oracle ([[draft-nex
 - **Local to the just-implemented step** (sentinel violation, wrong port name, malformed `tool_state`) — re-enter [[implement-galaxy-tool-step]] with the diagnostic.
 - **Wrapper-choice mismatch** (selected wrapper cannot satisfy the step's `_plan_*` contract — wrong datatype, missing parameter, incompatible collection shape) — back out to step 2 and pick a different wrapper, either via [[discover-shed-tool]] with refined criteria or by escalating to [[author-galaxy-tool-wrapper]].
 - **Earlier-step defect surfaced by the growing concrete projection** (e.g. a connection that looked fine in isolation breaks once a downstream step pulls a previously-deferred port into scope) — flag to the user. The orchestrator does not unwind prior iterations on its own; cross-step rework belongs at the harness level. *Open question: at what threshold should this Mold attempt to re-enter [[implement-galaxy-tool-step]] for an earlier step versus always escalating?*
+
+These are red-`draft-validate` buckets. The fourth escalation path — a step output uncomputable from its wired inputs — is **not** one of them: the draft validates green there, so it is detected from the ledger in step 5 above, not from a validation failure.
 
 Consult [[galaxy-tool-job-failure-reference]] when the wrapper has explicit failure semantics that affect routing — strict-shell behavior, dynamic outputs, or non-default stdio rules can present as wrapper-choice mismatches even when the static shape validates.
 

--- a/content/molds/compare-against-iwc-exemplar/index.md
+++ b/content/molds/compare-against-iwc-exemplar/index.md
@@ -25,6 +25,8 @@ input_artifacts:
     description: "Galaxy interface brief from [[freeform-summary-to-galaxy-interface]] when running the PAPER → GALAXY or INTERVIEW → GALAXY pipelines."
   - id: freeform-galaxy-data-flow
     description: "Galaxy data-flow brief from [[freeform-summary-to-galaxy-data-flow]] when running the PAPER → GALAXY or INTERVIEW → GALAXY pipelines."
+  - id: open-requirements-ledger
+    description: "Carried obligations ledger [[open-requirements-ledger]]: read prior open entries; this design step appends new unmet needs and marks ones its decisions resolve."
 output_artifacts:
   - id: iwc-comparison-notes
     kind: markdown
@@ -34,7 +36,19 @@ output_artifacts:
     kind: yaml
     default_filename: iwc-exemplar.gxwf.yml
     description: "Cleaned gxformat2 conversion (via [[convert]] --to format2 --compact) of the nearest IWC exemplar's relevant subgraph — the concrete idiom the downstream template draft pattern-matches against. Bounded to the relevant subgraph, not the whole workflow. Absent when no nearest exemplar is found."
+  - id: open-requirements-ledger
+    kind: yaml
+    default_filename: open-requirements.ledger.yml
+    description: "Updated obligations ledger: new unmet needs this step surfaces appended; prior entries its decisions close marked resolved."
 references:
+  - kind: research
+    ref: "[[open-requirements-ledger]]"
+    used_at: runtime
+    load: upfront
+    mode: verbatim
+    evidence: hypothesis
+    purpose: "Carry the open-requirements ledger: read open entries bearing on this step's decisions, mark resolved the ones it closes, and append any new unmet need it surfaces."
+    verification: "Promote after a worked run shows entries this Mold appends or resolves are consumed downstream without re-derivation."
   - kind: cli-command
     ref: "[[convert]]"
     used_at: runtime
@@ -130,3 +144,5 @@ Keep it size-bounded — a whole large workflow is noise; the relevant subgraph 
 - **No tool discovery.** Do not replace [[discover-shed-tool]].
 - **No automatic rewrite.** This Mold emits structural diff guidance; the harness or user decides which changes to apply.
 - **No forced nearest.** A no-match result is valid when IWC lacks a close exemplar.
+
+Carry the [[open-requirements-ledger]] through this step: read the open entries that bear on the choices you make here, mark resolved any your decisions close, and append any new unmet need you surface — a declared output with no producer, an unpinned parameter, a tool with no corpus exemplar — so a later Mold inherits it instead of re-deriving it.

--- a/content/molds/cwl-summary-to-galaxy-data-flow/index.md
+++ b/content/molds/cwl-summary-to-galaxy-data-flow/index.md
@@ -19,12 +19,26 @@ input_artifacts:
     description: "Structured CWL summary emitted by [[summarize-cwl]]; consumed alongside the Galaxy interface brief."
   - id: cwl-galaxy-interface
     description: "Preceding Galaxy interface brief from [[cwl-summary-to-galaxy-interface]] that pins inputs, outputs, and labels."
+  - id: open-requirements-ledger
+    description: "Carried obligations ledger [[open-requirements-ledger]]: read prior open entries; this design step appends new unmet needs and marks ones its decisions resolve."
 output_artifacts:
   - id: cwl-galaxy-data-flow
     kind: markdown
     default_filename: cwl-galaxy-data-flow.md
     description: "Reviewable Markdown brief: abstract topology, Galaxy collection semantics, placeholder transformations, unresolved Galaxy tool needs."
+  - id: open-requirements-ledger
+    kind: yaml
+    default_filename: open-requirements.ledger.yml
+    description: "Updated obligations ledger: new unmet needs this step surfaces appended; prior entries its decisions close marked resolved."
 references:
+  - kind: research
+    ref: "[[open-requirements-ledger]]"
+    used_at: runtime
+    load: upfront
+    mode: verbatim
+    evidence: hypothesis
+    purpose: "Carry the open-requirements ledger: read open entries bearing on this step's decisions, mark resolved the ones it closes, and append any new unmet need it surfaces."
+    verification: "Promote after a worked run shows entries this Mold appends or resolves are consumed downstream without re-derivation."
   - kind: schema
     ref: "[[summary-cwl]]"
     used_at: runtime
@@ -118,3 +132,5 @@ Read a CWL summary plus the preceding Galaxy interface brief and emit a reviewab
 CWL already carries structured workflow shape, so this Mold should be lighter than [[nextflow-summary-to-galaxy-data-flow]].
 
 Start from `summary-cwl.graph.edges[]` instead of rediscovering the DAG. The main work is translation pressure: CWL scatter into Galaxy map-over or collection steps, `linkMerge`/`pickValue` into explicit fan-in choices, secondary files into output contracts, and `valueFrom`/`when` into reviewable placeholders when Galaxy cannot express them directly.
+
+Carry the [[open-requirements-ledger]] through this step: read the open entries that bear on the choices you make here, mark resolved any your decisions close, and append any new unmet need you surface — a declared output with no producer, an unpinned parameter, a tool with no corpus exemplar — so a later Mold inherits it instead of re-deriving it.

--- a/content/molds/cwl-summary-to-galaxy-interface/index.md
+++ b/content/molds/cwl-summary-to-galaxy-interface/index.md
@@ -17,12 +17,26 @@ summary: "Map a CWL summary into a Galaxy workflow interface design brief."
 input_artifacts:
   - id: summary-cwl
     description: "Structured CWL summary emitted by [[summarize-cwl]]; the source-of-truth JSON for Galaxy interface choices."
+  - id: open-requirements-ledger
+    description: "Carried obligations ledger [[open-requirements-ledger]]: read prior open entries; this design step appends new unmet needs and marks ones its decisions resolve."
 output_artifacts:
   - id: cwl-galaxy-interface
     kind: markdown
     default_filename: cwl-galaxy-interface.md
     description: "Reviewable Markdown brief: Galaxy workflow inputs, outputs, labels, exposed and checkpoint outputs, source provenance, confidence."
+  - id: open-requirements-ledger
+    kind: yaml
+    default_filename: open-requirements.ledger.yml
+    description: "Updated obligations ledger: new unmet needs this step surfaces appended; prior entries its decisions close marked resolved."
 references:
+  - kind: research
+    ref: "[[open-requirements-ledger]]"
+    used_at: runtime
+    load: upfront
+    mode: verbatim
+    evidence: hypothesis
+    purpose: "Carry the open-requirements ledger: read open entries bearing on this step's decisions, mark resolved the ones it closes, and append any new unmet need it surfaces."
+    verification: "Promote after a worked run shows entries this Mold appends or resolves are consumed downstream without re-derivation."
   - kind: schema
     ref: "[[summary-cwl]]"
     used_at: runtime
@@ -83,3 +97,5 @@ Read a CWL summary and emit a reviewable Markdown interface brief for a Galaxy w
 The output is a design handoff, not gxformat2 and not a rich workflow schema.
 
 Prefer direct mappings when they are honest: CWL scalar inputs become Galaxy parameter inputs, `File` inputs become dataset inputs, `File[]` plus scatter commonly becomes a `list` collection, and declared formats seed Galaxy datatype choices. Surface `Directory`, records, expression-shaped defaults, and secondary-file-heavy outputs as review notes rather than flattening them silently.
+
+Carry the [[open-requirements-ledger]] through this step: read the open entries that bear on the choices you make here, mark resolved any your decisions close, and append any new unmet need you surface — a declared output with no producer, an unpinned parameter, a tool with no corpus exemplar — so a later Mold inherits it instead of re-deriving it.

--- a/content/molds/cwl-summary-to-galaxy-template/index.md
+++ b/content/molds/cwl-summary-to-galaxy-template/index.md
@@ -25,13 +25,27 @@ input_artifacts:
     description: "Structural diff guidance from [[compare-against-iwc-exemplar]] (run on the design briefs); steers the skeleton toward IWC-aligned structure before per-step authoring. Carries an inline gxformat2 excerpt of the nearest exemplar."
   - id: iwc-exemplar-gxformat2
     description: "Cleaned gxformat2 view of the nearest IWC exemplar's relevant subgraph from [[compare-against-iwc-exemplar]]; pattern-match the draft's input/collection shapes, map-over wiring, output promotion, and post-job actions against this concrete idiom. Absent when no nearest exemplar was found."
+  - id: open-requirements-ledger
+    description: "Carried obligations ledger [[open-requirements-ledger]]: read prior open entries; this design step appends new unmet needs and marks ones its decisions resolve."
 output_artifacts:
   - id: galaxy-workflow-draft
     kind: yaml
     default_filename: galaxy-workflow-draft.gxwf.yml
     schema: "[[galaxy-workflow-draft]]"
     description: "gxformat2 draft (see [[galaxy-workflow-draft-format]]): topology fully resolved (workflow inputs, outputs, step set, edges); tool_id / tool_state / tool_shed_repository and wrapper-determined port names may be TODO with free-text _plan_state / _plan_context / _plan_in / _plan_out per step for later implementation Molds."
+  - id: open-requirements-ledger
+    kind: yaml
+    default_filename: open-requirements.ledger.yml
+    description: "Updated obligations ledger: new unmet needs this step surfaces appended; prior entries its decisions close marked resolved."
 references:
+  - kind: research
+    ref: "[[open-requirements-ledger]]"
+    used_at: runtime
+    load: upfront
+    mode: verbatim
+    evidence: hypothesis
+    purpose: "Carry the open-requirements ledger: read open entries bearing on this step's decisions, mark resolved the ones it closes, and append any new unmet need it surfaces."
+    verification: "Promote after a worked run shows entries this Mold appends or resolves are consumed downstream without re-derivation."
   - kind: schema
     ref: "[[galaxy-workflow-draft]]"
     used_at: runtime
@@ -160,6 +174,8 @@ Topology is this Mold's job to settle. The output must be concrete gxformat2: wo
 Source tendency: a CWL `CommandLineTool` carries `baseCommand` / `arguments`, `DockerRequirement` / `SoftwareRequirement` hints, and explicit input/output bindings — so identity is often inferable to **Identity-pinned**, and a step reaches **Resolved** when a pattern page or IWC exemplar covers the operation (fill `tool_id`, parameters, and port names from the worked example). A custom-script tool with no Galaxy equivalent stays **Deferred** — pack `_plan_context` with the `baseCommand` / `arguments`, `DockerRequirement` URIs, `SoftwareRequirement` packages, and `EnvVarRequirement` / `ResourceRequirement` constraints the per-step Mold needs to pick a wrapper. Emitting `TODO` over a pattern-covered recipe discards real evidence the per-step Mold cannot recover.
 
 Optionally, once topology is settled, group the step set into titled stage frames via the gxformat2 `comments:` array (one frame per analysis stage, `contains_steps:` populated, color decorative) — see [[galaxy-workflow-comments]] for the convention.
+
+Before handing off, check each settled step is computable from what feeds it. The connection graph knows that ports connect, not what they carry — so a declared output that needs evidence no wired input supplies will validate yet can't be implemented. Where you find that gap, wire (or add) the producer; if you can't, append a blocking entry to the [[open-requirements-ledger]] naming the step, the uncomputable output, and the missing evidence (and record vague intent in `_plan_state`) so the per-step loop or [[repair-galaxy-draft-topology]] acts on it rather than discovering it late. More generally, carry the ledger: read the entries bearing on your topology decisions and mark resolved the ones you close.
 
 Output shape is gxformat2 with wrapper-tier relaxations and `_plan_state` / `_plan_context` / `_plan_in` / `_plan_out` per tool step — see [[galaxy-workflow-draft-format]]. Refinement open work for those planning fields lives in `refinement.md`.
 

--- a/content/molds/freeform-summary-to-galaxy-data-flow/index.md
+++ b/content/molds/freeform-summary-to-galaxy-data-flow/index.md
@@ -19,12 +19,26 @@ input_artifacts:
     description: "Free-form source summary emitted by [[summarize-paper]] or [[interview-to-freeform-summary]]; consumed alongside the Galaxy interface brief."
   - id: freeform-galaxy-interface
     description: "Preceding Galaxy interface brief from [[freeform-summary-to-galaxy-interface]] that pins inputs, outputs, and labels."
+  - id: open-requirements-ledger
+    description: "Carried obligations ledger [[open-requirements-ledger]]: read prior open entries; this design step appends new unmet needs and marks ones its decisions resolve."
 output_artifacts:
   - id: freeform-galaxy-data-flow
     kind: markdown
     default_filename: freeform-galaxy-data-flow.md
     description: "Reviewable Markdown brief: abstract operations, collection map/reduce choices, shape-changing placeholder steps, unresolved Galaxy tool needs, confidence, open questions."
+  - id: open-requirements-ledger
+    kind: yaml
+    default_filename: open-requirements.ledger.yml
+    description: "Updated obligations ledger: new unmet needs this step surfaces appended; prior entries its decisions close marked resolved."
 references:
+  - kind: research
+    ref: "[[open-requirements-ledger]]"
+    used_at: runtime
+    load: upfront
+    mode: verbatim
+    evidence: hypothesis
+    purpose: "Carry the open-requirements ledger: read open entries bearing on this step's decisions, mark resolved the ones it closes, and append any new unmet need it surfaces."
+    verification: "Promote after a worked run shows entries this Mold appends or resolves are consumed downstream without re-derivation."
   - kind: research
     ref: "[[galaxy-data-flow-draft-contract]]"
     used_at: runtime
@@ -84,3 +98,5 @@ Read a free-form source summary plus the preceding Galaxy interface brief and em
 Free-form sources rarely give enough to fix exact operations. Translate what the summary and interface brief support, classify the rest as unresolved tool needs or open questions, and do not present narrative intent as already-decided Galaxy wiring.
 
 The output is not gxformat2 and should not resolve exact Tool Shed tools. [[freeform-summary-to-galaxy-template]] turns this handoff and the interface brief into a skeleton.
+
+Carry the [[open-requirements-ledger]] through this step: read the open entries that bear on the choices you make here, mark resolved any your decisions close, and append any new unmet need you surface — a declared output with no producer, an unpinned parameter, a tool with no corpus exemplar — so a later Mold inherits it instead of re-deriving it.

--- a/content/molds/freeform-summary-to-galaxy-interface/index.md
+++ b/content/molds/freeform-summary-to-galaxy-interface/index.md
@@ -17,12 +17,26 @@ summary: "Map a free-form source summary into a Galaxy workflow interface design
 input_artifacts:
   - id: freeform-summary
     description: "Free-form source summary emitted by [[summarize-paper]] or [[interview-to-freeform-summary]]; methods, tools, sample data, references, and workflow intent with explicit uncertainty."
+  - id: open-requirements-ledger
+    description: "Carried obligations ledger [[open-requirements-ledger]]: read prior open entries; this design step appends new unmet needs and marks ones its decisions resolve."
 output_artifacts:
   - id: freeform-galaxy-interface
     kind: markdown
     default_filename: freeform-galaxy-interface.md
     description: "Reviewable Markdown brief: Galaxy workflow inputs, outputs, labels, collection shapes, checkpoint outputs, source-summary provenance, confidence, open questions."
+  - id: open-requirements-ledger
+    kind: yaml
+    default_filename: open-requirements.ledger.yml
+    description: "Updated obligations ledger: new unmet needs this step surfaces appended; prior entries its decisions close marked resolved."
 references:
+  - kind: research
+    ref: "[[open-requirements-ledger]]"
+    used_at: runtime
+    load: upfront
+    mode: verbatim
+    evidence: hypothesis
+    purpose: "Carry the open-requirements ledger: read open entries bearing on this step's decisions, mark resolved the ones it closes, and append any new unmet need it surfaces."
+    verification: "Promote after a worked run shows entries this Mold appends or resolves are consumed downstream without re-derivation."
   - kind: research
     ref: "[[galaxy-workflow-testability-design]]"
     used_at: runtime
@@ -58,3 +72,5 @@ Read a free-form source summary and emit a reviewable Markdown interface brief f
 Free-form sources are narrative- or interview-derived and carry explicit uncertainty. Translate what the summary supports into interface decisions; carry unresolved interface choices forward as open questions rather than inventing precise inputs, outputs, or labels.
 
 The output is not a gxformat2 skeleton and not a workflow schema. It is a design handoff consumed by [[freeform-summary-to-galaxy-data-flow]], [[freeform-summary-to-galaxy-template]], and later test-plan work.
+
+Carry the [[open-requirements-ledger]] through this step: read the open entries that bear on the choices you make here, mark resolved any your decisions close, and append any new unmet need you surface — a declared output with no producer, an unpinned parameter, a tool with no corpus exemplar — so a later Mold inherits it instead of re-deriving it.

--- a/content/molds/freeform-summary-to-galaxy-template/index.md
+++ b/content/molds/freeform-summary-to-galaxy-template/index.md
@@ -25,12 +25,18 @@ input_artifacts:
     description: "Structural diff guidance from [[compare-against-iwc-exemplar]] (run on the design brief); steers the skeleton toward IWC-aligned structure before per-step authoring. Carries an inline gxformat2 excerpt of the nearest exemplar."
   - id: iwc-exemplar-gxformat2
     description: "Cleaned gxformat2 view of the nearest IWC exemplar's relevant subgraph from [[compare-against-iwc-exemplar]]; pattern-match the draft's input/collection shapes, map-over wiring, output promotion, and post-job actions against this concrete idiom. Absent when no nearest exemplar was found."
+  - id: open-requirements-ledger
+    description: "Carried obligations ledger [[open-requirements-ledger]]: read prior open entries; this design step appends new unmet needs and marks ones its decisions resolve."
 output_artifacts:
   - id: galaxy-workflow-draft
     kind: yaml
     default_filename: galaxy-workflow-draft.gxwf.yml
     schema: "[[galaxy-workflow-draft]]"
     description: "gxformat2 draft (see [[galaxy-workflow-draft-format]]): topology fully resolved (workflow inputs, outputs, step set, edges); tool_id / tool_state / tool_shed_repository and wrapper-determined port names may be TODO with free-text _plan_state / _plan_context / _plan_in / _plan_out per step for later implementation Molds."
+  - id: open-requirements-ledger
+    kind: yaml
+    default_filename: open-requirements.ledger.yml
+    description: "Updated obligations ledger: new unmet needs this step surfaces appended; prior entries its decisions close marked resolved."
 references:
   - kind: schema
     ref: "[[galaxy-workflow-draft]]"
@@ -48,6 +54,14 @@ references:
     purpose: "Validate the emitted draft against draft-contract rules (sentinel form, topology, _plan_* placement) before handing off."
     trigger: "After writing or modifying the draft workflow file."
     verification: "Cast the skill, run on a representative paper-derived summary, confirm draft-validate diagnostics route back."
+  - kind: research
+    ref: "[[open-requirements-ledger]]"
+    used_at: runtime
+    load: upfront
+    mode: verbatim
+    evidence: hypothesis
+    purpose: "Carry the open-requirements ledger: read open entries bearing on this step's decisions, mark resolved the ones it closes, and append any new unmet need it surfaces."
+    verification: "Promote after a worked run shows entries this Mold appends or resolves are consumed downstream without re-derivation."
   - kind: research
     ref: "[[galaxy-workflow-draft-format]]"
     used_at: runtime
@@ -147,5 +161,7 @@ Things worth a second look:
 - if classification step, is that classification/enumeration possible only from inputs.
 
 Optionally, once topology is settled, group the step set into titled stage frames via the gxformat2 `comments:` array (one frame per analysis stage, `contains_steps:` populated, color decorative) — see [[galaxy-workflow-comments]] for the convention.
+
+Before handing off, check each settled step is computable from what feeds it. The connection graph knows that ports connect, not what they carry — so a declared output that needs evidence no wired input supplies will validate yet can't be implemented. Where you find that gap, wire (or add) the producer; if you can't, append a blocking entry to the [[open-requirements-ledger]] naming the step, the uncomputable output, and the missing evidence (and record vague intent in `_plan_state`) so the per-step loop or [[repair-galaxy-draft-topology]] acts on it rather than discovering it late. More generally, carry the ledger: read the entries bearing on your topology decisions and mark resolved the ones you close.
 
 Output shape is gxformat2 with wrapper-tier relaxations and `_plan_state` / `_plan_context` / `_plan_in` / `_plan_out` per tool step — see [[galaxy-workflow-draft-format]]. Refinement open work for those planning fields lives in `refinement.md`.

--- a/content/molds/implement-galaxy-tool-step/index.md
+++ b/content/molds/implement-galaxy-tool-step/index.md
@@ -17,13 +17,27 @@ input_artifacts:
     description: "Galaxy tool summary manifest from [[summarize-galaxy-tool]] conforming to [[galaxy-tool-summary]]; binds the abstract step to a concrete tool's ports via the embedded `parsed_tool` and generated `input_schemas`."
   - id: galaxy-workflow-draft
     description: "gxformat2 skeleton being filled in step by step; the step replaces a placeholder in this draft."
+  - id: open-requirements-ledger
+    description: "Carried obligations ledger [[open-requirements-ledger]]: read entries the design tier recorded against this step before implementing; append a blocking entry if its output can't be computed."
 output_artifacts:
   - id: galaxy-workflow-draft
     kind: yaml
     default_filename: galaxy-workflow-draft.gxwf.yml
     schema: "[[galaxy-workflow-draft]]"
     description: "gxformat2 skeleton with one more abstract step replaced by a concrete tool step (loop iteration output)."
+  - id: open-requirements-ledger
+    kind: yaml
+    default_filename: open-requirements.ledger.yml
+    description: "Ledger ([[open-requirements-ledger]]) with a blocking entry appended when a step's declared output can't be computed from its wired inputs; drives the fall-through to topology repair."
 references:
+  - kind: research
+    ref: "[[open-requirements-ledger]]"
+    used_at: runtime
+    load: upfront
+    mode: verbatim
+    evidence: hypothesis
+    purpose: "Carry the open-requirements ledger: read open entries bearing on this step's decisions, mark resolved the ones it closes, and append any new unmet need it surfaces."
+    verification: "Promote after a worked run shows entries this Mold appends or resolves are consumed downstream without re-derivation."
   - kind: schema
     ref: "[[galaxy-workflow-draft]]"
     used_at: runtime
@@ -122,3 +136,5 @@ Single step in scope. This Mold owns the chosen step and the wiring that connect
 ## Failure ownership
 
 When the wrapper can't cleanly carry what the plan needs — wrong datatype, missing parameter, unsupported collection shape — record where a later failure should be investigated: tool/job failure, data-flow mistake, template wiring mistake, wrapper mismatch, or test/assertion issue. Consult [[galaxy-tool-job-failure-reference]] when the selected wrapper has explicit failure semantics (exit-code rules, stdio regex, strict-shell, dynamic outputs); implement the step's labels and wiring so that evidence survives to runtime rather than being erased by the concretization.
+
+When the step's declared output cannot be computed from the inputs wired to it — the connection graph says the ports connect, but no wired input carries the evidence the output needs — do not fabricate it. Append a blocking entry to the [[open-requirements-ledger]] naming the step, the uncomputable output, and the missing evidence, and fall through to [[repair-galaxy-draft-topology]] rather than emitting a step that validates but can't run. A missing Tool Shed wrapper is not this case; that gap routes through the discover-or-author branch.

--- a/content/molds/nextflow-summary-to-galaxy-data-flow/index.md
+++ b/content/molds/nextflow-summary-to-galaxy-data-flow/index.md
@@ -21,12 +21,26 @@ input_artifacts:
     description: "Reference-data shape brief from [[nextflow-summary-to-galaxy-reference-data]] that pins per-asset reference inputs and rebuild-on-absence behavior."
   - id: nextflow-galaxy-interface
     description: "Preceding Galaxy interface brief from [[nextflow-summary-to-galaxy-interface]] that pins inputs, outputs, and labels."
+  - id: open-requirements-ledger
+    description: "Carried obligations ledger [[open-requirements-ledger]]: read prior open entries; this design step appends new unmet needs and marks ones its decisions resolve."
 output_artifacts:
   - id: nextflow-galaxy-data-flow
     kind: markdown
     default_filename: nextflow-galaxy-data-flow.md
     description: "Reviewable Markdown brief: abstract operations, collection map/reduce choices, shape-changing placeholder steps, unresolved Galaxy tool needs, confidence, open questions."
+  - id: open-requirements-ledger
+    kind: yaml
+    default_filename: open-requirements.ledger.yml
+    description: "Updated obligations ledger: new unmet needs this step surfaces appended; prior entries its decisions close marked resolved."
 references:
+  - kind: research
+    ref: "[[open-requirements-ledger]]"
+    used_at: runtime
+    load: upfront
+    mode: verbatim
+    evidence: hypothesis
+    purpose: "Carry the open-requirements ledger: read open entries bearing on this step's decisions, mark resolved the ones it closes, and append any new unmet need it surfaces."
+    verification: "Promote after a worked run shows entries this Mold appends or resolves are consumed downstream without re-derivation."
   - kind: schema
     ref: "[[summary-nextflow]]"
     used_at: runtime
@@ -141,3 +155,5 @@ related_notes:
 Read a Nextflow summary plus the preceding Galaxy interface brief and emit a reviewable Markdown data-flow brief. Capture abstract operations, collection map/reduce choices, shape-changing placeholder transformations, unresolved Galaxy tool needs, confidence, and open questions.
 
 The output is not gxformat2 and should not resolve exact Tool Shed tools. [[nextflow-summary-to-galaxy-template]] turns this handoff and the interface brief into a skeleton.
+
+Carry the [[open-requirements-ledger]] through this step: read the open entries that bear on the choices you make here, mark resolved any your decisions close, and append any new unmet need you surface — a declared output with no producer, an unpinned parameter, a tool with no corpus exemplar — so a later Mold inherits it instead of re-deriving it.

--- a/content/molds/nextflow-summary-to-galaxy-interface/index.md
+++ b/content/molds/nextflow-summary-to-galaxy-interface/index.md
@@ -19,12 +19,26 @@ input_artifacts:
     description: "Structured Nextflow pipeline summary emitted by [[summarize-nextflow]]; the source-of-truth JSON for interface choices."
   - id: nextflow-galaxy-reference-data
     description: "Reference-data shape brief from [[nextflow-summary-to-galaxy-reference-data]] that pins per-asset reference inputs and rebuild-on-absence behavior."
+  - id: open-requirements-ledger
+    description: "Carried obligations ledger [[open-requirements-ledger]]: read prior open entries; this design step appends new unmet needs and marks ones its decisions resolve."
 output_artifacts:
   - id: nextflow-galaxy-interface
     kind: markdown
     default_filename: nextflow-galaxy-interface.md
     description: "Reviewable Markdown brief: Galaxy workflow inputs, outputs, labels, collection shapes, checkpoint outputs, source provenance."
+  - id: open-requirements-ledger
+    kind: yaml
+    default_filename: open-requirements.ledger.yml
+    description: "Updated obligations ledger: new unmet needs this step surfaces appended; prior entries its decisions close marked resolved."
 references:
+  - kind: research
+    ref: "[[open-requirements-ledger]]"
+    used_at: runtime
+    load: upfront
+    mode: verbatim
+    evidence: hypothesis
+    purpose: "Carry the open-requirements ledger: read open entries bearing on this step's decisions, mark resolved the ones it closes, and append any new unmet need it surfaces."
+    verification: "Promote after a worked run shows entries this Mold appends or resolves are consumed downstream without re-derivation."
   - kind: schema
     ref: "[[summary-nextflow]]"
     used_at: runtime
@@ -97,3 +111,5 @@ related_notes:
 Read a Nextflow summary and emit a reviewable Markdown interface brief for a Galaxy workflow. Capture workflow inputs, workflow outputs, labels, Galaxy collection shapes, checkpoint outputs worth exposing for tests, source-summary provenance, confidence, and open questions.
 
 The output is not a gxformat2 skeleton and not a workflow schema. It is a design handoff consumed by [[nextflow-summary-to-galaxy-data-flow]], [[nextflow-summary-to-galaxy-template]], and later test-plan work.
+
+Carry the [[open-requirements-ledger]] through this step: read the open entries that bear on the choices you make here, mark resolved any your decisions close, and append any new unmet need you surface — a declared output with no producer, an unpinned parameter, a tool with no corpus exemplar — so a later Mold inherits it instead of re-deriving it.

--- a/content/molds/nextflow-summary-to-galaxy-reference-data/index.md
+++ b/content/molds/nextflow-summary-to-galaxy-reference-data/index.md
@@ -17,12 +17,26 @@ summary: "Decide the Galaxy-side shape of external reference data declared by a 
 input_artifacts:
   - id: summary-nextflow
     description: "Structured Nextflow pipeline summary emitted by [[summarize-nextflow]]; the source for reference-data param evidence."
+  - id: open-requirements-ledger
+    description: "Carried obligations ledger [[open-requirements-ledger]]: read prior open entries; this design step appends new unmet needs and marks ones its decisions resolve."
 output_artifacts:
   - id: nextflow-galaxy-reference-data
     kind: markdown
     default_filename: nextflow-galaxy-reference-data.md
     description: "Reviewable Markdown brief: per-asset reference inputs, requiredness, rebuild-on-absence behavior, iGenomes key disposition, open questions."
+  - id: open-requirements-ledger
+    kind: yaml
+    default_filename: open-requirements.ledger.yml
+    description: "Updated obligations ledger: new unmet needs this step surfaces appended; prior entries its decisions close marked resolved."
 references:
+  - kind: research
+    ref: "[[open-requirements-ledger]]"
+    used_at: runtime
+    load: upfront
+    mode: verbatim
+    evidence: hypothesis
+    purpose: "Carry the open-requirements ledger: read open entries bearing on this step's decisions, mark resolved the ones it closes, and append any new unmet need it surfaces."
+    verification: "Promote after a worked run shows entries this Mold appends or resolves are consumed downstream without re-derivation."
   - kind: schema
     ref: "[[summary-nextflow]]"
     used_at: runtime
@@ -76,3 +90,5 @@ The [[summary-nextflow]] schema surfaces reference-data evidence directly — re
 - **`subworkflows[].invocations[]`** — caller-side argument binding onto `take:` names. Use when `reference_assets[].used_by` is ambiguous or when verifying that the same param threads into multiple subworkflows.
 
 If a needed signal is missing from the summary (e.g. RNA-seq's positive-form rebuild idiom is not yet detected), say so in the brief and flag the asset as *rebuild-unverified* rather than re-parsing source files.
+
+Carry the [[open-requirements-ledger]] through this step: read the open entries that bear on the choices you make here, mark resolved any your decisions close, and append any new unmet need you surface — a declared output with no producer, an unpinned parameter, a tool with no corpus exemplar — so a later Mold inherits it instead of re-deriving it.

--- a/content/molds/nextflow-summary-to-galaxy-template/index.md
+++ b/content/molds/nextflow-summary-to-galaxy-template/index.md
@@ -27,13 +27,27 @@ input_artifacts:
     description: "Structural diff guidance from [[compare-against-iwc-exemplar]] (run on the design briefs); steers the skeleton toward IWC-aligned structure before per-step authoring. Carries an inline gxformat2 excerpt of the nearest exemplar."
   - id: iwc-exemplar-gxformat2
     description: "Cleaned gxformat2 view of the nearest IWC exemplar's relevant subgraph from [[compare-against-iwc-exemplar]]; pattern-match the draft's input/collection shapes, map-over wiring, output promotion, and post-job actions against this concrete idiom. Absent when no nearest exemplar was found."
+  - id: open-requirements-ledger
+    description: "Carried obligations ledger [[open-requirements-ledger]]: read prior open entries; this design step appends new unmet needs and marks ones its decisions resolve."
 output_artifacts:
   - id: galaxy-workflow-draft
     kind: yaml
     default_filename: galaxy-workflow-draft.gxwf.yml
     schema: "[[galaxy-workflow-draft]]"
     description: "gxformat2 draft (see [[galaxy-workflow-draft-format]]): topology fully resolved (workflow inputs, outputs, step set, edges); tool_id / tool_state / tool_shed_repository and wrapper-determined port names may be TODO with free-text _plan_state / _plan_context / _plan_in / _plan_out per step for later implementation Molds."
+  - id: open-requirements-ledger
+    kind: yaml
+    default_filename: open-requirements.ledger.yml
+    description: "Updated obligations ledger: new unmet needs this step surfaces appended; prior entries its decisions close marked resolved."
 references:
+  - kind: research
+    ref: "[[open-requirements-ledger]]"
+    used_at: runtime
+    load: upfront
+    mode: verbatim
+    evidence: hypothesis
+    purpose: "Carry the open-requirements ledger: read open entries bearing on this step's decisions, mark resolved the ones it closes, and append any new unmet need it surfaces."
+    verification: "Promote after a worked run shows entries this Mold appends or resolves are consumed downstream without re-derivation."
   - kind: schema
     ref: "[[galaxy-workflow-draft]]"
     used_at: runtime
@@ -180,5 +194,7 @@ Topology is this Mold's job to settle. The output must be concrete gxformat2: wo
 Source tendency: nf-core modules name their tool, pin a version, and carry the `command:` block, conda packages, and container tags — so steps reach **Resolved** when a pattern page or IWC exemplar covers the operation (fill `tool_id`, parameters, and port names from the worked example), and **Identity-pinned** when the module names the tool but its settings for this context stay open. **Deferred** is for domain-specific scientific tools with no covering pattern (alignment, variant calling, expression quantification, etc.) — pack `_plan_context` with the source command, conda specs, container tags, and pre/post conditions the per-step Mold needs to pick a wrapper. Emitting `TODO` over a pattern-covered recipe discards real evidence the per-step Mold cannot recover.
 
 Optionally, once topology is settled, group the step set into titled stage frames via the gxformat2 `comments:` array (one frame per analysis stage, `contains_steps:` populated, color decorative) — see [[galaxy-workflow-comments]] for the convention.
+
+Before handing off, check each settled step is computable from what feeds it. The connection graph knows that ports connect, not what they carry — so a declared output that needs evidence no wired input supplies will validate yet can't be implemented. Where you find that gap, wire (or add) the producer; if you can't, append a blocking entry to the [[open-requirements-ledger]] naming the step, the uncomputable output, and the missing evidence (and record vague intent in `_plan_state`) so the per-step loop or [[repair-galaxy-draft-topology]] acts on it rather than discovering it late. More generally, carry the ledger: read the entries bearing on your topology decisions and mark resolved the ones you close.
 
 Output shape is gxformat2 with wrapper-tier relaxations and `_plan_state` / `_plan_context` / `_plan_in` / `_plan_out` per tool step — see [[galaxy-workflow-draft-format]]. Refinement open work for those planning fields lives in `refinement.md`.

--- a/content/molds/repair-galaxy-draft-topology/eval.md
+++ b/content/molds/repair-galaxy-draft-topology/eval.md
@@ -1,0 +1,25 @@
+# repair-galaxy-draft-topology eval
+
+## Case: blocking entry is closed or surrendered, never left untouched
+
+- check: deterministic
+- fixture: a draft with a step whose declared output needs evidence no wired input carries, plus an `open-requirements-ledger` carrying the matching `open` blocking entry.
+- expectation: every blocking entry the repair claims to address transitions to `resolved` (with a note on how) or `surrendered` (with a note on why); no entry is left `open` while the Mold reports the region repaired. Catches the spin-or-fabricate failure the escalation exists to prevent.
+
+## Case: inserted steps are draft-tier, not fabricated
+
+- check: deterministic
+- fixture: a repair that adds a producer step or sub-path for the missing evidence.
+- expectation: new steps carry wrapper-tier `TODO` for `tool_id` / ports and `_plan_*` intent — they must not invent a concrete `tool_id`, `tool_version`, or Tool Shed repository, since wrapper resolution belongs to the downstream discover-or-author → implement machinery. A fabricated concrete tool id is a fail.
+
+## Case: repair stays local
+
+- check: llm-judged
+- fixture: a draft where one region is blocked but the rest is already realized (concrete tool steps, settled workflow interface).
+- expectation: the repair touches only the blocked region; already-realized steps, the workflow interface, and unrelated edges are not silently re-settled or contradicted. Adding/rewiring within the blocked region is expected; rewriting the surrounding workflow is not.
+
+## Case: no convergence-defeating producer
+
+- check: llm-judged
+- fixture: a blocking entry whose missing evidence has no producer in reach (e.g. SCCmec cassette evidence with no typing tool available).
+- expectation: the Mold either narrows the declared output to what its inputs honestly support, or surrenders the entry with a note — it must not insert a producer whose own output is itself uncomputable from what feeds it, which would grow the DAG without reducing the open-blocker count.

--- a/content/molds/repair-galaxy-draft-topology/index.md
+++ b/content/molds/repair-galaxy-draft-topology/index.md
@@ -1,0 +1,99 @@
+---
+type: mold
+name: repair-galaxy-draft-topology
+axis: target-specific
+target: galaxy
+tags:
+  - mold
+  - target/galaxy
+status: draft
+created: 2026-06-16
+revised: 2026-06-16
+revision: 1
+ai_generated: true
+summary: "Re-wire a Galaxy draft region when a step's declared output can't be computed from its wired inputs."
+input_artifacts:
+  - id: galaxy-workflow-draft
+    description: "Partially-realized gxformat2 draft (see [[galaxy-workflow-draft-format]]) whose topology can't support a declared step — the region to repair."
+  - id: open-requirements-ledger
+    description: "Carried obligations from [[open-requirements-ledger]]; the open blocking entries name which step output is uncomputable and what evidence is missing."
+output_artifacts:
+  - id: galaxy-workflow-draft
+    kind: yaml
+    default_filename: galaxy-workflow-draft.gxwf.yml
+    schema: "[[galaxy-workflow-draft]]"
+    description: "Re-wired gxformat2 draft: a producer step (or small sub-path) inserted so the previously-blocked step's declared output is computable; new steps land at draft (TODO) tier."
+  - id: open-requirements-ledger
+    kind: yaml
+    default_filename: open-requirements.ledger.yml
+    description: "Ledger with the addressed blocking entries marked resolved, or surrendered with a note when no producer can be found within the escalation budget."
+references:
+  - kind: schema
+    ref: "[[galaxy-workflow-draft]]"
+    used_at: runtime
+    load: upfront
+    mode: verbatim
+    evidence: cast-validated
+    purpose: "In/out contract: the draft this Mold reads and re-wires conforms to [[galaxy-workflow-draft]]; cast bundles the JSON Schema so the re-wired draft stays inside the superset the per-step loop expects."
+  - kind: research
+    ref: "[[galaxy-workflow-draft-format]]"
+    used_at: runtime
+    load: upfront
+    mode: verbatim
+    evidence: hypothesis
+    purpose: "Emit re-wired steps in the draft superset (TODO tool_id, _plan_* fields) so existing per-step machinery realizes them; respect the settle-vs-repair boundary."
+    verification: "Promote after a repair run inserts a producer the per-step loop then realizes without re-running the template Mold over the whole draft."
+  - kind: research
+    ref: "[[open-requirements-ledger]]"
+    used_at: runtime
+    load: upfront
+    mode: verbatim
+    evidence: hypothesis
+    purpose: "Read open blocking entries to scope the repair; mark each resolved or surrender it, feeding the loop's decreasing-blocker convergence gate."
+    verification: "Promote after a run closes a blocking entry and the loop terminates on the reduced open count."
+  - kind: research
+    ref: "[[galaxy-data-flow-draft-contract]]"
+    used_at: runtime
+    load: upfront
+    mode: verbatim
+    evidence: hypothesis
+    purpose: "Re-wire the affected region consistently with the data-flow design that settled the surrounding topology."
+    verification: "Promote after two repairs preserve the surrounding data-flow design without re-deriving it from the source."
+  - kind: research
+    ref: "[[galaxy-collection-semantics]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Preserve collection typing and map-over/reduction semantics when an inserted producer step joins or reshapes collection inputs."
+    trigger: "When the repair inserts or rewires steps touching collection inputs, outputs, or mapped/reduced connections."
+  - kind: pattern
+    ref: "[[galaxy-collection-patterns]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Choose a corpus-attested collection recipe when the missing producer is a collection construction, reshape, or bridge."
+    trigger: "When the repair sub-path needs collection cleanup, reshaping, relabeling, identifier synchronization, or a collection-tabular bridge."
+  - kind: pattern
+    ref: "[[galaxy-tabular-patterns]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Choose a corpus-attested tabular recipe when the missing evidence is a column, key, or aggregate a tabular step can produce."
+    trigger: "When the repair sub-path needs a computed column, join key, filter criterion, or aggregate the blocked step depends on."
+related_molds:
+  - "[[freeform-summary-to-galaxy-template]]"
+  - "[[implement-galaxy-tool-step]]"
+  - "[[compare-against-iwc-exemplar]]"
+---
+# repair-galaxy-draft-topology
+
+Topology is settled upstream by the `*-summary-to-galaxy-template` Mold, and the per-step loop is wrapper-tier — it does not edit topology. This Mold is the **escalation target** the loop reaches when implementation proves the settled topology cannot support a declared step: a step output that needs evidence no wired input carries (the connection graph validates fine, but nothing produces what the output requires). Wrapper-tier gaps — no Tool Shed wrapper picked yet — are not this case; those route through the discover-or-author branch.
+
+You are invoked with the partially-realized draft and the [[open-requirements-ledger]]. Read the open blocking entries: each names a step, the uncomputable output, and the missing evidence. Your job is **bounded topology repair** — not re-settling the workflow. Repair the named region and nothing else; the surrounding topology, already-realized steps, and workflow interface stay put.
+
+Decide the *shape* of the fix from the missing evidence, the surrounding data-flow design ([[galaxy-data-flow-draft-contract]]), IWC structure, and the pattern pages. It may be one producer step, or a small sub-path of a few tools, or — when the declared output is genuinely uncomputable and no producer exists — narrowing the step to what its inputs can support. Insert the new step(s) in the draft superset ([[galaxy-workflow-draft-format]]): concrete topology and edges, wrapper-tier `TODO` for `tool_id` and ports, `_plan_*` fields carrying intent. The existing discover-or-author → `summarize-galaxy-tool` → `implement-galaxy-tool-step` machinery realizes them on later loop iterations; do not resolve wrappers here.
+
+Then update the ledger. For each blocking entry your repair addresses, mark it `resolved` with a note on how (producer added, sub-path added, output narrowed). The loop's convergence gate counts open blocking entries and requires each escalation to strictly reduce that count, under a hard cap on escalations. If you cannot close an entry — no producer is discoverable and the output cannot be honestly narrowed — **surrender it**: leave it open with a note, so the terminal path writes it into the final draft as a labelled gap rather than spinning or fabricating. Never insert a producer whose own output is uncomputable from what feeds it; that grows the DAG without reducing the open count and the loop will not converge.

--- a/content/research/galaxy-workflow-draft-format.md
+++ b/content/research/galaxy-workflow-draft-format.md
@@ -15,6 +15,7 @@ related_notes:
   - "[[galaxy-data-flow-draft-contract]]"
   - "[[discover-shed-tool]]"
   - "[[galaxy-workflow-draft]]"
+  - "[[open-requirements-ledger]]"
 related_molds:
   - "[[nextflow-summary-to-galaxy-template]]"
   - "[[cwl-summary-to-galaxy-template]]"
@@ -22,6 +23,7 @@ related_molds:
   - "[[compare-against-iwc-exemplar]]"
   - "[[implement-galaxy-tool-step]]"
   - "[[advance-galaxy-draft-step]]"
+  - "[[repair-galaxy-draft-topology]]"
 summary: "gxformat2 draft superset: wrapper-tier TODOs (tool_id, tool_state, port names) plus _plan_state / _plan_context / _plan_in / _plan_out per tool step."
 ---
 
@@ -42,6 +44,8 @@ Each tool step is resolved to the tier its evidence supports — **evidence-gate
 - **Deferred** — `tool_id: TODO`, full `_plan_*`. Use when the evidence is weak, multi-candidate, a domain-specific scientific tool with no covering pattern or exemplar, or a corpus gap.
 
 Pin identity only on strong evidence — a wrapper an exemplar actually uses for the same operation, a worked pattern example, or a tool the source names explicitly — never on plausibility: a wrong pinned `tool_id` lets [[discover-shed-tool]] resolve the wrong tool's changeset instead of searching afresh. Port names follow the wrapper: real on a Resolved step, `TODO_<hint>` sentinels until the step resolves.
+
+The per-step loop does not edit topology — but it may **escalate back to a template-tier Mold** when implementation proves the settled topology can't support a declared step (see "Topology repair escalation" below). Wiring authority stays in the template tier; the loop only gains a path back to it.
 
 ## Relaxations vs. gxformat2
 
@@ -112,6 +116,17 @@ steps:
 - Carves a stable handoff between the template Mold and the per-step implementation Mold without sneaking tool resolution into either side.
 - Makes the boundary between topology (settled upstream) and wrapper-tier (deferred) explicit — the `_plan_*` family lives squarely on the deferred side.
 - Free-text `_plan_*` is intentional for v1: it lets the templating agent record intent without a contract pretending to be parameterizable yet. Structuring those fields is open work — see each template Mold's `refinement.md`.
+
+## Topology repair escalation
+
+The template Mold settles topology, but it can miss a **computability** gap: a step whose declared output needs evidence no wired input carries. The connection graph validates — ports connect — yet the step can't be implemented. The template's computability review pass catches most of these and either wires the producer or records the gap in the [[open-requirements-ledger]]; the rest surface in the per-step loop.
+
+When one surfaces, the per-step loop does not author topology to fix it. It **escalates**:
+
+- [[implement-galaxy-tool-step]] detects, while implementing, that the declared output can't be computed from the wired inputs. It appends a blocking entry to the [[open-requirements-ledger]] and falls through rather than fabricating the output.
+- [[repair-galaxy-draft-topology]] — a template-tier Mold sharing the template's reference set — reads the blocking entries and re-wires the affected region: one producer step, a small sub-path, or honest narrowing of the output. New steps land at draft (wrapper-tier `TODO`) tier, so the existing discover-or-author → implement machinery realizes them.
+
+This is **repair**, distinct from **settling**: it is narrow (one named region), reactive (only a detected computability gap triggers it), and bounded. The loop's convergence gate counts open blocking entries in the ledger; each escalation must strictly reduce that count, under a hard cap on escalations. When the cap is reached with entries still open, they are **surrendered** — written into the final draft as labelled gaps — the clean terminal that replaces spin-or-fabricate. So the boundary "topology decisions do not belong in the per-step loop" still holds: the loop never decides topology, it returns the decision to the template tier.
 
 ## Open work
 

--- a/content/research/open-requirements-ledger.md
+++ b/content/research/open-requirements-ledger.md
@@ -1,0 +1,91 @@
+---
+type: research
+subtype: design-spec
+title: "Open-requirements ledger"
+tags:
+  - research/design-spec
+  - target/galaxy
+status: draft
+created: 2026-06-16
+revised: 2026-06-16
+revision: 1
+ai_generated: true
+related_notes:
+  - "[[galaxy-workflow-draft-format]]"
+related_molds:
+  - "[[advance-galaxy-draft-step]]"
+  - "[[repair-galaxy-draft-topology]]"
+  - "[[implement-galaxy-tool-step]]"
+summary: "Carried unresolved-requirements artifact the source→Galaxy pipeline discharges or explicitly surrenders, autonomously."
+---
+
+# Open-requirements ledger
+
+The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact.
+
+## Framing: obligations the pipeline discharges, not questions a human answers
+
+This is deliberately *not* an "open questions for the user" list. The pipeline is autonomous — no human-in-the-loop gate is assumed. The ledger's consumers are **Molds and the loop's convergence gate**, with human readout a secondary affordance. An entry is closed by a downstream Mold doing work (wiring a producer, picking a wrapper, settling a value), or — when nothing can close it — surrendered: written into the final draft as a known, labelled gap rather than silently dropped or fabricated around.
+
+The distinction matters because a "questions for a human" framing leaks an operator's personal interaction style into a tool meant to run inside anyone's harness. The ledger must behave identically cast into a fresh harness with no ambient configuration; that holds only because every obligation is **materialized in the artifact**, never carried as operator habit.
+
+## Entry shape (v1, loose)
+
+Like the `_plan_*` family in [[galaxy-workflow-draft-format]], ledger entries are intentionally low-ceremony for v1 — enough structure to count and close, no contract pretending to be machine-parameterizable yet. A reasonable per-entry shape:
+
+```yaml
+- id: sccmec-evidence-missing
+  status: open                # open | resolved | surrendered
+  raised_by: implement-galaxy-tool-step   # Mold that appended it
+  step: classify_context       # draft step the obligation attaches to (if any)
+  unmet: "SCCmec-region candidate output category"
+  missing: "no wired input carries SCCmec cassette evidence"
+  resolved_by: null            # Mold that closed it, once closed
+  note: ""                     # how it was closed or why surrendered
+```
+
+Provenance (`raised_by`, `resolved_by`) is the audit trail for *when* each obligation entered and left — the traceability #281 asked for, and the evidence the convergence gate reads.
+
+## Role in topology repair
+
+In the Galaxy per-step loop, the ledger is the substrate the topology-repair escalation rides on (see [[galaxy-workflow-draft-format]] and [[repair-galaxy-draft-topology]]):
+
+- **[[implement-galaxy-tool-step]]** detects, mid-implementation, that a declared step output cannot be computed from its wired inputs — a defect invisible to `gxwf` structural validation, because the connection graph knows ports connect, not what they contain. Rather than fabricate, it appends a blocking entry and falls through to repair.
+- **[[repair-galaxy-draft-topology]]** reads the open blocking entries, re-wires the affected region (template-tier authoring — one step or a small sub-path), and marks each entry it closes `resolved`; the existing discover-or-author → implement machinery then realizes the new steps.
+- The loop's **decreasing-blocker invariant** counts open blocking entries: each repair escalation must strictly reduce that count, under a hard cap on escalations. When the cap is hit with entries still open, those entries are **surrendered** into the final draft — the clean terminal that replaces spin-or-fabricate.
+
+So the ledger is not a convenience here; it is the countable state the termination guard depends on.
+
+## Escalation budget (loop-level state)
+
+The decreasing-blocker invariant needs more than the entries themselves: "strictly reduce the open count, under a hard cap" is *loop-level* state — it spans iterations and belongs to no single entry. The ledger carries it in a small `topology_repair` header beside the `entries:` list:
+
+```yaml
+topology_repair:
+  escalations: 2           # repairs invoked this run
+  cap: 5                   # hard ceiling; at cap, still-open entries are surrendered
+  open_history: [4, 3, 2]  # open blocking-entry count after each escalation — must be strictly decreasing
+entries:
+  - id: sccmec-evidence-missing
+    status: open
+    # … per-entry shape above
+```
+
+- `escalations` — how many times [[advance-galaxy-draft-step]] has escalated to [[repair-galaxy-draft-topology]] this run. The orchestrator increments it on each escalation.
+- `cap` — the hard ceiling. When `escalations` reaches `cap`, the loop stops escalating and surrenders any still-`open` blocking entries into the final draft as labelled gaps rather than retrying forever.
+- `open_history` — the open blocking-entry count recorded after each escalation. The convergence gate requires it to be strictly decreasing: a repair that fails to lower the open count — or raises it by inserting a producer that is itself uncomputable — is non-convergent and trips the gate immediately, without waiting for the cap.
+
+This block lives in the ledger as a v1 expedient: the ledger is already the carried, cast-visible state the loop reads each iteration. Its better long-term home is the **draft itself** — a workflow-level annotation that travels with the artifact it bounds, so the budget survives even when the ledger is stripped at the terminal. Recorded here for now; migrate when the draft grows a home for it.
+
+## Threaded through the whole design tier
+
+The ledger is not loop-only. It is a single artifact every design-tier Mold in the source→Galaxy pipelines **consumes and re-emits** — the interface, reference-data, data-flow, IWC-comparison, and template Molds (`*-summary-to-galaxy-interface`, `*-summary-to-galaxy-data-flow`, `*-summary-to-galaxy-reference-data`, `compare-against-iwc-exemplar`, `*-summary-to-galaxy-template`). The first design Mold in a run creates it; each subsequent Mold reads the open entries, **appends** the unknowns it newly surfaces, and **marks resolved** the ones its own decisions close (the template settling a topology choice the data-flow left open, the interface pinning a parameter, …). This is the direct answer to #281: the chain stops re-deriving the same unknowns because each Mold inherits them.
+
+The template Mold's computability review pass is one notable appender — `*-summary-to-galaxy-template` re-reads each settled step and, where an output needs evidence no input carries, wires the producer or records the gap as a blocking entry. Source-summary Molds upstream of the design tier keep their own free-text open-questions; the design tier is where those formalize into the ledger.
+
+## Open work
+
+- Decide whether entry structure should harden (typed `unmet` / `missing`, links back to source-summary evidence, machine-checkable `status` transitions) once two or three worked runs exercise it.
+- Decide whether the source-summary Molds should also emit structured entries, or keep their free-text open-questions until the design tier formalizes them.
+- Specify how surrendered entries surface in the runnable gxformat2 (a workflow-level annotation, a report output, or a sidecar) when the draft is stripped of `_plan_*` and TODO sentinels.
+- Move the `topology_repair` escalation budget out of the ledger and into the draft (a workflow-level annotation) so it travels with the artifact it bounds; the ledger home is a v1 expedient.


### PR DESCRIPTION
> _Opened by Claude (AI assistant) on behalf of @jmchilton — not authored by them personally._

## Why

[#311](https://github.com/galaxyproject/foundry/issues/311): the per-step Galaxy authoring loop is **wrapper-tier only**. When a draft step's declared output can't be computed from the inputs wired to it — e.g. a classification category no upstream step produces — the loop's only paths are spin or fabricate. The connection graph validates (ports connect) but the step can't be implemented.

## Approach

The loop **never decides topology** — it escalates the decision back to the template tier. This preserves the draft-format boundary ("topology decisions do not belong in the per-step loop") rather than relaxing it.

- **`repair-galaxy-draft-topology`** (new Mold) — the escalation target. Bounded topology *repair* (insert a producer step or small sub-path, or honestly narrow the output) as distinct from the template Mold's *settling*. Reuses the template's reference set; emits draft-tier TODO steps the existing discover-or-author → implement machinery realizes.
- **`open-requirements-ledger`** (new artifact + research note) — reframes [#281](https://github.com/galaxyproject/foundry/issues/281) from "open questions for a human" to **obligations the autonomous pipeline discharges or explicitly surrenders**. It is the countable substrate for the loop's decreasing-blocker convergence invariant (each escalation must reduce open entries, under a hard cap; leftovers are surrendered into the draft as labelled gaps). Threaded read+write through the whole design tier (interface, data-flow, reference-data, design, IWC-compare, template) plus `implement-galaxy-tool-step` and `repair-galaxy-draft-topology`.
- **Detection** lives in `implement-galaxy-tool-step` (LLM, mid-implementation) — it can't live in the `gxwf` oracle, which is blind to whether wired inputs *carry* the needed evidence. It appends a blocking entry and falls through.
- **Pipelines** — the `implement-galaxy-tool-step` phase becomes an `implement-or-repair` `[branch]` with fallthrough to repair, mirroring `discover-or-author`, in all four Galaxy pipelines.
- **Template bodies** gain a computability-review pass targeting the ledger; design-tier bodies carry/append/resolve ledger entries (the threading is real, not inert frontmatter).
- Contract clause in `galaxy-workflow-draft-format.md` is **additive** (settle vs repair); glossary entries added; `Dashboard.md`/`Index.md` regenerated.

## Validation

`npm run validate` → 0 errors (158 pre-existing warnings, unchanged). `npm run test` → 100 pass.

## Known follow-ups (left as open work)

- How `validate-galaxy-step` treats a step backed by a *surrendered* (still-open) ledger entry is unspecified.
- How surrendered entries surface in the stripped runnable gxformat2.
- `implement-galaxy-tool-step` remains a stub apart from the now-real blocking-entry behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
