### PR TITLE
find-test-data: read the source summary, not just the design briefs

### DIFF
--- a/casts/claude/skills/find-test-data/SKILL.md
+++ b/casts/claude/skills/find-test-data/SKILL.md
@@ -13,7 +13,12 @@ Follow the procedure below and use the artifact/reference sections as the runtim
 
 ## Inputs
 
-- No upstream artifact inputs declared. See the procedure for user-supplied runtime inputs.
+- Read artifact `freeform-summary`. Produced by `interview-to-freeform-summary`, `summarize-paper`. Source summary from summarize-paper / interview-to-freeform-summary; mine its sample-data, public-data-candidate, accession, and data-sizing guidance — this is where the source's dataset evidence lives (the design briefs strip it).
+- Read artifact `summary-nextflow`. Schema: summary-nextflow. Produced by `summarize-nextflow`. Source summary from summarize-nextflow; mine its test_fixtures / sample-data evidence when running the NEXTFLOW → GALAXY pipeline.
+- Read artifact `summary-cwl`. Schema: summary-cwl. Produced by `summarize-cwl`. Source summary from summarize-cwl; mine its test-data / sample-data evidence when running the CWL → GALAXY pipeline.
+- Read artifact `freeform-galaxy-interface`. Produced by `freeform-summary-to-galaxy-interface`. Galaxy interface brief from freeform-summary-to-galaxy-interface pinning input labels, collection shapes, and datatypes for the PAPER / INTERVIEW → GALAXY pipelines.
+- Read artifact `nextflow-galaxy-interface`. Produced by `nextflow-summary-to-galaxy-interface`. Galaxy interface brief from nextflow-summary-to-galaxy-interface pinning input labels, collection shapes, and datatypes for the NEXTFLOW → GALAXY pipeline.
+- Read artifact `cwl-galaxy-interface`. Produced by `cwl-summary-to-galaxy-interface`. Galaxy interface brief from cwl-summary-to-galaxy-interface pinning input labels, collection shapes, and datatypes for the CWL → GALAXY pipeline.
 
 ## Outputs
 
@@ -38,21 +43,23 @@ Follow the procedure below and use the artifact/reference sections as the runtim
 
 ## Procedure
 
-Resolve concrete test data for the workflow's inputs. Read the upstream data-flow / interface brief, and for each workflow input search the IWC corpus and public sources for data that matches its Galaxy collection shape and datatype. Emit `test-data-refs.json`: one entry per input, each carrying a URL or path plus the expected shape, ready for implement-galaxy-workflow-test to stage.
+Resolve concrete test data for the workflow's inputs. Read the interface brief for each input's Galaxy shape and datatype, **and the source summary for the data the source itself names** — then search IWC fixtures and public sources for data that matches. Emit `test-data-refs.json`: one entry per input, each carrying a URL or path plus the expected shape, ready for implement-galaxy-workflow-test to stage.
 
 This skill is the first leg of the harness's `test-data-resolution` branch. It resolves what it can and reports gaps; the harness routes any unresolved input to the `user-supplied` fallthrough. Deciding to ask the user is a harness concern, not this skill's — its job is an honest, source-backed match.
 
 ### Sequence
 
