### PR TITLE
scenarios: 4 spec-only INTERVIEW → GALAXY cases (galaxy-brain #27-30)

### DIFF
--- a/content/pipelines/interview-to-galaxy/examples/UC4_HYPHY_issue.md
+++ b/content/pipelines/interview-to-galaxy/examples/UC4_HYPHY_issue.md
@@ -1,0 +1,96 @@
+# UC4 / HyPhy molecular-selection landscape across Dengue CDS genes — interview input
+
+> Pulled-down GitHub issue used as the **effective result of the INTERVIEW → GALAXY interview**
+> (the live interview mechanics are harness-owned and precede pipeline phase 1).
+> Source: galaxy-brain issue #27 (captured verbatim from the issue body).
+> No paired reference target: this case is **spec-only** — there is no vendored `.ga` golden to
+> reproduce. Judge the run against the `expect:` block in `scenarios.md` (an agent checks the
+> produced workflow against the issue's load-bearing intent at the end of the journey).
+
+---
+
+## Purpose
+
+Develop a Galaxy Notebooks paper/demo vignette for a molecular-evolution / natural-selection analysis. We are writing a paper about "Galaxy Notebooks" — history-attached Galaxy-flavored markdown documents that embed REAL on-graph Galaxy tool outputs (tables, heatmaps, plots, images) into narrative, and from which a reusable workflow can be extracted by walking the history provenance graph backward. The discipline that matters: every figure/table the notebook displays should be a genuine on-graph tool output (so it's auditable AND seeds workflow extraction), analyses should run as collection map-overs where possible, and off-graph/pasted artifacts should be avoided. This issue belongs to `galaxy-brain` because the deliverable is a paper/demo notebook, NOT a proposal to add or change an IWC workflow.
+
+## Objective
+
+Show the conceptual jump from "run one selection test on one gene alignment" to "map a whole panel of HyPhy selection methods across a collection of codon alignments, then collapse the per-gene JSONs into a single cross-gene summary table you can read as a selection landscape."
+
+- **MVP (Core):** Per-gene episodic diversifying vs. purifying selection across the two Dengue CDS genes that ship in the IWC test data, using MEME / FEL / BUSTED / PRIME run as a collection map-over, summarized into one combined table + per-site table.
+- **Stretch (Compare):** Has selection pressure *shifted* between historical (1980–2004) and recent (2023) DENV1 lineages? Label the three recent 2023 isolates as foreground and run RELAX (intensification/relaxation) and Contrast-FEL (CFEL, site-level foreground-vs-background dN/dS contrast), summarized into a combined comparison table.
+
+## Why this is a useful demo deviation
+
+The IWC HyPhy workflows are batch pipelines that emit collections of per-gene JSON blobs — machine-readable but not human-narratable. A notebook is exactly the right surface to turn those JSONs into an interpreted selection landscape: a combined summary table across genes, a per-site significance view, and (for Compare) an explicit "did selection relax or intensify in recent lineages" verdict. It also showcases two notebook-friendly Galaxy patterns at once: **collection map-over** (one HyPhy tool fanned across a codon-alignment collection) and **provenance-driven workflow extraction** (the combined-summary tool sits at the bottom of the graph, so walking backward reconstructs the full preprocessing + per-method pipeline). DRHIP, the combined-summary tool, gives us genuine on-graph tables to embed instead of hand-parsing JSON off-graph.
+
+## Existing analysis anchors
+
+IWC repo: https://github.com/galaxyproject/iwc — workflows under `workflows/comparative_genomics/hyphy/`.
+
+- `hyphy-core.ga` — Core selection panel as a per-gene map-over. Key tools (all `2.5.96+galaxy0`, genetic code `Universal`):
+  - `toolshed.g2.bx.psu.edu/repos/iuc/hyphy_meme/hyphy_meme/2.5.96+galaxy0` (MEME — episodic diversifying selection per site)
+  - `toolshed.g2.bx.psu.edu/repos/iuc/hyphy_fel/hyphy_fel/2.5.96+galaxy0` (FEL — pervasive site-level selection)
+  - `toolshed.g2.bx.psu.edu/repos/iuc/hyphy_busted/hyphy_busted/2.5.96+galaxy0` (BUSTED — gene-wide episodic selection)
+  - `toolshed.g2.bx.psu.edu/repos/iuc/hyphy_prime/hyphy_prime/2.5.96+galaxy0` (PRIME — property-informed selection)
+  - Exposed Core workflow outputs are the JSON collections `meme_output`, `fel_output`, `busted_output`, `prime_output`. Note: each HyPhy tool also produces an `*_md_report` markdown output, but those are NOT wired as workflow outputs in `hyphy-core.ga` — TASK to verify whether to surface them or rely on DRHIP.
+- `hyphy-preprocessing.ga` — codon-aware preprocessing chain feeding Core: `remove_terminal_stop_codons/1.0.0+galaxy0` → `collapse_dataset/5.1.0` → `ucsc_fasplit/fasplit/482` → `cawlign/0.1.15+galaxy0` (codon-aware alignment against the reference CDS) → `hyphy_cln/hyphy_cln/2.5.96+galaxy0` (CLN cleanup) → `iqtree/2.4.0+galaxy1` (per-gene ML tree). Outputs: codon-aware alignment collection (`output_file`) + gene-tree collection (`treefile`).
+- `hyphy-compare.ga` — foreground-vs-background contrast. Tools: `hyphy_annotate/2.5.96+galaxy0` (label foreground + reference branches on the trees), `hyphy_relax/hyphy_relax/2.5.96+galaxy0` (RELAX), `hyphy_cfel/hyphy_cfel/2.5.96+galaxy0` (Contrast-FEL). Takes the codon-alignment collection, the tree collection, and a foreground sequence list; exposes `labeled_tree`, `relax_output`, `cfel_output`.
+- `capheine-core-and-compare.ga` — the orchestrator (inspired by veg/capheine). It runs Preprocessing → Core, and optionally Compare (foreground via regex or explicit list). Crucially it ends in a **DRHIP** step `toolshed.g2.bx.psu.edu/repos/iuc/drhip/drhip/0.1.4+galaxy0` that collapses the per-gene JSONs into combined tables exposed as workflow outputs: `combined_summary`, `combined_sites`, `combined_comparison_summary`, `combined_comparison_site`. These are the on-graph tables the notebook should embed.
+
+## Public data candidates
+
+All anchor test data ships **in-repo** under `workflows/comparative_genomics/hyphy/test-data/` — no Zenodo/NCBI fetch is required to reproduce the MVP. What's actually present:
+
+- `denv1_ref_cds.fasta` — the reference CDS. **Only two genes**: `NC_001477.1|capsid_protein_C|95-394_DENV1` and `NC_001477.1|membrane_glycoprotein precursor_prM|437-934`. So the Core "landscape" spans two genes, not the full DENV1 polyprotein. (TASK: decide whether to enrich the reference with more DENV1 CDS regions from NCBI for a richer paper figure, or keep it honest at two genes for the reproducible MVP.)
+- `unaligned_seqs/` — **39 DENV1 isolate FASTAs**, named `ACCESSION|YEAR`, spanning 1980–2023. Historical accessions include `AY732474.1|1980`, `AY732483.1|1981`, `AY732481.1|1982`, `AF298807.1|1998`, `AB204803.1|2004`, etc. Recent 2023 lineage accessions are the `PP563xxx`/`PP564823` series (e.g. `PP563826.1|2023-08-21` … `PP564823.1|2023-10-06`).
+- `foreground_seqs_list.txt` — defines the Compare foreground as **three recent 2023 isolates**: `PP563838_1_2023_09_30`, `PP563839_1_2023_09_29`, `PP563841_1_2023_09_25` (underscore-normalized form of the accession|date names). This is the historical-vs-2023 contrast the test suite actually exercises.
+- `codon_alignments/` — precomputed codon alignments `capsid_protein_C.fasta`, `membrane_glycoprotein.fasta` (these let Compare run without re-aligning).
+- `iqtree_trees/` — precomputed per-gene trees `capsid_protein_C.nhx`, `membrane_glycoprotein.nhx`.
+
+**Recommendation:** Anchor the *paper story* on **Compare** (historical 1980–2004 vs. 2023 RELAX/CFEL shift) because that's the novel, narratable question and the foreground list is curated for exactly this contrast — but ship **Core** as the simpler MVP first, since Core has no foreground dependency and its combined summary table is the cleanest "selection landscape" artifact. Present Compare as the headline figure, Core as the foundation. Caveat the small reference panel (two genes) and small foreground (three sequences) honestly in the narrative.
+
+## Notebook workflow plan
+
+1. Import the reference CDS (`denv1_ref_cds.fasta`) as a single dataset and the 39 unaligned isolates as a **list collection** (one element per isolate). For Compare, also import `foreground_seqs_list.txt`.
+2. Run codon-aware **Preprocessing** end-to-end (remove terminal stop codons → collapse → faSplit → `cawlign` against the reference → CLN → IQ-TREE), yielding a **codon-alignment collection** and a **gene-tree collection**, both keyed by gene. Display the alignment collection as an on-graph artifact. (MVP shortcut: import the precomputed `codon_alignments/` + `iqtree_trees/` collections directly to skip alignment runtime.)
+3. **Core, as a collection map-over:** run MEME, FEL, BUSTED, and PRIME (genetic code `Universal`) each mapped over the codon-alignment collection → four per-gene JSON collections on-graph.
+4. Run **DRHIP** (`drhip/0.1.4+galaxy0`) over the JSON collections to produce `combined_summary` (per-gene gene-wide selection verdicts) and `combined_sites` (per-site significant codons across genes). Embed both tables directly.
+5. **Compare branch (stretch):** `hyphy_annotate` to label the 2023 foreground + reference branches on the gene trees (→ `labeled_tree` collection), then RELAX and Contrast-FEL mapped over the (labeled-tree, alignment) pairs → `relax_output` + `cfel_output` JSON collections.
+6. Run **DRHIP** comparison mode → `combined_comparison_summary` (RELAX K intensification/relaxation per gene) and `combined_comparison_site` (CFEL site-level foreground-vs-background dN/dS contrasts). Embed as the headline tables.
+7. Narrative interpretation cells beside each table: which genes/sites are under episodic diversifying (MEME) vs. pervasive (FEL) vs. gene-wide (BUSTED) selection; and whether RELAX reports relaxation (K<1) or intensification (K>1) in the 2023 lineage, with CFEL sites flagged.
+
+## Expected paper/demo artifacts
+
+- Codon-aware alignment collection (FASTA, per gene) — on-graph, audit-visible.
+- Per-gene ML phylogenies (Newick/NHX), shown rendered; for Compare, the **foreground-labeled tree** highlighting the 2023 isolates.
+- `combined_summary` table: per-gene gene-wide selection verdicts (BUSTED p-value, ω classes, etc.).
+- `combined_sites` table: per-site MEME/FEL significant codons across both genes — the "selection landscape" table, optionally rendered as a per-site significance heatmap/strip plot keyed on codon position.
+- `combined_comparison_summary` table (Compare): RELAX K and test p-value per gene — the headline "selection intensified vs. relaxed in 2023" result.
+- `combined_comparison_site` table (Compare): CFEL site-level foreground-vs-background dN/dS contrasts.
+- Optional per-method HyPhy markdown reports (`*_md_report`) if surfaced.
+
+## Scope and risks
+
+- **HyPhy input requirements:** codon sequences must be in-frame with **no internal stop codons**; the IWC README explicitly warns that internal stops or ongoing recombination can cause failures or *misleading* estimates. The preprocessing chain (`remove_terminal_stop_codons` + CLN) handles *terminal* stops and ambiguity, but does not screen recombination — flag this in the narrative; consider a recombination caveat or screen.
+- **Small panels:** the reference is only two genes and the foreground is only three 2023 sequences. RELAX/CFEL on three foreground branches is statistically thin — present results as illustrative of the *method/notebook pattern*, not as a strong epidemiological claim. (TASK: optionally widen the 2023 foreground set from the available `PP563xxx` isolates.)
+- **Genetic code:** workflows pin `Universal`; correct for DENV CDS — keep it, state it.
+- **Version pinning:** pin the exact tool versions seen in the `.ga` files (HyPhy `2.5.96+galaxy0`, `cawlign 0.1.15+galaxy0`, `iqtree 2.4.0+galaxy1`, `drhip 0.1.4+galaxy0`) so the embedded outputs are reproducible; HyPhy JSON schemas and DRHIP table columns can shift across versions.
+- **Runtime:** BUSTED and the alignment/IQ-TREE steps are the slow parts; the MVP should favor importing the precomputed `codon_alignments/` + `iqtree_trees/` collections so the notebook runs in workshop time.
+- Keep every displayed table/figure on-graph (DRHIP outputs, JSON collections) — no off-graph JSON parsing in pandas cells, since off-graph artifacts break provenance-driven workflow extraction.
+
+## Tasks
+
+- [ ] Decide final anchor: Core-only MVP vs. Compare-as-headline (recommendation: ship Core MVP, feature Compare). Confirm with co-authors.
+- [ ] Verify DRHIP (`drhip/0.1.4+galaxy0`) column schemas for `combined_summary`, `combined_sites`, `combined_comparison_summary`, `combined_comparison_site` against a real run, and confirm they render cleanly in a notebook.
+- [ ] Decide whether to keep the honest two-gene reference or enrich `denv1_ref_cds.fasta` with more DENV1 CDS regions from NCBI for a richer landscape figure.
+- [ ] Decide whether to widen the 2023 foreground beyond the three-isolate `foreground_seqs_list.txt`.
+- [ ] Confirm whether to surface the per-method `*_md_report` markdown outputs (not currently exposed in `hyphy-core.ga`) or rely solely on DRHIP tables.
+- [ ] Build the MVP notebook importing precomputed `codon_alignments/` + `iqtree_trees/` to skip alignment runtime.
+- [ ] Run Core as collection map-over (MEME/FEL/BUSTED/PRIME, `Universal`) and embed `combined_summary` + `combined_sites`.
+- [ ] Add Compare branch: annotate foreground → RELAX + CFEL → `combined_comparison_*` tables; embed labeled tree.
+- [ ] Write interpretation cells (diversifying vs. purifying per site; relaxation vs. intensification in 2023).
+- [ ] Add a recombination/internal-stop caveat and a "small-panel, illustrative" disclaimer to the narrative.
+- [ ] Validate that walking the history provenance graph backward from the DRHIP tables reconstructs the full pipeline (workflow-extraction check).
+- [ ] Validate runtime on a standard Galaxy instance; pin all tool versions.
+- [ ] Decide which tables/figures feed directly into the Galaxy Notebooks manuscript.

--- a/content/pipelines/interview-to-galaxy/examples/UC5_IHC_issue.md
+++ b/content/pipelines/interview-to-galaxy/examples/UC5_IHC_issue.md
@@ -1,0 +1,114 @@
+# UC5 / per-object IHC morphometry — control vs drug-treated — interview input
+
+> Pulled-down GitHub issue used as the **effective result of the INTERVIEW → GALAXY interview**
+> (the live interview mechanics are harness-owned and precede pipeline phase 1).
+> Source: galaxy-brain issue #28 (captured verbatim from the issue body).
+> No paired reference target: this case is **spec-only** — there is no vendored `.ga` golden to
+> reproduce. Judge the run against the `expect:` block in `scenarios.md` (an agent checks the
+> produced workflow against the issue's load-bearing intent at the end of the journey).
+
+---
+
+## Plain-language science (why this is interesting)
+
+A heart attack kills tissue; immune cells (macrophages/microglia) flood the damaged "infarct zone" to clean up. A marker protein, **CD11b**, sits on those immune cells, and an IHC stain makes CD11b show up as brown deposits — more brown = more immune infiltration. The shipped data compares an **untreated (vehicle/DMSO)** group against a group given an anti-inflammatory drug candidate (**4-oxo-RA**). The scientific question: *does the drug reduce immune-cell infiltration?*
+
+The tools: **color deconvolution** un-mixes the brown CD11b signal from the blue counterstain; **Otsu thresholding** decides which pixels are truly stained, producing a black-and-white mask. The thin version stops here and reports **one "% stained area" number per image** — a t-test on 6 numbers.
+
+The richer move: label each **connected stained region as a separate object** (one immune-cell cluster = one object), then measure each object's **size (area), shape (eccentricity, solidity, perimeter), and staining intensity**. Now each image yields dozens-to-hundreds of objects, each with ~8 numbers — a *distribution*, not a single percent. This can reveal that the drug doesn't just reduce total staining but shifts the *character* of the infiltrate (fewer large dense clusters, rounder vs more ramified cells) — a biologically richer claim. It's the imaging analogue of the move single-cell genomics made: stop reporting one bulk number, report the distribution of individual objects and how its shape changes between conditions.
+
+## Purpose
+
+Add an imaging vignette to the Galaxy Notebooks paper that is domain-novel (the existing three are bacterial AMR, differential ATAC-seq, differential ChIP) and analytically substantial. Instead of mapping a single "% stained area" over 6 images and t-testing it, we treat each stained region as an individual object, extract per-object morphology + intensity features, and compare the distributions between an untreated and a drug-treated cohort — producing a multi-figure notebook that embeds real on-graph segmentation-mask images alongside per-object tables, distribution plots, and a per-sample feature heatmap, then extracts to a reusable collection-map-over workflow via provenance.
+
+## Objective (MVP + stretch)
+
+**MVP**
+- Reuse the real IWC `histological-staining-area-quantification` tool chain (color deconvolution → channel split → Otsu threshold) on the shipped 6-ROI CD11b IHC cohort (3 vehicle control, 3 4-oxo-RA treated), run as a collection map-over.
+- Insert `ip_binary_to_labelimage` to turn each thresholded mask into a connected-components label map (one stained region = one object), then run `ip_2d_feature_extraction` with an expanded feature set → a per-object table per sample (area, area_filled, eccentricity, solidity, perimeter, axis lengths, mean/max intensity), instead of one merged ROI per image.
+- Embed, every artifact a genuine on-graph output: per-sample mask/label overlay image, per-sample per-object feature tables, control-vs-treatment distribution plots (object area / eccentricity / intensity), and the retained % area summary.
+- Extract the pipeline by walking the provenance graph; report Table 1 metrics (steps, map-over steps, exposed outputs, dangling, report warnings, science-identical re-run).
+
+**Stretch**
+- A per-sample × feature heatmap across all 6 samples (cohort view; on-graph plot tool) showing whether the 3 treated replicates separate from the 3 controls across multiple features at once.
+- A true tissue-microarray (TMA) cohort variant (dearray → per-core quantification → ranked cores → cohort heatmap) — *requires sourcing additional multi-core public TMA data; the shipped TMA exemplar dearrays to a single core* (verification task).
+
+## Why this is a useful demo deviation
+
+- **New domain + new figure type.** First imaging vignette; first to embed real on-graph mask/label images (segmentation results), directly exercising the manuscript's "a reference embeds an artifact that can be inspected, not a picture of one" argument in a visually obvious way.
+- **Object-level substance.** Moves from one number per image to per-object distributions across a cohort — the imaging analogue of the single-cell move, far richer than a 6-point t-test.
+- **Clean map-over + extraction.** The whole analysis is a collection map-over over a 6-element list — the extraction-friendly shape the paper rewards (mirrors Vignette 1's map-over story), and adds embedded mask images the ATAC/ChIP vignettes don't exercise.
+
+## Existing analysis anchors (real tool IDs / paths)
+
+Anchor: `iwc/workflows/imaging/histological-staining-area-quantification/histological-staining-area-quantification.ga`
+- `imgteam/color_deconvolution/ip_color_deconvolution/0.9+galaxy0` (`rgb2hed`)
+- `imgteam/split_image/ip_split_image/2.3.5+galaxy0`
+- `imgteam/2d_auto_threshold/ip_threshold/0.25.2+galaxy0` (Otsu)
+- `imgteam/2d_feature_extraction/ip_2d_feature_extraction/0.25.2+galaxy1` (current config: `mode=with-intensities`, `features=[label, mean_intensity, area, area_filled]` — to be expanded)
+
+Object lever, borrowed from `iwc/workflows/imaging/fluorescence-nuclei-segmentation-and-counting/`:
+- `imgteam/binary2labelimage/ip_binary_to_labelimage/0.5+galaxy0` (connected components)
+- `imgteam/count_objects/ip_count_objects/0.0.5-2`
+- `imgteam/overlay_images/ip_overlay_images/0.0.4+galaxy4` (numbered-object overlay image); `colorize_labels` available for a colored label image.
+
+Feature menu confirmed in the `2d_feature_extraction` tool XML: `area, area_convex, area_filled, axis_major_length, axis_minor_length, centroid, eccentricity, equivalent_diameter_area, extent, orientation, perimeter, solidity` + (with intensities) `mean/min/max_intensity`, one row per label.
+
+Plot/heatmap tools: confirm exact on-graph IDs on the target server (the ChIP vignette used `ggplot2_heatmap2`; need a box/violin plotter for object distributions) — see tasks.
+
+## Public data candidates (real shipped data)
+
+From `histological-staining-area-quantification-tests.yml` (one `list` collection, 6 elements, 600×600 px ROIs, `total_area=360000`):
+- `control_1` — `https://zenodo.org/records/20271100/files/Vehicle-66-rechts_10x_IZ-1.tif`
+- `control_2` — `https://zenodo.org/records/20271100/files/Vehicle-66-rechts_10x_IZ-2.tif`
+- `control_3` — `https://zenodo.org/records/20271100/files/Vehicle-66-links_10x_IZ-2.tif`
+- `treatment_1` — `https://zenodo.org/records/20157596/files/Treatment1-11-links_10x_IZ-1.tif`
+- `treatment_2` — `https://zenodo.org/records/20157596/files/Treatment1-11-links_10x_IZ-2.tif`
+- `treatment_3` — `https://zenodo.org/records/20157596/files/Treatment1-11-rechts_10x_IZ-1.tif`
+
+CD11b IHC ROIs, cardiac infarct zone; control = Vehicle/DMSO (Zenodo 20271100), treatment = 4-oxo-RA (Zenodo 20157596; 20158418 is a border-zone companion record). Stretch TMA: shipped exemplar dearrays to a single core — not a cohort; a multi-core TMA dataset must be sourced.
+
+## Notebook workflow plan (numbered, on-graph, map-over)
+
+Input: one `list` collection `IHC ROIs` (identifiers `control_1..3`, `treatment_1..3`).
+
+1. Color deconvolution (`ip_color_deconvolution`) map-over → HED image per sample.
+2. Split channels (`ip_split_image`) → DAB/CD11b channel per sample.
+3. Otsu threshold (`ip_threshold`) map-over → binary stain mask per sample (on-graph image, embeddable).
+4. Connected-components label (`ip_binary_to_labelimage`) map-over → label map per sample (one object per stained region) — replaces the single-merged-ROI step.
+5. Per-object feature extraction (`ip_2d_feature_extraction`, `with-intensities`, intensity = deconvolved DAB channel, expanded `features`) map-over → per-object table per sample.
+6. Count objects (`ip_count_objects`) map-over → objects-per-sample.
+7. Labeled overlay / colorized label image (`ip_overlay_images` / `colorize_labels`) map-over → embeddable segmentation image per sample.
+8. Concatenate per-object tables with a sample/condition tag (`column_maker` to add `sample_id`/`condition`, collapse) → one tidy long table (object × features × condition), on-graph.
+9. Distribution plots (on-graph plot tool): box/violin of object area, eccentricity, mean_intensity by condition.
+10. Per-sample summary (`collapse_dataset` + `column_maker`): retained % area and median object features per sample.
+11. (Stretch) Per-sample × feature heatmap (`ggplot2_heatmap2` or equivalent) → cohort view.
+
+Then `workflow_extraction_summary` (expect 0 warnings) → extract workflow.
+
+## Expected paper/demo artifacts
+
+- Multi-figure notebook: per-sample segmentation-mask images, per-sample per-object feature tables, control-vs-treatment distribution plots, % area summary table, (stretch) cohort heatmap — each an on-graph tool output.
+- Extracted collection-map-over workflow (`.ga`) re-running to identical numbers; a Table 1 row.
+- SI recipe (S4-style).
+
+## Scope and risks
+
+- **Threshold/labeling sensitivity:** Otsu on diffuse CD11b staining may over-merge touching regions into few large objects (CD11b clusters aren't as discrete as nuclei). Object counts/shapes are real but parameter-sensitive — disclose, and treat % area as the robust anchor. NEEDS A REAL TEST RUN (the central empirical risk).
+- **Intensity-image pairing:** `with-intensities` needs the intensity image single-channel and frame-matched to the label map — feed the deconvolved DAB channel (step 2), not the RGB original.
+- **n is small (3 v 3):** distributions are per-object (hundreds of points) but biological replication is 3 per arm; claims illustrative, not powered. Same honesty posture as Vignette 1/3.
+- **Plot/heatmap tool availability:** confirm exact on-graph IDs on the target server.
+- **Stretch TMA needs data:** shipped TMA test data is a single core.
+
+## Tasks
+
+- [ ] Run `ip_binary_to_labelimage` on the Otsu mask for the real CD11b ROIs; confirm a multi-object label map (counts plausible, not 1). THIS IS THE GO/NO-GO CHECK for the object-level framing.
+- [ ] Verify `ip_2d_feature_extraction` accepts the deconvolved DAB channel as `with-intensities` intensity image paired with the label map (validators pass).
+- [ ] Decide whether to keep particle-size filtering (`imagej2_analyze_particles_binary`) or replace fully with `binary2labelimage`.
+- [ ] Identify/pin exact tool IDs/versions for the object-distribution plot (box/violin) and per-sample feature heatmap.
+- [ ] Confirm the 6 Zenodo ROI URLs resolve; element identifiers carry through to a `condition` column.
+- [ ] Build the notebook as a collection map-over; embed each on-graph artifact (masks, per-object tables, distribution plots, % area summary).
+- [ ] Run `workflow_extraction_summary` (expect 0 warnings); extract; record Table 1 metrics; re-run for science-identical check.
+- [ ] Draft SI recipe S4 mirroring S1–S3.
+- [ ] If stretch TMA pursued, source a real multi-core public TMA dataset (shipped exemplar is single-core).
+- [ ] Confirm "4-oxo-RA" is the intended treatment label before encoding it in the notebook narrative.

--- a/content/pipelines/interview-to-galaxy/examples/UC6_PSEUDOBULK_issue.md
+++ b/content/pipelines/interview-to-galaxy/examples/UC6_PSEUDOBULK_issue.md
@@ -1,0 +1,85 @@
+# UC6 / cell-type-resolved pseudobulk differential expression (COVID-19) — interview input
+
+> Pulled-down GitHub issue used as the **effective result of the INTERVIEW → GALAXY interview**
+> (the live interview mechanics are harness-owned and precede pipeline phase 1).
+> Source: galaxy-brain issue #29 (captured verbatim from the issue body).
+> No paired reference target: this case is **spec-only** — there is no vendored `.ga` golden to
+> reproduce. Judge the run against the `expect:` block in `scenarios.md` (an agent checks the
+> produced workflow against the issue's load-bearing intent at the end of the journey).
+
+---
+
+## Plain-language science (why this is interesting)
+
+A single-cell RNA-seq experiment measures gene expression in thousands of individual cells from several people (here: some healthy "normal", some "COVID-19"). Each cell carries two labels: which **person** it came from (`individual`) and what **cell type** it is (B cell, CD4 T cell, monocyte, …).
+
+**Pseudobulk** = sum the raw counts of all cells of one type within one person into a single profile ("all B cells from patient 7" → one B-cell sample). This bridges single-cell data to trusted bulk statistics (edgeR), with **people as the real replicates** — the correct unit for a disease comparison (thousands of correlated cells from one person are not independent replicates).
+
+**Why per-cell-type DE matters:** the interesting question is rarely "is gene X up in disease overall" — it's "**which cell types are actually mounting the response, and do they respond the same way?**" In COVID you'd expect monocytes and some T-cell subsets to be transcriptionally inflamed while B cells barely move. Pooling all cell types (what the shipped workflow does) averages these together and can hide a strong cell-type-specific signal. Running DE separately per cell type asks the sharp question, then you can rank cell types by responsiveness and split genes into a **shared core** (e.g. interferon-stimulated genes lighting up everywhere) vs **cell-type-specific** sets. That decomposition is the scientific payoff and is invisible from a single pooled contrast.
+
+## Purpose
+
+Demonstrate a Galaxy Notebook that goes beyond a single bulk contrast: take an annotated single-cell dataset, aggregate it into pseudobulk profiles, and ask which cell types actually respond to disease and which genes are a shared response vs cell-type-specific. Every embedded figure/table is a genuine on-graph Galaxy tool output; the reusable workflow is extracted from the history provenance graph.
+
+## Objective (MVP + stretch)
+
+- **MVP (no recomposition needed):** Reproduce the shipped IWC pseudobulk→edgeR analysis as an on-graph narrative — pseudobulk aggregation (decoupler), the pooled `normal` vs `COVID_19` edgeR contrast, ranked DEG table, and volcano — but present it single-cell-natively: show the pseudobulk QC plot, explain people-as-replicates, display DEG table + volcano as on-graph artifacts. Novel vs the bulk-DESeq2 vignette (adds the pseudobulk aggregation axis) and vs clustering (ends in statistics).
+- **Stretch (the substantial deviation — requires recomposition):** Fan the analysis out per cell type — subset the pseudobulk count matrix by `cell_type`, map edgeR over the per-cell-type subsets as a collection, and synthesize a cross-cell-type comparison: a responder-ranking table (significant genes per cell type) and a shared-vs-cell-type-specific gene summary — all from on-graph collection operations.
+
+## Why this is a useful demo deviation
+
+- **vs the existing bulk DESeq2 vignette** (count matrix → ranked table → one volcano, supervised two-condition contrast): adds the pseudobulk aggregation of single cells into per-(cell type × person) samples (a single-cell-specific transform that is itself an on-graph teaching artifact) and, in the stretch, a per-cell-type fan-out producing a collection of contrasts plus a cross-cell-type synthesis. Exercises Galaxy Notebooks' collection-map-over story, not a single plot.
+- **vs a plain scanpy clustering tutorial** (cluster → UMAP → marker dotplot): clustering only names populations; here we use those names to quantify disease response per cell type. The narrative ends in cross-cell-type statistics, not a UMAP.
+
+## Existing analysis anchors (real tool ids / paths)
+
+Primary: `iwc/workflows/scRNAseq/pseudobulk-worflow-decoupler-edger/pseudo-bulk_edgeR.ga`
+- `ebi-gxa/decoupler_pseudobulk/decoupler_pseudobulk/1.4.0+galaxy8` (pseudobulk; outputs `count_matrix`, `samples_metadata`, `genes_metadata`, `plot_output` PNG, `filter_by_expr_plot` PNG)
+- `iuc/edger/edger/3.36.0+galaxy5` (DE; outputs `outTables`, `outReport` HTML)
+- `iuc/volcanoplot/volcanoplot/0.0.6`
+- supporting: `iuc/column_remove_by_header/1.0`, `bgruening/text_processing/{tp_replace_in_line,tp_replace_in_column,tp_awk_tool}/9.3+galaxy1`, `bgruening/split_file_to_collection/0.5.2`, `iuc/collection_element_identifiers/0.0.2`, `param_value_from_file`.
+
+Upstream annotation reference (optional chapter): `iwc/workflows/scRNAseq/scanpy-clustering/...Scanpy.ga` — `iuc/scanpy_*` 1.10.2+galaxy*, `iuc/anndata_*` 0.10.9+galaxy0; produces louvain clusters + manual cell-type annotation (the kind of `cell_type` label the pseudobulk step consumes).
+
+velocyto was evaluated and rejected as anchor: its IWC workflow outputs only a `.loom` of spliced/unspliced counts (no plotting tool, no scVelo) — no on-graph figures to embed.
+
+## Public data candidates (real shipped data + actual labels)
+
+- **Primary:** `Source AnnData file.h5ad` — `https://zenodo.org/records/13929549/files/Source%20AnnData%20file.h5ad` (from `pseudo-bulk_edgeR-tests.yml`). obs columns: `cell_type` (groupby), `individual` (sample key / replicate), `disease` (factor, values `normal` and `COVID_19`), `gene_symbol` (var), raw `counts` layer. Test confirms a real DEG table (`edgeR_normal-COVID_19`, ~1430 lines). *Verify exact set of `cell_type` values and per-cell-type sample counts before finalizing the stretch.*
+- **Optional upstream illustration:** scanpy clustering PBMC3k 10X (`barcodes.tsv`/`genes.tsv`/`matrix.mtx`, `https://zenodo.org/record/3581213/files/...`), annotated to CD4+ T, CD14+, B, CD8+ T, FCGR3A+, NK, Dendritic, Megakaryocytes — use only to show where cell-type labels come from.
+
+## Notebook workflow plan (numbered, on-graph)
+
+1. Load the annotated `h5ad`; show obs structure (cell_type / individual / disease) — narrative + small on-graph inspection table.
+2. Decoupler pseudobulk (groupby `cell_type`, sample_key `individual`, layer `counts`, factor `disease`): embed the on-graph pseudobulk QC plot and the filter-by-expression plot; show `count_matrix` head.
+3. MVP contrast: sanitation chain → edgeR `~ 0 + disease`, contrast `normal-COVID_19`; embed the on-graph DEG table and volcano.
+4. Stretch fan-out: split the pseudobulk `count_matrix` columns by `cell_type` into a collection (on-graph column/split ops) → map edgeR over the per-cell-type subsets → per-cell-type DEG tables + volcanoes as a collection.
+5. Cross-cell-type synthesis: from the per-cell-type DEG tables, build (a) a responder-ranking table (count of FDR-significant genes per cell type) and (b) a shared-vs-specific summary via on-graph set/column ops. Embed both.
+6. Extract the reusable workflow by walking the provenance graph backward from the synthesis outputs.
+
+## Expected paper/demo artifacts
+
+- Pseudobulk QC + filter plots (genuine decoupler PNGs).
+- MVP: one DEG table + one volcano (pooled contrast).
+- Stretch: a collection of per-cell-type volcanoes + DEG tables.
+- A responder-ranking table and a shared-vs-cell-type-specific gene summary (on-graph).
+- The extracted reusable workflow `.ga`.
+
+## Scope and risks (honest)
+
+- **Recomposition required for the headline (stretch).** The shipped workflow runs ONE pooled `~ 0 + disease` contrast across all cell types (single `count_matrix` → single edgeR run; the split step splits by disease-contrast, of which there's only one). Per-cell-type DE needs new on-graph steps to subset the pseudobulk matrix by cell type and map edgeR over the subsets. The MVP avoids this and is still novel. (This is structurally the same "irreducible → split it" arc as the manuscript's Vignette 3.)
+- **Per-cell-type statistical power.** Some cell types may have too few individuals for stable edgeR fits; the responder ranking must carry sample-count caveats. Verify per-cell-type sample counts in the test h5ad.
+- **Matrix-subsetting mechanics.** Splitting a wide pseudobulk matrix by cell-type column-group on-graph needs validation (confirm decoupler's column naming encodes `cell_type` parseably).
+- **Version/data.** Pin tool versions; confirm the Zenodo h5ad downloads and that `disease` has only the two expected levels.
+
+## Tasks
+
+- [ ] Download `Source AnnData file.h5ad`; enumerate exact `cell_type` values and per-(cell_type × disease) `individual` counts.
+- [ ] Run the shipped pseudobulk→edgeR workflow as-is; confirm on-graph outputs (pseudobulk plot, DEG table, volcano) render embeddably.
+- [ ] Build the MVP notebook around the pooled contrast (single-cell framing, people-as-replicates).
+- [ ] Prototype the stretch: on-graph subset of `count_matrix` by `cell_type` → collection → map edgeR over subsets.
+- [ ] Build cross-cell-type synthesis (responder-ranking; shared-vs-specific via on-graph set/column ops).
+- [ ] Verify per-cell-type sample sizes are adequate; document low-power caveats.
+- [ ] Extract reusable workflow from provenance graph; validate round-trip.
+- [ ] (Optional) Add an upstream "where annotations come from" chapter referencing the scanpy clustering workflow.
+- [ ] Confirm all displayed artifacts are genuine on-graph tool outputs (no pasted figures).

--- a/content/pipelines/interview-to-galaxy/examples/UC7_FTMS_issue.md
+++ b/content/pipelines/interview-to-galaxy/examples/UC7_FTMS_issue.md
@@ -1,0 +1,98 @@
+# UC7 / FT-MS van Krevelen chemical-space characterization — interview input
+
+> Pulled-down GitHub issue used as the **effective result of the INTERVIEW → GALAXY interview**
+> (the live interview mechanics are harness-owned and precede pipeline phase 1).
+> Source: galaxy-brain issue #30 (captured verbatim from the issue body).
+> No paired reference target: this case is **spec-only** — there is no vendored `.ga` golden to
+> reproduce. Judge the run against the `expect:` block in `scenarios.md` (an agent checks the
+> produced workflow against the issue's load-bearing intent at the end of the journey).
+
+---
+
+## Plain-language science (why this is interesting)
+
+Ultrahigh-resolution mass spectrometry (FT-ICR or Orbitrap) measures the mass of each molecule so precisely that you can deduce its exact **molecular formula** — how many carbons, hydrogens, oxygens, nitrogens, sulfurs — from the mass alone. A single complex environmental sample (dissolved organic matter from water, soil, or sediment) can contain **thousands of distinct formulas**.
+
+The signature way to look at that chemistry is the **van Krevelen diagram**: each assigned formula is a point plotted by its **O/C ratio (x-axis)** against its **H/C ratio (y-axis)**. Where a point lands tells you its compound class — lipids (low O/C, high H/C), carbohydrates (high O/C, high H/C), lignins/aromatics and tannins (lower H/C, mid O/C), proteins, etc. So one plot is a **fingerprint of the sample's entire chemical space**.
+
+Before the formulas can be trusted, the mass axis must be **recalibrated** — tiny systematic mass errors are corrected against a series of confident reference peaks, which is what tightens part-per-million accuracy enough to make assignment unambiguous. The error-vs-m/z plot literally shows that ppm error shrinking after recalibration. The workflow's job is exactly this sequence: estimate noise, separate isotope peaks, make a first formula pass, pick recalibrant series, recalibrate, re-assign with heteroatoms, and draw the diagnostic plots.
+
+## Purpose
+
+Add a **metabolomics / mass-spectrometry** vignette to the Galaxy Notebooks paper that is novel on **both** axes the genomics-only corpus lacks: a new **modality** (FT-MS) and a new **analytical shape** (descriptive chemical-space *characterization* of a single sample, rather than a two-condition differential). Every displayed figure/table is a genuine on-graph Galaxy tool output, so the linear assignment+recalibration pipeline extracts to a reusable single-sample workflow via the history provenance graph. This belongs in `galaxy-brain` because the deliverable is a paper/demo notebook, not a change to an IWC workflow.
+
+## Objective (MVP + stretch)
+
+**MVP:** Run the IWC `mfassignr` workflow on its shipped single high-resolution mass list to produce, all on-graph: noise estimate, isotope-filtered peaks, recalibrated mass series, final molecular-formula tables (Unambig / Ambig / None), and the diagnostic plot collection — then build a notebook whose money shot is the embedded **van Krevelen diagram**, narrated as "what chemical families make up this sample," with the recalibration error-m/z plot as the QC story.
+
+**Stretch:** A small on-graph **chemical-class composition summary** derived from the assigned formulas (e.g. counts/fractions of formulas falling in lipid / carbohydrate / lignin / aromatic regions of van Krevelen space, or by heteroatom class CHO vs CHON vs CHOS) as a ranked table or bar chart — turning the qualitative van Krevelen picture into a quantitative on-graph table. (Confirm an on-graph tool can compute the class binning, or it becomes a documented limitation.)
+
+## Why this is a useful demo deviation
+
+- **Shape-novel, not just modality-novel.** The three existing vignettes are all *differential comparisons* (AMR across isolates, ATAC between lineages, ChIP between lineages). This one is *characterization* — "describe the chemistry of this sample" — a notebook shape the paper hasn't shown, demonstrating that history-attached notebooks serve descriptive analysis, not only A-vs-B contrasts.
+- **The genomics-impossible figure.** The van Krevelen diagram has no analogue in sequencing; it's the figure that earns metabolomics a slot on more than data-modality grounds (this is the explicit reason for choosing the mfassignr anchor over a GC-MS differential, whose PCA+heatmap+volcano shape duplicates the ATAC vignette).
+- **Clean linear extraction.** The pipeline is a multi-step on-graph chain (noise → isotope filter → assign → recalibrate → re-assign → plot); walking the provenance graph backward from the van Krevelen plot recovers the whole assignment+recalibration workflow — an extraction story that needs no map-over, complementing the collection-heavy vignettes.
+
+## Existing analysis anchors (real tool ids / paths)
+
+Anchor workflow: `iwc/workflows/metabolomics/mfassignr/mfassignr.ga` (RECETOX/MUNI; MIT). Tools (all `recetox/mfassignr_*`, `1.1.2+galaxy*`):
+- `mfassignr_kmdnoise/mfassignr_kmdnoise/1.1.2+galaxy0` — Kendrick-mass-defect noise estimation
+- `mfassignr_histnoise/mfassignr_histnoise/1.1.2+galaxy0` — histogram-based noise estimation
+- `mfassignr_isofiltr/mfassignr_isofiltr/1.1.2+galaxy1` — isotope filtering (monoisotopic vs isotopologue peaks)
+- `mfassignr_mfassignCHO/mfassignr_mfassignCHO/1.1.2+galaxy1` — first-pass CHO-only formula assignment (for recalibration)
+- `mfassignr_recallist/mfassignr_recallist/1.1.2+galaxy0` — candidate recalibrant series
+- `mfassignr_findRecalSeries/mfassignr_findRecalSeries/1.1.2+galaxy1` — choose optimal recalibrant series
+- `mfassignr_recal/mfassignr_recal/1.1.2+galaxy0` — mass recalibration (emits `recal_series`, `final_series`, `MZplot`)
+- `mfassignr_mfassign/mfassignr_mfassign/1.1.2+galaxy1` — final formula assignment with heteroatoms (emits `Unambig`/`Ambig`/`None` tables + per-element `plots` collections containing VK, MSgroups, errorMZ, msassign)
+- `mfassignr_snplot/mfassignr_snplot/1.1.2+galaxy1` — signal-to-noise diagnostic (`SNplot`)
+
+IWC repo: `galaxyproject/iwc`, `workflows/metabolomics/mfassignr/`.
+
+## Public data candidates (real shipped data)
+
+From `mfassignr-tests.yml`:
+- Input: single `Feature table` — `https://zenodo.org/records/13768009/files/mfassignr_input.txt` (tabular; SHA-1 `3df0ba47…`), a high-resolution mass list (mass, intensity[, RT]). **One sample** — descriptive, not comparative.
+- Shipped expected outputs confirm the embeddable artifacts: `SNplot.png` (~58K), `MZplot.png` (~85K), `recal_series.tabular`, `final_series.tabular`, `Unambig.tabular`, `Ambig.tabular`, `None.tabular`, and per-element `plots` collections (CHO and full-element) each containing `VK` (van Krevelen, ~0.9 MB), `MSgroups`, `errorMZ`, `msassign`.
+
+## Notebook workflow plan (numbered, on-graph)
+
+1. Upload the high-resolution mass list (`mfassignr_input.txt`, Zenodo 13768009); show a head of the input as an on-graph table.
+2. Noise estimation — `mfassignr_kmdnoise` (and/or `mfassignr_histnoise`) → noise threshold; embed the **SN plot** (`mfassignr_snplot`) as the first QC figure.
+3. Isotope filtering — `mfassignr_isofiltr` → monoisotopic peak list.
+4. First-pass assignment — `mfassignr_mfassignCHO` → CHO formulas used as recalibration anchors.
+5. Recalibrant selection — `mfassignr_recallist` → `mfassignr_findRecalSeries` → chosen recalibrant series.
+6. Recalibration — `mfassignr_recal` → `recal_series`, `final_series`, and the **error-m/z plot** (`MZplot`); embed the error-m/z plot and narrate the ppm-accuracy improvement.
+7. Final assignment — `mfassignr_mfassign` → `Unambig` / `Ambig` / `None` formula tables and the per-element `plots` collection (VK, MSgroups, errorMZ, msassign).
+8. Embed the **van Krevelen diagram** (the `VK` element) as the money shot, with the `Unambig` formula table beside it; narrate the chemical-family interpretation.
+9. (Stretch) Compute an on-graph chemical-class composition summary from the `Unambig` table (van-Krevelen-region or heteroatom-class binning) → ranked table / bar chart.
+10. Walk the provenance graph backward from the van Krevelen plot to extract the reusable assignment+recalibration workflow.
+
+## Expected paper/demo artifacts
+
+- **Van Krevelen diagram** (on-graph `VK` plot) — the headline, genomics-impossible figure.
+- Error-m/z recalibration plot (`MZplot`) showing ppm-accuracy improvement; SN plot.
+- `Unambig` molecular-formula table (and `Ambig`/`None` for honesty about assignment confidence).
+- MSgroups / msassign diagnostic plots.
+- (Stretch) chemical-class composition summary table/bar.
+- The extracted single-sample assignment+recalibration workflow (`.ga`) + a Table 1 row (linear chain; no map-over).
+
+## Scope and risks
+
+- **Single sample, descriptive.** No biological comparison; the contribution is characterization + a distinctive figure + a non-differential notebook shape. Frame as such — do not imply a condition contrast.
+- **Assignment ambiguity is real.** High-resolution MS can fit multiple formulas to one mass within tolerance; the `Ambig`/`None` tables exist for this. The notebook must show ambiguity honestly, not just the clean `Unambig` set.
+- **Audience/literacy.** Van Krevelen and Kendrick-mass-defect literacy is high in environmental/petroleomics MS but low in genomics; the narrative must explain the axes and regions.
+- **Stretch class-binning tool.** The chemical-class composition summary needs an on-graph tool (column arithmetic on O/C, H/C from the formula table); confirm one exists or document it as a limitation rather than pasting an off-graph computation.
+- **Provenance/pinning.** Pin all `recetox/mfassignr_*` `1.1.2+galaxy*` versions and the Zenodo record (13768009); confirm the test passes on the target server. Element-collection structure (CHO vs full-element `plots`) must render in the notebook directive.
+
+## Tasks
+
+- [ ] Confirm the Zenodo input (`mfassignr_input.txt`, 13768009) resolves and the workflow runs end-to-end on the target server.
+- [ ] Run the chain; verify the on-graph `VK`, `MZplot`, `SNplot`, and `Unambig`/`Ambig`/`None` outputs render embeddably (esp. the per-element `plots` collection directive).
+- [ ] Build the notebook with the van Krevelen diagram as the money shot + the `Unambig` table + the error-m/z QC narrative.
+- [ ] Decide noise method (KMDNoise vs HistNoise) and document the choice and its effect.
+- [ ] Stretch: identify an on-graph tool to bin formulas into chemical classes (van-Krevelen region or heteroatom class) → composition table/bar; else document as a limitation.
+- [ ] Show assignment ambiguity honestly (Ambig/None), not only Unambig.
+- [ ] Walk the provenance graph backward from the VK plot; extract the reusable workflow; record Table 1 metrics (linear chain).
+- [ ] Pin all `recetox/mfassignr_*` 1.1.2 tool versions + the Zenodo record.
+- [ ] Write the plain-language axis/region explanation so non-MS readers can read the van Krevelen figure.
+- [ ] Draft SI recipe; connect the notebook to manuscript claims about on-graph auditability, descriptive (non-differential) notebook shape, and backward workflow extraction.

--- a/content/pipelines/interview-to-galaxy/scenarios.md
+++ b/content/pipelines/interview-to-galaxy/scenarios.md
@@ -17,22 +17,36 @@ The live interview is harness-owned and precedes phase 1
 stands in for a normalized interview transcript — so the journey can be driven
 from a fixed input.
 
-Each case also names a **reference target**: a `.ga` workflow extracted from a
-hand-built Galaxy history. These targets reproduce — each re-runs to its golden
-numbers (UC1 byte-identical, UC3 identical, both published in the Galaxy
-Notebooks supporting information) — but they are still a **compare-and-contrast
-reference, not a hard oracle**. The run may match the target, may exceed it (a
-cleaner or more complete realization), or may not reach its shape at all.
-Divergence is the signal worth inspecting, not an automatic failure. Judge the
-run against the issue's load-bearing scientific intent first; treat the `.ga` as
-one plausible — well-realized — answer to hold the run beside.
+Cases come in two tiers. **Reference-target cases** (UC1, UC3) name a `.ga`
+workflow extracted from a hand-built Galaxy history. These targets reproduce —
+each re-runs to its golden numbers (UC1 byte-identical, UC3 identical, both
+published in the Galaxy Notebooks supporting information) — but they are still a
+**compare-and-contrast reference, not a hard oracle**. The run may match the
+target, may exceed it (a cleaner or more complete realization), or may not reach
+its shape at all. Divergence is the signal worth inspecting, not an automatic
+failure. Judge the run against the issue's load-bearing scientific intent first;
+treat the `.ga` as one plausible — well-realized — answer to hold the run beside.
 
-Each target now carries the full workflow-level deliverables its issue calls for:
+Each target carries the full workflow-level deliverables its issue calls for:
 UC1 integrates Bakta whole-genome annotation and a per-isolate JBrowse locus
 view; UC3 materializes the filtered + ranked differential-peaks tables as real
 outputs. So target parity is a meaningful bar — a run that reaches the target's
 shape has covered the issue, and one that exceeds it (a tool the target skips, a
 tighter realization) is better still.
+
+**Spec-only cases** (UC4–UC7, captured from galaxy-brain issues #27–#30) carry
+**no reference target** — no hand-built `.ga`, no golden numbers. They exist to
+exercise the pipeline on domains and analytical shapes the reference-target pair
+doesn't cover (molecular selection, bioimage morphometry, single-cell pseudobulk,
+FT-MS characterization), where building a golden by hand would be costly and
+where there is nothing pre-built to compare against. For these the **oracle is
+the `expect:` block alone**: at the end of the journey an agent judges the
+produced gxformat2 workflow against the issue's load-bearing intent (does it
+validate and round-trip, are the load-bearing inputs/tools/outputs present, is
+the MVP-vs-stretch scope honored without silently widening or collapsing). Each
+spec-only case still cites the real IWC anchor workflow(s) the issue grounds in,
+so the [[compare-against-iwc-exemplar]] phase has corpus to lean on even though
+no target is vendored here.
 
 ## Case: MRSA mobile-AMR context across isolates
 
@@ -102,3 +116,137 @@ tighter realization) is better still.
   `featureCounts` and deepTools-QC branches the issue flags as out-of-MVP? Treat
   extra QC/PCA steps as a deliberate enrichment to weigh, not an automatic win;
   flag any thresholds or the `condition` factor that get lost between briefs.
+
+## Case: HyPhy molecular-selection landscape across Dengue CDS genes
+
+- fixture: `examples/UC4_HYPHY_issue.md` as the interview result (captured from
+  galaxy-brain issue #27). It describes a per-gene episodic-diversifying-vs-
+  purifying selection panel over the two Dengue (DENV1) CDS genes in the IWC
+  HyPhy test data: MEME / FEL / BUSTED / PRIME (genetic code `Universal`) run as
+  a **collection map-over** across a codon-alignment collection, then collapsed
+  by `DRHIP` into a `combined_summary` + `combined_sites` selection-landscape
+  table. The stretch is the Compare arc: label the three recent 2023 isolates as
+  foreground (`hyphy_annotate`), run RELAX (intensification/relaxation) and
+  Contrast-FEL, and collapse to `combined_comparison_summary` /
+  `combined_comparison_site`.
+- reference target: none — spec-only. IWC anchors the issue cites:
+  `comparative_genomics/hyphy/hyphy-core`, `hyphy-preprocessing`,
+  `hyphy-compare`, `capheine-core-and-compare` (the DRHIP orchestrator). No
+  hand-built `.ga` golden is vendored.
+- expect: the journey produces a gxformat2 workflow that validates and
+  round-trips, with a codon-alignment **collection** as the primary input (the
+  precomputed `codon_alignments/` + `iqtree_trees/` import shortcut is an
+  acceptable MVP entry), at least the Core selection methods (MEME/FEL/BUSTED/
+  PRIME) preserved and applied **as a map-over** rather than collapsed to a
+  single-gene run, genetic code carried as `Universal`, and a `DRHIP`-style
+  combined cross-gene summary table surfaced as a real workflow output rather
+  than leaving per-gene JSON blobs as the terminal artifact. If the run reaches
+  the stretch, the 2023-foreground RELAX/CFEL contrast appears as explicit
+  labeled steps, not a silent merge.
+- spec check (end of journey): with no target to diff against, an agent judges
+  the workflow against the issue's load-bearing intent — collection map-over
+  preserved (not silently reduced to one gene), JSON→table collapse present, the
+  small-panel honesty (two genes, three foreground isolates) reflected as a
+  scope note rather than overclaimed, and MVP (Core) vs stretch (Compare) scope
+  kept legible. Flag any HyPhy method, the `Universal` code, or the DRHIP
+  collapse that gets dropped between briefs.
+
+## Case: per-object IHC morphometry — control vs drug-treated
+
+- fixture: `examples/UC5_IHC_issue.md` as the interview result (captured from
+  galaxy-brain issue #28). It describes a bioimage cohort analysis over the IWC
+  `histological-staining-area-quantification` chain (color deconvolution → split
+  channel → Otsu threshold) on a 6-element CD11b IHC ROI collection (3 vehicle
+  control, 3 4-oxo-RA treated), run as a **collection map-over**, then pushed
+  past one "% stained area" number per image: `ip_binary_to_labelimage`
+  (connected components) → `ip_2d_feature_extraction` (`with-intensities`,
+  expanded feature set) yields a **per-object** table per sample (area,
+  eccentricity, solidity, perimeter, intensity), feeding control-vs-treatment
+  distribution plots and a retained-% area summary. Stretch: a per-sample ×
+  feature cohort heatmap.
+- reference target: none — spec-only. IWC anchors the issue cites:
+  `imaging/histological-staining-area-quantification` (base chain) and
+  `imaging/fluorescence-nuclei-segmentation-and-counting` (the
+  `binary2labelimage` / `count_objects` / overlay object lever). No hand-built
+  `.ga` golden is vendored.
+- expect: the journey produces a gxformat2 workflow that validates and
+  round-trips, with a single `list` collection of the 6 IHC ROIs keyed by
+  condition (`control_1..3`, `treatment_1..3`) as input, the deconvolution →
+  channel-split → Otsu chain preserved **as a map-over**, the object-level lever
+  present (a connected-components label step plus per-object feature extraction)
+  rather than stopping at one merged %-area number per image, and a per-object
+  feature table plus a control-vs-treatment distribution comparison surfaced as
+  real outputs. The intensity image fed to feature extraction is the deconvolved
+  DAB channel, not the RGB original.
+- spec check (end of journey): an agent judges against the issue's load-bearing
+  intent — that the run reaches per-object morphometry (the issue's whole point)
+  and not just the thin %-area t-test, that the map-over shape over the 6-element
+  collection is intact, and that element identifiers carry a `condition` tag
+  through to the distribution comparison. The 3-vs-3 replication and Otsu
+  over-merge sensitivity should read as honest caveats, not silently dropped.
+
+## Case: cell-type-resolved pseudobulk differential expression (COVID-19)
+
+- fixture: `examples/UC6_PSEUDOBULK_issue.md` as the interview result (captured
+  from galaxy-brain issue #29). It describes a single-cell→pseudobulk DE
+  analysis over the IWC `pseudo-bulk_edgeR` workflow: decoupler pseudobulk
+  aggregation (groupby `cell_type`, sample key `individual`, layer `counts`,
+  factor `disease`) of an annotated `h5ad`, then a pooled `normal` vs `COVID_19`
+  edgeR contrast → ranked DEG table + volcano, framed single-cell-natively
+  (people-as-replicates). Stretch (the substantial deviation, needs
+  recomposition): fan the analysis out **per cell type** — subset the pseudobulk
+  count matrix by `cell_type`, map edgeR over the per-cell-type subsets as a
+  collection, and synthesize a responder-ranking + shared-vs-cell-type-specific
+  gene summary.
+- reference target: none — spec-only. IWC anchors the issue cites:
+  `scRNAseq/pseudobulk-worflow-decoupler-edger/pseudo-bulk_edgeR` (primary) and
+  `scRNAseq/scanpy-clustering` (optional upstream annotation chapter). No
+  hand-built `.ga` golden is vendored.
+- expect: the journey produces a gxformat2 workflow that validates and
+  round-trips, with the annotated `h5ad` as input, the **pseudobulk aggregation**
+  step present (groupby `cell_type` / sample key `individual` / factor
+  `disease`), an edgeR contrast keyed on `normal-COVID_19`, and a DEG table plus
+  volcano as outputs. The MVP (one pooled contrast) is a complete answer; if the
+  run reaches the stretch, the per-cell-type fan-out appears as a real on-graph
+  subset → map-edgeR-over-collection → cross-cell-type synthesis, not a hand-
+  waved loop.
+- spec check (end of journey): an agent judges against the issue's load-bearing
+  intent — the pseudobulk axis (the single-cell-specific transform) is present
+  and not collapsed to a plain bulk DESeq2 contrast, the `disease` factor keeps
+  its two expected levels, and any stretch fan-out honors per-cell-type
+  statistical-power caveats rather than overclaiming on thin cell types. Flag if
+  the headline silently degrades from "which cell types respond" back to a single
+  pooled verdict.
+
+## Case: FT-MS van Krevelen chemical-space characterization
+
+- fixture: `examples/UC7_FTMS_issue.md` as the interview result (captured from
+  galaxy-brain issue #30). It describes a metabolomics / FT-MS vignette over the
+  IWC `mfassignr` workflow on a single high-resolution mass list — a
+  **descriptive, single-sample characterization**, not a two-condition
+  differential. The linear on-graph chain: noise estimation (`kmdnoise` /
+  `histnoise`) → isotope filter (`isofiltr`) → first-pass CHO assignment
+  (`mfassignCHO`) → recalibrant selection (`recallist` → `findRecalSeries`) →
+  recalibration (`recal`, emitting the error-m/z `MZplot`) → final
+  heteroatom-aware assignment (`mfassign`, emitting `Unambig`/`Ambig`/`None`
+  tables and the per-element `plots` collection). The money-shot output is the
+  **van Krevelen diagram** (`VK`); the error-m/z plot is the QC story. Stretch:
+  an on-graph chemical-class composition summary binned from the `Unambig`
+  table.
+- reference target: none — spec-only. IWC anchor the issue cites:
+  `metabolomics/mfassignr/mfassignr`. No hand-built `.ga` golden is vendored.
+- expect: the journey produces a gxformat2 workflow that validates and
+  round-trips, with the single feature-table mass list as input, the
+  noise→isotope-filter→assign→recalibrate→re-assign chain preserved as a **linear
+  pipeline (no map-over)**, the van Krevelen (`VK`) plot surfaced as a real
+  workflow output, and the molecular-formula tables (at least `Unambig`,
+  ideally `Ambig`/`None` for assignment-confidence honesty) exposed. The shape
+  stays **descriptive** — the run must not invent a condition contrast or a
+  differential framing the single sample can't support.
+- spec check (end of journey): an agent judges against the issue's load-bearing
+  intent — descriptive (non-differential) shape preserved, the recalibration QC
+  step present (not skipped as decoration), the van Krevelen plot reached as the
+  headline artifact, and assignment ambiguity represented honestly rather than
+  collapsing to only the clean `Unambig` set. This case is the corpus's check
+  that the pipeline handles a single-sample characterization, not only A-vs-B
+  contrasts.


### PR DESCRIPTION
Adds four new scenarios to the INTERVIEW → GALAXY pipeline, captured from galaxy-brain issues #27–#30. These are **spec-only**: unlike UC1/UC3 they carry **no vendored `.ga` reference target** — at the end of the journey an agent judges the produced gxformat2 workflow against the issue's `expect:` block, since there's nothing pre-built to diff against.

## New cases (`examples/` fixtures + `## Case:` blocks)

| Case | Issue | Domain / shape |
|------|-------|----------------|
| UC4 HYPHY | #27 | HyPhy molecular selection across Dengue CDS genes — collection map-over → DRHIP combined tables; stretch RELAX/CFEL |
| UC5 IHC | #28 | Per-object IHC morphometry, control vs drug-treated — bioimage; connected-components → per-object features |
| UC6 PSEUDOBULK | #29 | Cell-type-resolved pseudobulk DE (COVID-19) — decoupler → edgeR; stretch per-cell-type fan-out |
| UC7 FTMS | #30 | FT-MS van Krevelen characterization — single-sample, **descriptive (non-differential)** linear chain |

Deliberately span domains the UC1/UC3 pair doesn't (selection, bioimaging, single-cell, FT-MS), including UC7 as the one characterization-not-contrast shape.

## scenarios.md

- Intro reframed into two tiers: **reference-target** (UC1, UC3) vs **spec-only** (UC4–UC7).
- Each spec-only `## Case:` states `reference target: none`, distills the load-bearing `expect:`, cites the real IWC anchor workflow(s) so the `compare-against-iwc-exemplar` phase still has corpus, and adds an end-of-journey **spec check** bullet as the sole oracle.

## Fixtures

Issue bodies captured verbatim under `examples/` (GitHub attribution marker stripped, spec-only provenance header prepended). The validator allowlists `examples/`, so the frontmatter-less fixtures don't trip schema checks.

## Validation

`npm run validate` → **0 errors, 185 warnings** (unchanged from main).

> Naming note: numbered UC4–UC7 continuing the manuscript's vignette sequence (the issues reference "the existing three"), even though only UC1/UC3 are vendored here and there is no UC2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)