-1. **Read the brief.** From the data-flow / interface brief, enumerate the workflow inputs: label, Galaxy collection shape (File / list / paired / list:paired / record), and datatype.
-2. **Search IWC fixtures first.** Prefer existing IWC test data for the same domain — it already conforms to the conventions in iwc-test-data-conventions (remote URL, recorded hash, known collection layout). A near-neighbour IWC workflow's `-tests.yml` is the strongest source.
-3. **Fall to public sources.** When no IWC fixture fits, look for small public data (Zenodo, reference data archives) sized for a fast test run, matching the datatype and shape.
-4. **Emit refs.** Write one `test-data-refs.json` entry per input: the URL/path, the expected Galaxy shape, datatype, and integrity hash when known. Per galaxy-workflow-testability-design, make sure each entry maps to an addressable input label.
-5. **Report gaps.** For any input with no acceptable match, emit the input with `resolved: false` and a short reason rather than a guessed URL. These are what the harness hands to `user-supplied`.
+1. **Enumerate inputs and their required shape.** From the interface brief, list each workflow input: label, Galaxy collection shape (File / list / paired / list:paired / record), and datatype. This is the *target shape* every match must satisfy.
+2. **Mine the source summary for named data.** The interface and data-flow briefs are design artifacts — they deliberately drop dataset provenance. The source summary (`freeform-summary` / `summary-nextflow` / `summary-cwl`) is where the source names its data: sample-data locations, accessions, public-data candidates, fallback bundles, and sizing guidance ("one chromosome", "precomputed count matrix", "small subset"). Pull every candidate dataset and every data-sizing instruction the source gives.
+3. **Match each named candidate against the required shape — and don't stop at a shape mismatch.** Check each candidate against step 1's target shape and datatype. A candidate that is the wrong *shape* (e.g. raw signal / reads named when the input is a count matrix) is **not** a resolution — but it is also **not** the end of the search. When the source's named candidates don't fit, follow the source's own guidance to the right-shape public artifact: if the source says the input is a precomputed count matrix, find the canonical public count matrix for that study/domain (GEO/ENCODE/ArrayExpress series, a published supplementary table) rather than reporting "no data." "Named candidates are the wrong shape" ≠ "no data exists."
+4. **Search IWC fixtures and public sources.** Prefer existing IWC test data for the same domain — it already conforms to iwc-test-data-conventions (remote URL, recorded hash, known collection layout); a near-neighbour IWC `-tests.yml` is the strongest source. Otherwise resolve the right-shape public dataset found in step 3, sized for a fast test run.
+5. **"Small" is a documented subset of a real source, not a fabricated stand-in.** When the source asks for a small fixture (one chromosome, selected loci, a few samples) and only a full real dataset exists, that input is **resolved**: record the real source URL plus the data-import-boundary prep needed to reach the small shape (row-subset by key, column/sample split into the collection's element identifiers). The prep is a note on the ref, not an analysis step and not an excuse to mark the input unresolved. Resolve the *data*; leave analysis parameters (factors, thresholds, reference levels, top-N) to the design skills — they are not this skill's to decide.
+6. **Emit refs.** Write one `test-data-refs.json` entry per input: the URL/path, the expected Galaxy shape, datatype, element identifiers when it is a collection, integrity hash when known, and any subset/split prep. Per galaxy-workflow-testability-design, make sure each entry maps to an addressable input label.
+7. **Report genuine gaps only.** Mark `resolved: false` with a reason **only** when steps 2–5 turn up no real source of the right shape — not merely because the source's first-named candidate was the wrong shape or because a real source needs a documented subset. These honest gaps are what the harness hands to `user-supplied`.
 
 ### No fabrication
 
-Never invent a URL, accession, or path to make an input look resolved. A wrong-but-plausible fixture reference is worse than an honest gap: it survives static checks and fails only at run time, far from this skill. Every emitted ref must point at data that exists; everything else is a reported gap.
+Never invent a URL, accession, or path to make an input look resolved, and never emit a placeholder path (`sampleA.tabular`, `test-data/…`) for an input you could not resolve — an unresolved input stays `resolved: false` all the way through to the test, never papered over with a made-up path downstream. A wrong-but-plausible fixture reference is worse than an honest gap: it survives static checks and fails only at run time, far from this skill. Every emitted ref must point at data that exists (a real source, optionally plus a reproducible subset/split); everything else is a reported gap.
 
 ## Runtime Notes
 

--- a/casts/claude/skills/find-test-data/_provenance.json
+++ b/casts/claude/skills/find-test-data/_provenance.json
@@ -5,10 +5,10 @@
     "name": "find-test-data",
     "path": "content/molds/find-test-data/index.md",
     "revision": 2,
-    "content_hash": "607db69e32896890701577c9f156be662cce1371ac915cbfeb7244c602836e75",
-    "commit": "64a340bb8e24e9949be9cbd6678a51da42d14203"
+    "content_hash": "51697d0a76f73ecd17a93bcaf50f21bcd7311ed98de122c2790ac997c8acd44e",
+    "commit": "72b20f2ba4575f1414f2a083aab683e6147e5dcc"
   },
-  "cast_at": "2026-06-15T13:53:32.337Z",
+  "cast_at": "2026-06-19T15:13:10.016Z",
   "refs": [
     {
       "kind": "research",
@@ -50,6 +50,52 @@
         "description": "Test data matched from IWC fixtures or public sources, expressed as URLs/paths plus expected shapes for downstream test authoring."
       }
     ],
-    "consumes": []
+    "consumes": [
+      {
+        "id": "freeform-summary",
+        "description": "Source summary from [[summarize-paper]] / [[interview-to-freeform-summary]]; mine its sample-data, public-data-candidate, accession, and data-sizing guidance — this is where the source's dataset evidence lives (the design briefs strip it).",
+        "producers": [
+          "interview-to-freeform-summary",
+          "summarize-paper"
+        ]
+      },
+      {
+        "id": "summary-nextflow",
+        "description": "Source summary from [[summarize-nextflow]]; mine its test_fixtures / sample-data evidence when running the NEXTFLOW → GALAXY pipeline.",
+        "inherited_schema": "[[summary-nextflow]]",
+        "producers": [
+          "summarize-nextflow"
+        ]
+      },
+      {
+        "id": "summary-cwl",
+        "description": "Source summary from [[summarize-cwl]]; mine its test-data / sample-data evidence when running the CWL → GALAXY pipeline.",
+        "inherited_schema": "[[summary-cwl]]",
+        "producers": [
+          "summarize-cwl"
+        ]
+      },
+      {
+        "id": "freeform-galaxy-interface",
+        "description": "Galaxy interface brief from [[freeform-summary-to-galaxy-interface]] pinning input labels, collection shapes, and datatypes for the PAPER / INTERVIEW → GALAXY pipelines.",
+        "producers": [
+          "freeform-summary-to-galaxy-interface"
+        ]
+      },
+      {
+        "id": "nextflow-galaxy-interface",
+        "description": "Galaxy interface brief from [[nextflow-summary-to-galaxy-interface]] pinning input labels, collection shapes, and datatypes for the NEXTFLOW → GALAXY pipeline.",
+        "producers": [
+          "nextflow-summary-to-galaxy-interface"
+        ]
+      },
+      {
+        "id": "cwl-galaxy-interface",
+        "description": "Galaxy interface brief from [[cwl-summary-to-galaxy-interface]] pinning input labels, collection shapes, and datatypes for the CWL → GALAXY pipeline.",
+        "producers": [
+          "cwl-summary-to-galaxy-interface"
+        ]
+      }
+    ]
   }
 }

--- a/casts/claude/skills/find-test-data/_verify.json
+++ b/casts/claude/skills/find-test-data/_verify.json
@@ -1,4 +1,29 @@
 {
   "verify_schema_version": 1,
-  "entries": []
+  "entries": [
+    {
+      "artifact_id": "summary-cwl",
+      "direction": "input",
+      "kind": "json",
+      "default_filename": "summary-cwl.json",
+      "schema": "[[summary-cwl]]",
+      "validator_bin": "foundry",
+      "args": [
+        "validate-summary-cwl",
+        "{artifact_path}"
+      ]
+    },
+    {
+      "artifact_id": "summary-nextflow",
+      "direction": "input",
+      "kind": "json",
+      "default_filename": "summary-nextflow.json",
+      "schema": "[[summary-nextflow]]",
+      "validator_bin": "foundry",
+      "args": [
+        "validate-summary-nextflow",
+        "{artifact_path}"
+      ]
+    }
+  ]
 }

--- a/content/molds/find-test-data/index.md
+++ b/content/molds/find-test-data/index.md
@@ -10,6 +10,19 @@ revised: 2026-06-12
 revision: 2
 ai_generated: true
 summary: "Search IWC fixtures and public sources for test data matching a data-flow shape."
+input_artifacts:
+  - id: freeform-summary
+    description: "Source summary from [[summarize-paper]] / [[interview-to-freeform-summary]]; mine its sample-data, public-data-candidate, accession, and data-sizing guidance — this is where the source's dataset evidence lives (the design briefs strip it)."
+  - id: summary-nextflow
+    description: "Source summary from [[summarize-nextflow]]; mine its test_fixtures / sample-data evidence when running the NEXTFLOW → GALAXY pipeline."
+  - id: summary-cwl
+    description: "Source summary from [[summarize-cwl]]; mine its test-data / sample-data evidence when running the CWL → GALAXY pipeline."
+  - id: freeform-galaxy-interface
+    description: "Galaxy interface brief from [[freeform-summary-to-galaxy-interface]] pinning input labels, collection shapes, and datatypes for the PAPER / INTERVIEW → GALAXY pipelines."
+  - id: nextflow-galaxy-interface
+    description: "Galaxy interface brief from [[nextflow-summary-to-galaxy-interface]] pinning input labels, collection shapes, and datatypes for the NEXTFLOW → GALAXY pipeline."
+  - id: cwl-galaxy-interface
+    description: "Galaxy interface brief from [[cwl-summary-to-galaxy-interface]] pinning input labels, collection shapes, and datatypes for the CWL → GALAXY pipeline."
 output_artifacts:
   - id: test-data-refs
     kind: json
@@ -35,18 +48,20 @@ references:
 ---
 # find-test-data
 
-Resolve concrete test data for the workflow's inputs. Read the upstream data-flow / interface brief, and for each workflow input search the IWC corpus and public sources for data that matches its Galaxy collection shape and datatype. Emit `test-data-refs.json`: one entry per input, each carrying a URL or path plus the expected shape, ready for [[implement-galaxy-workflow-test]] to stage.
+Resolve concrete test data for the workflow's inputs. Read the interface brief for each input's Galaxy shape and datatype, **and the source summary for the data the source itself names** — then search IWC fixtures and public sources for data that matches. Emit `test-data-refs.json`: one entry per input, each carrying a URL or path plus the expected shape, ready for [[implement-galaxy-workflow-test]] to stage.
 
 This Mold is the first leg of the harness's `test-data-resolution` branch. It resolves what it can and reports gaps; the harness routes any unresolved input to the `user-supplied` fallthrough. Deciding to ask the user is a harness concern, not this Mold's — its job is an honest, source-backed match.
 
 ## Sequence
 
-1. **Read the brief.** From the data-flow / interface brief, enumerate the workflow inputs: label, Galaxy collection shape (File / list / paired / list:paired / record), and datatype.
-2. **Search IWC fixtures first.** Prefer existing IWC test data for the same domain — it already conforms to the conventions in [[iwc-test-data-conventions]] (remote URL, recorded hash, known collection layout). A near-neighbour IWC workflow's `-tests.yml` is the strongest source.
-3. **Fall to public sources.** When no IWC fixture fits, look for small public data (Zenodo, reference data archives) sized for a fast test run, matching the datatype and shape.
-4. **Emit refs.** Write one `test-data-refs.json` entry per input: the URL/path, the expected Galaxy shape, datatype, and integrity hash when known. Per [[galaxy-workflow-testability-design]], make sure each entry maps to an addressable input label.
-5. **Report gaps.** For any input with no acceptable match, emit the input with `resolved: false` and a short reason rather than a guessed URL. These are what the harness hands to `user-supplied`.
+1. **Enumerate inputs and their required shape.** From the interface brief, list each workflow input: label, Galaxy collection shape (File / list / paired / list:paired / record), and datatype. This is the *target shape* every match must satisfy.
+2. **Mine the source summary for named data.** The interface and data-flow briefs are design artifacts — they deliberately drop dataset provenance. The source summary (`freeform-summary` / `summary-nextflow` / `summary-cwl`) is where the source names its data: sample-data locations, accessions, public-data candidates, fallback bundles, and sizing guidance ("one chromosome", "precomputed count matrix", "small subset"). Pull every candidate dataset and every data-sizing instruction the source gives.
+3. **Match each named candidate against the required shape — and don't stop at a shape mismatch.** Check each candidate against step 1's target shape and datatype. A candidate that is the wrong *shape* (e.g. raw signal / reads named when the input is a count matrix) is **not** a resolution — but it is also **not** the end of the search. When the source's named candidates don't fit, follow the source's own guidance to the right-shape public artifact: if the source says the input is a precomputed count matrix, find the canonical public count matrix for that study/domain (GEO/ENCODE/ArrayExpress series, a published supplementary table) rather than reporting "no data." "Named candidates are the wrong shape" ≠ "no data exists."
+4. **Search IWC fixtures and public sources.** Prefer existing IWC test data for the same domain — it already conforms to [[iwc-test-data-conventions]] (remote URL, recorded hash, known collection layout); a near-neighbour IWC `-tests.yml` is the strongest source. Otherwise resolve the right-shape public dataset found in step 3, sized for a fast test run.
+5. **"Small" is a documented subset of a real source, not a fabricated stand-in.** When the source asks for a small fixture (one chromosome, selected loci, a few samples) and only a full real dataset exists, that input is **resolved**: record the real source URL plus the data-import-boundary prep needed to reach the small shape (row-subset by key, column/sample split into the collection's element identifiers). The prep is a note on the ref, not an analysis step and not an excuse to mark the input unresolved. Resolve the *data*; leave analysis parameters (factors, thresholds, reference levels, top-N) to the design Molds — they are not this Mold's to decide.
+6. **Emit refs.** Write one `test-data-refs.json` entry per input: the URL/path, the expected Galaxy shape, datatype, element identifiers when it is a collection, integrity hash when known, and any subset/split prep. Per [[galaxy-workflow-testability-design]], make sure each entry maps to an addressable input label.
+7. **Report genuine gaps only.** Mark `resolved: false` with a reason **only** when steps 2–5 turn up no real source of the right shape — not merely because the source's first-named candidate was the wrong shape or because a real source needs a documented subset. These honest gaps are what the harness hands to `user-supplied`.
 
 ## No fabrication
 
-Never invent a URL, accession, or path to make an input look resolved. A wrong-but-plausible fixture reference is worse than an honest gap: it survives static checks and fails only at run time, far from this Mold. Every emitted ref must point at data that exists; everything else is a reported gap.
+Never invent a URL, accession, or path to make an input look resolved, and never emit a placeholder path (`sampleA.tabular`, `test-data/…`) for an input you could not resolve — an unresolved input stays `resolved: false` all the way through to the test, never papered over with a made-up path downstream. A wrong-but-plausible fixture reference is worse than an honest gap: it survives static checks and fails only at run time, far from this Mold. Every emitted ref must point at data that exists (a real source, optionally plus a reproducible subset/split); everything else is a reported gap.

--- a/content/molds/find-test-data/refinements/2026-06-19-interview-atac-diff-accessibility.md
+++ b/content/molds/find-test-data/refinements/2026-06-19-interview-atac-diff-accessibility.md
@@ -1,0 +1,68 @@
+---
+mold: find-test-data
+date: 2026-06-19
+intent: INTERVIEW→GALAXY pipeline test-drive on the differential ATAC-seq accessibility scenario (galaxy-brain #14 / UC3)
+decision: eval-add
+---
+
+## What happened
+
+On the first emulation pass this Mold marked **both** workflow inputs
+(`ATAC counts`, `sample metadata`) `resolved: false` and fell through the
+`test-data-resolution` chain to the `user-supplied` sentinel — and the
+downstream `implement-galaxy-workflow-test` then staged **invented placeholder
+paths** (`test-data/counts/sampleA_rep1.tabular`, …). That is a double failure:
+a fabricated-data smell, and a *missed real resolution*. Real public data
+matching the data-flow shape was deducible:
+
+- **Corces 2016 ATAC count matrix — GEO `GSE74912`**
+  (`GSE74912_ATACseq_All_Counts.txt.gz`, 590,650 peaks × 132 samples, hg19),
+  a real URL (verified HTTP 200). This is the canonical public ATAC **count
+  matrix** and the source the published SI recipe uses.
+- The ENCODE accessions the issue named (ENCFF…/ENCSR…) are raw signal / peak
+  files — they do **not** match the peak×sample count-matrix input shape, so
+  "the issue's named candidates don't resolve" is *not* the same as "no data
+  exists." The Mold stopped at the former.
+- The GTN epigenetics/atac-seq tutorial (Zenodo 3862793) is single-sample chr22
+  raw-read preprocessing — confirms the upstream tier, supplies no count matrix.
+
+## Gaps surfaced
+
+1. **Never emit invented placeholder paths.** When resolution genuinely fails,
+   the entry must stay `resolved:false` with a reason and the branch must route
+   to `user-supplied` honestly — but the *implement* step must not then fabricate
+   paths. (This run's invented `sampleA/sampleB` paths are the thing the
+   no-fabricated-references property is meant to forbid; it held for the refs
+   file but the fabrication leaked into the tests file instead.)
+2. **Shape-mismatch ≠ no-data.** When the source names candidate datasets that
+   are the *wrong shape* for the required input, the Mold should keep searching
+   public sources for the right-shape artifact (here: a GEO/array-express count
+   matrix), not give up. A canonical public count matrix that matches the
+   data-flow shape outranks a same-domain raw-signal accession that doesn't.
+3. **"Small" = a documented subset of a real source, not a fabricated bundle.**
+   The issue's "keep to one chromosome / selected loci" is satisfied by a
+   row-subset (by peak-id chromosome prefix) + column-split of the real matrix —
+   a data-import-boundary prep — not by inventing a tiny stand-in. Record the
+   real source + the reproducible prep, and leave design parameters (factor,
+   reference level, thresholds, top-N) to the design Molds.
+
+## Proposed eval-add
+
+- A property: *no fabricated paths anywhere downstream* — extend the
+  no-fabricated-references guard so the staged test (`implement-galaxy-workflow-test`)
+  cannot introduce invented input paths for inputs this Mold left unresolved;
+  unresolved inputs stay unresolved through to the test, flagged, never
+  papered over with placeholder paths.
+- A property: *shape-driven public search* — when a source's named candidate
+  datasets don't match the required input shape, the run records that mismatch
+  *and* whether a shape-matching public source exists, rather than terminating
+  at "named candidates don't fit."
+
+## Open questions
+
+- Should `find-test-data` carry a small registry of canonical public matrices /
+  reference datasets per domain (GEO/ENCODE/ArrayExpress) so "the right-shape
+  public source" is reachable without re-deriving it each run?
+- Where does the subset+split prep belong — a note on the refs, or a real
+  data-prep Mold/step — so a future CI run can regenerate the small fixture from
+  GSE74912 deterministically?


### PR DESCRIPTION
## Problem

`find-test-data` declared **zero input artifacts**, and its procedure read only the data-flow / interface brief. Those briefs are *design* artifacts — they deliberately strip dataset provenance. So the Mold never saw the source's named datasets, accessions, public-data candidates, or sizing guidance (which live in the **source summary**), and could only emit `resolved: false` → `user-supplied` even when real test data was deducible from the source.

Surfaced by a `/test-pipeline interview-to-galaxy "differential ATAC-seq accessibility"` run: the Mold fell through to `user-supplied` and a downstream step then staged invented placeholder paths, when the issue carried enough to resolve a real public count matrix (GEO `GSE74912`).

## Fix (`content/molds/find-test-data/index.md`, re-cast)

- **Declare the inputs it actually needs**: the source summary (`freeform-summary` / `summary-nextflow` / `summary-cwl`) for dataset evidence, plus the `*-galaxy-interface` brief for input labels/shapes, across the three Galaxy-targeting pipelines.
- **Mine the source summary** for named datasets, accessions, fallback bundles, and data-sizing instructions.
- **Don't stop at a shape mismatch** — a wrong-shape named candidate (e.g. raw signal when the input is a count matrix) is not a resolution *and not the end of the search*; follow the source's own guidance to the right-shape public artifact (GEO/ENCODE/ArrayExpress, a published supplementary table).
- **"Small" = a documented subset/split of a real source** = resolved (record source + import-boundary prep), not a gap.
- **Resolve data only** — leave factors/thresholds/reference-level/top-N to the design Molds.
- **Never emit placeholder paths** downstream for an unresolved input.

Includes the refinement-journal entry that motivated the change.

## Validation

- `npm run validate` → 0 errors. New advisory warnings are the same cross-pipeline "input not produced locally" pattern `compare-against-iwc-exemplar` already emits for its polymorphic source inputs.
- Cast regenerated; `cast-skill-verify` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)