### PR TITLE
cast: render validator subcommand in SKILL Validation; make test-drive executable phases run

### DIFF
--- a/.claude/commands/test-drive.md
+++ b/.claude/commands/test-drive.md
@@ -17,6 +17,8 @@ Run a Mold or chain of Molds against real input, evaluate the outputs, and harve
 
 The shape of "test-drive" is the same regardless: ensure inputs exist, run the relevant Mold(s) by emulation (read the cast bundle's `SKILL.md` and follow it), evaluate, capture refinements. Don't impose a fixed N-step pipeline; let the scenario decide.
 
+**"By emulation" refers to skill *dispatch* only** — you read the bundle's `SKILL.md` and follow it instead of invoking it through the `Skill` tool (see the closing note). It does **not** license emulating the *work*. Following the SKILL means doing what it says: for an authoring Mold that is you writing the artifact; for an **executable** Mold (`validate-galaxy-workflow`, `run-workflow-test`, …) it is running the tool the SKILL names — for real (see step 4).
+
 ## 0. Read the scenario
 
 Parse `$1` and figure out:
@@ -68,7 +70,11 @@ For each Mold in scope, in order:
 - Read referenced files under `casts/claude/skills/<mold>/references/` *only as their `load:` and `trigger:` directives say to* — load-on-demand notes are loaded only when the trigger applies. Treat the skill bundle as a runtime contract.
 - Read upstream artifacts the Mold's `Inputs` section names. If the scenario points to existing inputs, use them; if the prior step in this run produced them, consume those.
 - Produce the Mold's declared `Outputs` artifact at the run dir. Use the default filename unless the user overrode.
-- For Molds with a CLI implementation (e.g. `summarize-nextflow` ships `@galaxy-foundry/summarize-nextflow`), prefer the CLI over LLM emulation. Note in the run summary which Molds ran by CLI vs by emulation.
+- **Authoring vs executable Molds.** An *authoring* Mold (summarize, interview→changeset, a `*-to-galaxy-*` brief, test-plan) is exercised by you following its `SKILL.md` — the LLM authoring *is* the work. An *executable* Mold runs a tool, and you **must run that tool**, not describe its result:
+  - `validate-galaxy-workflow` → `gxwf validate` / `draft-validate` / `roundtrip`.
+  - `run-workflow-test` → `planemo test`. Planemo is **self-bootstrapping**: `planemo test` launches its own ephemeral Galaxy and installs the workflow's tools from the Tool Shed/conda — no external server, so "no running Galaxy" is never a reason to skip. Remote-URL test data is fetched by planemo. Deferring the run is allowed **only** for a specific, named heavy cost (a multi-GB reference DB, an outsized tool install) and must be recorded as an explicit gap in the run summary — never a silent "not run".
+  - For Molds that ship a CLI implementation (e.g. `summarize-nextflow`), prefer the CLI over LLM emulation.
+- Note in the run summary which Molds ran by CLI/tool vs by authoring.
 
 If a Mold's procedure depends on a decision that's not in the source evidence (scope cuts, sibling-vs-flag, narrow-the-DAG), make the decision honestly, surface it as a top-level "Scope decision" or "Open question" in the artifact, and continue. Do not ask the user mid-chain unless the decision is irreducible — collect questions, surface them at the end.
 
@@ -81,7 +87,7 @@ For each Mold the run exercised:
 - Read `content/molds/<mold>/eval.md` (properties) and `content/molds/<mold>/scenarios.md` (cases).
 - The run bound a scenario — either a named `scenarios.md` case or an ad-hoc one from `$1`. Apply **every** `eval.md` property to the produced output: ✅, ❌, or N/A (a property this scenario didn't exercise).
 - Also check the bound scenario's own `expect:` assertions — the fixture-specific expected values (e.g. "11 processes").
-- For `bucket: schema` properties, run the deterministic check (e.g. `validate-summary-nextflow`) where applicable. For `bucket: utility` / `llm-judged`, score by inspection.
+- A property whose check is **deterministic** (`bucket: schema`, or any `check: deterministic` in `eval.md` — schema validation, a structural diff, `gxwf validate` / `roundtrip`, a `planemo test` run) is scored by **running the check**. It may not be marked ✅, N/A, or ⚠️ by inspection or emulation, and "not run" on a deterministic property is a trial failure, not a pass. For `bucket: utility` / `llm-judged`, score by inspection.
 
 In addition to Mold specific eval.md instructions, evaluate
 each skill run at a high-level. Does the Mold output seem appropriate for the job being done. Evaluate what research
@@ -148,6 +154,6 @@ the lessons learned.
 
 ## Notes on emulation vs runtime invocation
 
-A freshly-cast skill is on disk immediately and any `Read`-capable agent can follow its `SKILL.md`. What an in-session agent **can't** do is invoke the skill through the `Skill` tool — that registry is populated at session start (or after `/reload-plugins`). For test-drive we always emulate by reading the bundle, because the goal is to evaluate the bundle's contents and the user told us which Molds to run. Skill-tool invocation matters when an agent has to *discover* the right skill organically; that's not what test-drive is for.
+A freshly-cast skill is on disk immediately and any `Read`-capable agent can follow its `SKILL.md`. What an in-session agent **can't** do is invoke the skill through the `Skill` tool — that registry is populated at session start (or after `/reload-plugins`). For test-drive we always emulate by reading the bundle, because the goal is to evaluate the bundle's contents and the user told us which Molds to run. Skill-tool invocation matters when an agent has to *discover* the right skill organically; that's not what test-drive is for. **This is the only sense in which test-drive "emulates" — it bypasses skill *dispatch*, not the SKILL's procedure.** Reading the bundle and then running the `gxwf` / `foundry` / `planemo` commands the SKILL prescribes *is* executing the Mold for real; the deterministic phases (validate, run) are run, not described.
 
 If a run reveals that the cast bundle's `SKILL.md` is unclear, the procedure is wrong, or the references don't load when they should — that's a refinement entry, not a re-cast. Re-casting fixes the bundle; the refinement explains *why* the bundle needed fixing.

--- a/.claude/commands/test-pipeline.md
+++ b/.claude/commands/test-pipeline.md
@@ -22,6 +22,7 @@ Walk the `phases:` spine in order, in a single per-run working directory (see `/
 - **Mold-shaped phase** — drive the Mold's cast (step 4), then immediately apply that Mold's `eval.md` to the step output *before* feeding it downstream (step 5 → "Pipeline runs"). Catch a miss at the step that produced it, not three phases later.
 - **`[loop]` phase** — run the looped Mold until its own oracle reports done (e.g. `advance-galaxy-draft-step` → `gxwf draft-next-step`); evaluate at the **endstate**, not per iteration.
 - **`[branch]` phase** — route per the named pattern (e.g. `discover-or-author`); evaluate the **chosen** Mold's `eval.md`.
+- **Executable phase** — a validate/run/debug Mold (`validate-galaxy-workflow`, `run-workflow-test`, `debug-galaxy-workflow-output`) is *run*, not emulated: execute its tool (`gxwf validate`, `planemo test`) and score off the real result (see `/test-drive` step 4; planemo is self-bootstrapping — no external Galaxy needed). Reaching `run-workflow-test` without a green planemo result — or a specifically-justified, recorded deferral — means the journey **did not complete**; report it as incomplete rather than done.
 - **End of journey** — apply the pipeline `eval.md` end-to-end properties + the bound case's `expect:` assertions.
 
 ## Report

--- a/casts/claude/skills/apply-galaxy-workflow-changeset/SKILL.md
+++ b/casts/claude/skills/apply-galaxy-workflow-changeset/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: apply-galaxy-workflow-changeset
+description: "Apply a reviewed change-set to a concrete Galaxy workflow: untouched regions preserved, tool-introducing edits injected as drafty steps."
+---
+
+# apply-galaxy-workflow-changeset
+
+Follow the procedure below and use the artifact/reference sections as the runtime contract.
+
+## When To Use
+
+- Apply a reviewed change-set to a concrete Galaxy workflow: untouched regions preserved, tool-introducing edits injected as drafty steps.
+
+## Inputs
+
+- Read artifact `galaxy-workflow`. Produced by `advance-galaxy-draft-step`. The concrete gxformat2 workflow being modified (already converted from .ga if needed). The substrate edits apply to — untouched regions must survive byte-for-byte.
+- Read artifact `galaxy-workflow-changeset`. Produced by `interview-to-galaxy-workflow-changeset`. Reviewed, step-anchored change-set from interview-to-galaxy-workflow-changeset; the edit intents to realize.
+- Read artifact `open-requirements-ledger`. Produced by `advance-galaxy-draft-step`, `apply-galaxy-workflow-changeset`, `compare-against-iwc-exemplar`, `cwl-summary-to-galaxy-data-flow`, `cwl-summary-to-galaxy-interface`, `cwl-summary-to-galaxy-template`, `freeform-summary-to-galaxy-data-flow`, `freeform-summary-to-galaxy-interface`, `freeform-summary-to-galaxy-template`, `implement-galaxy-tool-step`, `interview-to-galaxy-workflow-changeset`, `nextflow-summary-to-galaxy-data-flow`, `nextflow-summary-to-galaxy-interface`, `nextflow-summary-to-galaxy-reference-data`, `nextflow-summary-to-galaxy-template`, `repair-galaxy-draft-topology`. Carried obligations ledger open-requirements-ledger: read open entries bearing on the edits; append any an edit cannot satisfy and mark resolved the ones it closes.
+
+## Outputs
+
+- Write artifact `galaxy-workflow-draft` as `galaxy-workflow-draft.gxwf.yml`. Format: `yaml`. Schema: galaxy-workflow-draft. gxformat2 draft (see galaxy-workflow-draft-format) of the whole workflow: untouched steps carried at Resolved tier verbatim; tool-introducing/replacing edits injected as drafty steps with _plan_* fields for the per-step loop; direct edits applied inline.
+- Write artifact `open-requirements-ledger` as `open-requirements.ledger.yml`. Format: `yaml`. Updated obligations ledger: new unmet needs an edit surfaces appended; prior entries its edits close marked resolved.
+
+## Required Tools
+
+- **`gxwf`** (gxwf). `npm install -g @galaxy-tool-util/cli@^1.8.1`.
+  Ephemeral run: `npx --yes --package @galaxy-tool-util/cli@1.8.1 gxwf`.
+  Check: `gxwf --help | grep -q draft-validate`.
+  Docs: https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli
+
+## Load Upfront
+
+- `references/notes/galaxy-workflow-draft-format.md`: Research note copied verbatim into the bundle. Represent the whole workflow as a draft: carry untouched steps at Resolved tier, inject tool-introducing/replacing edits as drafty steps with _plan_state / _plan_context / _plan_in / _plan_out.
+- `references/notes/open-requirements-ledger.md`: Research note copied verbatim into the bundle. Carry the open-requirements ledger: append an edit's unmet need (e.g. a rewire with no reachable producer) rather than fabricating a connection, and mark resolved the ones its edits close.
+- `references/schemas/galaxy-workflow-draft.schema.json`: Schema file copied verbatim into the bundle. Output contract: the emitted gxformat2 draft conforms to galaxy-workflow-draft. Cast bundles the JSON Schema so the skill carries its output shape alongside draft-validate checks.
+
+## Load On Demand
+
+- `references/cli/draft-validate.json`: CLI command reference packaged as a sidecar. Validate the emitted draft against draft-contract rules (sentinel form, topology, _plan_* placement) before handing off to the per-step loop. Use when: after writing the modified draft workflow file.
+
+## Validation
+
+- Validate `galaxy-workflow-draft.gxwf.yml` for artifact `galaxy-workflow-draft` against the galaxy-workflow-draft schema when a validator is available.
+
+## Procedure
+
+Apply a reviewed change-set to a concrete Galaxy workflow and emit a `galaxy-workflow-draft.gxwf.yml`. This skill plays the topology-settling role the `*-to-galaxy-template` skills play in the greenfield pipelines — but it starts from an already-concrete workflow, so its defining job is to change **only** what the change-set names and carry everything else through untouched.
+
+**An edit is a drafty region.** The Foundry already drains drafty steps out of a partially-concrete workflow via advance-galaxy-draft-step. So this skill does not resolve tools or run an edit loop of its own. It represents the whole modified workflow as a draft (see galaxy-workflow-draft-format): untouched steps carried at Resolved tier verbatim, and any edit that introduces or replaces a tool injected as a **drafty step + `_plan_*`** for the per-step loop to realize.
+
+### What to apply directly vs. defer
+
+- **Direct edits (applied inline, no drafty step).** `remove-step`, `rewire`, `relabel` / `annotate`, `change-parameter`, `add-input` / `remove-input`, `add-output` / `expose-output`. These need no tool resolution: edit the concrete step/input/output in place and rewire consumers as the change-set dictates. A change-set of purely direct edits yields a draft with `draft: false` — an immediately concrete workflow, no loop iterations.
+- **Deferred edits (injected as drafty steps).** `add-step` and `replace-tool` (when the replacement is a different tool or an unpinned version). Add the step at draft tier with `tool_id: TODO` (or Identity-pinned when the change-set pinned an id), and record the operation, source evidence, and constraints in `_plan_state` / `_plan_context` / `_plan_in` / `_plan_out` so advance-galaxy-draft-step can resolve a wrapper and concretize it.
+
+### Preserve untouched regions
+
+Every step, input, and output the change-set does not name must survive byte-for-byte: same `tool_id`, `tool_version`, `tool_state`, labels, and connections. Do not reorder, reformat, re-case, or "tidy" an unrelated region — a structural diff of the emitted workflow against the input must touch only the change-set's targets and their necessary consequences (e.g. rewiring a consumer of a replaced producer). Gratuitous churn is a defect, not a style choice.
+
+### Computability and the ledger
+
+An edit can create a gap the connection graph won't catch: a rewire whose source doesn't carry what the consumer needs, or a `replace-tool` whose new tool can't supply a downstream port. Before handing off, check each edited region is computable from what feeds it. Where you find a gap you can't wire, append a blocking entry to the open-requirements-ledger naming the edit, the uncomputable output, and the missing evidence — so the per-step loop or repair-galaxy-draft-topology acts on it rather than discovering it late. Never fabricate a connection to make the graph look complete. More generally, carry the ledger: read the entries bearing on the edits and mark resolved the ones the change-set closes.
+
+### Hand off
+
+Run draft-validate on the emitted draft (sentinel form, topology, `_plan_*` placement). On green, hand the draft to advance-galaxy-draft-step, which drains any injected drafty steps and extracts the concrete `galaxy-workflow.gxwf.yml`. If the change-set was all direct edits, the loop is a no-op and the workflow is already concrete.
+
+## Runtime Notes
+
+- Do not read Foundry source files at runtime; use only files packaged in this skill bundle and user-supplied artifacts.
+- Preserve declared artifact filenames unless the user or harness supplies explicit paths.
+- Carry unresolved assumptions into the output artifact instead of silently inventing missing source evidence.

--- a/casts/claude/skills/apply-galaxy-workflow-changeset/_provenance.json
+++ b/casts/claude/skills/apply-galaxy-workflow-changeset/_provenance.json
@@ -1,0 +1,132 @@
+{
+  "provenance_schema_version": 3,
+  "cast_target": "claude",
+  "mold": {
+    "name": "apply-galaxy-workflow-changeset",
+    "path": "content/molds/apply-galaxy-workflow-changeset/index.md",
+    "revision": 1,
+    "content_hash": "dbd3d8a2ba31fbe7b5b40111a79c6355b9fcb177ad69227cf850e585fbbf4bdf",
+    "commit": "e90a42769ba95218355e011fe62fb6daeaef28a7"
+  },
+  "cast_at": "2026-07-07T19:12:26.678Z",
+  "refs": [
+    {
+      "kind": "cli-command",
+      "mode": "sidecar",
+      "ref": "[[draft-validate]]",
+      "src": "content/cli/gxwf/draft-validate.md",
+      "dst": "references/cli/draft-validate.json",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "hypothesis",
+      "purpose": "Validate the emitted draft against draft-contract rules (sentinel form, topology, _plan_* placement) before handing off to the per-step loop.",
+      "trigger": "After writing the modified draft workflow file.",
+      "verification": "Cast the skill, run on a representative workflow + change-set, confirm draft-validate diagnostics route back.",
+      "src_hash": "9b75e618475a0f46c9fab322d274aee9998ebfd9f99f8447e2c1533c3e442cc6",
+      "dst_hash": "77e2efef3176ce4b4ea6fb3b0bbc4821b3dbf2e6678e8c20f943586791163b02",
+      "source": "deterministic"
+    },
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[galaxy-workflow-draft-format]]",
+      "src": "content/research/galaxy-workflow-draft-format.md",
+      "dst": "references/notes/galaxy-workflow-draft-format.md",
+      "used_at": "runtime",
+      "load": "upfront",
+      "evidence": "hypothesis",
+      "purpose": "Represent the whole workflow as a draft: carry untouched steps at Resolved tier, inject tool-introducing/replacing edits as drafty steps with _plan_state / _plan_context / _plan_in / _plan_out.",
+      "verification": "Promote after a downstream advance-galaxy-draft-step run drains the injected drafty steps without round-tripping back through the change-set.",
+      "src_hash": "e17baee79b786a2003c66baed9ce6e9c581f79b29b423e83c93c871b3e61bdda",
+      "dst_hash": "e17baee79b786a2003c66baed9ce6e9c581f79b29b423e83c93c871b3e61bdda",
+      "source": "deterministic"
+    },
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[open-requirements-ledger]]",
+      "src": "content/research/open-requirements-ledger.md",
+      "dst": "references/notes/open-requirements-ledger.md",
+      "used_at": "runtime",
+      "load": "upfront",
+      "evidence": "hypothesis",
+      "purpose": "Carry the open-requirements ledger: append an edit's unmet need (e.g. a rewire with no reachable producer) rather than fabricating a connection, and mark resolved the ones its edits close.",
+      "verification": "Promote after a worked run shows entries this Mold appends or resolves are consumed downstream without re-derivation.",
+      "src_hash": "04d5c952cf0e952ae6153b3962334066f0a440a64da4237cf61264a59920be4f",
+      "dst_hash": "04d5c952cf0e952ae6153b3962334066f0a440a64da4237cf61264a59920be4f",
+      "source": "deterministic"
+    },
+    {
+      "kind": "schema",
+      "mode": "verbatim",
+      "ref": "[[galaxy-workflow-draft]]",
+      "src": "package://@galaxy-tool-util/schema#galaxyWorkflowDraftJsonSchema",
+      "dst": "references/schemas/galaxy-workflow-draft.schema.json",
+      "used_at": "runtime",
+      "load": "upfront",
+      "evidence": "cast-validated",
+      "purpose": "Output contract: the emitted gxformat2 draft conforms to [[galaxy-workflow-draft]]. Cast bundles the JSON Schema so the skill carries its output shape alongside [[draft-validate]] checks.",
+      "license": "MIT",
+      "license_file": "LICENSES/galaxy-tool-util-ts.LICENSE",
+      "src_hash": "86822b6bf4c11ba1d9eaa12d9e442db7f7d28b2734a2daddf62b5cdd2f1f75aa",
+      "dst_hash": "86822b6bf4c11ba1d9eaa12d9e442db7f7d28b2734a2daddf62b5cdd2f1f75aa",
+      "source": "deterministic",
+      "license_file_hash": "383450c494c01c466bcf22df102540a39ac89da50563fd7be686ba06772f96b3"
+    }
+  ],
+  "artifacts": {
+    "produces": [
+      {
+        "id": "galaxy-workflow-draft",
+        "kind": "yaml",
+        "default_filename": "galaxy-workflow-draft.gxwf.yml",
+        "schema": "[[galaxy-workflow-draft]]",
+        "description": "gxformat2 draft (see [[galaxy-workflow-draft-format]]) of the whole workflow: untouched steps carried at Resolved tier verbatim; tool-introducing/replacing edits injected as drafty steps with _plan_* fields for the per-step loop; direct edits applied inline."
+      },
+      {
+        "id": "open-requirements-ledger",
+        "kind": "yaml",
+        "default_filename": "open-requirements.ledger.yml",
+        "description": "Updated obligations ledger: new unmet needs an edit surfaces appended; prior entries its edits close marked resolved."
+      }
+    ],
+    "consumes": [
+      {
+        "id": "galaxy-workflow",
+        "description": "The concrete gxformat2 workflow being modified (already converted from .ga if needed). The substrate edits apply to — untouched regions must survive byte-for-byte.",
+        "producers": [
+          "advance-galaxy-draft-step"
+        ]
+      },
+      {
+        "id": "galaxy-workflow-changeset",
+        "description": "Reviewed, step-anchored change-set from [[interview-to-galaxy-workflow-changeset]]; the edit intents to realize.",
+        "producers": [
+          "interview-to-galaxy-workflow-changeset"
+        ]
+      },
+      {
+        "id": "open-requirements-ledger",
+        "description": "Carried obligations ledger [[open-requirements-ledger]]: read open entries bearing on the edits; append any an edit cannot satisfy and mark resolved the ones it closes.",
+        "producers": [
+          "advance-galaxy-draft-step",
+          "apply-galaxy-workflow-changeset",
+          "compare-against-iwc-exemplar",
+          "cwl-summary-to-galaxy-data-flow",
+          "cwl-summary-to-galaxy-interface",
+          "cwl-summary-to-galaxy-template",
+          "freeform-summary-to-galaxy-data-flow",
+          "freeform-summary-to-galaxy-interface",
+          "freeform-summary-to-galaxy-template",
+          "implement-galaxy-tool-step",
+          "interview-to-galaxy-workflow-changeset",
+          "nextflow-summary-to-galaxy-data-flow",
+          "nextflow-summary-to-galaxy-interface",
+          "nextflow-summary-to-galaxy-reference-data",
+          "nextflow-summary-to-galaxy-template",
+          "repair-galaxy-draft-topology"
+        ]
+      }
+    ]
+  }
+}

--- a/casts/claude/skills/apply-galaxy-workflow-changeset/_required_tools.json
+++ b/casts/claude/skills/apply-galaxy-workflow-changeset/_required_tools.json
@@ -1,0 +1,16 @@
+[
+  {
+    "tool": "gxwf",
+    "origin": "npm",
+    "package": "@galaxy-tool-util/cli",
+    "package_version": "^1.8.1",
+    "invoke": "gxwf",
+    "invoke_fallback": "npx --yes --package @galaxy-tool-util/cli@1.8.1 gxwf",
+    "availability_check": "gxwf --help | grep -q draft-validate",
+    "docs_url": "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli",
+    "source": "implied",
+    "implied_by": [
+      "gxwf draft-validate"
+    ]
+  }
+]

--- a/casts/claude/skills/apply-galaxy-workflow-changeset/_verify.json
+++ b/casts/claude/skills/apply-galaxy-workflow-changeset/_verify.json
@@ -1,0 +1,4 @@
+{
+  "verify_schema_version": 1,
+  "entries": []
+}

--- a/casts/claude/skills/apply-galaxy-workflow-changeset/references/cli/draft-validate.json
+++ b/casts/claude/skills/apply-galaxy-workflow-changeset/references/cli/draft-validate.json
@@ -1,0 +1,123 @@
+{
+  "type": "cli-command",
+  "tool": "gxwf",
+  "command": "draft-validate",
+  "summary": "Validate a `class: GalaxyWorkflowDraft` workflow against draft-contract rules; with --concrete, also validate the extracted concrete subset.",
+  "source_path": "content/cli/gxwf/draft-validate.md",
+  "source_revision": 1,
+  "package": "@galaxy-tool-util/cli",
+  "description": "Validate a draft Galaxy workflow (class: GalaxyWorkflowDraft)",
+  "synopsis": "gxwf draft-validate [options] <file>",
+  "args": [
+    {
+      "raw": "file",
+      "name": "file",
+      "required": true,
+      "variadic": false,
+      "description": "Draft workflow file (.gxwf.yml)"
+    }
+  ],
+  "options": [
+    {
+      "flags": "--format <fmt>",
+      "name": "format",
+      "description": "Force format: format2 (native is rejected for drafts)",
+      "takesArgument": true,
+      "argumentPlaceholder": "<fmt>",
+      "optionalArgument": false,
+      "negatable": false
+    },
+    {
+      "flags": "--json",
+      "name": "json",
+      "description": "Output structured JSON report",
+      "takesArgument": false,
+      "optionalArgument": false,
+      "negatable": false
+    },
+    {
+      "flags": "--report-html [file]",
+      "name": "reportHtml",
+      "description": "Write HTML report to file (or stdout if omitted)",
+      "takesArgument": true,
+      "argumentPlaceholder": "[file]",
+      "optionalArgument": true,
+      "negatable": false
+    },
+    {
+      "flags": "--report-markdown [file]",
+      "name": "reportMarkdown",
+      "description": "Write Markdown report to file (or stdout if omitted)",
+      "takesArgument": true,
+      "argumentPlaceholder": "[file]",
+      "optionalArgument": true,
+      "negatable": false
+    },
+    {
+      "flags": "--concrete",
+      "name": "concrete",
+      "description": "Additionally extract the concrete subset and run the regular `gxwf validate` checks on it",
+      "takesArgument": false,
+      "optionalArgument": false,
+      "negatable": false
+    },
+    {
+      "flags": "--cache-dir <dir>",
+      "name": "cacheDir",
+      "description": "Tool cache directory (for --concrete tool-state validation)",
+      "takesArgument": true,
+      "argumentPlaceholder": "<dir>",
+      "optionalArgument": false,
+      "negatable": false
+    },
+    {
+      "flags": "--no-tool-state",
+      "name": "toolState",
+      "description": "Skip tool-state validation in the --concrete pass (default: enabled when --concrete is set)",
+      "takesArgument": false,
+      "optionalArgument": false,
+      "negatable": true
+    },
+    {
+      "flags": "--connections",
+      "name": "connections",
+      "description": "Validate connection-type compatibility on the --concrete subset (collection algebra, map-over)",
+      "takesArgument": false,
+      "optionalArgument": false,
+      "negatable": false
+    },
+    {
+      "flags": "--strict",
+      "name": "strict",
+      "description": "Shorthand for --strict-structure --strict-encoding --strict-state",
+      "takesArgument": false,
+      "optionalArgument": false,
+      "negatable": false
+    },
+    {
+      "flags": "--strict-structure",
+      "name": "strictStructure",
+      "description": "Reject unknown keys at envelope/step level",
+      "takesArgument": false,
+      "optionalArgument": false,
+      "negatable": false
+    },
+    {
+      "flags": "--strict-encoding",
+      "name": "strictEncoding",
+      "description": "Reject JSON-string tool_state and format2 field misuse",
+      "takesArgument": false,
+      "optionalArgument": false,
+      "negatable": false
+    },
+    {
+      "flags": "--strict-state",
+      "name": "strictState",
+      "description": "Require every tool step to validate; no skips allowed",
+      "takesArgument": false,
+      "optionalArgument": false,
+      "negatable": false
+    }
+  ],
+  "body": "# `gxwf draft-validate`\n\nValidate a draft Galaxy workflow against the **draft contract**: sentinel form, dangling edge references, top-level `_plan_*` placement, `_plan_*` on fully-resolved tool steps, and recursive draft subworkflows. Native (.ga) input is rejected — drafts are format2-only.\n\nDistinct from [[validate]], which validates a fully concrete `class: GalaxyWorkflow` and would reject the draft relaxations outright. Use `draft-validate` during the per-step authoring loop; use `validate` at the terminal pass once `promoteFullyConcreteDrafts` has flipped the class.\n\n## Output\n\nDefault output is human-readable: counted buckets for structure / topology / semantic errors and warnings, plus a one-line survey (TODO sentinel count, paths carrying `_plan_*`). `--json` emits a `SingleDraftValidationReport`; `--report-html` and `--report-markdown` write the same data as a self-contained HTML page or templated Markdown. With `--concrete`, the report carries an optional `concrete: ConcreteValidationReport` whose buckets (`structure_errors`, `strict_structure_errors`, `strict_encoding_errors`, `strict_state_errors`, `tool_state`, `connection_report`) are **absent when the corresponding check did not run** — readers should treat absence as \"not run,\" not as \"passed.\"\n\n## Flags\n\n`--concrete` runs the extract+promote pipeline (`extractConcreteSubset` → `stripPlanFields` → `promoteFullyConcreteDrafts`) and applies the full concrete `gxformat2` validation surface to the result. The following pass-through flags only take effect under `--concrete`; passing them without it prints a stderr warning and no-ops:\n\n- `--cache-dir <dir>` — tool cache for tool-state lookups.\n- `--no-tool-state` — skip tool-state validation on the concrete pass. Combined with `--strict-state`, the strict flag warns + no-ops (there's no state to be strict about).\n- `--connections` — run connection validation on the concrete subset.\n- `--strict` — escalate every strict bucket (structure, encoding, state) to error.\n- `--strict-structure` / `--strict-encoding` / `--strict-state` — escalate one bucket only.\n\nDraft structural errors gate the concrete pass entirely — the pipeline would mutate a malformed input, so the concrete section is skipped and only the draft buckets populate.\n\n## Examples\n\n```bash\ngxwf draft-validate workflow.gxwf.yml\ngxwf draft-validate workflow.gxwf.yml --json\ngxwf draft-validate workflow.gxwf.yml --concrete --json\ngxwf draft-validate workflow.gxwf.yml --concrete --strict --cache-dir ~/.cache/gxwf\ngxwf draft-validate workflow.gxwf.yml --report-html report.html\n```\n\n## Exit codes\n\n- `0` — clean draft (no structure / topology / semantic errors; warnings allowed). Under `--concrete`, also requires the concrete pass to be clean.\n- `1` — draft validation errors (topology or semantic). With `--concrete`, also returned when the concrete projection fails — including strict-* failures that `gxwf validate` would have exited `2` on standalone. The asymmetry is deliberate: the draft itself parsed, only its projection failed.\n- `2` — parse failure, native input rejected, structural decode failure (class is not `GalaxyWorkflowDraft`), or a stdout-sink collision between `--json` and `--report-{html,markdown}=-`.\n\n## Gotchas\n\n- The draft validator is **contract-shaped**, not workflow-shaped. It will not catch tool-state errors, parameter-name mismatches, or other concerns that belong to [[validate]] on the concretized subset. Use `--concrete` (or run [[draft-extract]] | [[validate]] manually) when you need both surfaces.\n- A draft with zero implemented steps still runs the `--concrete` pipeline, but the projection is empty — the concrete buckets report `skipped` semantics (absent in the JSON) rather than a green pass. Signal grows as the loop fills steps in; do not interpret early-loop runs as evidence the workflow concretizes correctly.\n- `_plan_*` on a fully-resolved tool step is a `semanticError`, not a warning. Strip planning fields explicitly via [[draft-extract]] (or `stripPlanFields`) when a step concretizes; the per-step Mold should never carry them forward.\n- Subworkflow draft roots are validated recursively; diagnostics carry the outer step path.\n- `TODO`, `TODO_x`, `TODO-x` are sentinels; `TODONE` and `TODOLIST` are not.\n- Prefer `--json` whenever a cast skill or harness needs to classify diagnostics."
+}

--- a/casts/claude/skills/apply-galaxy-workflow-changeset/references/notes/galaxy-workflow-draft-format.md
+++ b/casts/claude/skills/apply-galaxy-workflow-changeset/references/notes/galaxy-workflow-draft-format.md
@@ -1,0 +1,137 @@
+---
+type: research
+subtype: design-spec
+title: "Galaxy workflow draft format"
+tags:
+  - research/design-spec
+  - target/galaxy
+status: draft
+created: 2026-05-06
+revised: 2026-05-10
+revision: 2
+ai_generated: true
+related_notes:
+  - "[[gxformat2-schema]]"
+  - "[[galaxy-data-flow-draft-contract]]"
+  - "[[discover-shed-tool]]"
+  - "[[galaxy-workflow-draft]]"
+  - "[[open-requirements-ledger]]"
+related_molds:
+  - "[[nextflow-summary-to-galaxy-template]]"
+  - "[[cwl-summary-to-galaxy-template]]"
+  - "[[freeform-summary-to-galaxy-template]]"
+  - "[[compare-against-iwc-exemplar]]"
+  - "[[implement-galaxy-tool-step]]"
+  - "[[advance-galaxy-draft-step]]"
+  - "[[repair-galaxy-draft-topology]]"
+summary: "gxformat2 draft superset: wrapper-tier TODOs (tool_id, tool_state, port names) plus _plan_state / _plan_context / _plan_in / _plan_out per tool step."
+---
+
+# Galaxy workflow draft format
+
+The output artifact `galaxy-workflow-draft` produced by the `*-summary-to-galaxy-template` Molds is **gxformat2 with wrapper-tier relaxations and free-text planning fields**, sized to the gap between data-flow design and tool-resolved implementation.
+
+Topology — workflow inputs and their collection shapes, workflow outputs, the step set, the producer→consumer edge graph, branches, and `when:` guards — is **settled by the template Mold itself**, drawing on the upstream interface and data-flow briefs (see [[galaxy-data-flow-draft-contract]]). The output is concrete gxformat2 with no topology TODOs. Wrapper-tier resolution — which Tool Shed wrapper, what parameters, the wrapper-determined port names that populate `in:` / `out:` / `outputSource` — is **evidence-gated per step** (see Resolution tiers below): a step resolves fully when the evidence pins wrapper and parameters together, pins identity alone when the wrapper is named but its settings are not, and defers entirely when the evidence is weak.
+
+A step's declared `in:` arity is a topology decision and must be realizable by one wrapper. Combining N sources into one — concatenate, merge, union — is its own node (`gops_concat_1`, `cat1` for two/N datasets; `collapse_dataset` for a collection), never folded into a downstream 1→1 reshape. A step that would declare ≥2 dataset inputs under a reshape intent (awk, text-reformatting, "reshape") is a missing-combine-node smell: split it into an explicit combine step plus single-input reshapes. The relevant concat/merge/union recipes are reachable through the tabular, interval, and collection pattern indices the template already consults.
+
+## Resolution tiers
+
+Each tool step is resolved to the tier its evidence supports — **evidence-gated, not source-gated**. The source kind (free-form, nf-core, CWL) shifts how often a step reaches each tier but never caps it; each `*-summary-to-galaxy-template` Mold records its own source tendency.
+
+- **Resolved** — concrete `tool_id`, `tool_shed_repository` / changeset (or a stable built-in id), and bound `tool_state`; no `_plan_*`. Use when the evidence pins wrapper *and* parameters jointly: a built-in Galaxy tool with brief-determined params (`Filter1`, `Cut1`, a collection operation), or a pattern page / IWC exemplar worked example that supplies `tool_id`, changeset, and parameter values together. `draft-validate` rejects `_plan_*` on a fully-resolved step.
+- **Identity-pinned** — concrete `tool_id` with `tool_version: TODO` (changeset deferred); `tool_state` and `tool_shed_repository` absent; `_plan_state` (and any other open `_plan_*`) kept. The `tool_version: TODO` sentinel is load-bearing: it keeps the step drafty for [[draft-next-step]] and not-fully-resolved for [[draft-validate]], so the retained `_plan_state` is legal rather than a `semanticError`. (A step is "fully-resolved" — and so forbidden from carrying `_plan_*` — exactly when it has *no* remaining TODO sentinel in `tool_id`, `tool_version`, or any `in:` / `out:` port; pinning identity without this sentinel would trip that gate.) Use when the evidence confidently names *which* wrapper but not its settings or exact changeset for this context: a portion of an IWC exemplar that [[compare-against-iwc-exemplar]] flags as a high-confidence match, a pattern page's worked example, or a source summary that names a specific `tool_id` with evidence.
+- **Deferred** — `tool_id: TODO`, full `_plan_*`. Use when the evidence is weak, multi-candidate, a domain-specific scientific tool with no covering pattern or exemplar, or a corpus gap.
+
+Pin identity only on strong evidence — a wrapper an exemplar actually uses for the same operation, a worked pattern example, or a tool the source names explicitly — never on plausibility: a wrong pinned `tool_id` lets [[discover-shed-tool]] resolve the wrong tool's changeset instead of searching afresh. Port names follow the wrapper: real on a Resolved step, `TODO_<hint>` sentinels until the step resolves.
+
+The per-step loop does not edit topology — but it may **escalate back to a template-tier Mold** when implementation proves the settled topology can't support a declared step (see "Topology repair escalation" below). Wiring authority stays in the template tier; the loop only gains a path back to it.
+
+## Relaxations vs. gxformat2
+
+For tool steps, when the wrapper has not been picked:
+
+- `tool_id` and `tool_version` MAY be the literal string `TODO`. Resolution belongs to [[discover-shed-tool]] and the per-step implementation Mold.
+- `tool_shed_repository` (the `{ changeset_revision, name, owner, tool_shed }` block) MAY be absent.
+- `tool_state` / `state` MAY be absent.
+- Step `out[].id` and `in[]` keys MAY be `TODO_<hint>` sentinels (e.g. `TODO_trimmed_paired`, `TODO_input`). Workflow `outputs[].outputSource` MAY reference such a sentinel via `step/TODO_<hint>` so the connection graph still resolves syntactically. The connection itself (which step's output feeds which step's input) is topology and MUST be present; only the wrapper-determined port names are deferred.
+
+Workflow inputs (types, collection shapes, formats, optionality), workflow outputs, step labels, and the producer→consumer edge set MUST be expressed in normal gxformat2 form with concrete values — never `TODO`. The template Mold is the locus where these decisions are made; if the upstream brief leaves a topology choice open, decide it here from source evidence, IWC exemplars, and pattern pages rather than punting downstream.
+
+## Additions: `_plan_*` planning fields
+
+Free-text fields per tool step capture the template Mold's intent for the downstream per-step implementation Mold. All optional, but expected on any Identity-pinned or Deferred step (`tool_id` is `TODO`, or `tool_id` is pinned but `tool_state` is absent); a Resolved step carries none.
+
+- `_plan_state` — parameter binding intent: which knobs matter, value or range, why. Read by the per-step Mold to bind real `tool_state` once a wrapper is selected.
+- `_plan_context` — extras the per-step Mold needs to pick a wrapper: source `command:` block, conda packages, Docker/Singularity images, environment variables, preconditions, postconditions, container entrypoints, scratch-disk needs.
+- `_plan_in` — wrapper input port mapping intent. The connection graph already says "this source feeds this step"; `_plan_in` records the semantic role of each port and likely wrapper-side names (`single_paired` vs `paired_input` vs `input`) so the per-step Mold can collapse `TODO_*` keys to the real ones.
+- `_plan_out` — wrapper output surface intent: which outputs downstream consumers depend on (with the existing edges as evidence) so the per-step Mold can pick a wrapper that exposes them, or insert a follow-up step if it does not.
+
+The `_plan_*` family is **wrapper-tier**: each entry exists because the wrapper is not yet fully resolved and disappears the moment the step is. Topology decisions do not belong here.
+
+`_plan_*` fields are **draft-only**. They MUST be removed before the workflow is treated as a runnable gxformat2 document. Any remaining `TODO` / `TODO_*` sentinels MUST also be resolved at the same time.
+
+## Example (sketch)
+
+```yaml
+class: GalaxyWorkflowDraft
+inputs:
+  reads:
+    type: collection
+    collection_type: list:paired
+    format: fastqsanger.gz
+outputs:
+  trimmed:
+    outputSource: fastp/TODO_trimmed_paired
+steps:
+  fastp:
+    tool_id: TODO
+    label: trim and QC paired reads
+    in:
+      TODO_input: reads
+    out:
+      - id: TODO_trimmed_paired
+      - id: TODO_html_report
+    _plan_state: |
+      adapter trimming on, quality cutoff ~Q20, min length ~50.
+      preserve paired-end pairing for downstream alignment.
+    _plan_context: |
+      upstream: nf-core FASTP module.
+      conda: bioconda::fastp=0.23.4
+      container: quay.io/biocontainers/fastp:0.23.4--h5f740d0_0
+      precondition: paired list collection with sane element identifiers
+    _plan_in: |
+      single semantic port `reads`: feeds workflow `reads` (list:paired).
+      wrapper input port name likely one of `single_paired` | `paired_input` |
+      `input` depending on which fastp wrapper is picked.
+    _plan_out: |
+      need a paired output that preserves list:paired shape (downstream
+      alignment step consumes it). also expose the HTML report as a
+      checkpoint output for QC.
+```
+
+## Why this shape
+
+- Keeps the artifact recognizably gxformat2 so static tooling (`gxwf validate --no-tool-state`, structural diff against IWC) still applies to topology and port wiring.
+- Carves a stable handoff between the template Mold and the per-step implementation Mold without sneaking tool resolution into either side.
+- Makes the boundary between topology (settled upstream) and wrapper-tier (deferred) explicit — the `_plan_*` family lives squarely on the deferred side.
+- Free-text `_plan_*` is intentional for v1: it lets the templating agent record intent without a contract pretending to be parameterizable yet. Structuring those fields is open work — see each template Mold's `refinement.md`.
+
+## Topology repair escalation
+
+The template Mold settles topology, but it can miss a **computability** gap: a step whose declared output needs evidence no wired input carries. The connection graph validates — ports connect — yet the step can't be implemented. The template's computability review pass catches most of these and either wires the producer or records the gap in the [[open-requirements-ledger]]; the rest surface in the per-step loop.
+
+When one surfaces, the per-step loop does not author topology to fix it. It **escalates**:
+
+- [[implement-galaxy-tool-step]] detects, while implementing, that the declared output can't be computed from the wired inputs. It appends a blocking entry to the [[open-requirements-ledger]] and falls through rather than fabricating the output.
+- [[repair-galaxy-draft-topology]] — a template-tier Mold sharing the template's reference set — reads the blocking entries and re-wires the affected region: one producer step, a small sub-path, or honest narrowing of the output. New steps land at draft (wrapper-tier `TODO`) tier, so the existing discover-or-author → implement machinery realizes them.
+
+This is **repair**, distinct from **settling**: it is narrow (one named region), reactive (only a detected computability gap triggers it), and bounded. The loop's convergence gate counts open blocking entries in the ledger; each escalation must strictly reduce that count, under a hard cap on escalations. When the cap is reached with entries still open, they are **surrendered** — written into the final draft as labelled gaps — the clean terminal that replaces spin-or-fabricate. So the boundary "topology decisions do not belong in the per-step loop" still holds: the loop never decides topology, it returns the decision to the template tier.
+
+## Open work
+
+- Decide whether `_plan_state` should grow structure (parameter-name hints, value ranges, references back to the source summary).
+- Decide whether `_plan_context` should be split into typed fields (`source_command`, `conda`, `containers`, `env`, `pre`, `post`).
+- Decide structure for `_plan_in` and `_plan_out` once two or three worked drafts exercise them. Candidate `_plan_out`: array of `{ semantic_name, downstream_consumers[], required_for }`. Candidate `_plan_in`: map keyed by the `TODO_*` placeholder key to `{ semantic_name, source_step_output, shape_constraint }`.
+- Pick a JSON Schema strategy: extend the gxformat2 schema with `_plan_*` and the relaxed wrapper / port-name rules, or validate the draft via a sibling schema that wraps gxformat2 with the relaxations.
+- Specify the strip step that converts a draft into a runnable gxformat2 workflow. It MUST drop all `_plan_*` fields and reject any remaining `TODO` or `TODO_<hint>` sentinel in `tool_id`, `tool_version`, `out[].id`, `in[]` keys, or `outputSource`.

--- a/casts/claude/skills/apply-galaxy-workflow-changeset/references/notes/open-requirements-ledger.md
+++ b/casts/claude/skills/apply-galaxy-workflow-changeset/references/notes/open-requirements-ledger.md
@@ -1,0 +1,91 @@
+---
+type: research
+subtype: design-spec
+title: "Open-requirements ledger"
+tags:
+  - research/design-spec
+  - target/galaxy
+status: draft
+created: 2026-06-16
+revised: 2026-06-16
+revision: 1
+ai_generated: true
+related_notes:
+  - "[[galaxy-workflow-draft-format]]"
+related_molds:
+  - "[[advance-galaxy-draft-step]]"
+  - "[[repair-galaxy-draft-topology]]"
+  - "[[implement-galaxy-tool-step]]"
+summary: "Carried unresolved-requirements artifact the source→Galaxy pipeline discharges or explicitly surrenders, autonomously."
+---
+
+# Open-requirements ledger
+
+The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact.
+
+## Framing: obligations the pipeline discharges, not questions a human answers
+
+This is deliberately *not* an "open questions for the user" list. The pipeline is autonomous — no human-in-the-loop gate is assumed. The ledger's consumers are **Molds and the loop's convergence gate**, with human readout a secondary affordance. An entry is closed by a downstream Mold doing work (wiring a producer, picking a wrapper, settling a value), or — when nothing can close it — surrendered: written into the final draft as a known, labelled gap rather than silently dropped or fabricated around.
+
+The distinction matters because a "questions for a human" framing leaks an operator's personal interaction style into a tool meant to run inside anyone's harness. The ledger must behave identically cast into a fresh harness with no ambient configuration; that holds only because every obligation is **materialized in the artifact**, never carried as operator habit.
+
+## Entry shape (v1, loose)
+
+Like the `_plan_*` family in [[galaxy-workflow-draft-format]], ledger entries are intentionally low-ceremony for v1 — enough structure to count and close, no contract pretending to be machine-parameterizable yet. A reasonable per-entry shape:
+
+```yaml
+- id: sccmec-evidence-missing
+  status: open                # open | resolved | surrendered
+  raised_by: implement-galaxy-tool-step   # Mold that appended it
+  step: classify_context       # draft step the obligation attaches to (if any)
+  unmet: "SCCmec-region candidate output category"
+  missing: "no wired input carries SCCmec cassette evidence"
+  resolved_by: null            # Mold that closed it, once closed
+  note: ""                     # how it was closed or why surrendered
+```
+
+Provenance (`raised_by`, `resolved_by`) is the audit trail for *when* each obligation entered and left — the traceability #281 asked for, and the evidence the convergence gate reads.
+
+## Role in topology repair
+
+In the Galaxy per-step loop, the ledger is the substrate the topology-repair escalation rides on (see [[galaxy-workflow-draft-format]] and [[repair-galaxy-draft-topology]]):
+
+- **[[implement-galaxy-tool-step]]** detects, mid-implementation, that a declared step output cannot be computed from its wired inputs — a defect invisible to `gxwf` structural validation, because the connection graph knows ports connect, not what they contain. Rather than fabricate, it appends a blocking entry and falls through to repair.
+- **[[repair-galaxy-draft-topology]]** reads the open blocking entries, re-wires the affected region (template-tier authoring — one step or a small sub-path), and marks each entry it closes `resolved`; the existing discover-or-author → implement machinery then realizes the new steps.
+- The loop's **decreasing-blocker invariant** counts open blocking entries: each repair escalation must strictly reduce that count, under a hard cap on escalations. When the cap is hit with entries still open, those entries are **surrendered** into the final draft — the clean terminal that replaces spin-or-fabricate.
+
+So the ledger is not a convenience here; it is the countable state the termination guard depends on.
+
+## Escalation budget (loop-level state)
+
+The decreasing-blocker invariant needs more than the entries themselves: "strictly reduce the open count, under a hard cap" is *loop-level* state — it spans iterations and belongs to no single entry. The ledger carries it in a small `topology_repair` header beside the `entries:` list:
+
+```yaml
+topology_repair:
+  escalations: 2           # repairs invoked this run
+  cap: 5                   # hard ceiling; at cap, still-open entries are surrendered
+  open_history: [4, 3, 2]  # open blocking-entry count after each escalation — must be strictly decreasing
+entries:
+  - id: sccmec-evidence-missing
+    status: open
+    # … per-entry shape above
+```
+
+- `escalations` — how many times [[advance-galaxy-draft-step]] has escalated to [[repair-galaxy-draft-topology]] this run. The orchestrator increments it on each escalation.
+- `cap` — the hard ceiling. When `escalations` reaches `cap`, the loop stops escalating and surrenders any still-`open` blocking entries into the final draft as labelled gaps rather than retrying forever.
+- `open_history` — the open blocking-entry count recorded after each escalation. The convergence gate requires it to be strictly decreasing: a repair that fails to lower the open count — or raises it by inserting a producer that is itself uncomputable — is non-convergent and trips the gate immediately, without waiting for the cap.
+
+This block lives in the ledger as a v1 expedient: the ledger is already the carried, cast-visible state the loop reads each iteration. Its better long-term home is the **draft itself** — a workflow-level annotation that travels with the artifact it bounds, so the budget survives even when the ledger is stripped at the terminal. Recorded here for now; migrate when the draft grows a home for it.
+
+## Threaded through the whole design tier
+
+The ledger is not loop-only. It is a single artifact every design-tier Mold in the source→Galaxy pipelines **consumes and re-emits** — the interface, reference-data, data-flow, IWC-comparison, and template Molds (`*-summary-to-galaxy-interface`, `*-summary-to-galaxy-data-flow`, `*-summary-to-galaxy-reference-data`, `compare-against-iwc-exemplar`, `*-summary-to-galaxy-template`). The first design Mold in a run creates it; each subsequent Mold reads the open entries, **appends** the unknowns it newly surfaces, and **marks resolved** the ones its own decisions close (the template settling a topology choice the data-flow left open, the interface pinning a parameter, …). This is the direct answer to #281: the chain stops re-deriving the same unknowns because each Mold inherits them.
+
+The template Mold's computability review pass is one notable appender — `*-summary-to-galaxy-template` re-reads each settled step and, where an output needs evidence no input carries, wires the producer or records the gap as a blocking entry. Source-summary Molds upstream of the design tier keep their own free-text open-questions; the design tier is where those formalize into the ledger.
+
+## Open work
+
+- Decide whether entry structure should harden (typed `unmet` / `missing`, links back to source-summary evidence, machine-checkable `status` transitions) once two or three worked runs exercise it.
+- Decide whether the source-summary Molds should also emit structured entries, or keep their free-text open-questions until the design tier formalizes them.
+- Specify how surrendered entries surface in the runnable gxformat2 (a workflow-level annotation, a report output, or a sidecar) when the draft is stripped of `_plan_*` and TODO sentinels.
+- Move the `topology_repair` escalation budget out of the ledger and into the draft (a workflow-level annotation) so it travels with the artifact it bounds; the ledger home is a v1 expedient.

--- a/casts/claude/skills/apply-galaxy-workflow-changeset/references/schemas/galaxy-workflow-draft.schema.json
+++ b/casts/claude/skills/apply-galaxy-workflow-changeset/references/schemas/galaxy-workflow-draft.schema.json
@@ -1,0 +1,2727 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "WorkflowStepSchema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "id": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "label": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "doc": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "position": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "object",
+              "required": [
+                "top",
+                "left"
+              ],
+              "properties": {
+                "top": {
+                  "type": "number"
+                },
+                "left": {
+                  "type": "number"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "tool_id": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "tool_shed_repository": {
+          "$ref": "#/$defs/Shared15"
+        },
+        "tool_version": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "errors": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "uuid": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "in": {
+          "$ref": "#/$defs/Shared16"
+        },
+        "out": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/Shared4"
+              }
+            },
+            {
+              "type": "object",
+              "required": [],
+              "properties": {},
+              "additionalProperties": {
+                "$ref": "#/$defs/Shared4"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "state": {
+          "anyOf": [
+            {
+              "type": "object",
+              "required": [],
+              "properties": {},
+              "additionalProperties": {
+                "title": "unknown"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tool_state": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "required": [],
+              "properties": {},
+              "additionalProperties": {
+                "title": "unknown"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "post_job_actions": {
+          "anyOf": [
+            {
+              "type": "object",
+              "required": [],
+              "properties": {},
+              "additionalProperties": {
+                "title": "unknown"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "type": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "enum": [
+                "tool",
+                "subworkflow",
+                "pause",
+                "pick_value"
+              ]
+            }
+          ]
+        },
+        "run": {
+          "$ref": "#/$defs/Shared0"
+        },
+        "runtime_inputs": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "when": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Shared0": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "class": {
+              "enum": [
+                "GalaxyWorkflow"
+              ],
+              "type": "string"
+            },
+            "comments": {
+              "anyOf": [
+                {
+                  "items": {
+                    "$ref": "#/$defs/Shared2"
+                  },
+                  "type": "array"
+                },
+                {
+                  "additionalProperties": {
+                    "$ref": "#/$defs/Shared2"
+                  },
+                  "properties": {},
+                  "required": [],
+                  "type": "object"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "creator": {
+              "$ref": "#/$defs/Shared6"
+            },
+            "doc": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              ]
+            },
+            "id": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "inputs": {
+              "$ref": "#/$defs/Shared1"
+            },
+            "label": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "license": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "outputs": {
+              "$ref": "#/$defs/Shared14"
+            },
+            "release": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "report": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "markdown": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "markdown"
+                  ],
+                  "type": "object"
+                }
+              ]
+            },
+            "steps": {
+              "anyOf": [
+                {
+                  "items": {
+                    "$ref": "#/$defs/WorkflowStepSchema"
+                  },
+                  "type": "array"
+                },
+                {
+                  "additionalProperties": {
+                    "$ref": "#/$defs/WorkflowStepSchema"
+                  },
+                  "properties": {},
+                  "required": [],
+                  "type": "object"
+                }
+              ]
+            },
+            "tags": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "uuid": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "required": [
+            "inputs",
+            "outputs",
+            "class",
+            "steps"
+          ],
+          "type": "object"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "additionalProperties": {
+            "title": "unknown"
+          },
+          "properties": {},
+          "required": [],
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "Shared1": {
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Shared11"
+              },
+              {
+                "$ref": "#/$defs/Shared5"
+              },
+              {
+                "$ref": "#/$defs/Shared10"
+              },
+              {
+                "$ref": "#/$defs/Shared12"
+              },
+              {
+                "$ref": "#/$defs/Shared8"
+              },
+              {
+                "$ref": "#/$defs/Shared13"
+              }
+            ]
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Shared11"
+              },
+              {
+                "$ref": "#/$defs/Shared5"
+              },
+              {
+                "$ref": "#/$defs/Shared10"
+              },
+              {
+                "$ref": "#/$defs/Shared12"
+              },
+              {
+                "$ref": "#/$defs/Shared8"
+              },
+              {
+                "$ref": "#/$defs/Shared13"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "properties": {},
+          "required": [],
+          "type": "object"
+        },
+        {
+          "additionalProperties": {
+            "title": "unknown"
+          },
+          "properties": {},
+          "required": [],
+          "type": "object"
+        }
+      ]
+    },
+    "Shared2": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "bold": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
+            },
+            "color": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "italic": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
+            },
+            "label": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "position": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "size": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "text": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "text_size": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "number"
+                }
+              ]
+            },
+            "type": {
+              "enum": [
+                "text"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "color": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "label": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "position": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "size": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "text": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "type": {
+              "enum": [
+                "markdown"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "color": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "contains_comments": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
+                  },
+                  "type": "array"
+                }
+              ]
+            },
+            "contains_steps": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
+                  },
+                  "type": "array"
+                }
+              ]
+            },
+            "label": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "position": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "size": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "title": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "type": {
+              "enum": [
+                "frame"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "color": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "label": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "line": {
+              "anyOf": [
+                {
+                  "items": {
+                    "items": {
+                      "type": "number"
+                    },
+                    "type": "array"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "position": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "size": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "thickness": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "number"
+                }
+              ]
+            },
+            "type": {
+              "enum": [
+                "freehand"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "Shared3": {
+      "additionalProperties": false,
+      "properties": {
+        "_plan_context": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "_plan_in": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "_plan_out": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "_plan_state": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "doc": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "errors": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "id": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "in": {
+          "$ref": "#/$defs/Shared16"
+        },
+        "label": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "out": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/Shared4"
+              },
+              "type": "array"
+            },
+            {
+              "additionalProperties": {
+                "$ref": "#/$defs/Shared4"
+              },
+              "properties": {},
+              "required": [],
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "position": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "left": {
+                  "type": "number"
+                },
+                "top": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "top",
+                "left"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "post_job_actions": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "title": "unknown"
+              },
+              "properties": {},
+              "required": [],
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "run": {
+          "$ref": "#/$defs/Shared0"
+        },
+        "runtime_inputs": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "state": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "title": "unknown"
+              },
+              "properties": {},
+              "required": [],
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tool_id": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "tool_shed_repository": {
+          "$ref": "#/$defs/Shared15"
+        },
+        "tool_state": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "additionalProperties": {
+                "title": "unknown"
+              },
+              "properties": {},
+              "required": [],
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tool_version": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "type": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "enum": [
+                "tool",
+                "subworkflow",
+                "pause",
+                "pick_value"
+              ],
+              "type": "string"
+            }
+          ]
+        },
+        "uuid": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "when": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "required": [],
+      "type": "object"
+    },
+    "Shared4": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "add_tags": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              ]
+            },
+            "change_datatype": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "delete_intermediate_datasets": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
+            },
+            "hide": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
+            },
+            "id": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "remove_tags": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              ]
+            },
+            "rename": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "set_columns": {
+              "anyOf": [
+                {
+                  "additionalProperties": {
+                    "title": "unknown"
+                  },
+                  "properties": {},
+                  "required": [],
+                  "type": "object"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [],
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "Shared5": {
+      "additionalProperties": false,
+      "properties": {
+        "collection_type": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "column_definitions": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "default_value": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "boolean"
+                      }
+                    ]
+                  },
+                  "description": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "optional": {
+                    "type": "boolean"
+                  },
+                  "restrictions": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "boolean"
+                            }
+                          ]
+                        },
+                        "type": "array"
+                      }
+                    ]
+                  },
+                  "suggestions": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "boolean"
+                            }
+                          ]
+                        },
+                        "type": "array"
+                      }
+                    ]
+                  },
+                  "type": {
+                    "enum": [
+                      "string",
+                      "int",
+                      "float",
+                      "boolean",
+                      "element_identifier"
+                    ],
+                    "type": "string"
+                  },
+                  "validators": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "items": {
+                          "title": "unknown"
+                        },
+                        "type": "array"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "name",
+                  "type",
+                  "optional"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "default": {
+          "title": "unknown"
+        },
+        "doc": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "fields": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "format": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "File",
+                          "null",
+                          "boolean",
+                          "int",
+                          "float",
+                          "string"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "items": {
+                          "enum": [
+                            "File",
+                            "null",
+                            "boolean",
+                            "int",
+                            "float",
+                            "string"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "name",
+                  "type"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "format": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "id": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "label": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "optional": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "position": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "left": {
+                  "type": "number"
+                },
+                "top": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "top",
+                "left"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "collection"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "Shared6": {
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "address": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "alternateName": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "class": {
+                    "enum": [
+                      "Person"
+                    ],
+                    "type": "string"
+                  },
+                  "email": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "familyName": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "faxNumber": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "givenName": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "honorificPrefix": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "honorificSuffix": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "identifier": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "image": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "jobTitle": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "name": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "telephone": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "url": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "class"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "address": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "alternateName": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "class": {
+                    "enum": [
+                      "Organization"
+                    ],
+                    "type": "string"
+                  },
+                  "email": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "faxNumber": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "identifier": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "image": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "name": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "telephone": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "url": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "class"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "Shared7": {
+      "additionalProperties": false,
+      "properties": {
+        "doc": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "id": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "label": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "outputSource": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "type": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "enum": [
+                "null",
+                "boolean",
+                "int",
+                "long",
+                "float",
+                "double",
+                "string",
+                "integer",
+                "text",
+                "File",
+                "data",
+                "collection"
+              ],
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "required": [],
+      "type": "object"
+    },
+    "Shared8": {
+      "additionalProperties": false,
+      "properties": {
+        "default": {
+          "title": "unknown"
+        },
+        "doc": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "id": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "label": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "optional": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "position": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "left": {
+                  "type": "number"
+                },
+                "top": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "top",
+                "left"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "restrictOnConnections": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "boolean"
+            }
+          ]
+        },
+        "restrictions": {
+          "$ref": "#/$defs/Shared17"
+        },
+        "suggestions": {
+          "$ref": "#/$defs/Shared17"
+        },
+        "type": {
+          "enum": [
+            "text",
+            "string"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "Shared9": {
+      "additionalProperties": false,
+      "properties": {
+        "default": {
+          "title": "unknown"
+        },
+        "id": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "label": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "source": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
+        }
+      },
+      "required": [],
+      "type": "object"
+    },
+    "Shared10": {
+      "additionalProperties": false,
+      "properties": {
+        "default": {
+          "title": "unknown"
+        },
+        "doc": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "id": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "label": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "optional": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "position": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "left": {
+                  "type": "number"
+                },
+                "top": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "top",
+                "left"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "integer",
+            "int"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "Shared11": {
+      "additionalProperties": false,
+      "properties": {
+        "default": {
+          "title": "unknown"
+        },
+        "doc": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "format": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "id": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "label": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "optional": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "position": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "left": {
+                  "type": "number"
+                },
+                "top": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "top",
+                "left"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "type": {
+          "anyOf": [
+            {
+              "enum": [
+                "data",
+                "File"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [],
+      "type": "object"
+    },
+    "Shared12": {
+      "additionalProperties": false,
+      "properties": {
+        "default": {
+          "title": "unknown"
+        },
+        "doc": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "id": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "label": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "optional": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "position": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "left": {
+                  "type": "number"
+                },
+                "top": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "top",
+                "left"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "float"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "Shared13": {
+      "additionalProperties": false,
+      "properties": {
+        "default": {
+          "title": "unknown"
+        },
+        "doc": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "id": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "label": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "optional": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "position": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "left": {
+                  "type": "number"
+                },
+                "top": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "top",
+                "left"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "boolean"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "Shared14": {
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/Shared7"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Shared7"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "properties": {},
+          "required": [],
+          "type": "object"
+        },
+        {
+          "additionalProperties": {
+            "title": "unknown"
+          },
+          "properties": {},
+          "required": [],
+          "type": "object"
+        }
+      ]
+    },
+    "Shared15": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "changeset_revision": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "owner": {
+              "type": "string"
+            },
+            "tool_shed": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "changeset_revision",
+            "owner",
+            "tool_shed"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "Shared16": {
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/Shared9"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Shared9"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            ]
+          },
+          "properties": {},
+          "required": [],
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "Shared17": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "label": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "value"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          "type": "array"
+        }
+      ]
+    }
+  },
+  "type": "object",
+  "required": [
+    "inputs",
+    "outputs",
+    "class",
+    "steps"
+  ],
+  "properties": {
+    "id": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "label": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "doc": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "inputs": {
+      "$ref": "#/$defs/Shared1"
+    },
+    "outputs": {
+      "$ref": "#/$defs/Shared14"
+    },
+    "uuid": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "class": {
+      "type": "string",
+      "enum": [
+        "GalaxyWorkflowDraft"
+      ]
+    },
+    "steps": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Shared3"
+          }
+        },
+        {
+          "type": "object",
+          "required": [],
+          "properties": {},
+          "additionalProperties": {
+            "$ref": "#/$defs/Shared3"
+          }
+        }
+      ]
+    },
+    "report": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "required": [
+            "markdown"
+          ],
+          "properties": {
+            "markdown": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "tags": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "comments": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Shared2"
+          }
+        },
+        {
+          "type": "object",
+          "required": [],
+          "properties": {},
+          "additionalProperties": {
+            "$ref": "#/$defs/Shared2"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "creator": {
+      "$ref": "#/$defs/Shared6"
+    },
+    "license": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "release": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false
+}

--- a/casts/claude/skills/changeset-to-galaxy-test-plan/SKILL.md
+++ b/casts/claude/skills/changeset-to-galaxy-test-plan/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: changeset-to-galaxy-test-plan
+description: "Carry an existing Galaxy workflow's tests forward as a regression baseline and augment them for a change-set's deltas, emitting a Galaxy test plan."
+---
+
+# changeset-to-galaxy-test-plan
+
+Follow the procedure below and use the artifact/reference sections as the runtime contract.
+
+## When To Use
+
+- Carry an existing Galaxy workflow's tests forward as a regression baseline and augment them for a change-set's deltas, emitting a Galaxy test plan.
+
+## Inputs
+
+- Read artifact `summary-galaxy-workflow`. Schema: summary-galaxy-workflow. Produced by `summarize-galaxy-workflow`. Structured summary of the existing workflow from summarize-galaxy-workflow; its `tests[]` are the regression baseline to carry forward, and its resolved input/output labels are the anchors baseline assertions bind to.
+- Read artifact `galaxy-workflow-changeset`. Produced by `interview-to-galaxy-workflow-changeset`. Reviewed, step-anchored change-set from interview-to-galaxy-workflow-changeset; names which edits change observable behavior, hence which baseline cases to update and which new assertions to add.
+
+## Outputs
+
+- Write artifact `galaxy-test-plan` as `galaxy-test-plan.yml`. Format: `yaml`. Schema: galaxy-workflow-test-plan. Reviewable Galaxy workflow test plan (see galaxy-workflow-test-plan): baseline cases carried forward as test-evidence plus change-set-driven cases/assertions, with job inputs, expected outputs, assertion intent, fixture provenance, label status, unresolved mappings, and omissions.
+
+## Required Tools
+
+- None declared. Procedure should not assume external CLIs are present.
+
+## Load Upfront
+
+- `references/schemas/galaxy-workflow-test-plan.schema.json`: Schema file copied verbatim into the bundle. Output contract: the emitted plan conforms to galaxy-workflow-test-plan. Cast bundles the JSON Schema so the skill carries its output shape; validate with `foundry validate-galaxy-workflow-test-plan`.
+- `references/schemas/summary-galaxy-workflow.schema.json`: Schema file copied verbatim into the bundle. Input contract: read the existing workflow's `tests[]` (the regression baseline) and its resolved input/output labels so baseline assertions bind to real labels.
+
+## Load On Demand
+
+- `references/notes/galaxy-workflow-testability-design.md`: Research note copied verbatim into the bundle. Decide which change-set-exposed outputs and promoted checkpoints make meaningful new assertions, and how much a baseline assertion must loosen when an edit intentionally changes an output. Use when: adding assertions for a newly exposed output or a new step, or reconciling a baseline assertion an edit invalidates.
+- `references/notes/iwc-shortcuts-anti-patterns.md`: Research note copied verbatim into the bundle. Distinguish accepted IWC-style test shortcuts from assertion smells when loosening a baseline assertion or synthesizing a new one. Use when: considering existence-only, size-only, image-dimension, or tolerant output checks, or recording an omission.
+- `references/notes/iwc-test-data-conventions.md`: Research note copied verbatim into the bundle. Record job-input fixtures for change-set-added inputs (remote-URL-first locations, hashes, collection shapes) as fixture provenance, reusing the baseline's existing fixtures unchanged. Use when: a change-set adds a workflow input that needs new test data, or when recording provenance for a new fixture.
+- `references/notes/planemo-asserts-idioms.md`: Research note copied verbatim into the bundle. Pick the assertion family and tolerance for each change-set-driven expected output by output type. Use when: turning a change-set behavioral delta into assertion intent and a tolerance.
+- `references/notes/planemo-workflow-test-architecture.md`: Research note copied verbatim into the bundle. Keep the plan addressable by stable labels and artifacts Planemo can connect back to invocations, jobs, and outputs. Use when: recording the labels and checkpoints the downstream test must address.
+- `references/schemas/tests-format.schema.json`: Schema file copied verbatim into the bundle. Use the Galaxy workflow tests schema as the assertion-family vocabulary when carrying forward or synthesizing assertion intent. Use when: naming an assertion family or compare operator for a carried-forward or change-set-driven expected output.
+
+## Validation
+
+- Validate `galaxy-test-plan.yml` before returning it: run `foundry validate-galaxy-workflow-test-plan galaxy-test-plan.yml` from `@galaxy-foundry/foundry`. If the command is not on PATH, run `npx --package @galaxy-foundry/foundry foundry validate-galaxy-workflow-test-plan galaxy-test-plan.yml`. This checks artifact `galaxy-test-plan` against the galaxy-workflow-test-plan schema.
+
+## Procedure
+
+Produce a Galaxy workflow test plan for the update pipeline: carry the existing workflow's tests forward as a **regression baseline** and augment them for the change-set's behavioral deltas. The output is a reviewable YAML handoff conforming to galaxy-workflow-test-plan, not a concrete `tests-format` file — implement-galaxy-workflow-test authors the final `*-tests.yml` from it. This skill is the update pipeline's analogue of nextflow-test-to-galaxy-test-plan / freeform-summary-to-galaxy-test-plan: the dedicated test-plan producer every Galaxy-targeting pipeline places before the implement step.
+
+### Translate-and-augment, not synthesize-from-scratch
+
+The starting point is real test evidence — the existing workflow's own `tests[]`, captured in summary-galaxy-workflow. Most of the plan is those cases carried forward. So set the plan's `source.derived_from: mixed`: baseline cases keep `derived_from: test-evidence` with `evidence: test-evidence` on their assertions, while change-set-driven cases and assertions carry `evidence: intent` (raise to `test-evidence` only where the change-set pinned a concrete expected value). Unlike a freeform-synthesized plan, the baseline's workflow-label bindings are `label_status: resolved` — the summary read them off the concrete existing workflow, so they are known, not assumed.
+
+### What the change-set drives
+
+Walk the change-set and touch only the assertions its edits reach:
+
+- **Behavior-changing edit → update the affected baseline case.** A `change-parameter`, `replace-tool`, or `add-step` that alters an existing output's content means the baseline assertion on that output is now wrong. Update it — tighten to the new expected value where the change-set gave one, or loosen it (e.g. presence/format where a content check no longer holds) and record the loosening in `omissions[]` with a rationale. **Never delete a baseline case to make it pass**; a regression that silently drops coverage is the failure mode this pipeline exists to avoid.
+- **New observable behavior → a new assertion or case.** An `expose-output` / `add-output` needs a new `expected_outputs[]` entry asserting the promoted output; a new step whose result is observable needs assertion intent for it; a new `add-input` needs a `job_inputs[]` binding and a fixture. Bind change-set-added labels at `label_status: assumed` (the concrete labels settle downstream once the per-step loop resolves the step) and reconcile them in implement-galaxy-workflow-test.
+- **Internal-only edit → no assertion change.** A `rewire`, `relabel`, or `remove-step` that does not change an observable output changes no assertions; carry the baseline through untouched.
+
+### Scope discipline mirrors the change-set
+
+Change only the assertions the change-set reaches. Do not add assertions for untouched regions beyond what the baseline already covers, and do not tidy or re-tolerance a baseline assertion no edit touched — the update pipeline's contract is that untouched behavior is verified exactly as before. Gratuitous churn in the plan propagates into gratuitous test churn downstream.
+
+### Fixtures
+
+Reuse the baseline's existing fixtures verbatim — they already ship with the workflow and are the regression data. Only a change-set that adds a workflow input needs new test data: record it with iwc-test-data-conventions (remote-URL-first, `storage: unresolved` with provenance when the input names data only by description), and leave resolution to the harness test-data step / find-test-data and implement-galaxy-workflow-test. When an added input's data cannot be settled here, add an `unresolved[]` entry (with `blocking: true` when the new case cannot be authored without it) rather than inventing a location.
+
+Keep the plan addressable by stable labels and artifacts (planemo-workflow-test-architecture) so the downstream test, run, and debug skills can connect assertions back to invocations and outputs.
+
+## Runtime Notes
+
+- Do not read Foundry source files at runtime; use only files packaged in this skill bundle and user-supplied artifacts.
+- Preserve declared artifact filenames unless the user or harness supplies explicit paths.
+- Carry unresolved assumptions into the output artifact instead of silently inventing missing source evidence.

--- a/casts/claude/skills/changeset-to-galaxy-test-plan/_provenance.json
+++ b/casts/claude/skills/changeset-to-galaxy-test-plan/_provenance.json
@@ -1,0 +1,166 @@
+{
+  "provenance_schema_version": 3,
+  "cast_target": "claude",
+  "mold": {
+    "name": "changeset-to-galaxy-test-plan",
+    "path": "content/molds/changeset-to-galaxy-test-plan/index.md",
+    "revision": 1,
+    "content_hash": "6a8e4e609ec9b308ec692dc667b4fc02720354717d32d4354521841c0b8d3f77",
+    "commit": "e90a42769ba95218355e011fe62fb6daeaef28a7"
+  },
+  "cast_at": "2026-07-08T17:21:20.980Z",
+  "refs": [
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[galaxy-workflow-testability-design]]",
+      "src": "content/research/galaxy-workflow-testability-design.md",
+      "dst": "references/notes/galaxy-workflow-testability-design.md",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Decide which change-set-exposed outputs and promoted checkpoints make meaningful new assertions, and how much a baseline assertion must loosen when an edit intentionally changes an output.",
+      "trigger": "When adding assertions for a newly exposed output or a new step, or reconciling a baseline assertion an edit invalidates.",
+      "src_hash": "e4d5991a5085e0f9ad52b8e6856f64179362334bd51b77a3302faeb96732f980",
+      "dst_hash": "e4d5991a5085e0f9ad52b8e6856f64179362334bd51b77a3302faeb96732f980",
+      "source": "deterministic"
+    },
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[iwc-shortcuts-anti-patterns]]",
+      "src": "content/research/iwc-shortcuts-anti-patterns.md",
+      "dst": "references/notes/iwc-shortcuts-anti-patterns.md",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Distinguish accepted IWC-style test shortcuts from assertion smells when loosening a baseline assertion or synthesizing a new one.",
+      "trigger": "When considering existence-only, size-only, image-dimension, or tolerant output checks, or recording an omission.",
+      "src_hash": "69269abd774152694053f0b9922f88dfcd175ba8c3697b2c530d911740c7fcc6",
+      "dst_hash": "69269abd774152694053f0b9922f88dfcd175ba8c3697b2c530d911740c7fcc6",
+      "source": "deterministic"
+    },
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[iwc-test-data-conventions]]",
+      "src": "content/research/iwc-test-data-conventions.md",
+      "dst": "references/notes/iwc-test-data-conventions.md",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Record job-input fixtures for change-set-added inputs (remote-URL-first locations, hashes, collection shapes) as fixture provenance, reusing the baseline's existing fixtures unchanged.",
+      "trigger": "When a change-set adds a workflow input that needs new test data, or when recording provenance for a new fixture.",
+      "src_hash": "2c7ef6a674b84f434ed973fe5c93156a6b368fc774a432e828257ddbde5d4993",
+      "dst_hash": "2c7ef6a674b84f434ed973fe5c93156a6b368fc774a432e828257ddbde5d4993",
+      "source": "deterministic"
+    },
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[planemo-asserts-idioms]]",
+      "src": "content/research/planemo-asserts-idioms.md",
+      "dst": "references/notes/planemo-asserts-idioms.md",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Pick the assertion family and tolerance for each change-set-driven expected output by output type.",
+      "trigger": "When turning a change-set behavioral delta into assertion intent and a tolerance.",
+      "src_hash": "9d87cd37efcc3f5e3a378011892f3846c8fdecec7a5765193044d71edb746ed9",
+      "dst_hash": "9d87cd37efcc3f5e3a378011892f3846c8fdecec7a5765193044d71edb746ed9",
+      "source": "deterministic"
+    },
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[planemo-workflow-test-architecture]]",
+      "src": "content/research/planemo-workflow-test-architecture.md",
+      "dst": "references/notes/planemo-workflow-test-architecture.md",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Keep the plan addressable by stable labels and artifacts Planemo can connect back to invocations, jobs, and outputs.",
+      "trigger": "When recording the labels and checkpoints the downstream test must address.",
+      "src_hash": "f66d053cf71c5d5aa4151e0b55719f9b200f5848e7dc69e0200d63d991a9dacf",
+      "dst_hash": "f66d053cf71c5d5aa4151e0b55719f9b200f5848e7dc69e0200d63d991a9dacf",
+      "source": "deterministic"
+    },
+    {
+      "kind": "schema",
+      "mode": "verbatim",
+      "ref": "[[galaxy-workflow-test-plan]]",
+      "src": "package://@galaxy-foundry/foundry#galaxyWorkflowTestPlanSchema",
+      "dst": "references/schemas/galaxy-workflow-test-plan.schema.json",
+      "used_at": "runtime",
+      "load": "upfront",
+      "evidence": "hypothesis",
+      "purpose": "Output contract: the emitted plan conforms to [[galaxy-workflow-test-plan]]. Cast bundles the JSON Schema so the skill carries its output shape; validate with `foundry validate-galaxy-workflow-test-plan`.",
+      "verification": "Cast the skill, run on a summary with existing tests plus a change-set, confirm the emitted YAML validates and downstream [[implement-galaxy-workflow-test]] consumes it without re-reading the change-set.",
+      "license": "MIT",
+      "src_hash": "7bf899c777cb2757cbde359e86c481ef4b1a35b6a8270ed9f678c461226fd96b",
+      "dst_hash": "7bf899c777cb2757cbde359e86c481ef4b1a35b6a8270ed9f678c461226fd96b",
+      "source": "deterministic"
+    },
+    {
+      "kind": "schema",
+      "mode": "verbatim",
+      "ref": "[[summary-galaxy-workflow]]",
+      "src": "package://@galaxy-foundry/foundry#summaryGalaxyWorkflowSchema",
+      "dst": "references/schemas/summary-galaxy-workflow.schema.json",
+      "used_at": "runtime",
+      "load": "upfront",
+      "evidence": "cast-validated",
+      "purpose": "Input contract: read the existing workflow's `tests[]` (the regression baseline) and its resolved input/output labels so baseline assertions bind to real labels.",
+      "license": "MIT",
+      "src_hash": "bc083ab266392f2c6659cfc78d74364fb5552a3d262c9f274bfb487857895ee3",
+      "dst_hash": "bc083ab266392f2c6659cfc78d74364fb5552a3d262c9f274bfb487857895ee3",
+      "source": "deterministic"
+    },
+    {
+      "kind": "schema",
+      "mode": "verbatim",
+      "ref": "[[tests-format]]",
+      "src": "package://@galaxy-foundry/foundry#testsFormatSchema",
+      "dst": "references/schemas/tests-format.schema.json",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Use the Galaxy workflow tests schema as the assertion-family vocabulary when carrying forward or synthesizing assertion intent.",
+      "trigger": "When naming an assertion family or compare operator for a carried-forward or change-set-driven expected output.",
+      "license": "MIT",
+      "license_file": "LICENSES/galaxy-tool-util-ts.LICENSE",
+      "src_hash": "ff0de5041f4c3de0ab7abe9e7555c5a7120665b077f42661461301b0fb26f372",
+      "dst_hash": "ff0de5041f4c3de0ab7abe9e7555c5a7120665b077f42661461301b0fb26f372",
+      "source": "deterministic",
+      "license_file_hash": "383450c494c01c466bcf22df102540a39ac89da50563fd7be686ba06772f96b3"
+    }
+  ],
+  "artifacts": {
+    "produces": [
+      {
+        "id": "galaxy-test-plan",
+        "kind": "yaml",
+        "default_filename": "galaxy-test-plan.yml",
+        "schema": "[[galaxy-workflow-test-plan]]",
+        "description": "Reviewable Galaxy workflow test plan (see [[galaxy-workflow-test-plan]]): baseline cases carried forward as test-evidence plus change-set-driven cases/assertions, with job inputs, expected outputs, assertion intent, fixture provenance, label status, unresolved mappings, and omissions."
+      }
+    ],
+    "consumes": [
+      {
+        "id": "summary-galaxy-workflow",
+        "description": "Structured summary of the existing workflow from [[summarize-galaxy-workflow]]; its `tests[]` are the regression baseline to carry forward, and its resolved input/output labels are the anchors baseline assertions bind to.",
+        "inherited_schema": "[[summary-galaxy-workflow]]",
+        "producers": [
+          "summarize-galaxy-workflow"
+        ]
+      },
+      {
+        "id": "galaxy-workflow-changeset",
+        "description": "Reviewed, step-anchored change-set from [[interview-to-galaxy-workflow-changeset]]; names which edits change observable behavior, hence which baseline cases to update and which new assertions to add.",
+        "producers": [
+          "interview-to-galaxy-workflow-changeset"
+        ]
+      }
+    ]
+  }
+}

--- a/casts/claude/skills/changeset-to-galaxy-test-plan/_verify.json
+++ b/casts/claude/skills/changeset-to-galaxy-test-plan/_verify.json
@@ -1,0 +1,29 @@
+{
+  "verify_schema_version": 1,
+  "entries": [
+    {
+      "artifact_id": "summary-galaxy-workflow",
+      "direction": "input",
+      "kind": "json",
+      "default_filename": "summary-galaxy-workflow.json",
+      "schema": "[[summary-galaxy-workflow]]",
+      "validator_bin": "foundry",
+      "args": [
+        "validate-summary-galaxy-workflow",
+        "{artifact_path}"
+      ]
+    },
+    {
+      "artifact_id": "galaxy-test-plan",
+      "direction": "output",
+      "kind": "yaml",
+      "default_filename": "galaxy-test-plan.yml",
+      "schema": "[[galaxy-workflow-test-plan]]",
+      "validator_bin": "foundry",
+      "args": [
+        "validate-galaxy-workflow-test-plan",
+        "{artifact_path}"
+      ]
+    }
+  ]
+}

--- a/casts/claude/skills/changeset-to-galaxy-test-plan/references/notes/galaxy-workflow-testability-design.md
+++ b/casts/claude/skills/changeset-to-galaxy-test-plan/references/notes/galaxy-workflow-testability-design.md
@@ -1,0 +1,139 @@
+---
+type: research
+subtype: component
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-05-03
+revised: 2026-05-06
+revision: 2
+ai_generated: true
+related_notes:
+  - "[[iwc-workflow-testability-survey]]"
+  - "[[iwc-test-data-conventions]]"
+  - "[[planemo-asserts-idioms]]"
+  - "[[iwc-shortcuts-anti-patterns]]"
+  - "[[planemo-workflow-test-architecture]]"
+  - "[[implement-galaxy-workflow-test]]"
+  - "[[gxformat2-schema]]"
+  - "[[gxformat2-workflow-inputs]]"
+  - "[[galaxy-datatypes-conf]]"
+summary: "Design guidance for Galaxy workflow inputs, outputs, and checkpoints that make IWC-style workflow tests possible."
+---
+
+# Galaxy workflow testability design
+
+Use this note when authoring or translating a Galaxy workflow **before** the `-tests.yml` file exists. It covers workflow structure choices that make later IWC-style tests meaningful: labels, promoted checkpoints, collection identifiers, and fixture-compatible inputs.
+
+This is not a `content/patterns/` page. It is cross-cutting design guidance for Molds that need testable Galaxy workflows. Assertion syntax lives in [[planemo-asserts-idioms]]. Test YAML fixture shapes live in [[iwc-test-data-conventions]]. Accepted shortcut vs smell calls live in [[iwc-shortcuts-anti-patterns]]. Corpus evidence trail lives in [[iwc-workflow-testability-survey]].
+
+## 1. Treat labels as API
+
+Workflow input and output labels are not cosmetic. Planemo and IWC tests address workflow inputs and outputs by label, and the survey found exact label matches for every asserted output across 114 matched workflow/test pairs. A generated workflow should therefore pick stable, descriptive labels before test authoring starts.
+
+Rules:
+
+- Label every output that may need a test assertion.
+- Treat input/output renames as breaking changes requiring sibling `-tests.yml` updates.
+- Prefer stable domain names over tool-step defaults or positional names.
+- Do not rely on unlabeled or positional outputs for tests.
+
+Evidence:
+
+- Scanpy exposes outputs such as `Initial Anndata General Info`, `UMAP of louvain`, `Ranked genes with Wilcoxon test`, and `Dotplot of top genes on clusters` (`$IWC_FORMAT2/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy.gxwf.yml:105-147`). The sibling test keys assertions by those exact labels (`$IWC/workflows/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml:27-205`).
+- VGP scaffolding uses punctuation-heavy labels such as `Hi-C duplication stats on scaffolds: Raw`, `Hi-C duplication stats on scaffolds: MultiQc`, and `Merged Alignment stats` (`$IWC_FORMAT2/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8.gxwf.yml:170-196`). The test asserts those exact labels (`$IWC/workflows/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8-tests.yml:218-245`).
+
+## 2. Promote assertable checkpoints
+
+IWC workflow tests assert workflow-level outputs. Intermediate step results are invisible unless promoted to top-level workflow outputs. When final reports are weakly assertable, expose intermediate checkpoints that carry deterministic content or structure.
+
+Rules:
+
+- Promote intermediate outputs when they are the best deterministic or structural checkpoint.
+- Prefer a checkpoint table/text/HDF5 object that can prove content over a final plot/report that can only prove existence.
+- Accept some output-list clutter when it buys meaningful tests.
+- Do not promote every intermediate by default; expose checkpoints that map to concrete assertion intent.
+
+Evidence:
+
+- Scanpy exposes 21 workflow outputs and the sibling test asserts all 21. These include initial AnnData summaries, intermediate plots, ranked-gene tables, final AnnData, cluster-count tables, and final plots (`$IWC_FORMAT2/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy.gxwf.yml:105-147`; `$IWC/workflows/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml:27-205`).
+- RNA-seq paired-end exposes mapped reads, stranded/unstranded coverage, abundance estimates, expression tables, counts tables, and MultiQC reports (`$IWC_FORMAT2/transcriptomics/rnaseq-pe/rnaseq-pe.gxwf.yml:90-112`). The sibling test asserts sizes for coverage/read outputs and stronger regex/line checks for expression/count outputs (`$IWC/workflows/transcriptomics/rnaseq-pe/rnaseq-pe-tests.yml:48-97`).
+- MGnify complete exposes 83 workflow outputs; 38 are asserted in the sibling test, including MultiQC reports, FASTA collections, taxonomic classifications, OTU tables, and HDF5/JSON outputs (`$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/mgnify-amplicon-pipeline-v5-complete.gxwf.yml:163-329`; `$IWC/workflows/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/mgnify-amplicon-pipeline-v5-complete-tests.yml:15-120`).
+
+## 3. Stabilize collection output identifiers
+
+Collection tests key assertions by element identifier. If a workflow emits collections with unstable or opaque identifiers, the test cannot target elements cleanly.
+
+Rules:
+
+- Preserve biologically or sample-meaningful identifiers through map-over and collection reshaping.
+- When generating or relabeling collections, make the identifier derivation deterministic and visible in workflow structure.
+- For nested collections, ensure each axis has predictable identifiers.
+- Quote special identifiers in tests when YAML requires it, but do not simplify identifiers merely for YAML convenience.
+
+Evidence:
+
+- 59 of 115 IWC test files use `element_tests:`, with 227 `element_tests:` blocks in the corpus survey.
+- 10x CellPlex tests nested collection outputs by `subsample`, then inner `matrix`, `barcodes`, and `genes` elements (`$IWC/workflows/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:82-128`). The workflow exposes the corresponding collection outputs (`$IWC_FORMAT2/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex.gxwf.yml:73-91`).
+- HyPhy collection outputs are tested by generated gene identifiers such as `NC_001477.1|capsid_protein_C|95-394_DENV1` (`$IWC/workflows/comparative_genomics/hyphy/hyphy-core-tests.yml:31-71`). The workflow exposes collection outputs for MEME, PRIME, BUSTED, and FEL (`$IWC_FORMAT2/comparative_genomics/hyphy/hyphy-core.gxwf.yml:26-38`).
+
+## 4. Choose checkpoints by assertion strength
+
+Assertion choice is not only a test-file decision. It should feed back into workflow output design. If the only exposed output is a stochastic plot or binary file, the best possible test may be a weak size check. Exposing a sibling table, report, HDF5 structure, or summary line can make the same workflow much more testable.
+
+Rules:
+
+- For image-heavy workflows, expose data or summary outputs behind the plot when possible.
+- For stochastic statistical outputs, expose structural checkpoints and stable summary tokens.
+- For binary outputs, expose a text/table report or stats file when the tool can produce one.
+- Use [[planemo-asserts-idioms]] to select the assertion family after choosing the checkpoint.
+
+Evidence:
+
+- Scanpy image outputs are mostly smoke-tested with `has_size`, `has_image_width`, and `has_image_height`, but the same workflow also exposes AnnData HDF5 keys and cluster-count table checks (`$IWC/workflows/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml:33-205`).
+- RNA-seq paired-end pairs coarse size checks for coverage/mapped-read outputs with stronger regex and exact-line checks for expression/count tables (`$IWC/workflows/transcriptomics/rnaseq-pe/rnaseq-pe-tests.yml:48-97`).
+- VGP scaffolding tests combine stable text checks for scaffold/report stats with size checks for map/alignment artifacts (`$IWC/workflows/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8-tests.yml:173-245`).
+
+## 5. Design inputs with fixtures in mind
+
+Workflow input labels and types constrain the eventual `job:` block. Fixture planning is not only a test-file activity: it should influence whether the workflow exposes a file input, a collection input, a string data-table input, or a typed parameter.
+
+Rules:
+
+- Choose input labels that will be readable as test `job:` keys.
+- Match workflow input collection types to realistic fixture shapes.
+- Decide early whether reference data should be a portable remote file or a CVMFS/data-table string.
+- Keep typed parameters explicit when tests need to set them (`int`, `boolean`, `string`) rather than burying them in step defaults.
+
+Evidence:
+
+- 10x CellPlex job inputs include `fastq PE collection GEX`, `reference genome`, `gtf`, `cellranger_barcodes_3M-february-2018.txt`, `fastq PE collection CMO`, `sample name and CMO sequence collection`, and `Number of expected cells` (`$IWC/workflows/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:2-75`). The workflow declares matching collection, data, string, boolean, and int inputs (`$IWC_FORMAT2/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex.gxwf.yml:4-72`).
+- HyPhy accepts a `list` collection of unaligned sequences and preserves accession-like fixture identifiers through to output element assertions (`$IWC/workflows/comparative_genomics/hyphy/hyphy-core-tests.yml:7-30`; `$IWC_FORMAT2/comparative_genomics/hyphy/hyphy-core.gxwf.yml:14-25`).
+
+## 6. Know what a gxformat2 output entry contains
+
+Top-level gxformat2 `outputs:` is the public workflow-output surface. It is separate from per-step `out:` declarations and from step post-job actions such as `change_datatype` or `rename`.
+
+Authoring rules:
+
+- Use `label` as the stable public name tests and users will address.
+- Use `outputSource` to point at the producing step output; do not rely on positional output order.
+- Use `doc` for short user-facing context when the label is not self-explanatory.
+- Keep `type` aligned with the exposed value (`data`, `collection`, or scalar vocabulary from [[gxformat2-workflow-inputs]]) when the schema needs it.
+- Apply `change_datatype` at the producing step output when Galaxy needs a stronger datatype than the tool reports; choose values from [[galaxy-datatypes-conf]].
+- Use `rename` only for generated dataset names inside Galaxy histories. It is not a substitute for stable workflow-output `label`.
+- Treat `add_tags` and `remove_tags` as metadata helpers, not as the test API. IWC tests key by labels and collection element identifiers, not tags.
+- Avoid `hide` or `delete_intermediate_datasets` on outputs that are promoted as test checkpoints.
+
+Design inference: a workflow-output promotion decision should pick both the public `outputs:` entry and any producer-side post-job action needed to make that output useful. For example, a synthesized BED checkpoint needs a stable output `label` plus a producer-side `change_datatype: bed`; one without the other is incomplete for a testable workflow.
+
+## Cross-references
+
+- [[iwc-workflow-testability-survey]] — corpus survey and distribution rationale.
+- [[iwc-test-data-conventions]] — job/input YAML shapes, remote fixtures, hashes, collection fixture syntax.
+- [[planemo-asserts-idioms]] — assertion-family choice after an output is exposed.
+- [[iwc-shortcuts-anti-patterns]] — accepted shortcut vs smell calls for weak assertions and label coupling.
+- [[planemo-workflow-test-architecture]] — Planemo execution, output-problem ambiguity, and structured artifacts.
+- [[gxformat2-schema]] — structural vocabulary for top-level workflow outputs and step post-job actions.
+- [[galaxy-datatypes-conf]] — valid Galaxy datatype extensions for `format` and `change_datatype` choices.

--- a/casts/claude/skills/changeset-to-galaxy-test-plan/references/notes/iwc-shortcuts-anti-patterns.md
+++ b/casts/claude/skills/changeset-to-galaxy-test-plan/references/notes/iwc-shortcuts-anti-patterns.md
@@ -1,0 +1,360 @@
+---
+type: research
+subtype: component
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-04-30
+revised: 2026-05-03
+revision: 2
+ai_generated: true
+related_notes:
+  - "[[galaxy-workflow-testability-design]]"
+  - "[[iwc-test-data-conventions]]"
+  - "[[planemo-asserts-idioms]]"
+  - "[[implement-galaxy-workflow-test]]"
+  - "[[tests-format]]"
+  - "[[iwc-conditionals-survey]]"
+  - "[[iwc-map-over-lifecycle-survey]]"
+  - "[[iwc-tabular-operations-survey]]"
+  - "[[iwc-transformations-survey]]"
+summary: "What IWC test suites cut corners on (accepted) vs what's a code smell — existence-only probes, sim_size deltas, image dim checks, label coupling."
+---
+
+# IWC test-suite shortcuts and anti-patterns
+
+## Purpose
+
+When an agent translates or authors a Galaxy workflow for IWC submission, the test suite it writes will be reviewed against IWC's *de facto* style — not against an idealized assertion ladder. That style routinely tolerates assertions that look weak in isolation. This note distinguishes the corner-cutting that is **normal and accepted** in the corpus from the patterns that an agent should treat as **smells** worth flagging.
+
+This note owns accepted-vs-smell calls. For positive workflow-structure guidance behind label stability, checkpoint promotion, and collection identifier design, use [[galaxy-workflow-testability-design]].
+
+Grounding: 115 `*-tests.yml` files under `workflow-fixtures/iwc-src/workflows/` (mirror of `galaxyproject/iwc`), prior synthesis in `galaxy-brain/vault/projects/workflow_state/skills/COMPONENT_GALAXY_WORKFLOW_TESTING.md`. Path citations below are relative to `iwc-src/workflows/` unless absolute.
+
+## TL;DR rules of thumb
+
+1. **Default to tolerant assertions.** `compare: sim_size` + `delta:`, `has_image_*` + `delta:`, `has_text` substring, `has_h5_keys`, `has_n_lines` + `delta:` are *the IWC vocabulary*. Strict `compare: diff` or exact-`file:` is the exception, used only when the upstream tool is fully deterministic on fixed inputs.
+2. **No negative tests.** `expect_failure:` does not appear in the corpus. Don't author one.
+3. **No checksums.** `md5:` / `checksum:` do not appear on outputs in the corpus. SHA-1 hashes are used on **inputs** (integrity of remote fetch), never on output assertions.
+4. **Preserve labels.** Inputs and outputs are referenced by label. Renaming silently breaks tests; treat label changes as breaking changes that require a sibling `-tests.yml` update.
+5. **Big data goes to Zenodo.** In-repo `test-data/` is for toy fixtures and expected outputs only.
+
+---
+
+## 1. Existence-only content probes
+
+### Accepted
+
+The HyPhy test files reduce JSON output validation to "starts with `{`":
+
+- `comparative_genomics/hyphy/hyphy-core-tests.yml:32-71` — four output collections (`meme_output`, `prime_output`, `busted_output`, `fel_output`), each gene element asserts `has_text: text: "{"` and nothing else.
+- `comparative_genomics/hyphy/hyphy-compare-tests.yml`, `capheine-core-and-compare-tests.yml` — same pattern across the rest of the family.
+
+This is **accepted** because:
+- HyPhy's MEME/PRIME/BUSTED/FEL/CFEL/RELAX statistical outputs embed run-dependent floats throughout (likelihoods, AIC, posterior probabilities). Substring assertions on numeric fields would fail intermittently.
+- Selecting any specific gene name or category in the JSON would couple the test to internal HyPhy keying that the wrapper has changed across versions.
+- The assertion does verify "the tool ran, produced JSON, did not crash, and the collection structure matches expected element identifiers" — which is genuinely useful given HyPhy's history of opaque failures.
+
+A quick scan finds **298 lines** matching the existence-style `has_text:` pattern across the corpus (`grep "has_text:\s*$\|text: \"{\"$"` yields 298 hits across many files). It is widespread, not a HyPhy quirk.
+
+Other variants in the same accepted-shortcut family:
+
+- **First-line-of-header probes**: `amplicon/amplicon-mgnify/.../mgnify-amplicon-pipeline-v5-rrna-prediction-tests.yml:46-49` asserts `has_text: "# mapseq v1.2.6 (Jan 20 2023)"` — version banner only.
+- **`has_n_columns` schema probes**: same file lines 50-52, 67-69 — "the table has 15 columns" / "4 columns" with no row-content check.
+- **`has_h5_keys` structure probes**: `scRNAseq/scanpy-clustering/.../Preprocessing-...-Scanpy-tests.yml:27-32, 159-166` — confirms AnnData has `obs/louvain`, `var/highly_variable`, `uns/rank_genes_groups`, etc., but says nothing about cluster labels or values. Also `imaging/tissue-microarray-analysis/multiplex-tissue-microarray-analysis/multiplex-tma-tests.yml` for Merged anndata.
+
+### Smell
+
+Existence probes on **deterministic** outputs. If the underlying tool is deterministic on fixed inputs (alignment, simple QC stats, well-defined transformations), reducing to `has_text: "{"` is laziness — agent should at least pull a known stable substring from the expected JSON.
+
+Heuristic for an agent: **if the source workflow's tool is on the "stochastic / floating-point heavy / version-fragile" list (HyPhy, RepeatModeler, scanpy plots, MCMC samplers, ML inference), existence probes are accepted. Otherwise, prefer `has_text` against a stable token from a real output.**
+
+---
+
+## 2. Size-only comparisons (`compare: sim_size` + `delta:`)
+
+### Accepted
+
+Canonical example: `repeatmasking/RepeatMasking-Workflow-tests.yml:11-46` — every output is `compare: sim_size` with `delta: 30000` (30 KB) on small outputs and `delta: 90000000` (90 MB!) on the Stockholm seed-alignment file. RepeatModeler's discovered repeat families differ run-to-run; only output magnitude is reproducible.
+
+`grep "compare: sim_size"` returns 9 files using this pattern:
+- `repeatmasking/RepeatMasking-Workflow-tests.yml`, `repeatmasking/Repeat-masking-with-RepeatModeler-and-RepeatMasker-tests.yml` (RepeatModeler — large delta band)
+- `epigenetics/hic-hicup-cooler/chic-fastq-to-cool-hicup-cooler-tests.yml`, `epigenetics/hic-hicup-cooler/hic-fastq-to-cool-hicup-cooler-tests.yml` (HiC matrices)
+- `genome_annotation/functional-annotation/functional-annotation-of-sequences/Functional_annotation_of_sequences-tests.yml`
+- `VGP-assembly-v2/kmer-profiling-hifi-trio-VGP2/kmer-profiling-hifi-trio-VGP2-tests.yml`
+- `genome-assembly/polish-with-long-reads/Assembly-polishing-with-long-reads-tests.yml`
+- `scRNAseq/baredsc/baredSC-1d-logNorm-tests.yml`, `scRNAseq/baredsc/baredSC-2d-logNorm-tests.yml` (Bayesian sampling — uses `delta_frac:` here)
+
+### Delta-magnitude survey
+
+From `grep "delta: [0-9]+"` distribution across the corpus:
+
+| Delta band | Count | Typical use |
+|---|---|---|
+| 4–100 (tiny) | ~20 | image pixel dimensions, line counts |
+| 1K–10K | ~40 | small text/tabular outputs, plot PNGs |
+| 25K–100K | ~25 | mid-size reports, multi-page plots |
+| 200K–1M | ~10 | report HTML, BAM stats |
+| 1M–10M | ~10 | medium BAM/BCF/cool files |
+| 10M+ (up to 90M) | ~7 | RepeatModeler libraries, large alignments |
+
+The 90 MB delta on `RepeatMasking-Workflow-tests.yml:20` is at the extreme. It says "this output is somewhere between zero bytes and 180 MB" — effectively only catches the empty-output failure mode. Accepted because RepeatModeler's seed alignments are known to vary by tens of MB across runs.
+
+### `delta_frac:`
+
+Used in 3 files (`scRNAseq/baredsc/*`, `genome-assembly/polish-with-long-reads/*`). Preferred over absolute `delta:` when the expected output size scales with input. An agent translating a workflow whose output size depends on input volume should consider `delta_frac:` over `delta:`.
+
+### Smell
+
+`compare: sim_size` on outputs from a **deterministic** tool. If the tool is bwa/bowtie2/samtools-sort with fixed seeds and pinned versions, there's no excuse for size-only — `compare: diff` (with modest `lines_diff:`) or content assertions are appropriate.
+
+Also a smell: stacking size + `has_image_*` checks on a PNG without any content assertion when the workflow's claim is *about the data shown* (e.g., a clustering plot). The corpus does this routinely (Scanpy file below) — accepted, but a translated workflow that has a more deterministic plotter should do better.
+
+---
+
+## 3. Image plot assertions
+
+### Accepted
+
+`scRNAseq/scanpy-clustering/.../Preprocessing-...-Scanpy-tests.yml:33-205` is the dense example. ~15 PNG outputs each get the same triple:
+
+```yaml
+UMAP of louvain:
+  has_size:
+    size: 68416
+    delta: 6000
+  has_image_width:
+    width: 601
+    delta: 30
+  has_image_height:
+    height: 429
+    delta: 25
+```
+
+What this catches:
+- Plot was rendered (non-zero size).
+- Render dimensions are stable (matplotlib defaults didn't drift, theme didn't change).
+- Approximate file size hasn't shifted by an order of magnitude (no catastrophic content change like all-white or all-noise).
+
+What this **misses**: cluster assignments wrong, axes mislabeled, points in wrong positions, colors swapped, the wrong subset plotted, NaN handling regression. Two visually different UMAPs can have identical width/height/size-within-10%.
+
+Other observed image-assertion users (`grep "has_image"`):
+- `imaging/tissue-microarray-analysis/tissue-microarray-analysis/tissue-micro-array-analysis-tests.yml`
+- `imaging/tissue-microarray-analysis/multiplex-tissue-microarray-analysis/multiplex-tma-tests.yml`
+
+The TMA tests use a friendlier shorthand: `has_size: size: 181K, delta: 50K` (human-readable units).
+
+### Smell
+
+Asserting `has_image_width`/`has_image_height` with **zero delta** on a tool that re-encodes (PNG round-trips through matplotlib) is brittle. The corpus uses 5–10% deltas; an agent emitting `delta: 0` should be flagged unless the renderer is byte-stable.
+
+Note `has_image_channels`, `has_image_center_of_mass` are documented (galaxy XSD) but **not observed** in the sampled corpus. An agent with a deterministic mask/segmentation output could use `has_image_center_of_mass` to actually verify spatial correctness — this would be an *upgrade* over the current corpus norm, not a smell.
+
+---
+
+## 4. Happy-path-only culture (`expect_failure:`)
+
+`grep -r "expect_failure"` over all 115 tests files returns **zero hits**. The IWC corpus has no negative tests. Period.
+
+This is a structural property of IWC: the workflows are published artifacts intended to *succeed* on canonical inputs. Adversarial / error-path testing happens in tool wrappers, not in workflow tests.
+
+**Implication for an agent:** Do not author `expect_failure:` cases when translating a workflow. If the source pipeline (e.g., nf-core) had a "fail on bad reference" test, drop it — it doesn't belong in IWC. If the validation logic is important, it should be in a wrapper-level tool test, not a workflow test.
+
+---
+
+## 5. `md5:` / `checksum:` rarity
+
+`grep -r "md5:\|checksum:"` over `*-tests.yml`: **zero hits**.
+
+SHA-1 `hashes:` blocks are pervasive — but exclusively on **inputs** (`hash_function: SHA-1` paired with a remote `location:`), to guard against silent corruption of the fetched fixture. Output assertions never use them.
+
+Accepted. The reason is empirical: outputs of real bioinformatics tools (BAM with PG headers and timestamps, VCFs with command-line provenance, JSON with run dates) are almost never byte-stable across runs. A `checksum:` would fail intermittently.
+
+**Smell:** an agent emitting `checksum:` or `md5:` on a workflow output. Even for "fully deterministic" tools, embedded provenance breaks checksums. Use `compare: diff` + `lines_diff:` instead, or content assertions.
+
+---
+
+## 6. Output label coupling
+
+Test files key outputs by **workflow label**, with spaces, capitals, punctuation preserved verbatim. Examples:
+
+- `scanpy-clustering/.../Preprocessing-...-Scanpy-tests.yml:27` — `Anndata with Celltype Annotation:` (spaces, mixed case)
+- `scanpy-clustering/.../Preprocessing-...-Scanpy-tests.yml:33` — `UMAP of louvain and top ranked genes:`
+- `imaging/tissue-microarray-analysis/multiplex-tissue-microarray-analysis/multiplex-tma-tests.yml` — `Merged anndata:`, `Spatial Scatterplot Montage:`
+- `consensus-from-variation-tests.yml:30` — `multisample_consensus_fasta:` (snake-case style)
+
+**Both styles coexist.** Snake-case (older / SARS-CoV-2 family) and natural-language-with-spaces (newer / scanpy / TMA) are equally valid. Reviewers do not enforce a single convention.
+
+### Coupling consequences
+
+Renaming an output label in the `.ga` without updating the sibling `-tests.yml` is a silent breakage:
+- Test references the old label → key not present in invocation outputs → assertion mismatch surfaces as an opaque "output not found" error in planemo.
+- `planemo workflow_lint --iwc` enforces that workflow outputs are *labeled*, not that test labels match.
+
+**Discipline observed:** every output a test asserts on is a labeled workflow output. The corpus does not assert on positional / unlabeled outputs.
+
+**Smell:** a translated workflow with unlabeled outputs that later need test coverage. Agent should label every output it intends to assert on, before writing assertions.
+
+Positive design guidance now lives in [[galaxy-workflow-testability-design]]: pick stable labels before test authoring and treat renames as test-breaking API changes.
+
+---
+
+## 7. Intermediate-step output gap
+
+`-tests.yml` can only assert on workflow-level **outputs** (entries in the `.ga`'s top-level outputs). Intermediate step results are inaccessible to assertions.
+
+Observed workaround across the corpus: **promote the intermediate to a workflow output**. This is visible indirectly — many workflows expose what would naturally be intermediates as labeled outputs solely for testability:
+
+- `scanpy-clustering` exposes `Initial Anndata General Info`, `Anndata with raw attribute`, `Plot highly variable`, `Elbow plot of PCs and variance` — these are mid-pipeline checkpoints surfaced specifically to be assertable. Compare counts: 22 outputs asserted vs the 7-or-so "user-meaningful" final artifacts.
+- `MAGs-generation-tests.yml` exposes a `Full MultiQC Report` even though MultiQC is logically intermediate to MAG annotation.
+
+**Cost:** "test-only" outputs clutter the workflow's user-facing output list. Reviewers tolerate this in exchange for testability.
+
+**Accepted shortcut:** promoting an intermediate to a workflow output for test purposes. Not a smell.
+
+**Smell:** asserting on a step output via some side-channel (e.g., relying on Galaxy collection ordering, indexing into `tool_state`). The corpus does not do this and an agent should not invent it.
+
+Positive design guidance now lives in [[galaxy-workflow-testability-design]]: promote assertable checkpoints deliberately, especially when final reports or plots can only support weak smoke tests.
+
+---
+
+## 8. Remote-data fragility
+
+### Pattern
+
+Overwhelming preference for **Zenodo** as the input store. Every remote `location:` is paired with a SHA-1 `hashes:` block. Examples already cited in nearly every snippet above.
+
+Non-Zenodo remote sources observed (from `grep "ftp.sra.ebi\|ftp://\|figshare\|github.com"`):
+- `virology/pox-virus-amplicon/pox-virus-half-genome-tests.yml:27,34,48,55` — `ftp://ftp.sra.ebi.ac.uk/...` SRA fastqs
+- `amplicon/amplicon-mgnify/.../mgnify-amplicon-pipeline-v5-rrna-prediction-tests.yml:21` — `ftp://ftp.ebi.ac.uk/...` reference DB
+- `data-fetching/parallel-accession-download/parallel-accession-download-tests.yml`, `VGP-assembly-v2/Plot-Nx-Size/...` — accession-driven
+- `variant-calling/generic-variant-calling-wgs-pe/Generic-variation-analysis-on-WGS-PE-data-tests.yml` — github raw URLs
+
+### The fragility
+
+- **Zenodo is a single point of failure across CI.** A Zenodo outage breaks every IWC PR concurrently. SHA-1 hashes guard against silent corruption but provide no mitigation for outages or HTTP 503s.
+- **EBI/SRA FTP is even less reliable** — observed flake-prone in the broader Galaxy CI history.
+- No retry / backoff configured at the test-format level; planemo-ci-action's defaults handle transient failures only via re-running the chunk job manually.
+
+### Accepted
+
+This is just life in the IWC. Don't try to "fix" it in a translated workflow by inlining large data — reviewers will push back (see §10).
+
+### Smell
+
+Inputs hosted on a contributor's personal endpoint, S3 bucket, or Dropbox. Reviewers ask for migration to Zenodo before merge.
+
+---
+
+## 9. `compare: diff` on timestamped outputs
+
+`compare: diff` usage from `grep`:
+
+- `sars-cov-2-variant-calling/sars-cov-2-ont-artic-variant-calling/ont-artic-variation-tests.yml:32` — `compare: diff, lines_diff: 6` on annotated VCF
+- `sars-cov-2-variant-calling/sars-cov-2-pe-illumina-wgs-variant-calling/pe-wgs-variation-tests.yml:35` — same
+- `imaging/fluorescence-nuclei-segmentation-and-counting/segmentation-and-counting-tests.yml:16` — `lines_diff: 0`
+- `variant-calling/variation-reporting/Generic-variation-analysis-reporting-tests.yml:21,25,29,33` — `lines_diff: 6`
+- `variant-calling/generic-variant-calling-wgs-pe/Generic-variation-analysis-on-WGS-PE-data-tests.yml:39,45,55` — `lines_diff: 6`
+
+The `lines_diff: 6` constant is suspicious — 6 lines is the typical VCF header preamble that embeds `##fileDate=...` and `##source=...`. The use is **defensible**: tolerance window matches the known mutable header lines, content lines are diffed strictly.
+
+### Smell
+
+- `compare: diff` with `lines_diff: 0` on a file that contains *any* timestamp, command-line capture, version banner, or random tie-break (hash-ordered dictionaries in Python output, etc.). The single observed `lines_diff: 0` case (`segmentation-and-counting-tests.yml:16`) appears to be on a numeric tabular output where it's defensible — verify content type before flagging.
+- `compare: diff` on a BAM. BAM headers include `@PG` lines with full command lines and Galaxy job IDs. Use `has_size` + content extracts via `has_archive_member` or `samtools view`-piped XML asserts — not byte-level diff.
+
+**Recommended replacement** when timestamps appear:
+- For VCF: `compare: diff, lines_diff: <header-line-count>` (corpus convention is 6).
+- For tabular reports: `has_text` against stable column headers + `has_n_columns`.
+- For HTML reports (MultiQC etc.): `has_text` substring on stable section names — example `short-read-qc-trimming/short-read-quality-control-and-trimming-tests.yml:25-28` asserts `"Filtered Reads"` substring on the MultiQC HTML report rather than diffing.
+
+---
+
+## 10. Reviewer-feedback recurring asks
+
+Synthesized from the COMPONENT_GALAXY_WORKFLOW_TESTING.md analysis (sections 9 and the "Common PR-review feedback" subsection) plus structural observation of what every accepted workflow has and rejected drafts apparently lack:
+
+| Reviewer ask | Where it bites | Source |
+|---|---|---|
+| **Creator `identifier:` must be a full ORCID URI** (`https://orcid.org/...`), not bare ID. | `.ga` frontmatter `creator:` block. Most common lint failure. | planemo PR #1458; `consensus-from-variation.ga:4-10` shows the conformant shape. |
+| **Move large inputs to Zenodo.** Inline `path: test-data/big.bam` for >1 MB inputs gets pushback. | `-tests.yml` job inputs. | `iwc/workflows/README.md` (per prior analysis). |
+| **Bump `release` + add CHANGELOG.md entry in the same PR.** | `.ga` `release:` and sibling `CHANGELOG.md`. Enforced by `bump_version.py`. | `iwc/workflows/README.md:217-247`. |
+| **Generate tests via `planemo workflow_test_init --from_invocation <id>`**, not by hand. Reviewers push back on hand-authored job blocks. | Any new test contribution. | help.galaxyproject.org thread 13903. |
+| **Don't use `compare: diff` on outputs that embed timestamps.** Switch to `has_text`/`has_n_lines` with `delta:`. | See §9. | Recurring review comment. |
+| **Add labeled outputs for any output you assert on.** Unlabeled outputs caught by `planemo workflow_lint --iwc`. | `.ga` outputs. | §6 above. |
+| **Hashes on every remote `location:`.** SHA-1 block paired with the URL. Reviewers spot-check. | `-tests.yml` job inputs. | Universal in the corpus; missing hashes get flagged. |
+
+### Smell to flag for an agent submission
+
+- Bare ORCID ID (`0000-0002-...`) in `creator:` instead of full URL.
+- Test job referencing >1 MB local fixture instead of a Zenodo URL.
+- PR that bumps a workflow without CHANGELOG / `release:` bump.
+- Hand-authored `-tests.yml` that reads "too clean" — reviewers know `--from_invocation` output has a recognizable fingerprint.
+
+---
+
+## Summary cheatsheet for the implement-galaxy-workflow-test mold
+
+**Use these freely (accepted shortcuts):**
+- `has_text: text: "{"` for stochastic JSON outputs.
+- `compare: sim_size, delta:` for non-deterministic file outputs; pick delta from §2 distribution by tool family.
+- `has_image_width/height/has_size` triple with 5–10% delta for matplotlib plots.
+- `has_h5_keys` for AnnData/HDF5 — assert structure not values.
+- Promoting intermediates to workflow outputs to make them assertable.
+- Labels with spaces, mixed case, punctuation as the output key.
+- SHA-1 hashes on every input `location:`.
+
+**Avoid (smells reviewers or future-you will catch):**
+- `expect_failure:` — not an IWC pattern.
+- `md5:` / `checksum:` on outputs.
+- `compare: diff, lines_diff: 0` on anything containing timestamps, BAM `@PG` lines, or Python dict ordering.
+- `has_image_*` with zero delta.
+- Existence-only `has_text: "{"` on outputs from a deterministic tool.
+- Asserting on positional/unlabeled outputs.
+- Inlining >1 MB binary fixtures in `test-data/`.
+- Bare ORCID identifier in `.ga` frontmatter.
+
+**Review-time checklist before submission:**
+1. Every output asserted on has a label in the `.ga`.
+2. Every remote `location:` has a `hashes: SHA-1` block.
+3. Inputs >1 MB live on Zenodo, not in `test-data/`.
+4. `release:` bumped and `CHANGELOG.md` updated if `.ga` changed.
+5. `creator.identifier:` is a full `https://orcid.org/...` URL.
+6. Test was generated by `planemo workflow_test_init --from_invocation`, not hand-written.
+
+---
+
+## Sources
+
+- Positive workflow-structure guidance: [[galaxy-workflow-testability-design]].
+- Prior synthesis: `/Users/jxc755/projects/repositories/galaxy-brain/vault/projects/workflow_state/skills/COMPONENT_GALAXY_WORKFLOW_TESTING.md` (sections 2c, 2d, 2e, 9).
+- Corpus root: `/Users/jxc755/projects/repositories/workflow-fixtures/iwc-src/workflows/` (115 `*-tests.yml` files across 22 categories).
+- Specific files cited:
+  - `comparative_genomics/hyphy/hyphy-core-tests.yml`, `hyphy-compare-tests.yml`, `capheine-core-and-compare-tests.yml`
+  - `repeatmasking/RepeatMasking-Workflow-tests.yml`, `Repeat-masking-with-RepeatModeler-and-RepeatMasker-tests.yml`
+  - `scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml`
+  - `read-preprocessing/short-read-qc-trimming/short-read-quality-control-and-trimming-tests.yml`
+  - `virology/pox-virus-amplicon/pox-virus-half-genome-tests.yml`
+  - `metabolomics/lcms-preprocessing/Mass_spectrometry__LC-MS_preprocessing_with_XCMS-tests.yml`
+  - `sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation-tests.yml`
+  - `sars-cov-2-variant-calling/sars-cov-2-pe-illumina-wgs-variant-calling/pe-wgs-variation-tests.yml`
+  - `sars-cov-2-variant-calling/sars-cov-2-ont-artic-variant-calling/ont-artic-variation-tests.yml`
+  - `variant-calling/variation-reporting/Generic-variation-analysis-reporting-tests.yml`
+  - `variant-calling/generic-variant-calling-wgs-pe/Generic-variation-analysis-on-WGS-PE-data-tests.yml`
+  - `imaging/fluorescence-nuclei-segmentation-and-counting/segmentation-and-counting-tests.yml`
+  - `imaging/tissue-microarray-analysis/multiplex-tissue-microarray-analysis/multiplex-tma-tests.yml`
+  - `amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction-tests.yml`
+  - `epigenetics/atacseq/atacseq-tests.yml`
+  - `epigenetics/hic-hicup-cooler/chic-fastq-to-cool-hicup-cooler-tests.yml`, `hic-fastq-to-cool-hicup-cooler-tests.yml`
+  - `microbiome/mags-building/MAGs-generation-tests.yml`
+  - `genome-assembly/polish-with-long-reads/Assembly-polishing-with-long-reads-tests.yml`
+  - `scRNAseq/baredsc/baredSC-1d-logNorm-tests.yml`, `baredSC-2d-logNorm-tests.yml`
+- Corpus-wide grep tallies:
+  - `expect_failure`: 0 hits.
+  - `md5:|checksum:` on outputs: 0 hits.
+  - `compare: sim_size`: 9 files.
+  - `compare: diff`: 5 files (variant-calling and imaging).
+  - `has_image_*`: 3 files.
+  - Existence-style `has_text:` patterns: ~298 line matches.
+  - `delta_frac:`: 3 files.

--- a/casts/claude/skills/changeset-to-galaxy-test-plan/references/notes/iwc-test-data-conventions.md
+++ b/casts/claude/skills/changeset-to-galaxy-test-plan/references/notes/iwc-test-data-conventions.md
@@ -1,0 +1,311 @@
+---
+type: research
+subtype: component
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-04-30
+revised: 2026-05-03
+revision: 3
+ai_generated: true
+related_notes:
+  - "[[galaxy-workflow-testability-design]]"
+  - "[[iwc-shortcuts-anti-patterns]]"
+  - "[[planemo-asserts-idioms]]"
+  - "[[implement-galaxy-workflow-test]]"
+  - "[[tests-format]]"
+  - "[[iwc-tabular-operations-survey]]"
+summary: "How IWC workflows organize and reference test data — Zenodo-first, SHA-1 integrity, collection shapes, CVMFS gotchas."
+---
+
+# IWC test data conventions
+
+Reference for an agent implementing or editing a `<workflow>-tests.yml` in IWC style. All evidence cited from `/Users/jxc755/projects/repositories/workflow-fixtures/iwc-src/workflows/` (raw IWC clone) and `workflows/README.md`. Authoritative spec: [planemo.readthedocs.io/en/latest/test_format.html](https://planemo.readthedocs.io/en/latest/test_format.html). The companion analysis at `/Users/jxc755/projects/repositories/galaxy-brain/vault/projects/workflow_state/skills/COMPONENT_GALAXY_WORKFLOW_TESTING.md` is the synthesized source for several normative claims here.
+
+This note owns **test YAML fixture shapes**. For workflow-structure choices that make those fixtures possible before the test file exists, use [[galaxy-workflow-testability-design]].
+
+## 1. Where does test data live? Remote vs in-repo
+
+Two storage patterns. They mix freely inside one job.
+
+**Remote `location:` (default for any non-trivial input).** Strongly preferred for anything bigger than a toy fixture. Order of preference, observed in the corpus:
+
+- **Zenodo** — overwhelming default, persistent DOI-backed URL.
+  - `read-preprocessing/short-read-qc-trimming/short-read-quality-control-and-trimming-tests.yml:13,17` — `https://zenodo.org/records/11484215/files/paired_r1.fastq.gz` (note the modern `/records/` plural form; older entries use `/record/`).
+  - `metabolomics/lcms-preprocessing/Mass_spectrometry__LC-MS_preprocessing_with_XCMS-tests.yml:6,17,24,...` — 11+ mzML files all hosted at `zenodo.org/record/10130758/files/...`.
+  - `sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation-tests.yml:5` — `https://zenodo.org/record/4555735/files/NC_045512.2_reference.fasta?download=1`.
+  - `repeatmasking/RepeatMasking-Workflow-tests.yml:5` — `https://zenodo.org/record/8364146/files/eco.fasta?download=1`. The `?download=1` query suffix is acceptable but optional; both forms appear.
+- **EBI/ENA REST** — for canonical reference sequences.
+  - `virology/pox-virus-amplicon/pox-virus-half-genome-tests.yml:5` — `https://www.ebi.ac.uk/ena/browser/api/fasta/AF325528.1?download=true`.
+- **SRA / ENA FTP** — for raw read accessions where re-uploading to Zenodo is wasteful.
+  - `pox-virus-half-genome-tests.yml:27,34,49,56` — `ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR151/076/SRR15145276/SRR15145276_1.fastq.gz`.
+
+**In-repo `path: test-data/...` (toy fixtures + small expected outputs only).** Used when:
+
+- File is small enough to commit (rule of thumb from corpus: low single-digit MB or smaller).
+- File is a hand-crafted toy or trimmed reference (e.g. a 5-element FASTA for HyPhy).
+- File is the *expected output* baseline for a `file:` exact-comparison assertion: `consensus-from-variation-tests.yml:31` — `file: test-data/masked_consensus.fa`.
+
+`workflows/README.md:67` makes the contract explicit: "try to generate a toy dataset … and then publish it to zenodo to have a permanent URL." `workflows/README.md:98`: "if some outputs are large, it is better to use assertions than storing the whole output file to the iwc repository."
+
+Subdirectory layout inside `test-data/` is free-form and used to organize related fixtures, e.g. `comparative_genomics/hyphy/test-data/unaligned_seqs/`, `test-data/codon_alignments/`, `test-data/iqtree_trees/` (referenced from `hyphy-core-tests.yml:13,17,21,...`).
+
+**Decision rule for an agent:**
+
+1. Expected-output baseline that's small — commit to `test-data/`.
+2. Toy/trimmed input < ~5 MB — commit to `test-data/`.
+3. Anything else — Zenodo (or EBI/SRA for canonical accessions). Add `hashes:` SHA-1.
+4. If the input is a reference index resolvable from CVMFS (`hg38`, `dm6`, `mm10`, …), use the plain string form. See section 5.
+
+## 2. The `class: File` block — exact YAML shapes
+
+All snippets verbatim from the IWC corpus.
+
+### 2a. Single remote file (with integrity hash)
+
+`virology/pox-virus-amplicon/pox-virus-half-genome-tests.yml:3-9`:
+
+```yaml
+Reference FASTA:
+  class: File
+  location: "https://www.ebi.ac.uk/ena/browser/api/fasta/AF325528.1?download=true"
+  filetype: fasta
+  hashes:
+  - hash_function: SHA-1
+    hash_value: 927d0d00b7db6ad60524bb9e50d3ab41c4ac5ecf
+```
+
+Field order is conventional but not enforced. `filetype:` is the Galaxy datatype name (`fasta`, `fastqsanger.gz`, `mzml`, `bed`, `tabular`, `csv`, `gtf`, `vcf`, …). `location:` URLs may be quoted or bare; both forms occur.
+
+### 2b. Single local file
+
+`comparative_genomics/hyphy/hyphy-core-tests.yml:3-6`:
+
+```yaml
+reference cds:
+  class: File
+  path: test-data/denv1_ref_cds.fasta
+  filetype: fasta
+```
+
+`path:` is relative to the workflow directory (the directory containing the `-tests.yml`). Hashes are usually omitted on local files — the file is in-tree, so integrity is implicit. They are nonetheless added in some workflows: `consensus-from-variation-tests.yml:15-18` shows `path: test-data/aligned_reads_for_coverage.bam` paired with a SHA-1 hash. The pattern appears to be: hashes added when the `-tests.yml` was generated by `planemo workflow_test_init --from_invocation`, which mints them automatically.
+
+A dataset attribute can be set on a single file to force a `dbkey`, e.g. `epigenetics/consensus-peaks/consensus-peaks-chip-pe-tests.yml:7-10`:
+
+```yaml
+- class: File
+  identifier: rep1
+  path: test-data/rep1.bam
+  dbkey: mm10
+```
+
+`dbkey:` and `decompress: true` (`scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:30`) are documented per-file attributes that ride alongside `class: File`.
+
+### 2c. List collection
+
+`hyphy-core-tests.yml:7-30`:
+
+```yaml
+unaligned sequences:
+  class: Collection
+  collection_type: list
+  elements:
+  - identifier: AB178040.1|2002
+    class: File
+    path: test-data/unaligned_seqs/AB178040.1|2002.fasta
+    filetype: fasta
+  - identifier: AB195673.1|2003
+    class: File
+    path: test-data/unaligned_seqs/AB195673.1|2003.fasta
+    filetype: fasta
+  ...
+```
+
+Each element is a single-file dict with an `identifier:`. A larger remote-only example with hashes per element: `metabolomics/lcms-preprocessing/Mass_spectrometry__LC-MS_preprocessing_with_XCMS-tests.yml:11-22`:
+
+```yaml
+Mass-spectrometry Dataset Collection:
+  class: Collection
+  collection_type: list
+  elements:
+  - class: File
+    identifier: Blanc05.mzML
+    location: https://zenodo.org/record/10130758/files/Blanc05.mzML
+    filetype: mzml
+    hashes:
+    - hash_function: SHA-1
+      hash_value: e98d5a4cd8849a145a032bdc31c348ad97cb59c3
+```
+
+### 2d. Paired collection (single pair)
+
+A `paired` collection is a Collection whose two elements have identifiers `forward` and `reverse`. In IWC it is rarely used at top level — it is almost always wrapped as a single-element `list:paired` (see 2e). When it appears bare, the shape is the inner block of 2e without the outer `list:paired` wrapper.
+
+### 2e. `list:paired` collection
+
+`read-preprocessing/short-read-qc-trimming/short-read-quality-control-and-trimming-tests.yml:3-18`:
+
+```yaml
+Raw reads:
+  class: Collection
+  collection_type: list:paired
+  elements:
+  - class: Collection
+    type: paired
+    identifier: pair
+    elements:
+    - class: File
+      identifier: forward
+      location: https://zenodo.org/records/11484215/files/paired_r1.fastq.gz
+      filetype: fastqsanger.gz
+    - class: File
+      identifier: reverse
+      location: https://zenodo.org/records/11484215/files/paired_r2.fastq.gz
+      filetype: fastqsanger.gz
+```
+
+Note: outer `collection_type: list:paired`, inner `type: paired` (not `collection_type:`). Inner element identifiers are the literal strings `forward` and `reverse` — these are reserved.
+
+A multi-pair list:paired with full hashes: `virology/pox-virus-amplicon/pox-virus-half-genome-tests.yml:17-38` or `scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:3-24`.
+
+### 2f. `list:list:paired` and deeper
+
+Not directly observed in sampled IWC inputs. The shape is recursive — wrap a `list:paired` element list inside another `class: Collection, collection_type: list:list:paired`, where each outer element is `class: Collection, type: list:paired` (analogous to the `list:paired` → `paired` nesting in 2e). For deeply-nested collections planemo's [`_writing_collections.rst`](https://github.com/galaxyproject/planemo/blob/master/docs/_writing_collections.rst) is the de-facto reference.
+
+Output side: nested-collection assertions DO exist in the corpus. `scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:82-98`:
+
+```yaml
+Seurat input for gene expression (filtered):
+  attributes: {collection_type: list:list}
+  element_tests:
+    subsample:
+      elements:
+        matrix:
+          asserts:
+            has_line:
+              line: "23932 3 1171"
+        barcodes:
+          asserts:
+            has_line:
+              line: "CACATGATCATAAGGA"
+```
+
+Pattern: outer `element_tests:` keyed by outer identifier; inner `elements:` (note plural, not `element_tests:` here) keyed by inner identifier. Optional `attributes: {collection_type: ...}` asserts the shape of the produced collection.
+
+### 2g. `composite_data:`
+
+**Not observed** in the sampled IWC corpus (`grep -rln "composite\|imzml\|primary_file\|extra_files" workflows/ --include="*-tests.yml"` returns nothing). Per the planemo spec the shape is a `composite_data:` mapping listing each component file path, but an agent emitting one in IWC style has no in-corpus reference and should treat it as unproven territory — fall back to the planemo docs and verify against `galaxy.tool_util.parser.yaml`.
+
+### 2h. CWL-style shorthand (list of File dicts without identifiers)
+
+Documented in planemo; not observed in sampled IWC. IWC always supplies explicit identifiers.
+
+### 2i. `tags:` on elements (Galaxy 20.09+)
+
+Documented in planemo; not surfaced in sampled IWC `-tests.yml` files (`grep "  tags:" --include="*-tests.yml"` empty across the sampled set). Practical absence — IWC tests rely on identifier matching, not tags.
+
+## 3. SHA-1 integrity hashes — when, when not, why
+
+**Format.** Always a list under `hashes:`, even for one entry. Each entry is `{hash_function: SHA-1, hash_value: <40-hex>}`. Verbatim from `pox-virus-half-genome-tests.yml:7-9`:
+
+```yaml
+hashes:
+- hash_function: SHA-1
+  hash_value: 927d0d00b7db6ad60524bb9e50d3ab41c4ac5ecf
+```
+
+Only `SHA-1` observed in the IWC corpus. The planemo spec also accepts `MD5`, `SHA-256`, `SHA-512` as `hash_function:` values; IWC does not exercise these.
+
+**When present:**
+
+- Every remote `location:`-fetched input in the sampled corpus carries a SHA-1 (Zenodo, EBI REST, SRA FTP). The hash guards against silent upstream corruption — Zenodo records are immutable but bit-rot and CDN-edge errors do happen; ENA FASTA endpoints can quietly change line-wrap.
+- Many local `path:`-loaded inputs also carry a SHA-1. This is `--from_invocation` autogeneration leaking through (planemo emits hashes for every input it captured).
+- `consensus-from-variation-tests.yml:6-8,17-18,27-28` — every input in the test, local and remote, has a hash.
+
+**When omitted:**
+
+- Hand-written local-file fixtures often skip hashes — `hyphy-core-tests.yml:3-30` has zero `hashes:` blocks across six local-file inputs.
+- Output assertions: `file:`-comparison outputs and `location:`-comparison outputs (`RepeatMasking-Workflow-tests.yml:13`) **do not** carry `hashes:`. The integrity story for outputs is handled by `compare:` / `asserts:` instead.
+
+**Why bother on local files.** Catches accidental corruption when collaborators hand-edit `test-data/` fixtures.
+
+## 4. Element identifier conventions
+
+Identifiers are arbitrary strings, used both as the YAML key (`element_tests:`) and as the produced Galaxy collection element name. Conventions surfaced from the corpus:
+
+- **Pipes are legal** and survive YAML round-trip without quoting on the input side: `hyphy-core-tests.yml:11` — `identifier: AB178040.1|2002`. On the *output* side they're quoted because they appear as YAML mapping keys: `hyphy-core-tests.yml:34` — `"NC_001477.1|capsid_protein_C|95-394_DENV1":`. Quote when the identifier contains characters that would otherwise start a YAML flow node (`{`, `[`, `&`, `*`, `!`, `|`, `>`, `'`, `"`, `%`, `@`, `` ` ``) or look like a number/bool.
+- **Dots, hyphens, underscores** — common, no quoting needed: `Blanc05.mzML`, `HU_neg_048.mzML`, `SRR11578257`, `Rep1`, `subsample`, `pair`.
+- **Reserved inside `paired` collections:** `forward` and `reverse` (lowercase). Never use these names for outer identifiers in `list:paired`.
+- **Inline comments after identifier** are legal and used for provenance: `pox-virus-half-genome-tests.yml:23` — `identifier: 20L70   # SRR15145276`.
+- **Whitespace and special chars in workflow input *labels*** survive too — they are job-mapping keys, not collection identifiers, but the same YAML quoting rules apply. Example from the analysis doc: `Manually annotate celltypes?: true` as a job key in `Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml:23`.
+
+### 4a. Workflow-interface implications
+
+Fixture shape should feed back into workflow input design. Tests supply job inputs by workflow input label, and collection fixtures must match the workflow's declared collection type.
+
+- The 10x CellPlex test uses `fastq PE collection GEX`, `fastq PE collection CMO`, and `sample name and CMO sequence collection` as job keys with `list:paired` and `list` collection fixtures; the workflow declares matching collection inputs at `$IWC_FORMAT2/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex.gxwf.yml:4-72`.
+- CVMFS/data-table shortcuts like `reference genome: dm6` are workflow-interface choices as much as test YAML choices: they require the workflow input to be a string/data-table-backed parameter, not a file input.
+- If a fixture needs stable sample names, decide whether those names should enter through collection element identifiers, a mapping file, or a workflow parameter before writing assertions.
+
+Rule for an agent: when a new workflow input is being designed and the test fixture is already known, check [[galaxy-workflow-testability-design]] before locking the input label/type.
+
+## 5. CVMFS / `.loc` / built-in-index references
+
+When a workflow input is a Galaxy data-table-backed reference (built-in genome index, dbsnp file, kraken DB, …), the input takes a **plain string** matching the `value` column of a `.loc` file. No `class: File`, no `location:`. Examples:
+
+- `scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:25` — `reference genome: dm6 # To test on usegalaxy.eu dm6full`
+- `epigenetics/cutandrun/cutandrun-tests.yml:27` — `reference_genome: 'hg38canon'`
+- `epigenetics/atacseq/atacseq-tests.yml:25` — `reference_genome: hg19`
+- `microbiome/host-contamination-removal/host-contamination-removal-short-reads/host-or-contamination-removal-on-short-reads-tests.yml:19` — `Host/Contaminant Reference Genome: hg38`
+- `microbiome/pathogen-identification/nanopore-pre-processing/Nanopore-Pre-Processing-tests.yml:22` — `host_reference_genome: apiMel3`
+- `transcriptomics/goseq/goseq-go-kegg-enrichment-analsis-tests.yml:24` — `Select genome to use: mm10`
+
+The string is the first column of the `.loc` entry. `workflows/README.md:169-182` shows the lookup procedure: browse `http://datacache.galaxyproject.org/indexes/location/<table>.loc`, find the `.loc` row, take the value column (which column varies by tool — check the matching `tool_data_table_conf.xml.sample`).
+
+**Portability implication:** these tests **only** run on a Galaxy with CVMFS mounted at `/cvmfs/data.galaxyproject.org`. IWC CI mounts CVMFS in-runner (`setup-cvmfs: true` in `.github/workflows/test_workflows.yml`). On a plain developer laptop running `planemo test`, CVMFS-string inputs fail unresolved. An agent generating tests should either:
+
+1. Stay URL-driven: replace the CVMFS string with a `class: File` + `location:` to a Zenodo-hosted reference (portable, slower CI, larger inputs).
+2. Use the CVMFS string and document "CI-only" — the user cannot reproduce locally without a CVMFS mount.
+
+There is no `.loc`-resolution shorthand in the YAML — it is just a bare string parameter. Agents must not invent `class: DataTable` or similar.
+
+## 6. Reviewer-feedback patterns (PR-review)
+
+Recurring asks from IWC reviewers, distilled from the contribution README and community help threads:
+
+- **Move large data to Zenodo before merge.** Anything bigger than a toy fixture committed in `test-data/` will be flagged. `workflows/README.md:67`.
+- **Use assertions, not exact-file comparison, for large outputs.** `workflows/README.md:98` — "if some outputs are large, it is better to use assertions than storing the whole output file."
+- **Generate tests with `planemo workflow_test_init --from_invocation`, don't hand-write.** `workflows/README.md:88-94`. The autogenerated test will mint correct hashes, correct labels, and a working `test-data/` snapshot.
+- **Set creator `identifier:` to a full ORCID URL** (e.g. `https://orcid.org/0000-0002-1825-0097`) — `workflows/README.md:53`. The most common lint failure; enforced in [planemo#1458](https://github.com/galaxyproject/planemo/pull/1458).
+- **Don't use `compare: diff` on outputs that embed timestamps or non-deterministic ordering.** Switch to `has_text` / `has_n_lines` (with `delta:`) or `compare: sim_size`+`delta:`.
+- **Bump `release:` in the `.ga` and add a `CHANGELOG.md` entry** in the same PR — enforced by the IWC PR template; reviewers verify via `bump_version.py`.
+- **Lower-case + `-` only** in directory names — `workflows/README.md:11,72`.
+- **Element identifiers must round-trip** — quote in YAML when they contain pipes/colons/whitespace.
+
+## 7. What is *not* covered by current convention
+
+Gaps an agent should be aware of:
+
+- **`composite_data:` is unrepresented in the IWC corpus.** No working examples to imitate for imzml+ibd or other multi-file datatypes. Treat as off-trail; cite planemo docs and verify by parser.
+- **`tags:` on elements unused.** Galaxy 20.09+ supports them; IWC does not exercise them.
+- **CWL-style shorthand File lists unused.** IWC always names elements.
+- **No negative tests.** Zero `expect_failure:` across the sampled corpus. There is no IWC convention for asserting a workflow *should* fail on bad input.
+- **No checksum-based output assertion in the wild.** `checksum: "sha1$..."` is documented and used at the input side as `hashes:`, but output-side `checksum:` was not surfaced in sampled tests. The corpus prefers `file:` (exact), `compare: sim_size`+`delta:` (size only), or `asserts:` (content probes).
+- **No data-cache layer beyond pip/planemo.** Every test re-pulls remote inputs from Zenodo / EBI / SRA on every CI run. A Zenodo outage breaks many PRs simultaneously. There is no IWC-side mirror or cache.
+- **No per-test timeout / retry convention.** A hung tool blocks the whole chunk until the GitHub Actions 6-hour limit.
+- **No portable story for CVMFS-only tests.** The same `-tests.yml` either works locally (URL-driven) or works in CI (CVMFS-string-driven), not both. There is no documented switch.
+- **Hash function is de-facto SHA-1.** The spec accepts SHA-256/SHA-512/MD5; IWC does not use them. Agents that emit a stronger hash will pass planemo but break corpus convention.
+- **Local-file `hashes:` are inconsistently present.** `--from_invocation`-generated tests have them, hand-written tests usually don't. Either is accepted; don't expect uniformity.
+- **`decompress: true` and `dbkey:` are file-level attributes** but undocumented at the planemo test_format page in the same place as `class:`/`location:`/`hashes:`. Cross-reference against the `gxformat2` Schema-Salad bindings if unsure.
+- **`?download=1` query string on Zenodo URLs** is optional. Both forms appear (`/record/4555735/files/X?download=1` vs `/records/11484215/files/Y`). The newer `/records/` plural is the modern Zenodo URL form; both work.
+
+## Cross-references
+
+- [[galaxy-workflow-testability-design]] — workflow input/output structure choices that make these fixture shapes testable.
+- `/Users/jxc755/projects/repositories/galaxy-brain/vault/projects/workflow_state/skills/COMPONENT_GALAXY_WORKFLOW_TESTING.md` — full synthesis with assertion-vocabulary table, CI internals, and tooling rundown. Sections 2b, 3, 4, 5, 9 are the direct upstream of this note.
+- planemo test format spec: [planemo.readthedocs.io/en/latest/test_format.html](https://planemo.readthedocs.io/en/latest/test_format.html).
+- planemo best practices: [planemo.readthedocs.io/en/latest/best_practices_workflows.html](https://planemo.readthedocs.io/en/latest/best_practices_workflows.html).
+- planemo collections reference: [github.com/galaxyproject/planemo/blob/master/docs/_writing_collections.rst](https://github.com/galaxyproject/planemo/blob/master/docs/_writing_collections.rst).
+- IWC contribution contract: `workflows/README.md` in [github.com/galaxyproject/iwc](https://github.com/galaxyproject/iwc).
+- Galaxy datacache (CVMFS `.loc` browsing): [datacache.galaxyproject.org/indexes/location/](http://datacache.galaxyproject.org/indexes/location/).

--- a/casts/claude/skills/changeset-to-galaxy-test-plan/references/notes/planemo-asserts-idioms.md
+++ b/casts/claude/skills/changeset-to-galaxy-test-plan/references/notes/planemo-asserts-idioms.md
@@ -1,0 +1,249 @@
+---
+type: research
+subtype: component
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-04-30
+revised: 2026-05-11
+revision: 6
+ai_generated: true
+related_notes:
+  - "[[galaxy-workflow-testability-design]]"
+  - "[[iwc-test-data-conventions]]"
+  - "[[iwc-shortcuts-anti-patterns]]"
+  - "[[implement-galaxy-workflow-test]]"
+  - "[[tests-format]]"
+  - "[[planemo-workflow-test-architecture]]"
+  - "[[validate-tests]]"
+  - "[[iwc-tabular-operations-survey]]"
+  - "[[galaxy-discover-datasets]]"
+summary: "Decision and idiom guide for picking planemo workflow-test assertions: which family per output type, how to size tolerances, when to validate."
+---
+
+# Planemo asserts: idiom and decision guide
+
+Companion to [[iwc-test-data-conventions]] (input shapes), [[galaxy-workflow-testability-design]] (workflow structure before test YAML exists), and [[iwc-shortcuts-anti-patterns]] (what's accepted vs smell). This note is forward-looking: when authoring a new `<workflow>-tests.yml`, which assertion family fits which output, and what the recommended tolerances and operators are.
+
+The **vocabulary itself is not restated here** — every assertion's parameter list, types, defaults, required fields, and Python docstring is rendered from the test-format JSON Schema at [[tests-format]]. Assertion names below deep-link into that page (e.g. [[tests-format#has_text_model|has_text]] jumps straight to that `$def`).
+
+## 1. Choose by output type
+
+The single most useful decision table. Pick the row that matches the file format the workflow emits; default to the recommended assertion family.
+
+| Output type | Default assertion family | Why | Fallback |
+|---|---|---|---|
+| **Plain text reports / logs** (FastQC summary, MultiQC text section) | [[tests-format#has_text_model|has_text]] (substring on a known stable token) + [[tests-format#has_n_lines_model|has_n_lines]] with `delta:` | Substring is robust across versions; line count catches truncation | [[tests-format#has_text_matching_model|has_text_matching]] (regex) when token text changes per run |
+| **HTML reports** (MultiQC HTML, custom dashboards) | [[tests-format#has_text_model|has_text]] against stable section names | HTML embeds timestamps and asset hashes; byte-diff is hopeless | [[tests-format#has_size_model|has_size]] + large `delta` as last resort |
+| **Tabular** (TSV, CSV, BED-like) | [[tests-format#has_n_columns_model|has_n_columns]] + [[tests-format#has_text_model|has_text]] for headers + [[tests-format#has_n_lines_model|has_n_lines]] with `delta:` | Schema-shape + content probes; tolerant to row reordering | [[tests-format#has_line_matching_model|has_line_matching]] for a known canonical row |
+| **VCF** | `compare: diff` with `lines_diff: 6` | The `lines_diff: 6` constant matches the typical VCF header preamble that embeds `##fileDate=` and `##source=` | [[tests-format#has_text_matching_model|has_text_matching]] for known variants |
+| **BAM** | [[tests-format#has_size_model|has_size]] + [[tests-format#has_archive_member_model|has_archive_member]] (BAM is a gzipped block format) | Headers contain `@PG` lines with command lines and Galaxy job IDs; never byte-diff | Convert to SAM in a downstream step and assert on text |
+| **FASTA** (deterministic — assemblies, consensus) | `file:` exact comparison or [[tests-format#has_text_model|has_text]] for known sequence | Output is byte-stable when the upstream tool is deterministic | [[tests-format#has_n_lines_model|has_n_lines]] if line wrapping varies |
+| **FASTA** (non-deterministic — RepeatModeler libraries) | `compare: sim_size` with large `delta:` | Family content varies run-to-run | [[tests-format#has_n_lines_model|has_n_lines]] with `delta:` |
+| **FASTQ** (rare as workflow output) | [[tests-format#has_n_lines_model|has_n_lines]] (must be multiple of 4) | Quality scores are read-id-dependent | `compare: sim_size` |
+| **JSON** (deterministic — config dumps, params) | [[tests-format#has_json_property_with_value_model|has_json_property_with_value]] / [[tests-format#has_json_property_with_text_model|has_json_property_with_text]] | Surgical: assert on the property you care about, ignore the rest | `compare: diff` if the JSON is fully canonical |
+| **JSON** (stochastic — HyPhy stats, MCMC results) | `has_text: text: "{"` (existence-only) | Embedded floats break any structural assertion; see [[iwc-shortcuts-anti-patterns]] §1 | [[tests-format#has_h5_keys_model|has_h5_keys]]-equivalent for top-level structural keys |
+| **HDF5 / AnnData** | [[tests-format#has_h5_keys_model|has_h5_keys]] + [[tests-format#has_h5_attribute_model|has_h5_attribute]] for known structure | Asserts shape, not values — values are float-noisy | [[tests-format#has_size_model|has_size]] with `delta:` |
+| **XML** | [[tests-format#is_valid_xml_model|is_valid_xml]] + [[tests-format#has_element_with_path_model|has_element_with_path]] + `element_text_is`/`element_text_matches` | Surgical structural probes; byte-diff fails on whitespace/attribute-order | [[tests-format#has_n_elements_with_path_model|has_n_elements_with_path]] for cardinality |
+| **PNG / image plots** | [[tests-format#has_image_width_model|has_image_width]] + [[tests-format#has_image_height_model|has_image_height]] + [[tests-format#has_size_model|has_size]] with `delta:` (5–10%) | Catches "rendered something with the right dimensions"; corpus norm | [[tests-format#has_image_center_of_mass_model|has_image_center_of_mass]] if mask/segmentation outputs are deterministic |
+| **TIFF / multipage images** | [[tests-format#has_image_frames_model|has_image_frames]] + [[tests-format#has_image_channels_model|has_image_channels]] + [[tests-format#has_size_model|has_size]] with `delta:` | Same logic, channel/frame structure matters | — |
+| **Archives** (zip, tar.gz) | `has_archive_member: path: "regex"` with nested `asserts:` | Asserts on a specific member; archive timestamps never byte-stable | [[tests-format#has_size_model|has_size]] with `delta:` |
+| **GFF / GTF** | [[tests-format#has_n_lines_model|has_n_lines]] with `delta:` + [[tests-format#has_text_model|has_text]] for known feature | Tools reorder freely; hard to byte-diff | `has_n_columns: 9` (GFF spec) |
+| **Cool / HiC matrices** | `compare: sim_size` with multi-MB `delta:` | Binary, run-to-run variance | [[tests-format#has_archive_member_model|has_archive_member]] for HDF5 component |
+
+When in doubt: start with [[tests-format#has_size_model|has_size]] + `delta_frac: 0.1`. It catches the catastrophic failure mode (empty / 10x bigger output). Then add a content probe.
+
+### 1a. If the assertion is too weak, revisit the workflow output
+
+Assertion choice sometimes reveals a workflow-design problem. If the only available output can support only a size check or image-dimension smoke test, check whether the workflow should expose a stronger checkpoint before settling for the weak assertion.
+
+- Scanpy's plot outputs use size and image-dimension assertions, but the same workflow also exposes AnnData HDF5 checkpoints and a cluster-count table (`$IWC/workflows/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml:33-205`).
+- RNA-seq paired-end uses coarse size bands for coverage/mapped-read outputs, but expression/count tables get stronger regex and exact-line checks (`$IWC/workflows/transcriptomics/rnaseq-pe/rnaseq-pe-tests.yml:48-97`).
+
+Rule: if a translated workflow exposes only weakly assertable final reports, consult [[galaxy-workflow-testability-design]] and consider promoting a table/text/HDF5 checkpoint before writing the final assertions.
+
+## 2. The `compare:` operators
+
+Top-level on a `file:` output assertion. Vocabulary, in decreasing strictness:
+
+- **`diff`** (default). Byte-for-byte equality with optional `lines_diff:` tolerance for a fixed number of header lines. Use only when the upstream tool is deterministic on fixed inputs *and* the output has no embedded timestamps, command lines, version banners, or hash-ordered Python-dict-style keys.
+- **`re_match` / `re_match_multiline`**. Each line of the expected fixture is a regex that must match the corresponding output line. Useful when a few fields per row are timestamped but the rest is canonical. Rare in the corpus.
+- **`contains`**. The expected fixture is a substring of the output. Cheap; weak. Prefer `asserts: has_text` for new code unless you genuinely have a multi-line block to assert as a whole.
+- **`sim_size`**. Output file size matches the fixture's size within `delta:` (bytes) or `delta_frac:` (fraction). Use when the output is necessarily non-deterministic but its rough size is reproducible (RepeatModeler libraries, HiC matrices, Bayesian sampler outputs).
+
+Picking `lines_diff:`: count the mutable header lines in the output format. VCF: ~6 (`##fileformat`, `##fileDate`, `##source`, `##reference`, contig/info lines vary). SAM/text headers: count `@HD`/`@PG`/`@CO` lines. Set `lines_diff:` to the count exactly — looser values mask real diffs.
+
+## 3. Tolerance picking
+
+**`delta:`** is bytes (for [[tests-format#has_size_model|has_size]] and `compare: sim_size`) or absolute count (for [[tests-format#has_n_lines_model|has_n_lines]], [[tests-format#has_n_columns_model|has_n_columns]], [[tests-format#has_image_width_model|has_image_width]], etc.). Suffix multipliers documented in the schema — `1K`, `1M`, `1G` work.
+
+**`delta_frac:`** is a fraction (0.1 = 10%). Use when expected size scales with input volume. Three IWC tests use it (`scRNAseq/baredsc/*`, `genome-assembly/polish-with-long-reads/*`); the rest use absolute `delta:`.
+
+**Picking magnitudes** (from corpus survey in [[iwc-shortcuts-anti-patterns]] §2):
+
+- Image dimensions: `delta: 25–30` pixels (5% of typical matplotlib defaults).
+- Image file size: `delta: 5K–60K` (5–10% of file size).
+- Small text reports: `delta: 1K–10K`.
+- HTML reports: `delta: 25K–100K`.
+- BAM files: `delta: 1M–10M`.
+- RepeatModeler / Bayesian sampler outputs: `delta: 30K–90M` (extreme, but justified by the underlying nondeterminism).
+
+**Heuristic for new outputs:** `delta_frac: 0.1` is a defensible default. Tighten if the output proves more deterministic than expected.
+
+## 4. Text family — [[tests-format#has_text_model|has_text]] vs [[tests-format#has_text_matching_model|has_text_matching]] vs [[tests-format#has_line_model|has_line]] vs [[tests-format#has_line_matching_model|has_line_matching]] vs [[tests-format#has_n_lines_model|has_n_lines]]
+
+All five are common; choose by what you're verifying.
+
+- **[[tests-format#has_text_model|has_text]]** — output contains the substring `text:`. Anywhere in the output, any number of times. Add `n:` / `min:` / `max:` to constrain occurrence count. Add `delta:` to allow slack on the count.
+- **[[tests-format#has_text_matching_model|has_text_matching]]** — output matches the regex `expression:`. Use sparingly; prefer literal [[tests-format#has_text_model|has_text]] when you can.
+- **[[tests-format#has_line_model|has_line]]** — output has at least one *line* matching `line:` exactly. Use when line boundaries matter (e.g. asserting on a specific row in a table).
+- **[[tests-format#has_line_matching_model|has_line_matching]]** — same but with regex.
+- **[[tests-format#has_n_lines_model|has_n_lines]]** — assert the line count is `n:` ± `delta:`.
+
+A common combination in IWC: `has_n_lines: n: 100, delta: 5` + `has_text: text: "expected_token"` — line-count sanity-check plus a content marker. This catches both truncation and content drift in one assertion pair.
+
+`negate: true` is supported on every assertion. Used for the "this output should NOT contain X" case.
+
+## 5. Collection output assertions (`element_tests:`)
+
+For Galaxy collection outputs, the test format keys element assertions by element identifier:
+
+```yaml
+my_collection_output:
+  element_tests:
+    sample_1:
+      asserts:
+        has_text:
+          text: "expected"
+    sample_2:
+      file: test-data/expected_sample_2.txt
+```
+
+Optional `attributes:` at the collection level can assert on the produced collection shape:
+
+```yaml
+my_collection_output:
+  attributes: {collection_type: list:list}
+  element_tests:
+    ...
+```
+
+Nested collections: outer `element_tests:` keyed by outer identifier; inner uses `elements:` (note plural, no `_tests` suffix on the inner). See [[iwc-test-data-conventions]] §2f for the live example.
+
+For a list-of-files where every element should pass the same minimal check, the existence-probe pattern (`has_text: "{"` for JSON; `has_size: min: 100` for any non-empty binary) is widely used and accepted in IWC.
+
+## 6. The validate-against-workflow inner loop
+
+A `-tests.yml` file can be **structurally invalid** in two distinct ways:
+
+1. **Schema-invalid** — wrong field names, wrong nesting, wrong types. Caught by the test-format JSON Schema.
+2. **Workflow-incoherent** — schema-valid YAML, but the input/output labels don't match the actual workflow. Renaming an output in the `.ga` and forgetting to update its sibling `-tests.yml` produces this case. Planemo will surface it as an "output not found" error at test-runtime, but only after a full workflow run.
+
+The `@galaxy-tool-util/schema` npm package ships **two** validators that catch both cases statically — no Galaxy or Planemo invocation needed:
+
+- **`validateTestsFile(yaml)`** — runs the file against `tests.schema.json` (AJV). Reports schema violations with paths.
+- **`checkTestsAgainstWorkflow(workflow, tests)`** — cross-checks a `.ga` / format2 workflow against a tests file: missing input labels, missing output labels, type incompatibilities (e.g. test supplies a `File` for a parameter typed `int`).
+
+Both are pure-JS, take milliseconds, and have no Galaxy dependency. Wire them into the inner authoring loop:
+
+```
+edit -tests.yml
+  → validateTestsFile()                    # schema gate
+  → checkTestsAgainstWorkflow(.ga, tests)  # coherence gate
+  → planemo workflow_test_on_invocation    # assertion gate (no full re-run)
+  → planemo test                           # full integration (slow)
+```
+
+The first two gates short-circuit cheap mistakes before a slow planemo run. They are the static-validation equivalent of `gxwf` for tests, and the `implement-galaxy-workflow-test` mold should reference them as its primary inner-loop tooling. Source: galaxy-tool-util-ts package, `src/test-format/index.ts` exports.
+
+## 7. Authoring loop — generation, then refinement
+
+Reviewer convention is to **generate** the initial `-tests.yml` rather than hand-write it. Two planemo subcommands cover this:
+
+- **`planemo workflow_test_init --from_invocation <invocation_id>`** ([[planemo-workflow_test_init]]) — given a successful Galaxy invocation ID, emit a `-tests.yml` with a `job:` block that captures all inputs (with SHA-1 hashes) and an `outputs:` block with `file:` references to the actual outputs (downloaded into `test-data/`). Hand-tighten the assertions afterward.
+- **`planemo workflow_test_on_invocation <tests.yml> <invocation_id>`** ([[planemo-workflow_test_on_invocation]]) — re-evaluate an edited `-tests.yml` against a saved invocation without re-running the workflow. The fast inner loop for assertion iteration; complements the static gates in §6.
+
+Together these cut the assertion-iteration cost dramatically. An agent should:
+
+1. Run the workflow once on usegalaxy.* (or local) to get a known-good invocation.
+2. `--from_invocation` to bootstrap the test file.
+3. Replace the autogenerated `file:` exact-comparison assertions with assertion-family-appropriate alternatives per §1.
+4. [[planemo-workflow_test_on_invocation]] after each edit; full [[planemo-test]] at the end.
+
+## 8. What the schema gives you for free
+
+When the test-format schema lands as a Foundry-rendered note, the agent can consult any assertion's `$def` directly for: parameter types, defaults, required fields, the `that` discriminator constant, and the original Python docstring (carried through as `description`). This note does **not** restate that vocabulary — it complements it with the corpus-grounded *which-and-when*.
+
+What's still missing from the schema and worth keeping in research notes:
+
+- This decision table (§1) — output-type → assertion family.
+- Tolerance magnitudes (§3) — corpus-derived defaults.
+- The `validateTestsFile` / `checkTestsAgainstWorkflow` integration story (§6).
+- Anti-pattern flags — see [[iwc-shortcuts-anti-patterns]].
+
+## 9. Common combinations (recipes)
+
+Six recipes worth memorizing.
+
+**Stable text report (FastQC summary, simple stats).**
+```yaml
+my_report:
+  asserts:
+    has_n_lines: { n: 12, delta: 2 }
+    has_text: { text: "Total Sequences" }
+```
+
+**MultiQC HTML report.**
+```yaml
+multiqc_report:
+  asserts:
+    has_text: { text: "Filtered Reads" }
+    has_text: { text: "FastQC" }
+```
+
+**VCF (pinned tool, fixed reference).**
+```yaml
+called_variants:
+  file: test-data/expected.vcf
+  compare: diff
+  lines_diff: 6
+```
+
+**Stochastic JSON (HyPhy-style).**
+```yaml
+hyphy_meme:
+  element_tests:
+    geneA: { asserts: { has_text: { text: "{" } } }
+    geneB: { asserts: { has_text: { text: "{" } } }
+```
+
+**Matplotlib plot.**
+```yaml
+umap_plot:
+  asserts:
+    has_size: { size: 68416, delta: 6000 }
+    has_image_width: { width: 601, delta: 30 }
+    has_image_height: { height: 429, delta: 25 }
+```
+
+**AnnData (HDF5).**
+```yaml
+clustered_anndata:
+  asserts:
+    has_h5_keys: { keys: "obs/louvain" }
+    has_h5_keys: { keys: "var/highly_variable" }
+    has_h5_keys: { keys: "uns/rank_genes_groups" }
+    has_size: { size: 12000000, delta: 1500000 }
+```
+
+## 10. Cross-references
+
+- [[galaxy-workflow-testability-design]] — decide which workflow outputs and checkpoints to expose before choosing assertions.
+- [[iwc-test-data-conventions]] — input-side conventions (job inputs, collection shapes, `hashes:`, CVMFS).
+- [[iwc-shortcuts-anti-patterns]] — accepted-vs-smell catalog and corpus prevalence; this note's mirror image.
+- Test-format schema (`@galaxy-tool-util/schema` npm package) — authoritative vocabulary; will be vendored into a Foundry-rendered schema note. See `docs/COMPILATION_PIPELINE.md` for the casting story.
+- Planemo test-format spec: [planemo.readthedocs.io/en/latest/test_format.html](https://planemo.readthedocs.io/en/latest/test_format.html).
+- [[galaxy-xsd]] — Galaxy XSD assertion source of truth, vendored from upstream.
+- Tightening of the schema and Pydantic source: [galaxyproject/galaxy#22566](https://github.com/galaxyproject/galaxy/pull/22566).
+- TS schema sync into npm: [jmchilton/galaxy-tool-util-ts#75](https://github.com/jmchilton/galaxy-tool-util-ts/pull/75).

--- a/casts/claude/skills/changeset-to-galaxy-test-plan/references/notes/planemo-workflow-test-architecture.md
+++ b/casts/claude/skills/changeset-to-galaxy-test-plan/references/notes/planemo-workflow-test-architecture.md
@@ -1,0 +1,153 @@
+---
+type: research
+subtype: component
+title: "Planemo workflow-test architecture"
+tags:
+  - research/component
+  - tool/planemo
+  - target/galaxy
+status: draft
+created: 2026-05-02
+revised: 2026-05-11
+revision: 3
+ai_generated: true
+related_notes:
+  - "[[galaxy-workflow-testability-design]]"
+  - "[[galaxy-tool-job-failure-reference]]"
+  - "[[galaxy-workflow-invocation-failure-reference]]"
+  - "[[planemo-asserts-idioms]]"
+related_molds:
+  - "[[run-workflow-test]]"
+  - "[[debug-galaxy-workflow-output]]"
+  - "[[implement-galaxy-workflow-test]]"
+sources:
+  - "~/projects/repositories/planemo/planemo/commands/cmd_test.py"
+  - "~/projects/repositories/planemo/planemo/commands/cmd_run.py"
+  - "~/projects/repositories/planemo/planemo/galaxy/activity.py"
+  - "~/projects/repositories/planemo/planemo/galaxy/invocations"
+  - "~/projects/repositories/planemo/planemo/galaxy/config.py"
+summary: "Reference for Planemo workflow test/run architecture, Galaxy modes, API polling, and noisy failure boundaries."
+---
+
+# Planemo Workflow-Test Architecture
+
+This note describes Planemo architecture relevant to workflow tests and workflow runs. It is reference material for Molds that need to run tests or interpret Planemo artifacts, not a command-selection recipe.
+
+## Main Commands
+
+| User action | Command | Core behavior |
+|---|---|---|
+| Full workflow test | `planemo test <workflow>` ([[planemo-test]]) | Finds test definitions, starts or targets Galaxy, stages inputs, invokes workflow, checks assertions, writes reports. |
+| Direct run | `planemo run <workflow> <job.yml>` | Runs one workflow/job pair and can download outputs without assertion checks. |
+| Recheck assertions | `planemo workflow_test_on_invocation <tests.yml> <invocation_id>` ([[planemo-workflow_test_on_invocation]]) | Runs test assertions against an existing invocation without rerunning the workflow. |
+| Track invocation | `planemo workflow_track <invocation_id>` | Polls an existing invocation and displays progress. |
+| Generate test from invocation | `planemo workflow_test_init --from_invocation <id>` ([[planemo-workflow_test_init]]) | Builds a test template from a completed invocation and its outputs. |
+| Generate job template | `planemo workflow_job_init <workflow>` | Creates a job-input template for a workflow. |
+
+Observed code paths live under `~/projects/repositories/planemo/planemo/commands/`, `planemo/engine/`, and `planemo/galaxy/`.
+
+## Engine Selection
+
+Planemo chooses between engines early:
+
+- CWL runnables can use CWL-specific engines.
+- Supplying `--galaxy_url` implies an external running Galaxy unless an engine is explicitly selected.
+- Default Galaxy workflow testing uses a managed local Galaxy engine.
+- `--engine docker_galaxy` uses a managed Dockerized Galaxy.
+- `--engine external_galaxy` uses an existing running Galaxy.
+
+“Existing Galaxy” can mean two different things:
+
+- Existing local Galaxy source tree, still managed by Planemo for this run.
+- Existing running Galaxy server, addressed through URL and API keys.
+
+Mold output and eval logs should record which meaning applies.
+
+## Managed Galaxy Configuration
+
+For managed Galaxy, Planemo builds a temporary configuration directory and generated Galaxy config. It can configure tool config, shed tool config, job config, file sources, object store paths, dependency config, SQLite database by default, admin users, API keys, and environment overrides.
+
+Important managed-mode behavior:
+
+- Planemo may find a local Galaxy root or install/use a cached Galaxy source tree.
+- Managed Galaxy defaults are convenient but may not match production Galaxy behavior.
+- Planemo can install workflow tool dependencies through Tool Shed metadata when configured.
+- Test histories are created automatically unless a history id is supplied.
+
+## External Galaxy Configuration
+
+For external Galaxy, Planemo uses supplied Galaxy URL and API keys. A user key runs workflows; an admin key may be needed for installing missing repositories or creating a user key.
+
+External Galaxy mode is useful when the target environment matters, but failure surfaces can include server configuration, installed tools, permissions, and existing history state. Eval logs should preserve URL/key mode without storing secrets.
+
+## API Interaction
+
+Planemo primarily talks to Galaxy through BioBlend-backed clients.
+
+Important operations:
+
+- Import workflows into Galaxy.
+- Stage datasets and collections into histories.
+- Invoke workflows by input names.
+- Poll invocations and jobs.
+- Fetch job details with full detail when needed.
+- Download outputs and output collections.
+- Run assertion checks and write structured reports.
+
+For workflows, Planemo invokes Galaxy using input labels/names. Stable generated labels are therefore important for both test execution and debugging.
+
+Workflow testability design guidance lives in [[galaxy-workflow-testability-design]]. This architecture note only records why Planemo makes labels and workflow-level outputs operationally important.
+
+## Structured Artifacts
+
+Useful Planemo artifacts and fields:
+
+| Artifact or field | Use |
+|---|---|
+| `tool_test_output.json` | Primary structured result artifact for tests. |
+| invocation id | Key for Galaxy invocation API follow-up. |
+| history id | Key for history contents and output inspection. |
+| workflow id | Key for workflow invocation aliases and reruns. |
+| output problems | Assertion and missing-output failures. |
+| execution problem | Staging, invocation, API, or other execution-level failure. |
+| invocation details | Step/job/output details Planemo collected from Galaxy. |
+| job details | Tool id, state, exit code, command, stdout/stderr when collected. |
+
+Terminal output is not enough for durable failure analysis. Preserve structured output whenever possible.
+
+## Noisy Boundaries
+
+Planemo transforms and summarizes Galaxy failure information. These are likely information-loss boundaries:
+
+- Exceptions during execution can become stringified `ErrorRunResponse` values.
+- Polling may summarize “at least one job is in error” while detailed job evidence is printed elsewhere or stored separately.
+- Missing outputs become assertion/output problems, which can conflate label mismatch, workflow output omission, optional output absence, failed invocation, or output download issue.
+- Output download failures may be logged but not always propagated as the most specific failure.
+- External Galaxy without an admin key may defer missing-tool problems until runtime.
+- `allow_tool_state_corrections=True` can let Galaxy adjust tool state during invocation, which is useful but can mask definition drift.
+- `--no_wait` is not suitable for debug conclusions because invocation creation can succeed before jobs fail.
+
+## Reference Use For Molds
+
+For [[run-workflow-test]]:
+
+- Preserve structured Planemo result output, invocation id, history id, workflow id, and Galaxy mode.
+- Record whether the run used managed local Galaxy, Docker Galaxy, or external Galaxy.
+- Do not treat terminal output as the primary failure artifact.
+
+For [[debug-galaxy-workflow-output]]:
+
+- Start from structured Planemo output.
+- For missing-output failures, check label drift and omitted workflow-level outputs before assuming tool failure.
+- If the failure is job-level, inspect Galaxy job APIs described in [[galaxy-tool-job-failure-reference]].
+- If the failure is invocation-level, inspect Galaxy invocation APIs described in [[galaxy-workflow-invocation-failure-reference]].
+- If only assertions failed, use [[planemo-asserts-idioms]] before deciding to rerun.
+
+## Verification Gaps
+
+Actual runs should verify:
+
+- Which invocation messages Planemo exposes directly.
+- Whether target Planemo/Galaxy versions populate `completed`, `/completion`, and step job summaries.
+- How `workflow_test_on_invocation` behaves for failed, warning-only, mapped collection, and subworkflow invocations.
+- Whether generated test cases from invocation preserve nested output collection structure correctly.

--- a/casts/claude/skills/changeset-to-galaxy-test-plan/references/schemas/galaxy-workflow-test-plan.schema.json
+++ b/casts/claude/skills/changeset-to-galaxy-test-plan/references/schemas/galaxy-workflow-test-plan.schema.json
@@ -1,0 +1,551 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://galaxyproject.org/foundry/schemas/galaxy-workflow-test-plan.schema.json",
+  "$comment": "Canonical source: packages/foundry/src/schemas/galaxy-workflow-test-plan/galaxy-workflow-test-plan.schema.json in galaxyproject/foundry. Mold frontmatter cites this schema via [[galaxy-workflow-test-plan]] wiki-links; the cast pipeline imports the `galaxyWorkflowTestPlanSchema` runtime export and serializes it into cast bundles. The on-disk artifact is YAML; validate it with `foundry validate-galaxy-workflow-test-plan`.",
+  "title": "Galaxy Workflow Test Plan",
+  "description": "Intermediate, reviewable Galaxy workflow test-plan handoff produced by a *-test-to-galaxy-test-plan Mold (nextflow, cwl, or freeform) and consumed by implement-galaxy-workflow-test. It preserves test intent, fixture provenance, assertion intent, tolerances, label assumptions, unresolved mappings, and intentional omissions before any concrete tests-format `*-tests.yml` is authored. It is NOT the final test artifact: assertion vocabulary is referenced by family name from the tests-format schema, not duplicated here.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "plan_version",
+    "source",
+    "workflow",
+    "test_cases",
+    "unresolved",
+    "omissions",
+    "warnings"
+  ],
+  "properties": {
+    "plan_version": {
+      "type": "string",
+      "enum": [
+        "1"
+      ],
+      "description": "Test-plan schema major version."
+    },
+    "source": {
+      "$ref": "#/$defs/SourceRecord"
+    },
+    "workflow": {
+      "$ref": "#/$defs/WorkflowRef"
+    },
+    "test_cases": {
+      "type": "array",
+      "description": "One entry per planned Galaxy workflow test (each becomes one tests-format test entry downstream).",
+      "items": {
+        "$ref": "#/$defs/TestCase"
+      }
+    },
+    "unresolved": {
+      "type": "array",
+      "description": "Mappings the plan could not resolve and that implement-galaxy-workflow-test (or a reviewer) must settle before authoring the final test file.",
+      "items": {
+        "$ref": "#/$defs/UnresolvedItem"
+      }
+    },
+    "omissions": {
+      "type": "array",
+      "description": "Outputs or behaviors deliberately left unasserted, with rationale, so the gap is a recorded decision rather than an oversight.",
+      "items": {
+        "$ref": "#/$defs/Omission"
+      }
+    },
+    "warnings": {
+      "type": "array",
+      "description": "Plan-construction warnings: source-test evidence that could not be translated, expression-derived shapes, missing fixtures, and similar.",
+      "items": {
+        "$ref": "#/$defs/Warning"
+      }
+    }
+  },
+  "$defs": {
+    "SourceRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "name",
+        "derived_from",
+        "notes"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "nextflow",
+            "cwl",
+            "freeform"
+          ],
+          "description": "Source family of the Galaxy-targeting translator that produced this plan."
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-oriented workflow or source name the plan was derived from."
+        },
+        "derived_from": {
+          "type": "string",
+          "enum": [
+            "test-evidence",
+            "intent"
+          ],
+          "description": "Dominant basis for the plan: test-evidence means it was translated from existing upstream test fixtures/snapshots/job files (nf-test, CWL jobs); intent means it was synthesized from workflow intent and scenario-level expected outputs without upstream test evidence (freeform paper/interview sources)."
+        },
+        "notes": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Free-text provenance about the source and how test evidence was (or was not) available."
+        }
+      }
+    },
+    "WorkflowRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "How the plan relates to the Galaxy workflow it tests, and where its input/output labels came from.",
+      "required": [
+        "title",
+        "label_source",
+        "notes"
+      ],
+      "properties": {
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Galaxy workflow title/name when known."
+        },
+        "label_source": {
+          "type": "string",
+          "enum": [
+            "draft",
+            "interface-brief",
+            "assumed"
+          ],
+          "description": "Provenance of the input/output labels this plan references: draft means they were read from a concrete gxformat2 workflow draft (verifiable); interface-brief means they came from an upstream Galaxy interface brief; assumed means they were inferred and are unconfirmed against any workflow."
+        },
+        "notes": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Free-text notes about label confidence and workflow-binding assumptions."
+        }
+      }
+    },
+    "TestCase": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "doc",
+        "derived_from",
+        "provenance",
+        "job_inputs",
+        "expected_outputs"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Stable identifier for this planned test case."
+        },
+        "doc": {
+          "type": "string",
+          "description": "What this test exercises, in plain language; becomes the tests-format test `doc`."
+        },
+        "derived_from": {
+          "type": "string",
+          "enum": [
+            "test-evidence",
+            "intent",
+            "mixed"
+          ],
+          "description": "Basis for this case: translated from upstream test evidence, synthesized from intent, or a mix."
+        },
+        "provenance": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Where this case came from, e.g. an nf-test name, a CWL job file, a paper section, or an interview answer."
+        },
+        "job_inputs": {
+          "type": "array",
+          "description": "Planned workflow job inputs for this case.",
+          "items": {
+            "$ref": "#/$defs/JobInput"
+          }
+        },
+        "expected_outputs": {
+          "type": "array",
+          "description": "Planned workflow outputs to assert for this case.",
+          "items": {
+            "$ref": "#/$defs/ExpectedOutput"
+          }
+        }
+      }
+    },
+    "JobInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "workflow_label",
+        "label_status",
+        "description",
+        "collection_shape",
+        "datatype",
+        "fixture"
+      ],
+      "properties": {
+        "workflow_label": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Workflow input label this job entry binds to; null when the label is not yet known."
+        },
+        "label_status": {
+          "type": "string",
+          "enum": [
+            "resolved",
+            "assumed",
+            "unresolved"
+          ],
+          "description": "resolved means the label matches a concrete workflow draft input; assumed means it is inferred from a brief; unresolved means the binding label is not yet decided."
+        },
+        "description": {
+          "type": "string",
+          "description": "What this input is and the role it plays in the test."
+        },
+        "collection_shape": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Galaxy collection shape when the input is a collection, e.g. list, paired, list:paired, list:list; null for a single dataset or when unknown."
+        },
+        "datatype": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Galaxy datatype/extension hint, e.g. fastqsanger.gz, fasta, tabular; null when undecided."
+        },
+        "fixture": {
+          "$ref": "#/$defs/Fixture"
+        }
+      }
+    },
+    "Fixture": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "storage",
+        "location",
+        "checksum",
+        "provenance"
+      ],
+      "properties": {
+        "storage": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "remote-url",
+            "in-repo",
+            "cvmfs-string",
+            "generated-toy",
+            "unresolved",
+            null
+          ],
+          "description": "Where the fixture data lives or should live: remote-url (Zenodo/EBI/SRA location), in-repo (committed test-data path), cvmfs-string (data-table/built-in-index bare string), generated-toy (to be synthesized), or unresolved (not yet sourced)."
+        },
+        "location": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Concrete URL, repo-relative path, or data-table string when known; null when the fixture still needs resolution."
+        },
+        "checksum": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Integrity hash when available, e.g. SHA-1:<hex>; null when unknown."
+        },
+        "provenance": {
+          "type": "string",
+          "description": "Where this fixture comes from or how it was chosen, e.g. a translated source test-data reference, a Zenodo record, or a note that test-data-resolution must supply it."
+        }
+      }
+    },
+    "ExpectedOutput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "workflow_label",
+        "label_status",
+        "description",
+        "output_kind",
+        "collection_shape",
+        "assertion_intent"
+      ],
+      "properties": {
+        "workflow_label": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Workflow output label to assert against; null when the output label is not yet known."
+        },
+        "label_status": {
+          "type": "string",
+          "enum": [
+            "resolved",
+            "assumed",
+            "unresolved"
+          ],
+          "description": "resolved means the label matches a concrete workflow draft output; assumed means it is inferred from a brief; unresolved means the output label is not yet decided."
+        },
+        "description": {
+          "type": "string",
+          "description": "What this output is and why it is worth asserting."
+        },
+        "output_kind": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "dataset",
+            "collection",
+            null
+          ],
+          "description": "Whether the output is a single dataset or a collection; null when undecided. Collection outputs carry element-level assertion intent via assertion_intent[].element_identifier."
+        },
+        "collection_shape": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Galaxy collection shape for collection outputs, e.g. list, list:paired, list:list; null otherwise."
+        },
+        "assertion_intent": {
+          "type": "array",
+          "description": "Assertion intent for this output. May be empty when the output is intentionally unasserted (record the reason in omissions). Each entry names a tests-format assertion family by name rather than duplicating its full parameter object.",
+          "items": {
+            "$ref": "#/$defs/AssertionIntent"
+          }
+        }
+      }
+    },
+    "AssertionIntent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "family",
+        "intent",
+        "expected_value",
+        "tolerance",
+        "element_identifier",
+        "evidence",
+        "confidence"
+      ],
+      "properties": {
+        "family": {
+          "type": "string",
+          "description": "tests-format assertion family or compare operator this intent maps to, by name, e.g. has_text, has_n_lines, has_n_columns, has_size, has_image_width, has_h5_keys, file, compare:diff, compare:sim_size. Names reference the tests-format schema vocabulary; this plan does not restate parameter shapes."
+        },
+        "intent": {
+          "type": "string",
+          "description": "What this assertion verifies, in plain language, so implement-galaxy-workflow-test can materialize the concrete assertion without re-reading the source tests."
+        },
+        "expected_value": {
+          "type": [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "null"
+          ],
+          "description": "Concrete expected token, count, size, or comparison fixture when known; null when synthesized from intent without a concrete value."
+        },
+        "tolerance": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Tolerance"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Tolerance for the expected value when applicable; null for exact or existence-only assertions."
+        },
+        "element_identifier": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Collection element identifier this assertion targets, for element-level (element_tests) assertions; null for top-level dataset assertions."
+        },
+        "evidence": {
+          "type": "string",
+          "enum": [
+            "test-evidence",
+            "intent"
+          ],
+          "description": "Whether this assertion was translated from upstream test evidence or synthesized from intent."
+        },
+        "confidence": {
+          "type": "string",
+          "enum": [
+            "high",
+            "medium",
+            "low"
+          ],
+          "description": "How firmly the expected value and family are believed correct; synthesized assertions are typically medium or low."
+        }
+      }
+    },
+    "Tolerance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "magnitude",
+        "rationale"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "delta",
+            "delta_frac",
+            "lines_diff",
+            "none"
+          ],
+          "description": "Tolerance operator: delta (absolute count/bytes, suffixes like 1K/1M allowed as strings), delta_frac (fraction such as 0.1), lines_diff (number of mutable header lines for compare:diff), or none."
+        },
+        "magnitude": {
+          "type": [
+            "string",
+            "number",
+            "integer",
+            "null"
+          ],
+          "description": "Tolerance magnitude, e.g. 6, \"10K\", or 0.1; null when kind is none or the magnitude is undecided."
+        },
+        "rationale": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Why this magnitude was chosen, e.g. mutable VCF header line count, percentage of typical file size, or nondeterministic output."
+        }
+      }
+    },
+    "UnresolvedItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "description",
+        "blocking",
+        "suggested_resolution"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "input-label",
+            "output-label",
+            "fixture",
+            "assertion",
+            "datatype",
+            "collection-shape",
+            "other"
+          ],
+          "description": "Category of the unresolved mapping."
+        },
+        "description": {
+          "type": "string",
+          "description": "What could not be resolved and why."
+        },
+        "blocking": {
+          "type": "boolean",
+          "description": "Whether implement-galaxy-workflow-test must resolve this before authoring a runnable test."
+        },
+        "suggested_resolution": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "A proposed way to resolve it when one is apparent; null otherwise."
+        }
+      }
+    },
+    "Omission": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "target",
+        "reason",
+        "category"
+      ],
+      "properties": {
+        "target": {
+          "type": "string",
+          "description": "What is intentionally left unasserted, e.g. a workflow output label or a class of outputs."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Why it is omitted, e.g. nondeterministic content, no stable checkpoint, or asserted only weakly elsewhere."
+        },
+        "category": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "nondeterministic",
+            "no-stable-checkpoint",
+            "weak-output",
+            "out-of-scope",
+            "other",
+            null
+          ],
+          "description": "Coarse omission category; null when none fits."
+        }
+      }
+    },
+    "Warning": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "message",
+        "path"
+      ],
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "Stable warning code, e.g. untranslatable-snapshot, missing-fixture, expression-derived-shape."
+        },
+        "message": {
+          "type": "string",
+          "description": "Human-readable warning detail."
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Pointer into the source or plan the warning refers to; null when not applicable."
+        }
+      }
+    }
+  }
+}

--- a/casts/claude/skills/changeset-to-galaxy-test-plan/references/schemas/summary-galaxy-workflow.schema.json
+++ b/casts/claude/skills/changeset-to-galaxy-test-plan/references/schemas/summary-galaxy-workflow.schema.json
@@ -1,0 +1,665 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://galaxyproject.org/foundry/schemas/summary-galaxy-workflow.schema.json",
+  "$comment": "Canonical source: packages/foundry/src/schemas/summary-galaxy-workflow/summary-galaxy-workflow.schema.json in galaxyproject/foundry. Mold frontmatter cites this schema via [[summary-galaxy-workflow]] wiki-links; the cast pipeline imports the `summaryGalaxyWorkflowSchema` runtime export and serializes it into cast bundles.",
+  "title": "Galaxy Workflow Summary",
+  "description": "Structured summary emitted by the summarize-galaxy-workflow Mold. Galaxy gxformat2 is already a typed workflow language, so this schema records validated and normalized workflow structure (inputs, outputs, steps, edges, existing tests) rather than inferred pipeline semantics. When the user supplies a legacy .ga workflow it is converted to gxformat2 first and the conversion is recorded under documents.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "summary_version",
+    "source",
+    "documents",
+    "workflow_inputs",
+    "workflow_outputs",
+    "steps",
+    "graph",
+    "tests",
+    "warnings"
+  ],
+  "properties": {
+    "summary_version": {
+      "type": "string",
+      "enum": [
+        "1"
+      ],
+      "description": "Summary schema major version."
+    },
+    "source": {
+      "$ref": "#/$defs/SourceRecord"
+    },
+    "documents": {
+      "$ref": "#/$defs/DocumentSet"
+    },
+    "workflow_inputs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/WorkflowInput"
+      }
+    },
+    "workflow_outputs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/WorkflowOutput"
+      }
+    },
+    "steps": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/WorkflowStep"
+      }
+    },
+    "graph": {
+      "$ref": "#/$defs/WorkflowGraph"
+    },
+    "tests": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/TestCase"
+      }
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Warning"
+      }
+    }
+  },
+  "$defs": {
+    "SourceRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "ecosystem",
+        "workflow",
+        "url",
+        "version",
+        "license",
+        "slug",
+        "format",
+        "original_format",
+        "release",
+        "annotation"
+      ],
+      "properties": {
+        "ecosystem": {
+          "type": "string",
+          "enum": [
+            "galaxy"
+          ],
+          "description": "Source ecosystem; fixed for this per-source schema."
+        },
+        "workflow": {
+          "type": "string",
+          "description": "Human-oriented workflow name, usually the gxformat2 `name:` or the source filename stem."
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Original path or URL supplied by the user."
+        },
+        "version": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Pinned commit, tag, release, or digest when available."
+        },
+        "license": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "License identifier from the gxformat2 `license:` field or a detected license file."
+        },
+        "slug": {
+          "type": "string",
+          "description": "Stable kebab-case run slug."
+        },
+        "format": {
+          "type": "string",
+          "enum": [
+            "gxformat2"
+          ],
+          "description": "Normalized workflow format this summary describes; always gxformat2."
+        },
+        "original_format": {
+          "type": "string",
+          "enum": [
+            "gxformat2",
+            "ga"
+          ],
+          "description": "Format the user supplied. `ga` means the legacy native format was converted to gxformat2 before summarizing (see documents.converted_path)."
+        },
+        "release": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "gxformat2 `release:` version string when present."
+        },
+        "annotation": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Workflow-level annotation/description when present."
+        }
+      }
+    },
+    "DocumentSet": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "entrypoint",
+        "converted_path",
+        "validation"
+      ],
+      "properties": {
+        "entrypoint": {
+          "type": "string",
+          "description": "Local path or URL of the workflow document as supplied."
+        },
+        "converted_path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Path to the gxformat2 document produced by `gxwf convert` when the entrypoint was a legacy .ga; null when the entrypoint was already gxformat2."
+        },
+        "validation": {
+          "$ref": "#/$defs/ValidationResult"
+        }
+      }
+    },
+    "ValidationResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "command",
+        "status",
+        "diagnostics"
+      ],
+      "properties": {
+        "command": {
+          "type": "string",
+          "description": "Validation command or library operation used, e.g. `gxwf validate`."
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "valid",
+            "warning",
+            "invalid",
+            "not-run"
+          ]
+        },
+        "diagnostics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "WorkflowInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "label",
+        "type",
+        "collection_type",
+        "optional",
+        "default",
+        "format",
+        "doc"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "gxformat2 input step key (label) that later edges address."
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "data",
+            "collection",
+            "parameter"
+          ],
+          "description": "Galaxy workflow input class: a single dataset, a dataset collection, or a runtime parameter."
+        },
+        "collection_type": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Galaxy collection type expression when type is collection, e.g. list, paired, list:paired."
+        },
+        "optional": {
+          "type": "boolean"
+        },
+        "default": {
+          "description": "Verbatim default value when present.",
+          "type": [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "object",
+            "array",
+            "null"
+          ]
+        },
+        "format": {
+          "type": [
+            "string",
+            "array",
+            "null"
+          ],
+          "description": "Declared datatype/extension restriction(s) when present.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doc": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "WorkflowOutput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "label",
+        "source",
+        "type",
+        "doc"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Workflow output name as exposed in the gxformat2 `outputs:` block."
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "source": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Producing `step_label/output_name` this workflow output promotes."
+        },
+        "type": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Compact datatype/collection-shape hint when derivable."
+        },
+        "doc": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "WorkflowStep": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "label",
+        "type",
+        "tool_id",
+        "tool_version",
+        "tool_shed_repository",
+        "tool_state",
+        "in",
+        "out",
+        "when",
+        "annotation"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Step key/label as it appears in the gxformat2 `steps:` mapping; the anchor edits address."
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "tool",
+            "data_input",
+            "data_collection_input",
+            "parameter_input",
+            "subworkflow",
+            "pause"
+          ],
+          "description": "gxformat2 step class."
+        },
+        "tool_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Fully qualified Tool Shed tool id or short built-in id; null for non-tool steps."
+        },
+        "tool_version": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Pinned tool version when present."
+        },
+        "tool_shed_repository": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "owner",
+            "changeset_revision",
+            "tool_shed"
+          ],
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "owner": {
+              "type": "string"
+            },
+            "changeset_revision": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "tool_shed": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "description": "Pinned Tool Shed repository record when the step cites one."
+        },
+        "tool_state": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true,
+          "description": "Verbatim gxformat2 tool_state for this step, preserved so downstream change-set edits can address individual parameters. Null for non-tool steps."
+        },
+        "in": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/StepInput"
+          }
+        },
+        "out": {
+          "type": "array",
+          "description": "Declared output names this step produces.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "when": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Conditional-execution guard preserved verbatim when present."
+        },
+        "annotation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "StepInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "source",
+        "default",
+        "value_from"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Input connection name on this step."
+        },
+        "source": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Upstream `step_label/output_name` or workflow input this connection reads; null when driven by a default or runtime value."
+        },
+        "default": {
+          "description": "Verbatim connection default when present.",
+          "type": [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "object",
+            "array",
+            "null"
+          ]
+        },
+        "value_from": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Runtime/expression source preserved verbatim when present."
+        }
+      }
+    },
+    "WorkflowGraph": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "nodes",
+        "edges"
+      ],
+      "properties": {
+        "nodes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GraphNode"
+          }
+        },
+        "edges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GraphEdge"
+          }
+        }
+      }
+    },
+    "GraphNode": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "kind",
+        "label"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "workflow-input",
+            "step",
+            "workflow-output"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "GraphEdge": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "from",
+        "to",
+        "via"
+      ],
+      "properties": {
+        "from": {
+          "type": "string"
+        },
+        "to": {
+          "type": "string"
+        },
+        "via": {
+          "type": "array",
+          "description": "Shape-affecting Galaxy features on this edge, e.g. map-over, batch, collection-reduction.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "TestCase": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "job_path",
+        "expected_outputs",
+        "provenance"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "job_path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Path to the tests YAML/job definition when discoverable, e.g. a sibling *-tests.yml."
+        },
+        "expected_outputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ExpectedOutputRef"
+          }
+        },
+        "provenance": {
+          "type": "string"
+        }
+      }
+    },
+    "ExpectedOutputRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "path",
+        "url",
+        "filetype",
+        "checksum",
+        "assertions"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "filetype": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "checksum": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "assertions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Warning": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "message",
+        "path"
+      ],
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/casts/claude/skills/changeset-to-galaxy-test-plan/references/schemas/tests-format.schema.json
+++ b/casts/claude/skills/changeset-to-galaxy-test-plan/references/schemas/tests-format.schema.json
@@ -1,0 +1,7328 @@
+{
+  "$defs": {
+    "Collection": {
+      "additionalProperties": false,
+      "properties": {
+        "class": {
+          "const": "Collection",
+          "title": "Class",
+          "type": "string"
+        },
+        "collection_type": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Collection Type"
+        },
+        "elements": {
+          "anyOf": [
+            {
+              "items": {
+                "oneOf": [
+                  {
+                    "oneOf": [
+                      {
+                        "$ref": "#/$defs/LocationFile"
+                      },
+                      {
+                        "$ref": "#/$defs/PathFile"
+                      },
+                      {
+                        "$ref": "#/$defs/ContentsFile"
+                      },
+                      {
+                        "$ref": "#/$defs/CompositeDataFile"
+                      }
+                    ]
+                  },
+                  {
+                    "$ref": "#/$defs/Collection"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Elements"
+        },
+        "identifier": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Identifier"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Name"
+        },
+        "rows": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "items": {},
+                "type": "array"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rows"
+        }
+      },
+      "required": [
+        "class"
+      ],
+      "title": "Collection",
+      "type": "object"
+    },
+    "CollectionAttributes": {
+      "additionalProperties": false,
+      "properties": {
+        "collection_type": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Collection Type"
+        }
+      },
+      "title": "CollectionAttributes",
+      "type": "object"
+    },
+    "CompositeDataFile": {
+      "additionalProperties": false,
+      "properties": {
+        "class": {
+          "const": "File",
+          "title": "Class",
+          "type": "string"
+        },
+        "composite_data": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Composite Data",
+          "type": "array"
+        },
+        "contents": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Contents"
+        },
+        "dbkey": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Dbkey"
+        },
+        "decompress": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Decompress"
+        },
+        "deferred": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Deferred"
+        },
+        "filetype": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "File Type"
+        },
+        "hashes": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/HashEntry"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Hashes"
+        },
+        "identifier": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Identifier"
+        },
+        "info": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Info"
+        },
+        "location": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Location"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Name"
+        },
+        "path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Path"
+        },
+        "space_to_tab": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Space To Tab"
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tags"
+        },
+        "to_posix_lines": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "To POSIX Lines"
+        }
+      },
+      "required": [
+        "class",
+        "composite_data"
+      ],
+      "title": "CompositeDataFile",
+      "type": "object"
+    },
+    "ContentsFile": {
+      "additionalProperties": false,
+      "description": "CWL File literal — content inlined as a string.",
+      "properties": {
+        "class": {
+          "const": "File",
+          "title": "Class",
+          "type": "string"
+        },
+        "composite_data": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Composite Data"
+        },
+        "contents": {
+          "title": "Contents",
+          "type": "string"
+        },
+        "dbkey": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Dbkey"
+        },
+        "decompress": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Decompress"
+        },
+        "deferred": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Deferred"
+        },
+        "filetype": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "File Type"
+        },
+        "hashes": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/HashEntry"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Hashes"
+        },
+        "identifier": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Identifier"
+        },
+        "info": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Info"
+        },
+        "location": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Location"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Name"
+        },
+        "path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Path"
+        },
+        "space_to_tab": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Space To Tab"
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tags"
+        },
+        "to_posix_lines": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "To POSIX Lines"
+        }
+      },
+      "required": [
+        "class",
+        "contents"
+      ],
+      "title": "ContentsFile",
+      "type": "object"
+    },
+    "Directory": {
+      "additionalProperties": false,
+      "description": "CWL-style directory input. Supported by stage_inputs for directory-typed\ndatasets (e.g. bwa_mem2_index test fixtures). Rare in workflow tests; IWC\ndoes not use it.",
+      "properties": {
+        "class": {
+          "const": "Directory",
+          "title": "Class",
+          "type": "string"
+        },
+        "filetype": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "File Type"
+        },
+        "location": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Location"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Name"
+        },
+        "path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Path"
+        }
+      },
+      "required": [
+        "class"
+      ],
+      "title": "Directory",
+      "type": "object"
+    },
+    "HashEntry": {
+      "additionalProperties": false,
+      "properties": {
+        "hash_function": {
+          "enum": [
+            "MD5",
+            "SHA-1",
+            "SHA-256",
+            "SHA-512"
+          ],
+          "title": "Hash Function",
+          "type": "string"
+        },
+        "hash_value": {
+          "title": "Hash Value",
+          "type": "string"
+        }
+      },
+      "required": [
+        "hash_function",
+        "hash_value"
+      ],
+      "title": "HashEntry",
+      "type": "object"
+    },
+    "Job": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "oneOf": [
+              {
+                "$ref": "#/$defs/LocationFile"
+              },
+              {
+                "$ref": "#/$defs/PathFile"
+              },
+              {
+                "$ref": "#/$defs/ContentsFile"
+              },
+              {
+                "$ref": "#/$defs/CompositeDataFile"
+              }
+            ]
+          },
+          {
+            "$ref": "#/$defs/Collection"
+          },
+          {
+            "$ref": "#/$defs/Directory"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "integer"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "boolean"
+          },
+          {
+            "items": {
+              "anyOf": [
+                {
+                  "oneOf": [
+                    {
+                      "$ref": "#/$defs/LocationFile"
+                    },
+                    {
+                      "$ref": "#/$defs/PathFile"
+                    },
+                    {
+                      "$ref": "#/$defs/ContentsFile"
+                    },
+                    {
+                      "$ref": "#/$defs/CompositeDataFile"
+                    }
+                  ]
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "title": "Job",
+      "type": "object"
+    },
+    "LocationFile": {
+      "additionalProperties": false,
+      "properties": {
+        "class": {
+          "const": "File",
+          "title": "Class",
+          "type": "string"
+        },
+        "composite_data": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Composite Data"
+        },
+        "contents": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Contents"
+        },
+        "dbkey": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Dbkey"
+        },
+        "decompress": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Decompress"
+        },
+        "deferred": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Deferred"
+        },
+        "filetype": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "File Type"
+        },
+        "hashes": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/HashEntry"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Hashes"
+        },
+        "identifier": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Identifier"
+        },
+        "info": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Info"
+        },
+        "location": {
+          "title": "Location",
+          "type": "string"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Name"
+        },
+        "path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Path"
+        },
+        "space_to_tab": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Space To Tab"
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tags"
+        },
+        "to_posix_lines": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "To POSIX Lines"
+        }
+      },
+      "required": [
+        "class",
+        "location"
+      ],
+      "title": "LocationFile",
+      "type": "object"
+    },
+    "OutputCompareType": {
+      "enum": [
+        "diff",
+        "re_match",
+        "sim_size",
+        "re_match_multiline",
+        "contains",
+        "image_diff"
+      ],
+      "title": "OutputCompareType",
+      "type": "string"
+    },
+    "PathFile": {
+      "additionalProperties": false,
+      "properties": {
+        "class": {
+          "const": "File",
+          "title": "Class",
+          "type": "string"
+        },
+        "composite_data": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Composite Data"
+        },
+        "contents": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Contents"
+        },
+        "dbkey": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Dbkey"
+        },
+        "decompress": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Decompress"
+        },
+        "deferred": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Deferred"
+        },
+        "filetype": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "File Type"
+        },
+        "hashes": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/HashEntry"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Hashes"
+        },
+        "identifier": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Identifier"
+        },
+        "info": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Info"
+        },
+        "location": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Location"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Name"
+        },
+        "path": {
+          "title": "Path",
+          "type": "string"
+        },
+        "space_to_tab": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Space To Tab"
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tags"
+        },
+        "to_posix_lines": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "To POSIX Lines"
+        }
+      },
+      "required": [
+        "class",
+        "path"
+      ],
+      "title": "PathFile",
+      "type": "object"
+    },
+    "TestCollectionCollectionElementAssertions": {
+      "additionalProperties": false,
+      "properties": {
+        "class": {
+          "anyOf": [
+            {
+              "const": "Collection",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "Collection",
+          "title": "Class"
+        },
+        "element_tests": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "else": {
+                  "$ref": "#/$defs/TestCollectionDatasetElementAssertions"
+                },
+                "if": {
+                  "properties": {
+                    "class": {
+                      "const": "Collection"
+                    }
+                  },
+                  "required": [
+                    "class"
+                  ],
+                  "type": "object"
+                },
+                "then": {
+                  "$ref": "#/$defs/TestCollectionCollectionElementAssertions"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Element Tests"
+        },
+        "elements": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "else": {
+                  "$ref": "#/$defs/TestCollectionDatasetElementAssertions"
+                },
+                "if": {
+                  "properties": {
+                    "class": {
+                      "const": "Collection"
+                    }
+                  },
+                  "required": [
+                    "class"
+                  ],
+                  "type": "object"
+                },
+                "then": {
+                  "$ref": "#/$defs/TestCollectionCollectionElementAssertions"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Elements"
+        }
+      },
+      "title": "TestCollectionCollectionElementAssertions",
+      "type": "object"
+    },
+    "TestCollectionDatasetElementAssertions": {
+      "additionalProperties": false,
+      "properties": {
+        "asserts": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "$ref": "#/$defs/assertion_dict"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Assertions about the content of the output.",
+          "title": "Asserts"
+        },
+        "checksum": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The target output's checksum should match the value specified here, in the form `hash_type$hash_value` (e.g. `sha1$8156d7ca0f46ed7abac98f82e36cfaddb2aca041`). Useful for large static files where uploading the whole file is inconvenient.",
+          "title": "Checksum"
+        },
+        "class": {
+          "anyOf": [
+            {
+              "const": "File",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "File",
+          "title": "Class"
+        },
+        "compare": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OutputCompareType"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Comparison mode used when matching the output against the reference file.",
+          "title": "Compare"
+        },
+        "decompress": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "If true, decompress files before comparison. Applies to assertions expressed with `assert_contents` or `compare` set to anything but `sim_size`. Useful for testing compressed outputs that are non-deterministic despite having deterministic decompressed contents. By default, only files compressed with bz2, gzip and zip are automatically decompressed.",
+          "title": "Decompress"
+        },
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "If `compare` is set to `sim_size`, the maximum allowed absolute size difference (in bytes) between the generated data set and the reference file in `test-data/`. Default is 10000 bytes. Can be combined with `delta_frac`.",
+          "title": "Delta"
+        },
+        "delta_frac": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "If `compare` is set to `sim_size`, the maximum allowed relative size difference between the generated data set and the reference file in `test-data/`. 0.1 means the generated file can differ by at most 10%. Default is not to check for relative size difference. Can be combined with `delta`.",
+          "title": "Delta Frac"
+        },
+        "file": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Name of the output file stored in the target `test-data` directory that will be used to compare against the results of executing the tool via the functional test framework.",
+          "title": "File"
+        },
+        "ftype": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "If specified, this value is checked against the corresponding output's data type. If these do not match, the test will fail.",
+          "title": "File Type"
+        },
+        "lines_diff": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Applies when `compare` is set to `diff`, `re_match`, or `contains`. For `diff`, the number of lines of difference to allow (a modified line counts as two: one added, one removed).",
+          "title": "Lines Diff"
+        },
+        "location": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "URL that points to a remote output file that will be downloaded and used for output comparison. Use only when the file cannot be included in the `test-data` folder. May be combined with `file` (downloads when missing on disk) or used alone (filename inferred from the URL). A `checksum` is also used to verify the download when provided.",
+          "title": "Location"
+        },
+        "metadata": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Mapping of metadata keys to expected values for this output.",
+          "title": "Metadata"
+        },
+        "path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Filesystem path to a local output file used for comparison.",
+          "title": "Path"
+        },
+        "sort": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Applies only if `compare` is `diff`, `re_match` or `re_match_multiline`. Sorts the lines of the history data set before comparison; for `diff` and `re_match` the local file is also sorted. Useful for non-deterministic output.",
+          "title": "Sort"
+        }
+      },
+      "title": "TestCollectionDatasetElementAssertions",
+      "type": "object"
+    },
+    "TestCollectionOutputAssertions": {
+      "additionalProperties": false,
+      "properties": {
+        "attributes": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CollectionAttributes"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Attributes"
+        },
+        "class": {
+          "anyOf": [
+            {
+              "const": "Collection",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "Collection",
+          "title": "Class"
+        },
+        "collection_type": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Collection Type"
+        },
+        "element_count": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Element Count"
+        },
+        "element_tests": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "else": {
+                  "$ref": "#/$defs/TestCollectionDatasetElementAssertions"
+                },
+                "if": {
+                  "properties": {
+                    "class": {
+                      "const": "Collection"
+                    }
+                  },
+                  "required": [
+                    "class"
+                  ],
+                  "type": "object"
+                },
+                "then": {
+                  "$ref": "#/$defs/TestCollectionCollectionElementAssertions"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Element Tests"
+        },
+        "elements": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "else": {
+                  "$ref": "#/$defs/TestCollectionDatasetElementAssertions"
+                },
+                "if": {
+                  "properties": {
+                    "class": {
+                      "const": "Collection"
+                    }
+                  },
+                  "required": [
+                    "class"
+                  ],
+                  "type": "object"
+                },
+                "then": {
+                  "$ref": "#/$defs/TestCollectionCollectionElementAssertions"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Elements"
+        }
+      },
+      "title": "TestCollectionOutputAssertions",
+      "type": "object"
+    },
+    "TestDataOutputAssertions": {
+      "additionalProperties": false,
+      "properties": {
+        "asserts": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "$ref": "#/$defs/assertion_dict"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Assertions about the content of the output.",
+          "title": "Asserts"
+        },
+        "checksum": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The target output's checksum should match the value specified here, in the form `hash_type$hash_value` (e.g. `sha1$8156d7ca0f46ed7abac98f82e36cfaddb2aca041`). Useful for large static files where uploading the whole file is inconvenient.",
+          "title": "Checksum"
+        },
+        "class": {
+          "anyOf": [
+            {
+              "const": "File",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "File",
+          "title": "Class"
+        },
+        "compare": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OutputCompareType"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Comparison mode used when matching the output against the reference file.",
+          "title": "Compare"
+        },
+        "decompress": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "If true, decompress files before comparison. Applies to assertions expressed with `assert_contents` or `compare` set to anything but `sim_size`. Useful for testing compressed outputs that are non-deterministic despite having deterministic decompressed contents. By default, only files compressed with bz2, gzip and zip are automatically decompressed.",
+          "title": "Decompress"
+        },
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "If `compare` is set to `sim_size`, the maximum allowed absolute size difference (in bytes) between the generated data set and the reference file in `test-data/`. Default is 10000 bytes. Can be combined with `delta_frac`.",
+          "title": "Delta"
+        },
+        "delta_frac": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "If `compare` is set to `sim_size`, the maximum allowed relative size difference between the generated data set and the reference file in `test-data/`. 0.1 means the generated file can differ by at most 10%. Default is not to check for relative size difference. Can be combined with `delta`.",
+          "title": "Delta Frac"
+        },
+        "file": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Name of the output file stored in the target `test-data` directory that will be used to compare against the results of executing the tool via the functional test framework.",
+          "title": "File"
+        },
+        "ftype": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "If specified, this value is checked against the corresponding output's data type. If these do not match, the test will fail.",
+          "title": "File Type"
+        },
+        "lines_diff": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Applies when `compare` is set to `diff`, `re_match`, or `contains`. For `diff`, the number of lines of difference to allow (a modified line counts as two: one added, one removed).",
+          "title": "Lines Diff"
+        },
+        "location": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "URL that points to a remote output file that will be downloaded and used for output comparison. Use only when the file cannot be included in the `test-data` folder. May be combined with `file` (downloads when missing on disk) or used alone (filename inferred from the URL). A `checksum` is also used to verify the download when provided.",
+          "title": "Location"
+        },
+        "metadata": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Mapping of metadata keys to expected values for this output.",
+          "title": "Metadata"
+        },
+        "path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Filesystem path to a local output file used for comparison.",
+          "title": "Path"
+        },
+        "sort": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Applies only if `compare` is `diff`, `re_match` or `re_match_multiline`. Sorts the lines of the history data set before comparison; for `diff` and `re_match` the local file is also sorted. Useful for non-deterministic output.",
+          "title": "Sort"
+        }
+      },
+      "title": "TestDataOutputAssertions",
+      "type": "object"
+    },
+    "TestJob": {
+      "additionalProperties": false,
+      "properties": {
+        "doc": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Describes the purpose of the test.",
+          "title": "Doc"
+        },
+        "expect_failure": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": false,
+          "description": "If true, the workflow is expected to produce an error.",
+          "title": "Expect Failure"
+        },
+        "job": {
+          "$ref": "#/$defs/Job",
+          "description": "Defines the job to execute. Can be a path to a file or an inline dictionary describing the job inputs."
+        },
+        "outputs": {
+          "additionalProperties": {
+            "else": {
+              "else": {
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "if": {
+                "type": "object"
+              },
+              "then": {
+                "$ref": "#/$defs/TestDataOutputAssertions"
+              }
+            },
+            "if": {
+              "properties": {
+                "class": {
+                  "const": "Collection"
+                }
+              },
+              "required": [
+                "class"
+              ],
+              "type": "object"
+            },
+            "then": {
+              "$ref": "#/$defs/TestCollectionOutputAssertions"
+            }
+          },
+          "description": "Defines assertions about outputs (datasets, collections or parameters). Each key corresponds to a labeled output; values are dictionaries describing the expected output.",
+          "title": "Outputs",
+          "type": "object"
+        }
+      },
+      "required": [
+        "job",
+        "outputs"
+      ],
+      "title": "TestJob",
+      "type": "object"
+    },
+    "assertion_dict": {
+      "additionalProperties": false,
+      "properties": {
+        "attribute_is": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_attribute_is_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Attribute Is"
+        },
+        "attribute_matches": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_attribute_matches_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Attribute Matches"
+        },
+        "element_text": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_element_text_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Element Text"
+        },
+        "element_text_is": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_element_text_is_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Element Text Is"
+        },
+        "element_text_matches": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_element_text_matches_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Element Text Matches"
+        },
+        "has_archive_member": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_archive_member_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Archive Member"
+        },
+        "has_element_with_path": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_element_with_path_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Element With Path"
+        },
+        "has_h5_attribute": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_h5_attribute_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has H5 Attribute"
+        },
+        "has_h5_keys": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_h5_keys_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has H5 Keys"
+        },
+        "has_image_center_of_mass": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_image_center_of_mass_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Image Center Of Mass"
+        },
+        "has_image_channels": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_image_channels_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Image Channels"
+        },
+        "has_image_depth": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_image_depth_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Image Depth"
+        },
+        "has_image_frames": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_image_frames_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Image Frames"
+        },
+        "has_image_height": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_image_height_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Image Height"
+        },
+        "has_image_mean_intensity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_image_mean_intensity_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Image Mean Intensity"
+        },
+        "has_image_mean_object_size": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_image_mean_object_size_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Image Mean Object Size"
+        },
+        "has_image_n_labels": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_image_n_labels_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Image N Labels"
+        },
+        "has_image_width": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_image_width_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Image Width"
+        },
+        "has_json_property_with_text": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_json_property_with_text_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Json Property With Text"
+        },
+        "has_json_property_with_value": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_json_property_with_value_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Json Property With Value"
+        },
+        "has_line": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_line_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Line"
+        },
+        "has_line_matching": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_line_matching_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Line Matching"
+        },
+        "has_n_columns": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_n_columns_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has N Columns"
+        },
+        "has_n_elements_with_path": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_n_elements_with_path_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has N Elements With Path"
+        },
+        "has_n_lines": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_n_lines_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has N Lines"
+        },
+        "has_size": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_size_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Size"
+        },
+        "has_text": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_text_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Text"
+        },
+        "has_text_matching": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_text_matching_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Text Matching"
+        },
+        "is_valid_xml": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_is_valid_xml_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Is Valid Xml"
+        },
+        "not_has_text": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_not_has_text_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Not Has Text"
+        },
+        "xml_element": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_xml_element_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Xml Element"
+        }
+      },
+      "title": "assertion_dict",
+      "type": "object"
+    },
+    "assertion_list": {
+      "items": {
+        "anyOf": [
+          {
+            "discriminator": {
+              "mapping": {
+                "attribute_is": "#/$defs/attribute_is_model",
+                "attribute_matches": "#/$defs/attribute_matches_model",
+                "element_text": "#/$defs/element_text_model",
+                "element_text_is": "#/$defs/element_text_is_model",
+                "element_text_matches": "#/$defs/element_text_matches_model",
+                "has_archive_member": "#/$defs/has_archive_member_model",
+                "has_element_with_path": "#/$defs/has_element_with_path_model",
+                "has_h5_attribute": "#/$defs/has_h5_attribute_model",
+                "has_h5_keys": "#/$defs/has_h5_keys_model",
+                "has_image_center_of_mass": "#/$defs/has_image_center_of_mass_model",
+                "has_image_channels": "#/$defs/has_image_channels_model",
+                "has_image_depth": "#/$defs/has_image_depth_model",
+                "has_image_frames": "#/$defs/has_image_frames_model",
+                "has_image_height": "#/$defs/has_image_height_model",
+                "has_image_mean_intensity": "#/$defs/has_image_mean_intensity_model",
+                "has_image_mean_object_size": "#/$defs/has_image_mean_object_size_model",
+                "has_image_n_labels": "#/$defs/has_image_n_labels_model",
+                "has_image_width": "#/$defs/has_image_width_model",
+                "has_json_property_with_text": "#/$defs/has_json_property_with_text_model",
+                "has_json_property_with_value": "#/$defs/has_json_property_with_value_model",
+                "has_line": "#/$defs/has_line_model",
+                "has_line_matching": "#/$defs/has_line_matching_model",
+                "has_n_columns": "#/$defs/has_n_columns_model",
+                "has_n_elements_with_path": "#/$defs/has_n_elements_with_path_model",
+                "has_n_lines": "#/$defs/has_n_lines_model",
+                "has_size": "#/$defs/has_size_model",
+                "has_text": "#/$defs/has_text_model",
+                "has_text_matching": "#/$defs/has_text_matching_model",
+                "is_valid_xml": "#/$defs/is_valid_xml_model",
+                "not_has_text": "#/$defs/not_has_text_model",
+                "xml_element": "#/$defs/xml_element_model"
+              },
+              "propertyName": "that"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/has_line_model"
+              },
+              {
+                "$ref": "#/$defs/has_line_matching_model"
+              },
+              {
+                "$ref": "#/$defs/has_n_lines_model"
+              },
+              {
+                "$ref": "#/$defs/has_text_model"
+              },
+              {
+                "$ref": "#/$defs/has_text_matching_model"
+              },
+              {
+                "$ref": "#/$defs/not_has_text_model"
+              },
+              {
+                "$ref": "#/$defs/has_n_columns_model"
+              },
+              {
+                "$ref": "#/$defs/attribute_is_model"
+              },
+              {
+                "$ref": "#/$defs/attribute_matches_model"
+              },
+              {
+                "$ref": "#/$defs/element_text_model"
+              },
+              {
+                "$ref": "#/$defs/element_text_is_model"
+              },
+              {
+                "$ref": "#/$defs/element_text_matches_model"
+              },
+              {
+                "$ref": "#/$defs/has_element_with_path_model"
+              },
+              {
+                "$ref": "#/$defs/has_n_elements_with_path_model"
+              },
+              {
+                "$ref": "#/$defs/is_valid_xml_model"
+              },
+              {
+                "$ref": "#/$defs/xml_element_model"
+              },
+              {
+                "$ref": "#/$defs/has_json_property_with_text_model"
+              },
+              {
+                "$ref": "#/$defs/has_json_property_with_value_model"
+              },
+              {
+                "$ref": "#/$defs/has_h5_attribute_model"
+              },
+              {
+                "$ref": "#/$defs/has_h5_keys_model"
+              },
+              {
+                "$ref": "#/$defs/has_archive_member_model"
+              },
+              {
+                "$ref": "#/$defs/has_size_model"
+              },
+              {
+                "$ref": "#/$defs/has_image_center_of_mass_model"
+              },
+              {
+                "$ref": "#/$defs/has_image_channels_model"
+              },
+              {
+                "$ref": "#/$defs/has_image_depth_model"
+              },
+              {
+                "$ref": "#/$defs/has_image_frames_model"
+              },
+              {
+                "$ref": "#/$defs/has_image_height_model"
+              },
+              {
+                "$ref": "#/$defs/has_image_mean_intensity_model"
+              },
+              {
+                "$ref": "#/$defs/has_image_mean_object_size_model"
+              },
+              {
+                "$ref": "#/$defs/has_image_n_labels_model"
+              },
+              {
+                "$ref": "#/$defs/has_image_width_model"
+              }
+            ]
+          },
+          {
+            "$ref": "#/$defs/has_line_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_line_matching_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_n_lines_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_text_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_text_matching_model_nested"
+          },
+          {
+            "$ref": "#/$defs/not_has_text_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_n_columns_model_nested"
+          },
+          {
+            "$ref": "#/$defs/attribute_is_model_nested"
+          },
+          {
+            "$ref": "#/$defs/attribute_matches_model_nested"
+          },
+          {
+            "$ref": "#/$defs/element_text_model_nested"
+          },
+          {
+            "$ref": "#/$defs/element_text_is_model_nested"
+          },
+          {
+            "$ref": "#/$defs/element_text_matches_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_element_with_path_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_n_elements_with_path_model_nested"
+          },
+          {
+            "$ref": "#/$defs/is_valid_xml_model_nested"
+          },
+          {
+            "$ref": "#/$defs/xml_element_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_json_property_with_text_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_json_property_with_value_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_h5_attribute_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_h5_keys_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_archive_member_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_size_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_image_center_of_mass_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_image_channels_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_image_depth_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_image_frames_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_image_height_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_image_mean_intensity_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_image_mean_object_size_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_image_n_labels_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_image_width_model_nested"
+          }
+        ]
+      },
+      "title": "assertion_list",
+      "type": "array"
+    },
+    "attribute_is_model": {
+      "additionalProperties": false,
+      "description": "Asserts the XML ``attribute`` for the element (or tag) with the specified\nXPath-like ``path`` is the specified ``text``.\n\nFor example:\n\n```xml\n<attribute_is path=\"outerElement/innerElement1\" attribute=\"foo\" text=\"bar\" />\n```\n\nThe assertion implicitly also asserts that an element matching ``path`` exists.\nWith ``negate`` the result of the assertion (on the equality) can be inverted (the\nimplicit assertion on the existence of the path is not affected).",
+      "properties": {
+        "attribute": {
+          "description": "The XML attribute name to test against from the target XML element.",
+          "title": "Attribute",
+          "type": "string"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        },
+        "text": {
+          "description": "The expected attribute value to test against on the target XML element",
+          "title": "Text",
+          "type": "string"
+        },
+        "that": {
+          "const": "attribute_is",
+          "default": "attribute_is",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "attribute",
+        "text"
+      ],
+      "title": "Assert Attribute Is",
+      "type": "object"
+    },
+    "attribute_is_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "attribute_is": {
+          "$ref": "#/$defs/base_attribute_is_model",
+          "title": "Assert Attribute Is"
+        }
+      },
+      "required": [
+        "attribute_is"
+      ],
+      "title": "Assert Attribute Is (Nested)",
+      "type": "object"
+    },
+    "attribute_matches_model": {
+      "additionalProperties": false,
+      "description": "Asserts the XML ``attribute`` for the element (or tag) with the specified\nXPath-like ``path`` matches the regular expression specified by ``expression``.\n\nFor example:\n\n```xml\n<attribute_matches path=\"outerElement/innerElement2\" attribute=\"foo2\" expression=\"bar\\d+\" />\n```\n\nThe assertion implicitly also asserts that an element matching ``path`` exists.\nWith ``negate`` the result of the assertion (on the matching) can be inverted (the\nimplicit assertion on the existence of the path is not affected).",
+      "properties": {
+        "attribute": {
+          "description": "The XML attribute name to test against from the target XML element.",
+          "title": "Attribute",
+          "type": "string"
+        },
+        "expression": {
+          "description": "The regular expressions to apply against the named attribute on the target XML element.",
+          "title": "Expression",
+          "type": "string"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        },
+        "that": {
+          "const": "attribute_matches",
+          "default": "attribute_matches",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "attribute",
+        "expression"
+      ],
+      "title": "Assert Attribute Matches",
+      "type": "object"
+    },
+    "attribute_matches_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "attribute_matches": {
+          "$ref": "#/$defs/base_attribute_matches_model",
+          "title": "Assert Attribute Matches"
+        }
+      },
+      "required": [
+        "attribute_matches"
+      ],
+      "title": "Assert Attribute Matches (Nested)",
+      "type": "object"
+    },
+    "base_attribute_is_model": {
+      "additionalProperties": false,
+      "description": "base model for attribute_is describing attributes.",
+      "properties": {
+        "attribute": {
+          "description": "The XML attribute name to test against from the target XML element.",
+          "title": "Attribute",
+          "type": "string"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        },
+        "text": {
+          "description": "The expected attribute value to test against on the target XML element",
+          "title": "Text",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "attribute",
+        "text"
+      ],
+      "title": "base_attribute_is_model",
+      "type": "object"
+    },
+    "base_attribute_matches_model": {
+      "additionalProperties": false,
+      "description": "base model for attribute_matches describing attributes.",
+      "properties": {
+        "attribute": {
+          "description": "The XML attribute name to test against from the target XML element.",
+          "title": "Attribute",
+          "type": "string"
+        },
+        "expression": {
+          "description": "The regular expressions to apply against the named attribute on the target XML element.",
+          "title": "Expression",
+          "type": "string"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "attribute",
+        "expression"
+      ],
+      "title": "base_attribute_matches_model",
+      "type": "object"
+    },
+    "base_element_text_is_model": {
+      "additionalProperties": false,
+      "description": "base model for element_text_is describing attributes.",
+      "properties": {
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        },
+        "text": {
+          "description": "The expected element text (body of the XML tag) to test against on the target XML element",
+          "title": "Text",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "text"
+      ],
+      "title": "base_element_text_is_model",
+      "type": "object"
+    },
+    "base_element_text_matches_model": {
+      "additionalProperties": false,
+      "description": "base model for element_text_matches describing attributes.",
+      "properties": {
+        "expression": {
+          "description": "The regular expressions to apply against the target element.",
+          "title": "Expression",
+          "type": "string"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "expression"
+      ],
+      "title": "base_element_text_matches_model",
+      "type": "object"
+    },
+    "base_element_text_model": {
+      "additionalProperties": false,
+      "description": "base model for element_text describing attributes.",
+      "properties": {
+        "asserts": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Asserts"
+        },
+        "children": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Children"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "base_element_text_model",
+      "type": "object"
+    },
+    "base_has_archive_member_model": {
+      "additionalProperties": false,
+      "description": "base model for has_archive_member describing attributes.",
+      "properties": {
+        "all": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "Check the sub-assertions for all paths matching the path. Default: false, i.e. only the first",
+          "title": "All"
+        },
+        "asserts": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Asserts"
+        },
+        "children": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Children"
+        },
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The regular expression specifying the archive member.",
+          "title": "Path",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "base_has_archive_member_model",
+      "type": "object"
+    },
+    "base_has_element_with_path_model": {
+      "additionalProperties": false,
+      "description": "base model for has_element_with_path describing attributes.",
+      "properties": {
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "base_has_element_with_path_model",
+      "type": "object"
+    },
+    "base_has_h5_attribute_model": {
+      "additionalProperties": false,
+      "description": "base model for has_h5_attribute describing attributes.",
+      "properties": {
+        "key": {
+          "description": "HDF5 attribute to check value of.",
+          "title": "Key",
+          "type": "string"
+        },
+        "value": {
+          "description": "Expected value of HDF5 attribute to check.",
+          "title": "Value",
+          "type": "string"
+        }
+      },
+      "required": [
+        "key",
+        "value"
+      ],
+      "title": "base_has_h5_attribute_model",
+      "type": "object"
+    },
+    "base_has_h5_keys_model": {
+      "additionalProperties": false,
+      "description": "base model for has_h5_keys describing attributes.",
+      "properties": {
+        "keys": {
+          "description": "HDF5 attributes to check value of as a comma-separated string.",
+          "title": "Keys",
+          "type": "string"
+        }
+      },
+      "required": [
+        "keys"
+      ],
+      "title": "base_has_h5_keys_model",
+      "type": "object"
+    },
+    "base_has_image_center_of_mass_model": {
+      "additionalProperties": false,
+      "description": "base model for has_image_center_of_mass describing attributes.",
+      "properties": {
+        "center_of_mass": {
+          "description": "The required center of mass of the image intensities (horizontal and vertical coordinate, separated by a comma).",
+          "title": "Center Of Mass",
+          "type": "string"
+        },
+        "channel": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific channel of the image (where ``0`` corresponds to the first image channel).",
+          "title": "Channel"
+        },
+        "eps": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.01,
+          "description": "The maximum allowed Euclidean distance to the required center of mass (defaults to ``0.01``).",
+          "title": "Eps"
+        },
+        "frame": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific frame of the image sequence (where ``0`` corresponds to the first image frame).",
+          "title": "Frame"
+        },
+        "slice": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific slice of the image (where ``0`` corresponds to the first image slice).",
+          "title": "Slice"
+        }
+      },
+      "required": [
+        "center_of_mass"
+      ],
+      "title": "base_has_image_center_of_mass_model",
+      "type": "object"
+    },
+    "base_has_image_channels_model": {
+      "additionalProperties": false,
+      "description": "base model for has_image_channels describing attributes.",
+      "properties": {
+        "channels": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected number of channels of the image.",
+          "title": "Channels"
+        },
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the number of channels (default is 0). The observed number of channels has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed number of channels.",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed number of channels.",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        }
+      },
+      "title": "base_has_image_channels_model",
+      "type": "object"
+    },
+    "base_has_image_depth_model": {
+      "additionalProperties": false,
+      "description": "base model for has_image_depth describing attributes.",
+      "properties": {
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the image depth (number of slices, default is 0). The observed depth has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "depth": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected depth of the image (number of slices).",
+          "title": "Depth"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed depth of the image (number of slices).",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed depth of the image (number of slices).",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        }
+      },
+      "title": "base_has_image_depth_model",
+      "type": "object"
+    },
+    "base_has_image_frames_model": {
+      "additionalProperties": false,
+      "description": "base model for has_image_frames describing attributes.",
+      "properties": {
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the number of frames in the image sequence (number of time steps, default is 0). The observed number of frames has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "frames": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected number of frames in the image sequence (number of time steps).",
+          "title": "Frames"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed number of frames in the image sequence (number of time steps).",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed number of frames in the image sequence (number of time steps).",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        }
+      },
+      "title": "base_has_image_frames_model",
+      "type": "object"
+    },
+    "base_has_image_height_model": {
+      "additionalProperties": false,
+      "description": "base model for has_image_height describing attributes.",
+      "properties": {
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the image height (in pixels, default is 0). The observed height has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "height": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected height of the image (in pixels).",
+          "title": "Height"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed height of the image (in pixels).",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed height of the image (in pixels).",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        }
+      },
+      "title": "base_has_image_height_model",
+      "type": "object"
+    },
+    "base_has_image_mean_intensity_model": {
+      "additionalProperties": false,
+      "description": "base model for has_image_mean_intensity describing attributes.",
+      "properties": {
+        "channel": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific channel of the image (where ``0`` corresponds to the first image channel).",
+          "title": "Channel"
+        },
+        "eps": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.01,
+          "description": "The absolute tolerance to be used for ``value`` (defaults to ``0.01``). The observed mean value of the image intensities has to be in the range ``value +- eps``.",
+          "title": "Eps"
+        },
+        "frame": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific frame of the image sequence (where ``0`` corresponds to the first image frame).",
+          "title": "Frame"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "An upper bound of the required mean value of the image intensities.",
+          "title": "Max"
+        },
+        "mean_intensity": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The required mean value of the image intensities.",
+          "title": "Mean Intensity"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A lower bound of the required mean value of the image intensities.",
+          "title": "Min"
+        },
+        "slice": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific slice of the image (where ``0`` corresponds to the first image slice).",
+          "title": "Slice"
+        }
+      },
+      "title": "base_has_image_mean_intensity_model",
+      "type": "object"
+    },
+    "base_has_image_mean_object_size_model": {
+      "additionalProperties": false,
+      "description": "base model for has_image_mean_object_size describing attributes.",
+      "properties": {
+        "channel": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific channel of the image (where ``0`` corresponds to the first image channel).",
+          "title": "Channel"
+        },
+        "eps": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.01,
+          "description": "The absolute tolerance to be used for ``value`` (defaults to ``0.01``). The observed mean size of the uniquely labeled objects has to be in the range ``value +- eps``.",
+          "title": "Eps"
+        },
+        "exclude_labels": {
+          "anyOf": [
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "List of labels to be excluded from consideration, separated by a comma. The primary usage of this attribute is to exclude the background of a label image. Cannot be used in combination with ``labels``.",
+          "title": "Exclude Labels"
+        },
+        "frame": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific frame of the image sequence (where ``0`` corresponds to the first image frame).",
+          "title": "Frame"
+        },
+        "labels": {
+          "anyOf": [
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "List of labels, separated by a comma. Labels *not* on this list will be excluded from consideration. Cannot be used in combination with ``exclude_labels``.",
+          "title": "Labels"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "An upper bound of the required mean size of the uniquely labeled objects.",
+          "title": "Max"
+        },
+        "mean_object_size": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The required mean size of the uniquely labeled objects.",
+          "title": "Mean Object Size"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A lower bound of the required mean size of the uniquely labeled objects.",
+          "title": "Min"
+        },
+        "slice": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific slice of the image (where ``0`` corresponds to the first image slice).",
+          "title": "Slice"
+        }
+      },
+      "title": "base_has_image_mean_object_size_model",
+      "type": "object"
+    },
+    "base_has_image_n_labels_model": {
+      "additionalProperties": false,
+      "description": "base model for has_image_n_labels describing attributes.",
+      "properties": {
+        "channel": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific channel of the image (where ``0`` corresponds to the first image channel).",
+          "title": "Channel"
+        },
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the number of labels (default is 0). The observed number of labels has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "exclude_labels": {
+          "anyOf": [
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "List of labels to be excluded from consideration, separated by a comma. The primary usage of this attribute is to exclude the background of a label image. Cannot be used in combination with ``labels``.",
+          "title": "Exclude Labels"
+        },
+        "frame": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific frame of the image sequence (where ``0`` corresponds to the first image frame).",
+          "title": "Frame"
+        },
+        "labels": {
+          "anyOf": [
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "List of labels, separated by a comma. Labels *not* on this list will be excluded from consideration. Cannot be used in combination with ``exclude_labels``.",
+          "title": "Labels"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed number of labels.",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed number of labels.",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected number of labels.",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "slice": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific slice of the image (where ``0`` corresponds to the first image slice).",
+          "title": "Slice"
+        }
+      },
+      "title": "base_has_image_n_labels_model",
+      "type": "object"
+    },
+    "base_has_image_width_model": {
+      "additionalProperties": false,
+      "description": "base model for has_image_width describing attributes.",
+      "properties": {
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the image width (in pixels, default is 0). The observed width has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed width of the image (in pixels).",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed width of the image (in pixels).",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "width": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected width of the image (in pixels).",
+          "title": "Width"
+        }
+      },
+      "title": "base_has_image_width_model",
+      "type": "object"
+    },
+    "base_has_json_property_with_text_model": {
+      "additionalProperties": false,
+      "description": "base model for has_json_property_with_text describing attributes.",
+      "properties": {
+        "property": {
+          "description": "The property name to search the JSON document for.",
+          "title": "Property",
+          "type": "string"
+        },
+        "text": {
+          "description": "The expected text value of the target JSON attribute.",
+          "title": "Text",
+          "type": "string"
+        }
+      },
+      "required": [
+        "property",
+        "text"
+      ],
+      "title": "base_has_json_property_with_text_model",
+      "type": "object"
+    },
+    "base_has_json_property_with_value_model": {
+      "additionalProperties": false,
+      "description": "base model for has_json_property_with_value describing attributes.",
+      "properties": {
+        "property": {
+          "description": "The property name to search the JSON document for.",
+          "title": "Property",
+          "type": "string"
+        },
+        "value": {
+          "description": "The expected JSON value of the target JSON attribute (as a JSON encoded string).",
+          "title": "Value",
+          "type": "string"
+        }
+      },
+      "required": [
+        "property",
+        "value"
+      ],
+      "title": "base_has_json_property_with_value_model",
+      "type": "object"
+    },
+    "base_has_line_matching_model": {
+      "additionalProperties": false,
+      "description": "base model for has_line_matching describing attributes.",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "expression": {
+          "description": "The regular expressions to attempt match in the output.",
+          "title": "Expression",
+          "type": "string"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        }
+      },
+      "required": [
+        "expression"
+      ],
+      "title": "base_has_line_matching_model",
+      "type": "object"
+    },
+    "base_has_line_model": {
+      "additionalProperties": false,
+      "description": "base model for has_line describing attributes.",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "line": {
+          "description": "The full line of text to search for in the output.",
+          "title": "Line",
+          "type": "string"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        }
+      },
+      "required": [
+        "line"
+      ],
+      "title": "base_has_line_model",
+      "type": "object"
+    },
+    "base_has_n_columns_model": {
+      "additionalProperties": false,
+      "description": "base model for has_n_columns describing attributes.",
+      "properties": {
+        "comment": {
+          "default": "",
+          "description": "Comment character(s) used to skip comment lines (which should not be used for counting columns)",
+          "title": "Comment",
+          "type": "string"
+        },
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "sep": {
+          "default": "\t",
+          "description": "Separator defining columns, default: tab",
+          "title": "Sep",
+          "type": "string"
+        }
+      },
+      "title": "base_has_n_columns_model",
+      "type": "object"
+    },
+    "base_has_n_elements_with_path_model": {
+      "additionalProperties": false,
+      "description": "base model for has_n_elements_with_path describing attributes.",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "base_has_n_elements_with_path_model",
+      "type": "object"
+    },
+    "base_has_n_lines_model": {
+      "additionalProperties": false,
+      "description": "base model for has_n_lines describing attributes.",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        }
+      },
+      "title": "base_has_n_lines_model",
+      "type": "object"
+    },
+    "base_has_size_model": {
+      "additionalProperties": false,
+      "description": "base model for has_size describing attributes.",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "size": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired size of the output (in bytes), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Size"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Deprecated alias for `size`",
+          "title": "Value"
+        }
+      },
+      "title": "base_has_size_model",
+      "type": "object"
+    },
+    "base_has_text_matching_model": {
+      "additionalProperties": false,
+      "description": "base model for has_text_matching describing attributes.",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "expression": {
+          "description": "The regular expressions to attempt match in the output.",
+          "title": "Expression",
+          "type": "string"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        }
+      },
+      "required": [
+        "expression"
+      ],
+      "title": "base_has_text_matching_model",
+      "type": "object"
+    },
+    "base_has_text_model": {
+      "additionalProperties": false,
+      "description": "base model for has_text describing attributes.",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "text": {
+          "description": "The text to search for in the output.",
+          "title": "Text",
+          "type": "string"
+        }
+      },
+      "required": [
+        "text"
+      ],
+      "title": "base_has_text_model",
+      "type": "object"
+    },
+    "base_is_valid_xml_model": {
+      "additionalProperties": false,
+      "description": "base model for is_valid_xml describing attributes.",
+      "properties": {},
+      "title": "base_is_valid_xml_model",
+      "type": "object"
+    },
+    "base_not_has_text_model": {
+      "additionalProperties": false,
+      "description": "base model for not_has_text describing attributes.",
+      "properties": {
+        "text": {
+          "description": "The text to search for in the output.",
+          "title": "Text",
+          "type": "string"
+        }
+      },
+      "required": [
+        "text"
+      ],
+      "title": "base_not_has_text_model",
+      "type": "object"
+    },
+    "base_xml_element_model": {
+      "additionalProperties": false,
+      "description": "base model for xml_element describing attributes.",
+      "properties": {
+        "all": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "Check the sub-assertions for all paths matching the path. Default: false, i.e. only the first ",
+          "title": "All"
+        },
+        "asserts": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Asserts"
+        },
+        "attribute": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The XML attribute name to test against from the target XML element.",
+          "title": "Attribute"
+        },
+        "children": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Children"
+        },
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "base_xml_element_model",
+      "type": "object"
+    },
+    "element_text_is_model": {
+      "additionalProperties": false,
+      "description": "Asserts the text of the XML element with the specified XPath-like ``path`` is\nthe specified ``text``.\n\nFor example:\n\n```xml\n<element_text_is path=\"BlastOutput_program\" text=\"blastp\" />\n```\n\nThe assertion implicitly also asserts that an element matching ``path`` exists.\nWith ``negate`` the result of the assertion (on the equality) can be inverted (the\nimplicit assertion on the existence of the path is not affected).",
+      "properties": {
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        },
+        "text": {
+          "description": "The expected element text (body of the XML tag) to test against on the target XML element",
+          "title": "Text",
+          "type": "string"
+        },
+        "that": {
+          "const": "element_text_is",
+          "default": "element_text_is",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "text"
+      ],
+      "title": "Assert Element Text Is",
+      "type": "object"
+    },
+    "element_text_is_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "element_text_is": {
+          "$ref": "#/$defs/base_element_text_is_model",
+          "title": "Assert Element Text Is"
+        }
+      },
+      "required": [
+        "element_text_is"
+      ],
+      "title": "Assert Element Text Is (Nested)",
+      "type": "object"
+    },
+    "element_text_matches_model": {
+      "additionalProperties": false,
+      "description": "Asserts the text of the XML element with the specified XPath-like ``path``\nmatches the regular expression defined by ``expression``.\n\nFor example:\n\n```xml\n<element_text_matches path=\"BlastOutput_version\" expression=\"BLASTP\\s+2\\.2.*\"/>\n```\n\nThe assertion implicitly also asserts that an element matching ``path`` exists.\nWith ``negate`` the result of the assertion (on the matching) can be inverted (the\nimplicit assertion on the existence of the path is not affected).",
+      "properties": {
+        "expression": {
+          "description": "The regular expressions to apply against the target element.",
+          "title": "Expression",
+          "type": "string"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        },
+        "that": {
+          "const": "element_text_matches",
+          "default": "element_text_matches",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "expression"
+      ],
+      "title": "Assert Element Text Matches",
+      "type": "object"
+    },
+    "element_text_matches_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "element_text_matches": {
+          "$ref": "#/$defs/base_element_text_matches_model",
+          "title": "Assert Element Text Matches"
+        }
+      },
+      "required": [
+        "element_text_matches"
+      ],
+      "title": "Assert Element Text Matches (Nested)",
+      "type": "object"
+    },
+    "element_text_model": {
+      "additionalProperties": false,
+      "description": "This tag allows the developer to recurisively specify additional assertions as\nchild elements about just the text contained in the element specified by the\nXPath-like ``path``, e.g.\n\n```xml\n<element_text path=\"BlastOutput_iterations/Iteration/Iteration_hits/Hit/Hit_def\">\n  <not_has_text text=\"EDK72998.1\" />\n</element_text>\n```\n\nThe assertion implicitly also asserts that an element matching ``path`` exists.\nWith ``negate`` the result of the implicit assertions can be inverted.\nThe sub-assertions, which have their own ``negate`` attribute, are not affected\nby ``negate``.",
+      "properties": {
+        "asserts": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Asserts"
+        },
+        "children": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Children"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        },
+        "that": {
+          "const": "element_text",
+          "default": "element_text",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "Assert Element Text",
+      "type": "object"
+    },
+    "element_text_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "element_text": {
+          "$ref": "#/$defs/base_element_text_model",
+          "title": "Assert Element Text"
+        }
+      },
+      "required": [
+        "element_text"
+      ],
+      "title": "Assert Element Text (Nested)",
+      "type": "object"
+    },
+    "has_archive_member_model": {
+      "additionalProperties": false,
+      "description": "This tag allows to check if ``path`` is contained in a compressed file.\n\nThe path is a regular expression that is matched against the full paths of the objects in\nthe compressed file (remember that \"matching\" means it is checked if a prefix of\nthe full path of an archive member is described by the regular expression).\nValid archive formats include ``.zip``, ``.tar``, and ``.tar.gz``. Note that\ndepending on the archive creation method:\n\n- full paths of the members may be prefixed with ``./``\n- directories may be treated as empty files\n\n```xml\n<has_archive_member path=\"./path/to/my-file.txt\"/>\n```\n\nWith ``n`` and ``delta`` (or ``min`` and ``max``) assertions on the number of\narchive members matching ``path`` can be expressed. The following could be used,\ne.g., to assert an archive containing n&plusmn;1 elements out of which at least\n4 need to have a ``txt`` extension.\n\n```xml\n<has_archive_member path=\".*\" n=\"10\" delta=\"1\"/>\n<has_archive_member path=\".*\\.txt\" min=\"4\"/>\n```\n\nIn addition the tag can contain additional assertions as child elements about\nthe first member in the archive matching the regular expression ``path``. For\ninstance\n\n```xml\n<has_archive_member path=\".*/my-file.txt\">\n  <not_has_text text=\"EDK72998.1\"/>\n</has_archive_member>\n```\n\nIf the ``all`` attribute is set to ``true`` then all archive members are subject\nto the assertions. Note that, archive members matching the ``path`` are sorted\nalphabetically.\n\nThe ``negate`` attribute of the ``has_archive_member`` assertion only affects\nthe asserts on the presence and number of matching archive members, but not any\nsub-assertions (which can offer the ``negate`` attribute on their own).  The\ncheck if the file is an archive at all, which is also done by the function, is\nnot affected.",
+      "properties": {
+        "all": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "Check the sub-assertions for all paths matching the path. Default: false, i.e. only the first",
+          "title": "All"
+        },
+        "asserts": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Asserts"
+        },
+        "children": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Children"
+        },
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The regular expression specifying the archive member.",
+          "title": "Path",
+          "type": "string"
+        },
+        "that": {
+          "const": "has_archive_member",
+          "default": "has_archive_member",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "Assert Has Archive Member",
+      "type": "object"
+    },
+    "has_archive_member_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_archive_member": {
+          "$ref": "#/$defs/base_has_archive_member_model",
+          "title": "Assert Has Archive Member"
+        }
+      },
+      "required": [
+        "has_archive_member"
+      ],
+      "title": "Assert Has Archive Member (Nested)",
+      "type": "object"
+    },
+    "has_element_with_path_model": {
+      "additionalProperties": false,
+      "description": "Asserts the XML output contains at least one element (or tag) with the specified\nXPath-like ``path``, e.g.\n\n```xml\n<has_element_with_path path=\"BlastOutput_param/Parameters/Parameters_matrix\" />\n```\n\nWith ``negate`` the result of the assertion can be inverted.",
+      "properties": {
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        },
+        "that": {
+          "const": "has_element_with_path",
+          "default": "has_element_with_path",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "Assert Has Element With Path",
+      "type": "object"
+    },
+    "has_element_with_path_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_element_with_path": {
+          "$ref": "#/$defs/base_has_element_with_path_model",
+          "title": "Assert Has Element With Path"
+        }
+      },
+      "required": [
+        "has_element_with_path"
+      ],
+      "title": "Assert Has Element With Path (Nested)",
+      "type": "object"
+    },
+    "has_h5_attribute_model": {
+      "additionalProperties": false,
+      "description": "Asserts HDF5 output contains the specified ``value`` for an attribute (``key``), e.g.\n\n```xml\n<has_h5_attribute key=\"nchroms\" value=\"15\" />\n```",
+      "properties": {
+        "key": {
+          "description": "HDF5 attribute to check value of.",
+          "title": "Key",
+          "type": "string"
+        },
+        "that": {
+          "const": "has_h5_attribute",
+          "default": "has_h5_attribute",
+          "title": "That",
+          "type": "string"
+        },
+        "value": {
+          "description": "Expected value of HDF5 attribute to check.",
+          "title": "Value",
+          "type": "string"
+        }
+      },
+      "required": [
+        "key",
+        "value"
+      ],
+      "title": "Assert Has H5 Attribute",
+      "type": "object"
+    },
+    "has_h5_attribute_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_h5_attribute": {
+          "$ref": "#/$defs/base_has_h5_attribute_model",
+          "title": "Assert Has H5 Attribute"
+        }
+      },
+      "required": [
+        "has_h5_attribute"
+      ],
+      "title": "Assert Has H5 Attribute (Nested)",
+      "type": "object"
+    },
+    "has_h5_keys_model": {
+      "additionalProperties": false,
+      "description": "Asserts the specified HDF5 output has the given keys.",
+      "properties": {
+        "keys": {
+          "description": "HDF5 attributes to check value of as a comma-separated string.",
+          "title": "Keys",
+          "type": "string"
+        },
+        "that": {
+          "const": "has_h5_keys",
+          "default": "has_h5_keys",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "keys"
+      ],
+      "title": "Assert Has H5 Keys",
+      "type": "object"
+    },
+    "has_h5_keys_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_h5_keys": {
+          "$ref": "#/$defs/base_has_h5_keys_model",
+          "title": "Assert Has H5 Keys"
+        }
+      },
+      "required": [
+        "has_h5_keys"
+      ],
+      "title": "Assert Has H5 Keys (Nested)",
+      "type": "object"
+    },
+    "has_image_center_of_mass_model": {
+      "additionalProperties": false,
+      "description": "Asserts the specified output is an image and has the specified center of mass.\n\nAsserts the output is an image and has a specific center of mass,\nor has an Euclidean distance of ``eps`` or less to that point (e.g.,\n``<has_image_center_of_mass center_of_mass=\"511.07, 223.34\" />``).",
+      "properties": {
+        "center_of_mass": {
+          "description": "The required center of mass of the image intensities (horizontal and vertical coordinate, separated by a comma).",
+          "title": "Center Of Mass",
+          "type": "string"
+        },
+        "channel": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific channel of the image (where ``0`` corresponds to the first image channel).",
+          "title": "Channel"
+        },
+        "eps": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.01,
+          "description": "The maximum allowed Euclidean distance to the required center of mass (defaults to ``0.01``).",
+          "title": "Eps"
+        },
+        "frame": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific frame of the image sequence (where ``0`` corresponds to the first image frame).",
+          "title": "Frame"
+        },
+        "slice": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific slice of the image (where ``0`` corresponds to the first image slice).",
+          "title": "Slice"
+        },
+        "that": {
+          "const": "has_image_center_of_mass",
+          "default": "has_image_center_of_mass",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "center_of_mass"
+      ],
+      "title": "Assert Has Image Center Of Mass",
+      "type": "object"
+    },
+    "has_image_center_of_mass_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_image_center_of_mass": {
+          "$ref": "#/$defs/base_has_image_center_of_mass_model",
+          "title": "Assert Has Image Center Of Mass"
+        }
+      },
+      "required": [
+        "has_image_center_of_mass"
+      ],
+      "title": "Assert Has Image Center Of Mass (Nested)",
+      "type": "object"
+    },
+    "has_image_channels_model": {
+      "additionalProperties": false,
+      "description": "Asserts the output is an image and has a specific number of channels.\n\nThe number of channels is plus/minus ``delta`` (e.g., ``<has_image_channels channels=\"3\" />``).\n\nAlternatively the range of the expected number of channels can be specified by ``min`` and/or ``max``.",
+      "properties": {
+        "channels": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected number of channels of the image.",
+          "title": "Channels"
+        },
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the number of channels (default is 0). The observed number of channels has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed number of channels.",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed number of channels.",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "that": {
+          "const": "has_image_channels",
+          "default": "has_image_channels",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "title": "Assert Has Image Channels",
+      "type": "object"
+    },
+    "has_image_channels_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_image_channels": {
+          "$ref": "#/$defs/base_has_image_channels_model",
+          "title": "Assert Has Image Channels"
+        }
+      },
+      "required": [
+        "has_image_channels"
+      ],
+      "title": "Assert Has Image Channels (Nested)",
+      "type": "object"
+    },
+    "has_image_depth_model": {
+      "additionalProperties": false,
+      "description": "Asserts the output is an image and has a specific depth (number of slices).\n\nThe depth is plus/minus ``delta`` (e.g., ``<has_image_depth depth=\"512\" delta=\"2\" />``).\nAlternatively the range of the expected depth can be specified by ``min`` and/or ``max``.",
+      "properties": {
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the image depth (number of slices, default is 0). The observed depth has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "depth": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected depth of the image (number of slices).",
+          "title": "Depth"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed depth of the image (number of slices).",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed depth of the image (number of slices).",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "that": {
+          "const": "has_image_depth",
+          "default": "has_image_depth",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "title": "Assert Has Image Depth",
+      "type": "object"
+    },
+    "has_image_depth_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_image_depth": {
+          "$ref": "#/$defs/base_has_image_depth_model",
+          "title": "Assert Has Image Depth"
+        }
+      },
+      "required": [
+        "has_image_depth"
+      ],
+      "title": "Assert Has Image Depth (Nested)",
+      "type": "object"
+    },
+    "has_image_frames_model": {
+      "additionalProperties": false,
+      "description": "Asserts the output is an image and has a specific number of frames (number of time steps).\n\nThe number of frames is plus/minus ``delta`` (e.g., ``<has_image_frames depth=\"512\" delta=\"2\" />``).\nAlternatively the range of the expected number of frames can be specified by ``min`` and/or ``max``.",
+      "properties": {
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the number of frames in the image sequence (number of time steps, default is 0). The observed number of frames has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "frames": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected number of frames in the image sequence (number of time steps).",
+          "title": "Frames"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed number of frames in the image sequence (number of time steps).",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed number of frames in the image sequence (number of time steps).",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "that": {
+          "const": "has_image_frames",
+          "default": "has_image_frames",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "title": "Assert Has Image Frames",
+      "type": "object"
+    },
+    "has_image_frames_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_image_frames": {
+          "$ref": "#/$defs/base_has_image_frames_model",
+          "title": "Assert Has Image Frames"
+        }
+      },
+      "required": [
+        "has_image_frames"
+      ],
+      "title": "Assert Has Image Frames (Nested)",
+      "type": "object"
+    },
+    "has_image_height_model": {
+      "additionalProperties": false,
+      "description": "Asserts the output is an image and has a specific height (in pixels).\n\nThe height is plus/minus ``delta`` (e.g., ``<has_image_height height=\"512\" delta=\"2\" />``).\nAlternatively the range of the expected height can be specified by ``min`` and/or ``max``.",
+      "properties": {
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the image height (in pixels, default is 0). The observed height has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "height": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected height of the image (in pixels).",
+          "title": "Height"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed height of the image (in pixels).",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed height of the image (in pixels).",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "that": {
+          "const": "has_image_height",
+          "default": "has_image_height",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "title": "Assert Has Image Height",
+      "type": "object"
+    },
+    "has_image_height_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_image_height": {
+          "$ref": "#/$defs/base_has_image_height_model",
+          "title": "Assert Has Image Height"
+        }
+      },
+      "required": [
+        "has_image_height"
+      ],
+      "title": "Assert Has Image Height (Nested)",
+      "type": "object"
+    },
+    "has_image_mean_intensity_model": {
+      "additionalProperties": false,
+      "description": "Asserts the output is an image and has a specific mean intensity value.\n\nThe mean intensity value is plus/minus ``eps`` (e.g., ``<has_image_mean_intensity mean_intensity=\"0.83\" />``).\nAlternatively the range of the expected mean intensity value can be specified by ``min`` and/or ``max``.",
+      "properties": {
+        "channel": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific channel of the image (where ``0`` corresponds to the first image channel).",
+          "title": "Channel"
+        },
+        "eps": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.01,
+          "description": "The absolute tolerance to be used for ``value`` (defaults to ``0.01``). The observed mean value of the image intensities has to be in the range ``value +- eps``.",
+          "title": "Eps"
+        },
+        "frame": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific frame of the image sequence (where ``0`` corresponds to the first image frame).",
+          "title": "Frame"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "An upper bound of the required mean value of the image intensities.",
+          "title": "Max"
+        },
+        "mean_intensity": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The required mean value of the image intensities.",
+          "title": "Mean Intensity"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A lower bound of the required mean value of the image intensities.",
+          "title": "Min"
+        },
+        "slice": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific slice of the image (where ``0`` corresponds to the first image slice).",
+          "title": "Slice"
+        },
+        "that": {
+          "const": "has_image_mean_intensity",
+          "default": "has_image_mean_intensity",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "title": "Assert Has Image Mean Intensity",
+      "type": "object"
+    },
+    "has_image_mean_intensity_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_image_mean_intensity": {
+          "$ref": "#/$defs/base_has_image_mean_intensity_model",
+          "title": "Assert Has Image Mean Intensity"
+        }
+      },
+      "required": [
+        "has_image_mean_intensity"
+      ],
+      "title": "Assert Has Image Mean Intensity (Nested)",
+      "type": "object"
+    },
+    "has_image_mean_object_size_model": {
+      "additionalProperties": false,
+      "description": "Asserts the output is an image with labeled objects which have the specified mean size (number of pixels),\n\nThe mean size is plus/minus ``eps`` (e.g., ``<has_image_mean_object_size mean_object_size=\"111.87\" exclude_labels=\"0\" />``).\n\nThe labels must be unique.",
+      "properties": {
+        "channel": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific channel of the image (where ``0`` corresponds to the first image channel).",
+          "title": "Channel"
+        },
+        "eps": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.01,
+          "description": "The absolute tolerance to be used for ``value`` (defaults to ``0.01``). The observed mean size of the uniquely labeled objects has to be in the range ``value +- eps``.",
+          "title": "Eps"
+        },
+        "exclude_labels": {
+          "anyOf": [
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "List of labels to be excluded from consideration, separated by a comma. The primary usage of this attribute is to exclude the background of a label image. Cannot be used in combination with ``labels``.",
+          "title": "Exclude Labels"
+        },
+        "frame": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific frame of the image sequence (where ``0`` corresponds to the first image frame).",
+          "title": "Frame"
+        },
+        "labels": {
+          "anyOf": [
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "List of labels, separated by a comma. Labels *not* on this list will be excluded from consideration. Cannot be used in combination with ``exclude_labels``.",
+          "title": "Labels"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "An upper bound of the required mean size of the uniquely labeled objects.",
+          "title": "Max"
+        },
+        "mean_object_size": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The required mean size of the uniquely labeled objects.",
+          "title": "Mean Object Size"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A lower bound of the required mean size of the uniquely labeled objects.",
+          "title": "Min"
+        },
+        "slice": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific slice of the image (where ``0`` corresponds to the first image slice).",
+          "title": "Slice"
+        },
+        "that": {
+          "const": "has_image_mean_object_size",
+          "default": "has_image_mean_object_size",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "title": "Assert Has Image Mean Object Size",
+      "type": "object"
+    },
+    "has_image_mean_object_size_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_image_mean_object_size": {
+          "$ref": "#/$defs/base_has_image_mean_object_size_model",
+          "title": "Assert Has Image Mean Object Size"
+        }
+      },
+      "required": [
+        "has_image_mean_object_size"
+      ],
+      "title": "Assert Has Image Mean Object Size (Nested)",
+      "type": "object"
+    },
+    "has_image_n_labels_model": {
+      "additionalProperties": false,
+      "description": "Asserts the output is an image and has the specified labels.\n\nLabels can be a number of labels or unique values (e.g.,\n``<has_image_n_labels n=\"187\" exclude_labels=\"0\" />``).\n\nThe primary usage of this assertion is to verify the number of objects in images with uniquely labeled objects.",
+      "properties": {
+        "channel": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific channel of the image (where ``0`` corresponds to the first image channel).",
+          "title": "Channel"
+        },
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the number of labels (default is 0). The observed number of labels has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "exclude_labels": {
+          "anyOf": [
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "List of labels to be excluded from consideration, separated by a comma. The primary usage of this attribute is to exclude the background of a label image. Cannot be used in combination with ``labels``.",
+          "title": "Exclude Labels"
+        },
+        "frame": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific frame of the image sequence (where ``0`` corresponds to the first image frame).",
+          "title": "Frame"
+        },
+        "labels": {
+          "anyOf": [
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "List of labels, separated by a comma. Labels *not* on this list will be excluded from consideration. Cannot be used in combination with ``exclude_labels``.",
+          "title": "Labels"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed number of labels.",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed number of labels.",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected number of labels.",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "slice": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific slice of the image (where ``0`` corresponds to the first image slice).",
+          "title": "Slice"
+        },
+        "that": {
+          "const": "has_image_n_labels",
+          "default": "has_image_n_labels",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "title": "Assert Has Image N Labels",
+      "type": "object"
+    },
+    "has_image_n_labels_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_image_n_labels": {
+          "$ref": "#/$defs/base_has_image_n_labels_model",
+          "title": "Assert Has Image N Labels"
+        }
+      },
+      "required": [
+        "has_image_n_labels"
+      ],
+      "title": "Assert Has Image N Labels (Nested)",
+      "type": "object"
+    },
+    "has_image_width_model": {
+      "additionalProperties": false,
+      "description": "Asserts the output is an image and has a specific width (in pixels).\n\nThe width is plus/minus ``delta`` (e.g., ``<has_image_width width=\"512\" delta=\"2\" />``).\nAlternatively the range of the expected width can be specified by ``min`` and/or ``max``.",
+      "properties": {
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the image width (in pixels, default is 0). The observed width has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed width of the image (in pixels).",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed width of the image (in pixels).",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "that": {
+          "const": "has_image_width",
+          "default": "has_image_width",
+          "title": "That",
+          "type": "string"
+        },
+        "width": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected width of the image (in pixels).",
+          "title": "Width"
+        }
+      },
+      "title": "Assert Has Image Width",
+      "type": "object"
+    },
+    "has_image_width_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_image_width": {
+          "$ref": "#/$defs/base_has_image_width_model",
+          "title": "Assert Has Image Width"
+        }
+      },
+      "required": [
+        "has_image_width"
+      ],
+      "title": "Assert Has Image Width (Nested)",
+      "type": "object"
+    },
+    "has_json_property_with_text_model": {
+      "additionalProperties": false,
+      "description": "Asserts the JSON document contains a property or key with the specified text (i.e. string) value.\n\n```xml\n<has_json_property_with_text property=\"color\" text=\"red\" />\n```",
+      "properties": {
+        "property": {
+          "description": "The property name to search the JSON document for.",
+          "title": "Property",
+          "type": "string"
+        },
+        "text": {
+          "description": "The expected text value of the target JSON attribute.",
+          "title": "Text",
+          "type": "string"
+        },
+        "that": {
+          "const": "has_json_property_with_text",
+          "default": "has_json_property_with_text",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "property",
+        "text"
+      ],
+      "title": "Assert Has Json Property With Text",
+      "type": "object"
+    },
+    "has_json_property_with_text_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_json_property_with_text": {
+          "$ref": "#/$defs/base_has_json_property_with_text_model",
+          "title": "Assert Has Json Property With Text"
+        }
+      },
+      "required": [
+        "has_json_property_with_text"
+      ],
+      "title": "Assert Has Json Property With Text (Nested)",
+      "type": "object"
+    },
+    "has_json_property_with_value_model": {
+      "additionalProperties": false,
+      "description": "Asserts the JSON document contains a property or key with the specified JSON value.\n\n```xml\n<has_json_property_with_value property=\"skipped_columns\" value=\"[1, 3, 5]\" />\n```",
+      "properties": {
+        "property": {
+          "description": "The property name to search the JSON document for.",
+          "title": "Property",
+          "type": "string"
+        },
+        "that": {
+          "const": "has_json_property_with_value",
+          "default": "has_json_property_with_value",
+          "title": "That",
+          "type": "string"
+        },
+        "value": {
+          "description": "The expected JSON value of the target JSON attribute (as a JSON encoded string).",
+          "title": "Value",
+          "type": "string"
+        }
+      },
+      "required": [
+        "property",
+        "value"
+      ],
+      "title": "Assert Has Json Property With Value",
+      "type": "object"
+    },
+    "has_json_property_with_value_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_json_property_with_value": {
+          "$ref": "#/$defs/base_has_json_property_with_value_model",
+          "title": "Assert Has Json Property With Value"
+        }
+      },
+      "required": [
+        "has_json_property_with_value"
+      ],
+      "title": "Assert Has Json Property With Value (Nested)",
+      "type": "object"
+    },
+    "has_line_matching_model": {
+      "additionalProperties": false,
+      "description": "Asserts the specified output contains a line matching the\nregular expression specified by the argument expression. If n is given\nthe assertion checks for exactly n occurrences.",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "expression": {
+          "description": "The regular expressions to attempt match in the output.",
+          "title": "Expression",
+          "type": "string"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "that": {
+          "const": "has_line_matching",
+          "default": "has_line_matching",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "expression"
+      ],
+      "title": "Assert Has Line Matching",
+      "type": "object"
+    },
+    "has_line_matching_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_line_matching": {
+          "$ref": "#/$defs/base_has_line_matching_model",
+          "title": "Assert Has Line Matching"
+        }
+      },
+      "required": [
+        "has_line_matching"
+      ],
+      "title": "Assert Has Line Matching (Nested)",
+      "type": "object"
+    },
+    "has_line_model": {
+      "additionalProperties": false,
+      "description": "Asserts the specified output contains the line specified by the\nargument line. The exact number of occurrences can be optionally\nspecified by the argument n",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "line": {
+          "description": "The full line of text to search for in the output.",
+          "title": "Line",
+          "type": "string"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "that": {
+          "const": "has_line",
+          "default": "has_line",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "line"
+      ],
+      "title": "Assert Has Line",
+      "type": "object"
+    },
+    "has_line_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_line": {
+          "$ref": "#/$defs/base_has_line_model",
+          "title": "Assert Has Line"
+        }
+      },
+      "required": [
+        "has_line"
+      ],
+      "title": "Assert Has Line (Nested)",
+      "type": "object"
+    },
+    "has_n_columns_model": {
+      "additionalProperties": false,
+      "description": "Asserts tabular output  contains the specified\nnumber (``n``) of columns.\n\nFor instance, ``<has_n_columns n=\"3\"/>``. The assertion tests only the first line.\nNumber of columns can optionally also be specified with ``delta``. Alternatively the\nrange of expected occurrences can be specified by ``min`` and/or ``max``.\n\nOptionally a column separator (``sep``, default is ``       ``) `and comment character(s)\ncan be specified (``comment``, default is empty string). The first non-comment\nline is used for determining the number of columns.",
+      "properties": {
+        "comment": {
+          "default": "",
+          "description": "Comment character(s) used to skip comment lines (which should not be used for counting columns)",
+          "title": "Comment",
+          "type": "string"
+        },
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "sep": {
+          "default": "\t",
+          "description": "Separator defining columns, default: tab",
+          "title": "Sep",
+          "type": "string"
+        },
+        "that": {
+          "const": "has_n_columns",
+          "default": "has_n_columns",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "title": "Assert Has N Columns",
+      "type": "object"
+    },
+    "has_n_columns_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_n_columns": {
+          "$ref": "#/$defs/base_has_n_columns_model",
+          "title": "Assert Has N Columns"
+        }
+      },
+      "required": [
+        "has_n_columns"
+      ],
+      "title": "Assert Has N Columns (Nested)",
+      "type": "object"
+    },
+    "has_n_elements_with_path_model": {
+      "additionalProperties": false,
+      "description": "Asserts the XML output contains the specified number (``n``, optionally with ``delta``) of elements (or\ntags) with the specified XPath-like ``path``.\n\nFor example:\n\n```xml\n<has_n_elements_with_path n=\"9\" path=\"BlastOutput_iterations/Iteration/Iteration_hits/Hit/Hit_num\" />\n```\n\nAlternatively to ``n`` and ``delta`` also the ``min`` and ``max`` attributes\ncan be used to specify the range of the expected number of occurrences.\nWith ``negate`` the result of the assertion can be inverted.",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        },
+        "that": {
+          "const": "has_n_elements_with_path",
+          "default": "has_n_elements_with_path",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "Assert Has N Elements With Path",
+      "type": "object"
+    },
+    "has_n_elements_with_path_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_n_elements_with_path": {
+          "$ref": "#/$defs/base_has_n_elements_with_path_model",
+          "title": "Assert Has N Elements With Path"
+        }
+      },
+      "required": [
+        "has_n_elements_with_path"
+      ],
+      "title": "Assert Has N Elements With Path (Nested)",
+      "type": "object"
+    },
+    "has_n_lines_model": {
+      "additionalProperties": false,
+      "description": "Asserts the specified output contains ``n`` lines allowing\nfor a difference in the number of lines (delta)\nor relative differebce in the number of lines",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "that": {
+          "const": "has_n_lines",
+          "default": "has_n_lines",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "title": "Assert Has N Lines",
+      "type": "object"
+    },
+    "has_n_lines_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_n_lines": {
+          "$ref": "#/$defs/base_has_n_lines_model",
+          "title": "Assert Has N Lines"
+        }
+      },
+      "required": [
+        "has_n_lines"
+      ],
+      "title": "Assert Has N Lines (Nested)",
+      "type": "object"
+    },
+    "has_size_model": {
+      "additionalProperties": false,
+      "description": "Asserts the specified output has a size of the specified value\n\nAttributes size and value or synonyms though value is considered deprecated.\nThe size optionally allows for absolute (``delta``) difference.",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "size": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired size of the output (in bytes), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Size"
+        },
+        "that": {
+          "const": "has_size",
+          "default": "has_size",
+          "title": "That",
+          "type": "string"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Deprecated alias for `size`",
+          "title": "Value"
+        }
+      },
+      "title": "Assert Has Size",
+      "type": "object"
+    },
+    "has_size_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_size": {
+          "$ref": "#/$defs/base_has_size_model",
+          "title": "Assert Has Size"
+        }
+      },
+      "required": [
+        "has_size"
+      ],
+      "title": "Assert Has Size (Nested)",
+      "type": "object"
+    },
+    "has_text_matching_model": {
+      "additionalProperties": false,
+      "description": "Asserts the specified output contains text matching the\nregular expression specified by the argument expression.\nIf n is given the assertion checks for exactly n (nonoverlapping)\noccurrences.",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "expression": {
+          "description": "The regular expressions to attempt match in the output.",
+          "title": "Expression",
+          "type": "string"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "that": {
+          "const": "has_text_matching",
+          "default": "has_text_matching",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "expression"
+      ],
+      "title": "Assert Has Text Matching",
+      "type": "object"
+    },
+    "has_text_matching_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_text_matching": {
+          "$ref": "#/$defs/base_has_text_matching_model",
+          "title": "Assert Has Text Matching"
+        }
+      },
+      "required": [
+        "has_text_matching"
+      ],
+      "title": "Assert Has Text Matching (Nested)",
+      "type": "object"
+    },
+    "has_text_model": {
+      "additionalProperties": false,
+      "description": "Asserts specified output contains the substring specified by\nthe argument text. The exact number of occurrences can be\noptionally specified by the argument n",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "text": {
+          "description": "The text to search for in the output.",
+          "title": "Text",
+          "type": "string"
+        },
+        "that": {
+          "const": "has_text",
+          "default": "has_text",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "text"
+      ],
+      "title": "Assert Has Text",
+      "type": "object"
+    },
+    "has_text_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_text": {
+          "$ref": "#/$defs/base_has_text_model",
+          "title": "Assert Has Text"
+        }
+      },
+      "required": [
+        "has_text"
+      ],
+      "title": "Assert Has Text (Nested)",
+      "type": "object"
+    },
+    "is_valid_xml_model": {
+      "additionalProperties": false,
+      "description": "Asserts the output is a valid XML file (e.g. ``<is_valid_xml />``).",
+      "properties": {
+        "that": {
+          "const": "is_valid_xml",
+          "default": "is_valid_xml",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "title": "Assert Is Valid Xml",
+      "type": "object"
+    },
+    "is_valid_xml_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "is_valid_xml": {
+          "$ref": "#/$defs/base_is_valid_xml_model",
+          "title": "Assert Is Valid Xml"
+        }
+      },
+      "required": [
+        "is_valid_xml"
+      ],
+      "title": "Assert Is Valid Xml (Nested)",
+      "type": "object"
+    },
+    "not_has_text_model": {
+      "additionalProperties": false,
+      "description": "Asserts specified output does not contain the substring\nspecified by the argument text",
+      "properties": {
+        "text": {
+          "description": "The text to search for in the output.",
+          "title": "Text",
+          "type": "string"
+        },
+        "that": {
+          "const": "not_has_text",
+          "default": "not_has_text",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "text"
+      ],
+      "title": "Assert Not Has Text",
+      "type": "object"
+    },
+    "not_has_text_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "not_has_text": {
+          "$ref": "#/$defs/base_not_has_text_model",
+          "title": "Assert Not Has Text"
+        }
+      },
+      "required": [
+        "not_has_text"
+      ],
+      "title": "Assert Not Has Text (Nested)",
+      "type": "object"
+    },
+    "xml_element_model": {
+      "additionalProperties": false,
+      "description": "Assert if the XML file contains element(s) or tag(s) with the specified\n[XPath-like ``path``](https://lxml.de/xpathxslt.html).  If ``n`` and ``delta``\nor ``min`` and ``max`` are given also the number of occurrences is checked.\n\n```xml\n<assert_contents>\n  <xml_element path=\"./elem\"/>\n  <xml_element path=\"./elem/more[2]\"/>\n  <xml_element path=\".//more\" n=\"3\" delta=\"1\"/>\n</assert_contents>\n```\n\nWith ``negate=\"true\"`` the outcome of the assertions wrt the presence and number\nof ``path`` can be negated. If there are any sub assertions then check them against\n\n- the content of the attribute ``attribute``\n- the element's text if no attribute is given\n\n```xml\n<assert_contents>\n  <xml_element path=\"./elem/more[2]\" attribute=\"name\">\n    <has_text_matching expression=\"foo$\"/>\n  </xml_element>\n</assert_contents>\n```\n\nSub-assertions are not subject to the ``negate`` attribute of ``xml_element``.\nIf ``all`` is ``true`` then the sub assertions are checked for all occurrences.\n\nNote that all other XML assertions can be expressed by this assertion (Galaxy\nalso implements the other assertions by calling this one).",
+      "properties": {
+        "all": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "Check the sub-assertions for all paths matching the path. Default: false, i.e. only the first ",
+          "title": "All"
+        },
+        "asserts": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Asserts"
+        },
+        "attribute": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The XML attribute name to test against from the target XML element.",
+          "title": "Attribute"
+        },
+        "children": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Children"
+        },
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        },
+        "that": {
+          "const": "xml_element",
+          "default": "xml_element",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "Assert Xml Element",
+      "type": "object"
+    },
+    "xml_element_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "xml_element": {
+          "$ref": "#/$defs/base_xml_element_model",
+          "title": "Assert Xml Element"
+        }
+      },
+      "required": [
+        "xml_element"
+      ],
+      "title": "Assert Xml Element (Nested)",
+      "type": "object"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Galaxy workflow tests file — a YAML list of test entries asserting the expected inputs and outputs of a workflow run.",
+  "items": {
+    "$ref": "#/$defs/TestJob"
+  },
+  "title": "GalaxyWorkflowTests",
+  "type": "array"
+}

--- a/casts/claude/skills/discover-shed-tool/SKILL.md
+++ b/casts/claude/skills/discover-shed-tool/SKILL.md
@@ -39,7 +39,7 @@ Follow the procedure below and use the artifact/reference sections as the runtim
 
 ## Validation
 
-- Validate `galaxy-tool-pin.json` before returning it: run `foundry galaxy-tool-pin.json` from `@galaxy-foundry/foundry`. If the command is not on PATH, run `npx --package @galaxy-foundry/foundry foundry galaxy-tool-pin.json`. This checks artifact `galaxy-tool-pin` against the galaxy-tool-discovery schema.
+- Validate `galaxy-tool-pin.json` before returning it: run `foundry validate-galaxy-tool-discovery galaxy-tool-pin.json` from `@galaxy-foundry/foundry`. If the command is not on PATH, run `npx --package @galaxy-foundry/foundry foundry validate-galaxy-tool-discovery galaxy-tool-pin.json`. This checks artifact `galaxy-tool-pin` against the galaxy-tool-discovery schema.
 
 ## Procedure
 

--- a/casts/claude/skills/discover-shed-tool/_provenance.json
+++ b/casts/claude/skills/discover-shed-tool/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/discover-shed-tool/index.md",
     "revision": 4,
     "content_hash": "2e5fa1f8b22f1f9c984fa4c4dc05999294de5db706a9c1691d3af7b3459cbecb",
-    "commit": "7e21e08dee76406496df85fe6d41e5096879f55d"
+    "commit": "e90a42769ba95218355e011fe62fb6daeaef28a7"
   },
-  "cast_at": "2026-07-01T23:45:52.578Z",
+  "cast_at": "2026-07-09T14:20:22.945Z",
   "cast_date": "2026-05-07",
   "cast_revision": 5,
   "cast_history": [

--- a/casts/claude/skills/freeform-summary-to-galaxy-test-plan/SKILL.md
+++ b/casts/claude/skills/freeform-summary-to-galaxy-test-plan/SKILL.md
@@ -42,7 +42,7 @@ Follow the procedure below and use the artifact/reference sections as the runtim
 
 ## Validation
 
-- Validate `galaxy-test-plan.yml` before returning it: run `foundry galaxy-test-plan.yml` from `@galaxy-foundry/foundry`. If the command is not on PATH, run `npx --package @galaxy-foundry/foundry foundry galaxy-test-plan.yml`. This checks artifact `galaxy-test-plan` against the galaxy-workflow-test-plan schema.
+- Validate `galaxy-test-plan.yml` before returning it: run `foundry validate-galaxy-workflow-test-plan galaxy-test-plan.yml` from `@galaxy-foundry/foundry`. If the command is not on PATH, run `npx --package @galaxy-foundry/foundry foundry validate-galaxy-workflow-test-plan galaxy-test-plan.yml`. This checks artifact `galaxy-test-plan` against the galaxy-workflow-test-plan schema.
 
 ## Procedure
 

--- a/casts/claude/skills/freeform-summary-to-galaxy-test-plan/_provenance.json
+++ b/casts/claude/skills/freeform-summary-to-galaxy-test-plan/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/freeform-summary-to-galaxy-test-plan/index.md",
     "revision": 1,
     "content_hash": "37c8ad10dcf4ebaf9aefc132bd365b1172fbd1c00534893f52a53f65e99e0d9b",
-    "commit": "7e21e08dee76406496df85fe6d41e5096879f55d"
+    "commit": "e90a42769ba95218355e011fe62fb6daeaef28a7"
   },
-  "cast_at": "2026-07-01T23:45:56.653Z",
+  "cast_at": "2026-07-09T14:20:24.299Z",
   "refs": [
     {
       "kind": "research",

--- a/casts/claude/skills/interview-to-galaxy-workflow-changeset/SKILL.md
+++ b/casts/claude/skills/interview-to-galaxy-workflow-changeset/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: interview-to-galaxy-workflow-changeset
+description: "Interview a user against an existing Galaxy workflow summary and emit a reviewable, step-anchored change-set."
+---
+
+# interview-to-galaxy-workflow-changeset
+
+Follow the procedure below and use the artifact/reference sections as the runtime contract.
+
+## When To Use
+
+- Interview a user against an existing Galaxy workflow summary and emit a reviewable, step-anchored change-set.
+
+## Inputs
+
+- Read artifact `summary-galaxy-workflow`. Schema: summary-galaxy-workflow. Produced by `summarize-galaxy-workflow`. Structured summary of the existing workflow from summarize-galaxy-workflow; the anchor set the change-set addresses (step labels, input labels, output names, tool_state keys).
+- Read artifact `open-requirements-ledger`. Produced by `advance-galaxy-draft-step`, `apply-galaxy-workflow-changeset`, `compare-against-iwc-exemplar`, `cwl-summary-to-galaxy-data-flow`, `cwl-summary-to-galaxy-interface`, `cwl-summary-to-galaxy-template`, `freeform-summary-to-galaxy-data-flow`, `freeform-summary-to-galaxy-interface`, `freeform-summary-to-galaxy-template`, `implement-galaxy-tool-step`, `interview-to-galaxy-workflow-changeset`, `nextflow-summary-to-galaxy-data-flow`, `nextflow-summary-to-galaxy-interface`, `nextflow-summary-to-galaxy-reference-data`, `nextflow-summary-to-galaxy-template`, `repair-galaxy-draft-topology`. Carried obligations ledger open-requirements-ledger: read prior open entries; append requested changes the workflow cannot yet support.
+
+## Outputs
+
+- Write artifact `galaxy-workflow-changeset` as `galaxy-workflow-changeset.md`. Format: `markdown`. Reviewable, ordered list of edit intents, each anchored to an existing step/input/output by label (or marked `new`), with edit kind, target, intent, and acceptance note. The human approval gate before any edits are applied.
+- Write artifact `open-requirements-ledger` as `open-requirements.ledger.yml`. Format: `yaml`. Updated obligations ledger: requested changes the workflow cannot support appended as open entries; prior entries this interview resolves marked resolved.
+
+## Required Tools
+
+- None declared. Procedure should not assume external CLIs are present.
+
+## Load Upfront
+
+- `references/notes/open-requirements-ledger.md`: Research note copied verbatim into the bundle. Carry the open-requirements ledger: append requested changes the current workflow cannot support rather than inventing or dropping them, and mark resolved the ones this step closes.
+- `references/schemas/summary-galaxy-workflow.schema.json`: Schema file copied verbatim into the bundle. Input contract: read the existing-workflow summary to anchor every change-set entry to a real step/input/output.
+
+## Load On Demand
+
+- None declared.
+
+## Validation
+
+- None declared.
+
+## Procedure
+
+Turn a modification interview into a **reviewable change-set** against an existing Galaxy workflow. This is the update pipeline's analogue of interview-to-freeform-summary: the harness owns the live interaction; the skill's job is the normalized handoff. But unlike the greenfield summary, the output is *anchored to concrete steps* of a workflow that already exists — it names what to change, not what to build.
+
+The harness owns the interaction style (interactive session, saved transcript, or custom UI). Read the summary-galaxy-workflow first so every change is expressed against real labels rather than a mental model of the workflow.
+
+### Output: the change-set
+
+Emit Markdown: an ordered list of edit intents. Each entry carries:
+
+- **kind** — one of: `add-step`, `replace-tool`, `remove-step`, `change-parameter`, `add-input`, `remove-input`, `add-output` / `expose-output`, `rewire`, `relabel` / `annotate`.
+- **anchor** — the existing step label, input label, output name, or `tool_state` key the edit targets, quoted from the summary; or `new` for an added element.
+- **intent** — what the user wants, in their words plus the concrete target value where they gave one (e.g. a parameter's new value).
+- **acceptance** — how a reviewer or a test would confirm the edit landed (a new output is present, a parameter reads the new value, a step feeds its intended consumer).
+
+Order edits so dependencies read top-to-bottom (add a step before rewiring its consumer). The change-set is a **reviewable artifact** — the natural human approval gate before apply-galaxy-workflow-changeset touches the workflow.
+
+### Anchor discipline
+
+Every entry must anchor to something the summary actually contains, or be explicitly marked `new`. Do not reference a step the workflow does not have, and do not silently rename an existing anchor. If the user asks for a change the workflow cannot support as described — an operation on a step that isn't there, a parameter a tool doesn't expose, a rewire that would break the graph — record it on the open-requirements-ledger as an open entry rather than inventing an anchor or quietly dropping the request.
+
+### Don't over-specify
+
+- **Don't resolve tools here.** An `add-step` or `replace-tool` names the *operation and any user-given tool/version*, not a resolved Tool Shed changeset — wrapper resolution is the per-step loop's job downstream. Record vague tool intent as intent plus, if needed, an open-requirements entry.
+- **Don't apply the edit.** This skill decides *what* changes; apply-galaxy-workflow-changeset decides *how* the gxformat2 changes. Keep the two separate so the change-set stays reviewable.
+- **Preserve scope.** Capture only what the interview supports. Do not fold in unrequested "while we're here" tidying — untouched regions must stay untouched, and a change-set that quietly widens scope propagates gratuitous churn downstream.
+
+## Runtime Notes
+
+- Do not read Foundry source files at runtime; use only files packaged in this skill bundle and user-supplied artifacts.
+- Preserve declared artifact filenames unless the user or harness supplies explicit paths.
+- Carry unresolved assumptions into the output artifact instead of silently inventing missing source evidence.

--- a/casts/claude/skills/interview-to-galaxy-workflow-changeset/_provenance.json
+++ b/casts/claude/skills/interview-to-galaxy-workflow-changeset/_provenance.json
@@ -1,0 +1,92 @@
+{
+  "provenance_schema_version": 3,
+  "cast_target": "claude",
+  "mold": {
+    "name": "interview-to-galaxy-workflow-changeset",
+    "path": "content/molds/interview-to-galaxy-workflow-changeset/index.md",
+    "revision": 1,
+    "content_hash": "3d6d8fc9dd09c98125a3ab4c0f7ae5972e85b5afc1707e2922c2e4132d2871a3",
+    "commit": "e90a42769ba95218355e011fe62fb6daeaef28a7"
+  },
+  "cast_at": "2026-07-07T19:12:25.508Z",
+  "refs": [
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[open-requirements-ledger]]",
+      "src": "content/research/open-requirements-ledger.md",
+      "dst": "references/notes/open-requirements-ledger.md",
+      "used_at": "runtime",
+      "load": "upfront",
+      "evidence": "hypothesis",
+      "purpose": "Carry the open-requirements ledger: append requested changes the current workflow cannot support rather than inventing or dropping them, and mark resolved the ones this step closes.",
+      "verification": "Promote after a worked run shows entries this Mold appends are consumed by apply-galaxy-workflow-changeset or a reviewer without re-derivation.",
+      "src_hash": "04d5c952cf0e952ae6153b3962334066f0a440a64da4237cf61264a59920be4f",
+      "dst_hash": "04d5c952cf0e952ae6153b3962334066f0a440a64da4237cf61264a59920be4f",
+      "source": "deterministic"
+    },
+    {
+      "kind": "schema",
+      "mode": "verbatim",
+      "ref": "[[summary-galaxy-workflow]]",
+      "src": "package://@galaxy-foundry/foundry#summaryGalaxyWorkflowSchema",
+      "dst": "references/schemas/summary-galaxy-workflow.schema.json",
+      "used_at": "runtime",
+      "load": "upfront",
+      "evidence": "cast-validated",
+      "purpose": "Input contract: read the existing-workflow summary to anchor every change-set entry to a real step/input/output.",
+      "license": "MIT",
+      "src_hash": "bc083ab266392f2c6659cfc78d74364fb5552a3d262c9f274bfb487857895ee3",
+      "dst_hash": "bc083ab266392f2c6659cfc78d74364fb5552a3d262c9f274bfb487857895ee3",
+      "source": "deterministic"
+    }
+  ],
+  "artifacts": {
+    "produces": [
+      {
+        "id": "galaxy-workflow-changeset",
+        "kind": "markdown",
+        "default_filename": "galaxy-workflow-changeset.md",
+        "description": "Reviewable, ordered list of edit intents, each anchored to an existing step/input/output by label (or marked `new`), with edit kind, target, intent, and acceptance note. The human approval gate before any edits are applied."
+      },
+      {
+        "id": "open-requirements-ledger",
+        "kind": "yaml",
+        "default_filename": "open-requirements.ledger.yml",
+        "description": "Updated obligations ledger: requested changes the workflow cannot support appended as open entries; prior entries this interview resolves marked resolved."
+      }
+    ],
+    "consumes": [
+      {
+        "id": "summary-galaxy-workflow",
+        "description": "Structured summary of the existing workflow from [[summarize-galaxy-workflow]]; the anchor set the change-set addresses (step labels, input labels, output names, tool_state keys).",
+        "inherited_schema": "[[summary-galaxy-workflow]]",
+        "producers": [
+          "summarize-galaxy-workflow"
+        ]
+      },
+      {
+        "id": "open-requirements-ledger",
+        "description": "Carried obligations ledger [[open-requirements-ledger]]: read prior open entries; append requested changes the workflow cannot yet support.",
+        "producers": [
+          "advance-galaxy-draft-step",
+          "apply-galaxy-workflow-changeset",
+          "compare-against-iwc-exemplar",
+          "cwl-summary-to-galaxy-data-flow",
+          "cwl-summary-to-galaxy-interface",
+          "cwl-summary-to-galaxy-template",
+          "freeform-summary-to-galaxy-data-flow",
+          "freeform-summary-to-galaxy-interface",
+          "freeform-summary-to-galaxy-template",
+          "implement-galaxy-tool-step",
+          "interview-to-galaxy-workflow-changeset",
+          "nextflow-summary-to-galaxy-data-flow",
+          "nextflow-summary-to-galaxy-interface",
+          "nextflow-summary-to-galaxy-reference-data",
+          "nextflow-summary-to-galaxy-template",
+          "repair-galaxy-draft-topology"
+        ]
+      }
+    ]
+  }
+}

--- a/casts/claude/skills/interview-to-galaxy-workflow-changeset/_verify.json
+++ b/casts/claude/skills/interview-to-galaxy-workflow-changeset/_verify.json
@@ -1,0 +1,17 @@
+{
+  "verify_schema_version": 1,
+  "entries": [
+    {
+      "artifact_id": "summary-galaxy-workflow",
+      "direction": "input",
+      "kind": "json",
+      "default_filename": "summary-galaxy-workflow.json",
+      "schema": "[[summary-galaxy-workflow]]",
+      "validator_bin": "foundry",
+      "args": [
+        "validate-summary-galaxy-workflow",
+        "{artifact_path}"
+      ]
+    }
+  ]
+}

--- a/casts/claude/skills/interview-to-galaxy-workflow-changeset/references/notes/open-requirements-ledger.md
+++ b/casts/claude/skills/interview-to-galaxy-workflow-changeset/references/notes/open-requirements-ledger.md
@@ -1,0 +1,91 @@
+---
+type: research
+subtype: design-spec
+title: "Open-requirements ledger"
+tags:
+  - research/design-spec
+  - target/galaxy
+status: draft
+created: 2026-06-16
+revised: 2026-06-16
+revision: 1
+ai_generated: true
+related_notes:
+  - "[[galaxy-workflow-draft-format]]"
+related_molds:
+  - "[[advance-galaxy-draft-step]]"
+  - "[[repair-galaxy-draft-topology]]"
+  - "[[implement-galaxy-tool-step]]"
+summary: "Carried unresolved-requirements artifact the source→Galaxy pipeline discharges or explicitly surrenders, autonomously."
+---
+
+# Open-requirements ledger
+
+The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact.
+
+## Framing: obligations the pipeline discharges, not questions a human answers
+
+This is deliberately *not* an "open questions for the user" list. The pipeline is autonomous — no human-in-the-loop gate is assumed. The ledger's consumers are **Molds and the loop's convergence gate**, with human readout a secondary affordance. An entry is closed by a downstream Mold doing work (wiring a producer, picking a wrapper, settling a value), or — when nothing can close it — surrendered: written into the final draft as a known, labelled gap rather than silently dropped or fabricated around.
+
+The distinction matters because a "questions for a human" framing leaks an operator's personal interaction style into a tool meant to run inside anyone's harness. The ledger must behave identically cast into a fresh harness with no ambient configuration; that holds only because every obligation is **materialized in the artifact**, never carried as operator habit.
+
+## Entry shape (v1, loose)
+
+Like the `_plan_*` family in [[galaxy-workflow-draft-format]], ledger entries are intentionally low-ceremony for v1 — enough structure to count and close, no contract pretending to be machine-parameterizable yet. A reasonable per-entry shape:
+
+```yaml
+- id: sccmec-evidence-missing
+  status: open                # open | resolved | surrendered
+  raised_by: implement-galaxy-tool-step   # Mold that appended it
+  step: classify_context       # draft step the obligation attaches to (if any)
+  unmet: "SCCmec-region candidate output category"
+  missing: "no wired input carries SCCmec cassette evidence"
+  resolved_by: null            # Mold that closed it, once closed
+  note: ""                     # how it was closed or why surrendered
+```
+
+Provenance (`raised_by`, `resolved_by`) is the audit trail for *when* each obligation entered and left — the traceability #281 asked for, and the evidence the convergence gate reads.
+
+## Role in topology repair
+
+In the Galaxy per-step loop, the ledger is the substrate the topology-repair escalation rides on (see [[galaxy-workflow-draft-format]] and [[repair-galaxy-draft-topology]]):
+
+- **[[implement-galaxy-tool-step]]** detects, mid-implementation, that a declared step output cannot be computed from its wired inputs — a defect invisible to `gxwf` structural validation, because the connection graph knows ports connect, not what they contain. Rather than fabricate, it appends a blocking entry and falls through to repair.
+- **[[repair-galaxy-draft-topology]]** reads the open blocking entries, re-wires the affected region (template-tier authoring — one step or a small sub-path), and marks each entry it closes `resolved`; the existing discover-or-author → implement machinery then realizes the new steps.
+- The loop's **decreasing-blocker invariant** counts open blocking entries: each repair escalation must strictly reduce that count, under a hard cap on escalations. When the cap is hit with entries still open, those entries are **surrendered** into the final draft — the clean terminal that replaces spin-or-fabricate.
+
+So the ledger is not a convenience here; it is the countable state the termination guard depends on.
+
+## Escalation budget (loop-level state)
+
+The decreasing-blocker invariant needs more than the entries themselves: "strictly reduce the open count, under a hard cap" is *loop-level* state — it spans iterations and belongs to no single entry. The ledger carries it in a small `topology_repair` header beside the `entries:` list:
+
+```yaml
+topology_repair:
+  escalations: 2           # repairs invoked this run
+  cap: 5                   # hard ceiling; at cap, still-open entries are surrendered
+  open_history: [4, 3, 2]  # open blocking-entry count after each escalation — must be strictly decreasing
+entries:
+  - id: sccmec-evidence-missing
+    status: open
+    # … per-entry shape above
+```
+
+- `escalations` — how many times [[advance-galaxy-draft-step]] has escalated to [[repair-galaxy-draft-topology]] this run. The orchestrator increments it on each escalation.
+- `cap` — the hard ceiling. When `escalations` reaches `cap`, the loop stops escalating and surrenders any still-`open` blocking entries into the final draft as labelled gaps rather than retrying forever.
+- `open_history` — the open blocking-entry count recorded after each escalation. The convergence gate requires it to be strictly decreasing: a repair that fails to lower the open count — or raises it by inserting a producer that is itself uncomputable — is non-convergent and trips the gate immediately, without waiting for the cap.
+
+This block lives in the ledger as a v1 expedient: the ledger is already the carried, cast-visible state the loop reads each iteration. Its better long-term home is the **draft itself** — a workflow-level annotation that travels with the artifact it bounds, so the budget survives even when the ledger is stripped at the terminal. Recorded here for now; migrate when the draft grows a home for it.
+
+## Threaded through the whole design tier
+
+The ledger is not loop-only. It is a single artifact every design-tier Mold in the source→Galaxy pipelines **consumes and re-emits** — the interface, reference-data, data-flow, IWC-comparison, and template Molds (`*-summary-to-galaxy-interface`, `*-summary-to-galaxy-data-flow`, `*-summary-to-galaxy-reference-data`, `compare-against-iwc-exemplar`, `*-summary-to-galaxy-template`). The first design Mold in a run creates it; each subsequent Mold reads the open entries, **appends** the unknowns it newly surfaces, and **marks resolved** the ones its own decisions close (the template settling a topology choice the data-flow left open, the interface pinning a parameter, …). This is the direct answer to #281: the chain stops re-deriving the same unknowns because each Mold inherits them.
+
+The template Mold's computability review pass is one notable appender — `*-summary-to-galaxy-template` re-reads each settled step and, where an output needs evidence no input carries, wires the producer or records the gap as a blocking entry. Source-summary Molds upstream of the design tier keep their own free-text open-questions; the design tier is where those formalize into the ledger.
+
+## Open work
+
+- Decide whether entry structure should harden (typed `unmet` / `missing`, links back to source-summary evidence, machine-checkable `status` transitions) once two or three worked runs exercise it.
+- Decide whether the source-summary Molds should also emit structured entries, or keep their free-text open-questions until the design tier formalizes them.
+- Specify how surrendered entries surface in the runnable gxformat2 (a workflow-level annotation, a report output, or a sidecar) when the draft is stripped of `_plan_*` and TODO sentinels.
+- Move the `topology_repair` escalation budget out of the ledger and into the draft (a workflow-level annotation) so it travels with the artifact it bounds; the ledger home is a v1 expedient.

--- a/casts/claude/skills/interview-to-galaxy-workflow-changeset/references/schemas/summary-galaxy-workflow.schema.json
+++ b/casts/claude/skills/interview-to-galaxy-workflow-changeset/references/schemas/summary-galaxy-workflow.schema.json
@@ -1,0 +1,665 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://galaxyproject.org/foundry/schemas/summary-galaxy-workflow.schema.json",
+  "$comment": "Canonical source: packages/foundry/src/schemas/summary-galaxy-workflow/summary-galaxy-workflow.schema.json in galaxyproject/foundry. Mold frontmatter cites this schema via [[summary-galaxy-workflow]] wiki-links; the cast pipeline imports the `summaryGalaxyWorkflowSchema` runtime export and serializes it into cast bundles.",
+  "title": "Galaxy Workflow Summary",
+  "description": "Structured summary emitted by the summarize-galaxy-workflow Mold. Galaxy gxformat2 is already a typed workflow language, so this schema records validated and normalized workflow structure (inputs, outputs, steps, edges, existing tests) rather than inferred pipeline semantics. When the user supplies a legacy .ga workflow it is converted to gxformat2 first and the conversion is recorded under documents.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "summary_version",
+    "source",
+    "documents",
+    "workflow_inputs",
+    "workflow_outputs",
+    "steps",
+    "graph",
+    "tests",
+    "warnings"
+  ],
+  "properties": {
+    "summary_version": {
+      "type": "string",
+      "enum": [
+        "1"
+      ],
+      "description": "Summary schema major version."
+    },
+    "source": {
+      "$ref": "#/$defs/SourceRecord"
+    },
+    "documents": {
+      "$ref": "#/$defs/DocumentSet"
+    },
+    "workflow_inputs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/WorkflowInput"
+      }
+    },
+    "workflow_outputs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/WorkflowOutput"
+      }
+    },
+    "steps": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/WorkflowStep"
+      }
+    },
+    "graph": {
+      "$ref": "#/$defs/WorkflowGraph"
+    },
+    "tests": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/TestCase"
+      }
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Warning"
+      }
+    }
+  },
+  "$defs": {
+    "SourceRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "ecosystem",
+        "workflow",
+        "url",
+        "version",
+        "license",
+        "slug",
+        "format",
+        "original_format",
+        "release",
+        "annotation"
+      ],
+      "properties": {
+        "ecosystem": {
+          "type": "string",
+          "enum": [
+            "galaxy"
+          ],
+          "description": "Source ecosystem; fixed for this per-source schema."
+        },
+        "workflow": {
+          "type": "string",
+          "description": "Human-oriented workflow name, usually the gxformat2 `name:` or the source filename stem."
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Original path or URL supplied by the user."
+        },
+        "version": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Pinned commit, tag, release, or digest when available."
+        },
+        "license": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "License identifier from the gxformat2 `license:` field or a detected license file."
+        },
+        "slug": {
+          "type": "string",
+          "description": "Stable kebab-case run slug."
+        },
+        "format": {
+          "type": "string",
+          "enum": [
+            "gxformat2"
+          ],
+          "description": "Normalized workflow format this summary describes; always gxformat2."
+        },
+        "original_format": {
+          "type": "string",
+          "enum": [
+            "gxformat2",
+            "ga"
+          ],
+          "description": "Format the user supplied. `ga` means the legacy native format was converted to gxformat2 before summarizing (see documents.converted_path)."
+        },
+        "release": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "gxformat2 `release:` version string when present."
+        },
+        "annotation": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Workflow-level annotation/description when present."
+        }
+      }
+    },
+    "DocumentSet": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "entrypoint",
+        "converted_path",
+        "validation"
+      ],
+      "properties": {
+        "entrypoint": {
+          "type": "string",
+          "description": "Local path or URL of the workflow document as supplied."
+        },
+        "converted_path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Path to the gxformat2 document produced by `gxwf convert` when the entrypoint was a legacy .ga; null when the entrypoint was already gxformat2."
+        },
+        "validation": {
+          "$ref": "#/$defs/ValidationResult"
+        }
+      }
+    },
+    "ValidationResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "command",
+        "status",
+        "diagnostics"
+      ],
+      "properties": {
+        "command": {
+          "type": "string",
+          "description": "Validation command or library operation used, e.g. `gxwf validate`."
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "valid",
+            "warning",
+            "invalid",
+            "not-run"
+          ]
+        },
+        "diagnostics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "WorkflowInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "label",
+        "type",
+        "collection_type",
+        "optional",
+        "default",
+        "format",
+        "doc"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "gxformat2 input step key (label) that later edges address."
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "data",
+            "collection",
+            "parameter"
+          ],
+          "description": "Galaxy workflow input class: a single dataset, a dataset collection, or a runtime parameter."
+        },
+        "collection_type": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Galaxy collection type expression when type is collection, e.g. list, paired, list:paired."
+        },
+        "optional": {
+          "type": "boolean"
+        },
+        "default": {
+          "description": "Verbatim default value when present.",
+          "type": [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "object",
+            "array",
+            "null"
+          ]
+        },
+        "format": {
+          "type": [
+            "string",
+            "array",
+            "null"
+          ],
+          "description": "Declared datatype/extension restriction(s) when present.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doc": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "WorkflowOutput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "label",
+        "source",
+        "type",
+        "doc"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Workflow output name as exposed in the gxformat2 `outputs:` block."
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "source": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Producing `step_label/output_name` this workflow output promotes."
+        },
+        "type": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Compact datatype/collection-shape hint when derivable."
+        },
+        "doc": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "WorkflowStep": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "label",
+        "type",
+        "tool_id",
+        "tool_version",
+        "tool_shed_repository",
+        "tool_state",
+        "in",
+        "out",
+        "when",
+        "annotation"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Step key/label as it appears in the gxformat2 `steps:` mapping; the anchor edits address."
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "tool",
+            "data_input",
+            "data_collection_input",
+            "parameter_input",
+            "subworkflow",
+            "pause"
+          ],
+          "description": "gxformat2 step class."
+        },
+        "tool_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Fully qualified Tool Shed tool id or short built-in id; null for non-tool steps."
+        },
+        "tool_version": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Pinned tool version when present."
+        },
+        "tool_shed_repository": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "owner",
+            "changeset_revision",
+            "tool_shed"
+          ],
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "owner": {
+              "type": "string"
+            },
+            "changeset_revision": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "tool_shed": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "description": "Pinned Tool Shed repository record when the step cites one."
+        },
+        "tool_state": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true,
+          "description": "Verbatim gxformat2 tool_state for this step, preserved so downstream change-set edits can address individual parameters. Null for non-tool steps."
+        },
+        "in": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/StepInput"
+          }
+        },
+        "out": {
+          "type": "array",
+          "description": "Declared output names this step produces.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "when": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Conditional-execution guard preserved verbatim when present."
+        },
+        "annotation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "StepInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "source",
+        "default",
+        "value_from"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Input connection name on this step."
+        },
+        "source": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Upstream `step_label/output_name` or workflow input this connection reads; null when driven by a default or runtime value."
+        },
+        "default": {
+          "description": "Verbatim connection default when present.",
+          "type": [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "object",
+            "array",
+            "null"
+          ]
+        },
+        "value_from": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Runtime/expression source preserved verbatim when present."
+        }
+      }
+    },
+    "WorkflowGraph": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "nodes",
+        "edges"
+      ],
+      "properties": {
+        "nodes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GraphNode"
+          }
+        },
+        "edges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GraphEdge"
+          }
+        }
+      }
+    },
+    "GraphNode": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "kind",
+        "label"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "workflow-input",
+            "step",
+            "workflow-output"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "GraphEdge": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "from",
+        "to",
+        "via"
+      ],
+      "properties": {
+        "from": {
+          "type": "string"
+        },
+        "to": {
+          "type": "string"
+        },
+        "via": {
+          "type": "array",
+          "description": "Shape-affecting Galaxy features on this edge, e.g. map-over, batch, collection-reduction.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "TestCase": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "job_path",
+        "expected_outputs",
+        "provenance"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "job_path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Path to the tests YAML/job definition when discoverable, e.g. a sibling *-tests.yml."
+        },
+        "expected_outputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ExpectedOutputRef"
+          }
+        },
+        "provenance": {
+          "type": "string"
+        }
+      }
+    },
+    "ExpectedOutputRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "path",
+        "url",
+        "filetype",
+        "checksum",
+        "assertions"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "filetype": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "checksum": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "assertions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Warning": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "message",
+        "path"
+      ],
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/casts/claude/skills/summarize-cwl/SKILL.md
+++ b/casts/claude/skills/summarize-cwl/SKILL.md
@@ -51,7 +51,7 @@ Follow the procedure below and use the artifact/reference sections as the runtim
 
 ## Validation
 
-- Validate `summary-cwl.json` before returning it: run `foundry summary-cwl.json` from `@galaxy-foundry/foundry`. If the command is not on PATH, run `npx --package @galaxy-foundry/foundry foundry summary-cwl.json`. This checks artifact `summary-cwl` against the summary-cwl schema.
+- Validate `summary-cwl.json` before returning it: run `foundry validate-summary-cwl summary-cwl.json` from `@galaxy-foundry/foundry`. If the command is not on PATH, run `npx --package @galaxy-foundry/foundry foundry validate-summary-cwl summary-cwl.json`. This checks artifact `summary-cwl` against the summary-cwl schema.
 
 ## Procedure
 

--- a/casts/claude/skills/summarize-cwl/_provenance.json
+++ b/casts/claude/skills/summarize-cwl/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/summarize-cwl/index.md",
     "revision": 2,
     "content_hash": "fc96f678cb072237347f4990644a86c47d84f4fff303160fbb4ae3a92a55e1c5",
-    "commit": "7e21e08dee76406496df85fe6d41e5096879f55d"
+    "commit": "e90a42769ba95218355e011fe62fb6daeaef28a7"
   },
-  "cast_at": "2026-07-01T23:46:04.640Z",
+  "cast_at": "2026-07-09T14:32:48.116Z",
   "refs": [
     {
       "kind": "cli-tool",

--- a/casts/claude/skills/summarize-galaxy-tool/SKILL.md
+++ b/casts/claude/skills/summarize-galaxy-tool/SKILL.md
@@ -43,7 +43,7 @@ Follow the procedure below and use the artifact/reference sections as the runtim
 
 ## Validation
 
-- Validate `galaxy-tool-summary.json` before returning it: run `foundry galaxy-tool-summary.json` from `@galaxy-foundry/foundry`. If the command is not on PATH, run `npx --package @galaxy-foundry/foundry foundry galaxy-tool-summary.json`. This checks artifact `galaxy-tool-summary` against the galaxy-tool-summary schema.
+- Validate `galaxy-tool-summary.json` before returning it: run `foundry validate-galaxy-tool-summary galaxy-tool-summary.json` from `@galaxy-foundry/foundry`. If the command is not on PATH, run `npx --package @galaxy-foundry/foundry foundry validate-galaxy-tool-summary galaxy-tool-summary.json`. This checks artifact `galaxy-tool-summary` against the galaxy-tool-summary schema.
 
 ## Procedure
 

--- a/casts/claude/skills/summarize-galaxy-tool/_provenance.json
+++ b/casts/claude/skills/summarize-galaxy-tool/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/summarize-galaxy-tool/index.md",
     "revision": 7,
     "content_hash": "f02491928ff799d2ce8ed27d84da66f90bbde8b18b71bdbb2c2e07f2221beb46",
-    "commit": "7e21e08dee76406496df85fe6d41e5096879f55d"
+    "commit": "e90a42769ba95218355e011fe62fb6daeaef28a7"
   },
-  "cast_at": "2026-07-01T23:46:05.878Z",
+  "cast_at": "2026-07-09T14:20:26.879Z",
   "refs": [
     {
       "kind": "cli-command",

--- a/casts/claude/skills/summarize-galaxy-workflow/SKILL.md
+++ b/casts/claude/skills/summarize-galaxy-workflow/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: summarize-galaxy-workflow
+description: "Read an existing Galaxy gxformat2 (or .ga) workflow and emit a structured summary for interview and change-set steps."
+---
+
+# summarize-galaxy-workflow
+
+Follow the procedure below and use the artifact/reference sections as the runtime contract.
+
+## When To Use
+
+- Read an existing Galaxy gxformat2 (or .ga) workflow and emit a structured summary for interview and change-set steps.
+
+## Inputs
+
+- No upstream artifact inputs declared. See the procedure for user-supplied runtime inputs.
+
+## Outputs
+
+- Write artifact `summary-galaxy-workflow` as `summary-galaxy-workflow.json`. Format: `json`. Schema: summary-galaxy-workflow. Structured summary of an existing Galaxy workflow: source/format provenance, inputs, outputs, per-step tool_id/version/tool_state, edge graph, and any existing tests as a regression baseline.
+
+## Required Tools
+
+- **`foundry`** (foundry). `npm install -g @galaxy-foundry/foundry`.
+  Ephemeral run: `npx --package @galaxy-foundry/foundry foundry`.
+  Check: `foundry --help`.
+  Docs: https://github.com/galaxyproject/foundry/blob/main/packages/foundry/README.md
+  Bundled reference: `references/cli/foundry.md`.
+- **`gxwf`** (gxwf). `npm install -g @galaxy-tool-util/cli@^1.8.1`.
+  Ephemeral run: `npx --yes --package @galaxy-tool-util/cli@1.8.1 gxwf`.
+  Check: `gxwf --help | grep -q draft-validate`.
+  Docs: https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli
+
+## Load Upfront
+
+- `references/cli/validate.json`: CLI command reference packaged as a sidecar. Validate the gxformat2 workflow before extraction and record diagnostics under documents.validation. Use when: before extracting structure from the workflow document.
+- `references/cli/foundry.md`: CLI tool reference copied verbatim into the bundle. Schema-check summary-galaxy-workflow.json with `foundry validate-summary-galaxy-workflow` before returning it from the skill.
+- `references/schemas/summary-galaxy-workflow.schema.json`: Schema file copied verbatim into the bundle. Validate the emitted Galaxy workflow summary JSON and provide downstream consumers the output contract.
+
+## Load On Demand
+
+- `references/cli/convert.json`: CLI command reference packaged as a sidecar. Convert a legacy `.ga` workflow to gxformat2 before summarizing, and record the conversion under documents.converted_path. Use when: the supplied workflow is native `.ga` rather than gxformat2.
+
+## Validation
+
+- Validate `summary-galaxy-workflow.json` before returning it: run `foundry validate-summary-galaxy-workflow summary-galaxy-workflow.json` from `@galaxy-foundry/foundry`. If the command is not on PATH, run `npx --package @galaxy-foundry/foundry foundry validate-summary-galaxy-workflow summary-galaxy-workflow.json`. This checks artifact `summary-galaxy-workflow` against the summary-galaxy-workflow schema.
+
+## Procedure
+
+Read an existing Galaxy workflow and emit `summary-galaxy-workflow.json`. This skill is source-specific and target-agnostic: it records what the workflow *is* — inputs, outputs, steps, wiring, and existing tests — and leaves every modification decision to the downstream change-set and apply skills. It mirrors summarize-cwl on the Galaxy-as-source side.
+
+gxformat2 is already a typed workflow graph, so do not infer structure — read it. The summary is an LLM-digestible index of the existing workflow that anchors the interview and the change-set; it is **context**, not the substrate edits apply to. The substrate the edits are applied against is the raw gxformat2 workflow file itself (owned by apply-galaxy-workflow-changeset).
+
+### Inputs
+
+- A local workflow path or an HTTP(S) URL. Accept both gxformat2 (`.gxwf.yml` / `.gxfmt2.yml`) and legacy native `.ga`.
+- Optional pin/version metadata supplied by the harness or user.
+- Optional sibling tests file (`*-tests.yml`); if none is supplied or discoverable, emit `tests: []`.
+
+### Procedure
+
+1. **Normalize format.** If the input is native `.ga`, convert it to gxformat2 with convert (`--to format2`) and record the output path in `documents.converted_path`. If it is already gxformat2, leave `converted_path` null. Set `source.original_format` accordingly. All downstream extraction reads the gxformat2 form.
+2. **Validate.** Run gxwf validate on the gxformat2 workflow and record `command`, `status`, and `diagnostics` under `documents.validation`. If invalid, still emit source provenance and diagnostics; do not invent graph structure past what parses.
+3. **Extract the interface.** Record `workflow_inputs` (class `data` / `collection` / `parameter`, `collection_type`, optionality, defaults, format restrictions) and `workflow_outputs` (each promoted `step/output` source), preserving gxformat2 labels verbatim — those labels are the anchors the change-set will address.
+4. **Extract steps.** For each step record its class, `tool_id`, `tool_version`, pinned `tool_shed_repository`, verbatim `tool_state`, named input connections with their upstream sources, declared outputs, and any `when:` guard. Keep `tool_state` verbatim so a later change-set can address an individual parameter.
+5. **Build the graph.** Emit workflow-input → step, step → step, and step → workflow-output edges. Add `via` markers for shape-affecting features (map-over, batch, collection reduction).
+6. **Record tests.** When a sibling tests file or embedded tests exist, record each case's name, job path, and expected outputs as the regression baseline. Do not fabricate expected outputs from tool names.
+7. **Schema-check.** Validate the assembled object with `foundry validate-summary-galaxy-workflow summary-galaxy-workflow.json` before returning it.
+
+### Caveats Baked Into The Procedure
+
+- **Labels are load-bearing.** Preserve step and input labels exactly; the change-set anchors edits to them, and a relabel here would silently break that anchoring.
+- **`tool_state` is preserved, not interpreted.** Record it verbatim. Deciding which parameter an interview wants changed is the change-set's job, not this skill's.
+- **Existing tests are the regression baseline.** Capture them faithfully; the update pipeline judges the modified workflow against them.
+- **Conversion is lossy-aware.** If `.ga` → gxformat2 conversion drops or rewrites anything, surface it in `warnings[]` rather than presenting a clean summary.
+
+### Non-Goals
+
+- **Modification.** Interviewing for changes, building a change-set, and applying edits belong to interview-to-galaxy-workflow-changeset and apply-galaxy-workflow-changeset.
+- **Tool discovery or wrapper authoring.** `tool_id` / `tool_shed_repository` are recorded as-found; resolving newly introduced tools is the per-step Galaxy loop's job.
+- **Runtime execution.** This skill summarizes structure; run-workflow-test owns execution.
+
+## Runtime Notes
+
+- Do not read Foundry source files at runtime; use only files packaged in this skill bundle and user-supplied artifacts.
+- Preserve declared artifact filenames unless the user or harness supplies explicit paths.
+- Carry unresolved assumptions into the output artifact instead of silently inventing missing source evidence.

--- a/casts/claude/skills/summarize-galaxy-workflow/_provenance.json
+++ b/casts/claude/skills/summarize-galaxy-workflow/_provenance.json
@@ -1,0 +1,87 @@
+{
+  "provenance_schema_version": 3,
+  "cast_target": "claude",
+  "mold": {
+    "name": "summarize-galaxy-workflow",
+    "path": "content/molds/summarize-galaxy-workflow/index.md",
+    "revision": 1,
+    "content_hash": "510c980436c2687312af52625201020019572924f11912b29977c55aef2a5865",
+    "commit": "e90a42769ba95218355e011fe62fb6daeaef28a7"
+  },
+  "cast_at": "2026-07-09T14:32:49.290Z",
+  "refs": [
+    {
+      "kind": "cli-command",
+      "mode": "sidecar",
+      "ref": "[[convert]]",
+      "src": "content/cli/gxwf/convert.md",
+      "dst": "references/cli/convert.json",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "hypothesis",
+      "purpose": "Convert a legacy `.ga` workflow to gxformat2 before summarizing, and record the conversion under documents.converted_path.",
+      "trigger": "When the supplied workflow is native `.ga` rather than gxformat2.",
+      "verification": "Cast the skill, run on one `.ga` and one gxformat2 fixture; confirm the `.ga` case populates documents.converted_path and both summaries validate.",
+      "src_hash": "24b91f53b0e7850d1dfc38df1074f2d4270c72f20778d0e4d710545bf64be3e0",
+      "dst_hash": "1cdf49f10f77039af6efc5b82fe79720bb18e50d1f57d653670697f7262c7640",
+      "source": "deterministic"
+    },
+    {
+      "kind": "cli-command",
+      "mode": "sidecar",
+      "ref": "[[gxwf validate]]",
+      "src": "content/cli/gxwf/validate.md",
+      "dst": "references/cli/validate.json",
+      "used_at": "runtime",
+      "load": "upfront",
+      "evidence": "hypothesis",
+      "purpose": "Validate the gxformat2 workflow before extraction and record diagnostics under documents.validation.",
+      "trigger": "Before extracting structure from the workflow document.",
+      "verification": "Cast the skill, run on one valid and one malformed workflow; the malformed one surfaces gxwf validate diagnostics in the summary.",
+      "src_hash": "8fdf834e8b3bd2c70e9625c9148eb246855a40625510f0be5f6351885b057aa4",
+      "dst_hash": "caec1f5cc5a69b56f2a033f8e96a5330a8393b76ff606d3ea7468b1eb7922de6",
+      "source": "deterministic"
+    },
+    {
+      "kind": "cli-tool",
+      "mode": "verbatim",
+      "ref": "[[foundry]]",
+      "src": "content/cli/foundry/index.md",
+      "dst": "references/cli/foundry.md",
+      "used_at": "runtime",
+      "load": "upfront",
+      "evidence": "cast-validated",
+      "purpose": "Schema-check summary-galaxy-workflow.json with `foundry validate-summary-galaxy-workflow` before returning it from the skill.",
+      "src_hash": "0211ac0ab62e3bc536043cb93ef7b340dcc359b9a876340deeca7fd9a0317fe3",
+      "dst_hash": "0211ac0ab62e3bc536043cb93ef7b340dcc359b9a876340deeca7fd9a0317fe3",
+      "source": "deterministic"
+    },
+    {
+      "kind": "schema",
+      "mode": "verbatim",
+      "ref": "[[summary-galaxy-workflow]]",
+      "src": "package://@galaxy-foundry/foundry#summaryGalaxyWorkflowSchema",
+      "dst": "references/schemas/summary-galaxy-workflow.schema.json",
+      "used_at": "both",
+      "load": "upfront",
+      "evidence": "cast-validated",
+      "purpose": "Validate the emitted Galaxy workflow summary JSON and provide downstream consumers the output contract.",
+      "license": "MIT",
+      "src_hash": "bc083ab266392f2c6659cfc78d74364fb5552a3d262c9f274bfb487857895ee3",
+      "dst_hash": "bc083ab266392f2c6659cfc78d74364fb5552a3d262c9f274bfb487857895ee3",
+      "source": "deterministic"
+    }
+  ],
+  "artifacts": {
+    "produces": [
+      {
+        "id": "summary-galaxy-workflow",
+        "kind": "json",
+        "default_filename": "summary-galaxy-workflow.json",
+        "schema": "[[summary-galaxy-workflow]]",
+        "description": "Structured summary of an existing Galaxy workflow: source/format provenance, inputs, outputs, per-step tool_id/version/tool_state, edge graph, and any existing tests as a regression baseline."
+      }
+    ],
+    "consumes": []
+  }
+}

--- a/casts/claude/skills/summarize-galaxy-workflow/_required_tools.json
+++ b/casts/claude/skills/summarize-galaxy-workflow/_required_tools.json
@@ -1,0 +1,28 @@
+[
+  {
+    "tool": "foundry",
+    "origin": "npm",
+    "package": "@galaxy-foundry/foundry",
+    "invoke": "foundry",
+    "invoke_fallback": "npx --package @galaxy-foundry/foundry foundry",
+    "availability_check": "foundry --help",
+    "docs_url": "https://github.com/galaxyproject/foundry/blob/main/packages/foundry/README.md",
+    "reference": "references/cli/foundry.md",
+    "source": "referenced"
+  },
+  {
+    "tool": "gxwf",
+    "origin": "npm",
+    "package": "@galaxy-tool-util/cli",
+    "package_version": "^1.8.1",
+    "invoke": "gxwf",
+    "invoke_fallback": "npx --yes --package @galaxy-tool-util/cli@1.8.1 gxwf",
+    "availability_check": "gxwf --help | grep -q draft-validate",
+    "docs_url": "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli",
+    "source": "implied",
+    "implied_by": [
+      "gxwf convert",
+      "gxwf validate"
+    ]
+  }
+]

--- a/casts/claude/skills/summarize-galaxy-workflow/_verify.json
+++ b/casts/claude/skills/summarize-galaxy-workflow/_verify.json
@@ -1,0 +1,17 @@
+{
+  "verify_schema_version": 1,
+  "entries": [
+    {
+      "artifact_id": "summary-galaxy-workflow",
+      "direction": "output",
+      "kind": "json",
+      "default_filename": "summary-galaxy-workflow.json",
+      "schema": "[[summary-galaxy-workflow]]",
+      "validator_bin": "foundry",
+      "args": [
+        "validate-summary-galaxy-workflow",
+        "{artifact_path}"
+      ]
+    }
+  ]
+}

--- a/casts/claude/skills/summarize-galaxy-workflow/references/cli/convert.json
+++ b/casts/claude/skills/summarize-galaxy-workflow/references/cli/convert.json
@@ -1,0 +1,123 @@
+{
+  "type": "cli-command",
+  "tool": "gxwf",
+  "command": "convert",
+  "summary": "Convert a Galaxy workflow between native (.ga) and format2 (.gxwf.yml) representations.",
+  "source_path": "content/cli/gxwf/convert.md",
+  "source_revision": 2,
+  "package": "@galaxy-tool-util/cli",
+  "description": "Convert between native (.ga) and format2 (.gxwf.yml) formats",
+  "synopsis": "gxwf convert [options] <file>",
+  "args": [
+    {
+      "raw": "file",
+      "name": "file",
+      "required": true,
+      "variadic": false,
+      "description": "Workflow file (.ga, .gxwf.yml)"
+    }
+  ],
+  "options": [
+    {
+      "flags": "--to <format>",
+      "name": "to",
+      "description": "Target format: native or format2 (infers opposite by default)",
+      "takesArgument": true,
+      "argumentPlaceholder": "<format>",
+      "optionalArgument": false,
+      "negatable": false
+    },
+    {
+      "flags": "--output <file>",
+      "name": "output",
+      "description": "Write result to file (default: stdout)",
+      "takesArgument": true,
+      "argumentPlaceholder": "<file>",
+      "optionalArgument": false,
+      "negatable": false
+    },
+    {
+      "flags": "--compact",
+      "name": "compact",
+      "description": "Omit position info in format2 output",
+      "takesArgument": false,
+      "optionalArgument": false,
+      "negatable": false
+    },
+    {
+      "flags": "--json",
+      "name": "json",
+      "description": "Force JSON output",
+      "takesArgument": false,
+      "optionalArgument": false,
+      "negatable": false
+    },
+    {
+      "flags": "--yaml",
+      "name": "yaml",
+      "description": "Force YAML output",
+      "takesArgument": false,
+      "optionalArgument": false,
+      "negatable": false
+    },
+    {
+      "flags": "--format <fmt>",
+      "name": "format",
+      "description": "Force source format (auto-detected by default)",
+      "takesArgument": true,
+      "argumentPlaceholder": "<fmt>",
+      "optionalArgument": false,
+      "negatable": false
+    },
+    {
+      "flags": "--stateful",
+      "name": "stateful",
+      "description": "Use cached tool definitions for schema-aware state re-encoding",
+      "takesArgument": false,
+      "optionalArgument": false,
+      "negatable": false
+    },
+    {
+      "flags": "--cache-dir <dir>",
+      "name": "cacheDir",
+      "description": "Tool cache directory (for --stateful)",
+      "takesArgument": true,
+      "argumentPlaceholder": "<dir>",
+      "optionalArgument": false,
+      "negatable": false
+    },
+    {
+      "flags": "--strict",
+      "name": "strict",
+      "description": "Shorthand for --strict-structure --strict-encoding --strict-state",
+      "takesArgument": false,
+      "optionalArgument": false,
+      "negatable": false
+    },
+    {
+      "flags": "--strict-structure",
+      "name": "strictStructure",
+      "description": "Reject unknown keys at envelope/step level",
+      "takesArgument": false,
+      "optionalArgument": false,
+      "negatable": false
+    },
+    {
+      "flags": "--strict-encoding",
+      "name": "strictEncoding",
+      "description": "Reject JSON-string tool_state and format2 field misuse",
+      "takesArgument": false,
+      "optionalArgument": false,
+      "negatable": false
+    },
+    {
+      "flags": "--strict-state",
+      "name": "strictState",
+      "description": "Require every tool step to validate; no skips allowed",
+      "takesArgument": false,
+      "optionalArgument": false,
+      "negatable": false
+    }
+  ],
+  "body": "# `gxwf convert`\n\nConvert a Galaxy workflow between the native `.ga` JSON and the `.gxwf.yml` format2 representation. Use this to normalize fetched IWC workflows into a consistent comparison representation.\n\n## Output\n\nDefault output is the converted workflow on stdout. With `--output`, the result is written to a file. JSON output is selected with `--json` (or `--to native`); YAML output is selected with `--yaml` (or `--to format2`).\n\n## Examples\n\n```bash\ngxwf convert workflow.ga --to format2 --output workflow.gxwf.yml\ngxwf convert workflow.ga --to format2 --compact\ngxwf convert workflow.gxwf.yml --to native --output workflow.ga\n```\n\n## Gotchas\n\n- Default output is stdout; pipe or pass `--output` when persisting.\n- `--compact` drops node position metadata; useful for structural diffs and skeleton generation.\n- `--stateful` requires a populated tool cache (see `galaxy-tool-cache`); without it, tool-state stays as fetched."
+}

--- a/casts/claude/skills/summarize-galaxy-workflow/references/cli/foundry.md
+++ b/casts/claude/skills/summarize-galaxy-workflow/references/cli/foundry.md
@@ -1,0 +1,27 @@
+---
+type: cli-tool
+tool: foundry
+origin: npm
+package: "@galaxy-foundry/foundry"
+invoke: foundry
+invoke_fallback: "npx --package @galaxy-foundry/foundry foundry"
+availability_check: "foundry --help"
+docs_url: "https://github.com/galaxyproject/foundry/blob/main/packages/foundry/README.md"
+tags:
+  - cli-tool
+  - cli/foundry
+status: draft
+created: 2026-05-11
+revised: 2026-05-11
+revision: 1
+ai_generated: true
+summary: "Foundry CLI: bundles all Mold IO validators and a summarize-nextflow subcommand."
+---
+
+# foundry
+
+Unified Foundry CLI. Subcommands cover every Mold IO validator plus a `summarize-nextflow` wrapper around the standalone `@galaxy-foundry/summarize-nextflow` package. Per-subcommand synopsis, args, and options are rendered from `@galaxy-foundry/foundry/meta`.
+
+## Install
+
+`npx --package @galaxy-foundry/foundry foundry <subcommand>` runs without a global install. For repeat use, `npm install -g @galaxy-foundry/foundry`.

--- a/casts/claude/skills/summarize-galaxy-workflow/references/cli/validate.json
+++ b/casts/claude/skills/summarize-galaxy-workflow/references/cli/validate.json
@@ -1,0 +1,125 @@
+{
+  "type": "cli-command",
+  "tool": "gxwf",
+  "command": "validate",
+  "summary": "Validate Galaxy workflow structure, tool state, and optional connection compatibility before runtime execution.",
+  "source_path": "content/cli/gxwf/validate.md",
+  "source_revision": 3,
+  "package": "@galaxy-tool-util/cli",
+  "description": "Validate Galaxy workflow files (structure + optional tool state)",
+  "synopsis": "gxwf validate [options] <file>",
+  "args": [
+    {
+      "raw": "file",
+      "name": "file",
+      "required": true,
+      "variadic": false,
+      "description": "Workflow file (.ga, .gxwf.yml)"
+    }
+  ],
+  "options": [
+    {
+      "flags": "--format <fmt>",
+      "name": "format",
+      "description": "Force format: native or format2 (auto-detected by default)",
+      "takesArgument": true,
+      "argumentPlaceholder": "<fmt>",
+      "optionalArgument": false,
+      "negatable": false
+    },
+    {
+      "flags": "--no-tool-state",
+      "name": "toolState",
+      "description": "Skip tool state validation",
+      "takesArgument": false,
+      "optionalArgument": false,
+      "negatable": true
+    },
+    {
+      "flags": "--cache-dir <dir>",
+      "name": "cacheDir",
+      "description": "Tool cache directory",
+      "takesArgument": true,
+      "argumentPlaceholder": "<dir>",
+      "optionalArgument": false,
+      "negatable": false
+    },
+    {
+      "flags": "--mode <mode>",
+      "name": "mode",
+      "description": "Validation backend: effect (default) or json-schema",
+      "takesArgument": true,
+      "argumentPlaceholder": "<mode>",
+      "optionalArgument": false,
+      "negatable": false,
+      "defaultValue": "effect"
+    },
+    {
+      "flags": "--tool-schema-dir <dir>",
+      "name": "toolSchemaDir",
+      "description": "Directory of pre-exported per-tool JSON Schemas (for offline json-schema mode)",
+      "takesArgument": true,
+      "argumentPlaceholder": "<dir>",
+      "optionalArgument": false,
+      "negatable": false
+    },
+    {
+      "flags": "--json",
+      "name": "json",
+      "description": "Output structured JSON report",
+      "takesArgument": false,
+      "optionalArgument": false,
+      "negatable": false
+    },
+    {
+      "flags": "--report-html [file]",
+      "name": "reportHtml",
+      "description": "Write HTML report to file (or stdout if omitted)",
+      "takesArgument": true,
+      "argumentPlaceholder": "[file]",
+      "optionalArgument": true,
+      "negatable": false
+    },
+    {
+      "flags": "--connections",
+      "name": "connections",
+      "description": "Validate connection-type compatibility (collection algebra, map-over)",
+      "takesArgument": false,
+      "optionalArgument": false,
+      "negatable": false
+    },
+    {
+      "flags": "--strict",
+      "name": "strict",
+      "description": "Shorthand for --strict-structure --strict-encoding --strict-state",
+      "takesArgument": false,
+      "optionalArgument": false,
+      "negatable": false
+    },
+    {
+      "flags": "--strict-structure",
+      "name": "strictStructure",
+      "description": "Reject unknown keys at envelope/step level",
+      "takesArgument": false,
+      "optionalArgument": false,
+      "negatable": false
+    },
+    {
+      "flags": "--strict-encoding",
+      "name": "strictEncoding",
+      "description": "Reject JSON-string tool_state and format2 field misuse",
+      "takesArgument": false,
+      "optionalArgument": false,
+      "negatable": false
+    },
+    {
+      "flags": "--strict-state",
+      "name": "strictState",
+      "description": "Require every tool step to validate; no skips allowed",
+      "takesArgument": false,
+      "optionalArgument": false,
+      "negatable": false
+    }
+  ],
+  "body": "# `gxwf validate`\n\nValidate a Galaxy workflow source file before attempting runtime execution. Use this as the design-time guardrail after step implementation and again after final workflow assembly.\n\n## Output\n\nDefault output is human-readable diagnostics. JSON output should be treated as the preferred cast-skill interface; free-text diagnostics are a fallback for humans.\n\n## Examples\n\n```bash\ngxwf validate workflow.ga\ngxwf validate workflow.gxwf.yml --json\ngxwf validate workflow.gxwf.yml --json --connections --strict\ngxwf validate workflow.ga --mode json-schema --tool-schema-dir ./tool-schemas --json\n```\n\n## Gotchas\n\n- Validation is design-time structure checking. It does not prove that a workflow test will pass under Planemo.\n- Run after each generated Galaxy step when the harness can still attribute failures to the fresh step.\n- Run again after assembly to catch cross-step or workflow-level issues before runtime testing.\n- Prefer `--json` whenever a cast skill or harness needs to classify diagnostics.\n- Use `--connections` when tool cache metadata is available and data-shape compatibility matters, especially around collections and map-over.\n- `--no-tool-state` weakens validation. If used, record why tool metadata was unavailable and rerun without it before final runtime testing."
+}

--- a/casts/claude/skills/summarize-galaxy-workflow/references/schemas/summary-galaxy-workflow.schema.json
+++ b/casts/claude/skills/summarize-galaxy-workflow/references/schemas/summary-galaxy-workflow.schema.json
@@ -1,0 +1,665 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://galaxyproject.org/foundry/schemas/summary-galaxy-workflow.schema.json",
+  "$comment": "Canonical source: packages/foundry/src/schemas/summary-galaxy-workflow/summary-galaxy-workflow.schema.json in galaxyproject/foundry. Mold frontmatter cites this schema via [[summary-galaxy-workflow]] wiki-links; the cast pipeline imports the `summaryGalaxyWorkflowSchema` runtime export and serializes it into cast bundles.",
+  "title": "Galaxy Workflow Summary",
+  "description": "Structured summary emitted by the summarize-galaxy-workflow Mold. Galaxy gxformat2 is already a typed workflow language, so this schema records validated and normalized workflow structure (inputs, outputs, steps, edges, existing tests) rather than inferred pipeline semantics. When the user supplies a legacy .ga workflow it is converted to gxformat2 first and the conversion is recorded under documents.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "summary_version",
+    "source",
+    "documents",
+    "workflow_inputs",
+    "workflow_outputs",
+    "steps",
+    "graph",
+    "tests",
+    "warnings"
+  ],
+  "properties": {
+    "summary_version": {
+      "type": "string",
+      "enum": [
+        "1"
+      ],
+      "description": "Summary schema major version."
+    },
+    "source": {
+      "$ref": "#/$defs/SourceRecord"
+    },
+    "documents": {
+      "$ref": "#/$defs/DocumentSet"
+    },
+    "workflow_inputs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/WorkflowInput"
+      }
+    },
+    "workflow_outputs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/WorkflowOutput"
+      }
+    },
+    "steps": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/WorkflowStep"
+      }
+    },
+    "graph": {
+      "$ref": "#/$defs/WorkflowGraph"
+    },
+    "tests": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/TestCase"
+      }
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Warning"
+      }
+    }
+  },
+  "$defs": {
+    "SourceRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "ecosystem",
+        "workflow",
+        "url",
+        "version",
+        "license",
+        "slug",
+        "format",
+        "original_format",
+        "release",
+        "annotation"
+      ],
+      "properties": {
+        "ecosystem": {
+          "type": "string",
+          "enum": [
+            "galaxy"
+          ],
+          "description": "Source ecosystem; fixed for this per-source schema."
+        },
+        "workflow": {
+          "type": "string",
+          "description": "Human-oriented workflow name, usually the gxformat2 `name:` or the source filename stem."
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Original path or URL supplied by the user."
+        },
+        "version": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Pinned commit, tag, release, or digest when available."
+        },
+        "license": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "License identifier from the gxformat2 `license:` field or a detected license file."
+        },
+        "slug": {
+          "type": "string",
+          "description": "Stable kebab-case run slug."
+        },
+        "format": {
+          "type": "string",
+          "enum": [
+            "gxformat2"
+          ],
+          "description": "Normalized workflow format this summary describes; always gxformat2."
+        },
+        "original_format": {
+          "type": "string",
+          "enum": [
+            "gxformat2",
+            "ga"
+          ],
+          "description": "Format the user supplied. `ga` means the legacy native format was converted to gxformat2 before summarizing (see documents.converted_path)."
+        },
+        "release": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "gxformat2 `release:` version string when present."
+        },
+        "annotation": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Workflow-level annotation/description when present."
+        }
+      }
+    },
+    "DocumentSet": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "entrypoint",
+        "converted_path",
+        "validation"
+      ],
+      "properties": {
+        "entrypoint": {
+          "type": "string",
+          "description": "Local path or URL of the workflow document as supplied."
+        },
+        "converted_path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Path to the gxformat2 document produced by `gxwf convert` when the entrypoint was a legacy .ga; null when the entrypoint was already gxformat2."
+        },
+        "validation": {
+          "$ref": "#/$defs/ValidationResult"
+        }
+      }
+    },
+    "ValidationResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "command",
+        "status",
+        "diagnostics"
+      ],
+      "properties": {
+        "command": {
+          "type": "string",
+          "description": "Validation command or library operation used, e.g. `gxwf validate`."
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "valid",
+            "warning",
+            "invalid",
+            "not-run"
+          ]
+        },
+        "diagnostics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "WorkflowInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "label",
+        "type",
+        "collection_type",
+        "optional",
+        "default",
+        "format",
+        "doc"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "gxformat2 input step key (label) that later edges address."
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "data",
+            "collection",
+            "parameter"
+          ],
+          "description": "Galaxy workflow input class: a single dataset, a dataset collection, or a runtime parameter."
+        },
+        "collection_type": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Galaxy collection type expression when type is collection, e.g. list, paired, list:paired."
+        },
+        "optional": {
+          "type": "boolean"
+        },
+        "default": {
+          "description": "Verbatim default value when present.",
+          "type": [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "object",
+            "array",
+            "null"
+          ]
+        },
+        "format": {
+          "type": [
+            "string",
+            "array",
+            "null"
+          ],
+          "description": "Declared datatype/extension restriction(s) when present.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "doc": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "WorkflowOutput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "label",
+        "source",
+        "type",
+        "doc"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Workflow output name as exposed in the gxformat2 `outputs:` block."
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "source": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Producing `step_label/output_name` this workflow output promotes."
+        },
+        "type": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Compact datatype/collection-shape hint when derivable."
+        },
+        "doc": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "WorkflowStep": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "label",
+        "type",
+        "tool_id",
+        "tool_version",
+        "tool_shed_repository",
+        "tool_state",
+        "in",
+        "out",
+        "when",
+        "annotation"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Step key/label as it appears in the gxformat2 `steps:` mapping; the anchor edits address."
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "tool",
+            "data_input",
+            "data_collection_input",
+            "parameter_input",
+            "subworkflow",
+            "pause"
+          ],
+          "description": "gxformat2 step class."
+        },
+        "tool_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Fully qualified Tool Shed tool id or short built-in id; null for non-tool steps."
+        },
+        "tool_version": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Pinned tool version when present."
+        },
+        "tool_shed_repository": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "owner",
+            "changeset_revision",
+            "tool_shed"
+          ],
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "owner": {
+              "type": "string"
+            },
+            "changeset_revision": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "tool_shed": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "description": "Pinned Tool Shed repository record when the step cites one."
+        },
+        "tool_state": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true,
+          "description": "Verbatim gxformat2 tool_state for this step, preserved so downstream change-set edits can address individual parameters. Null for non-tool steps."
+        },
+        "in": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/StepInput"
+          }
+        },
+        "out": {
+          "type": "array",
+          "description": "Declared output names this step produces.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "when": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Conditional-execution guard preserved verbatim when present."
+        },
+        "annotation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "StepInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "source",
+        "default",
+        "value_from"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Input connection name on this step."
+        },
+        "source": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Upstream `step_label/output_name` or workflow input this connection reads; null when driven by a default or runtime value."
+        },
+        "default": {
+          "description": "Verbatim connection default when present.",
+          "type": [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "object",
+            "array",
+            "null"
+          ]
+        },
+        "value_from": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Runtime/expression source preserved verbatim when present."
+        }
+      }
+    },
+    "WorkflowGraph": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "nodes",
+        "edges"
+      ],
+      "properties": {
+        "nodes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GraphNode"
+          }
+        },
+        "edges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GraphEdge"
+          }
+        }
+      }
+    },
+    "GraphNode": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "kind",
+        "label"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "workflow-input",
+            "step",
+            "workflow-output"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "GraphEdge": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "from",
+        "to",
+        "via"
+      ],
+      "properties": {
+        "from": {
+          "type": "string"
+        },
+        "to": {
+          "type": "string"
+        },
+        "via": {
+          "type": "array",
+          "description": "Shape-affecting Galaxy features on this edge, e.g. map-over, batch, collection-reduction.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "TestCase": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "job_path",
+        "expected_outputs",
+        "provenance"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "job_path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Path to the tests YAML/job definition when discoverable, e.g. a sibling *-tests.yml."
+        },
+        "expected_outputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ExpectedOutputRef"
+          }
+        },
+        "provenance": {
+          "type": "string"
+        }
+      }
+    },
+    "ExpectedOutputRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "path",
+        "url",
+        "filetype",
+        "checksum",
+        "assertions"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "filetype": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "checksum": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "assertions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Warning": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "message",
+        "path"
+      ],
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/casts/claude/skills/summarize-nextflow/SKILL.md
+++ b/casts/claude/skills/summarize-nextflow/SKILL.md
@@ -45,7 +45,7 @@ Follow the procedure below and use the artifact/reference sections as the runtim
 
 ## Validation
 
-- Validate `summary-nextflow.json` before returning it: run `foundry summary-nextflow.json` from `@galaxy-foundry/summarize-nextflow`. If the command is not on PATH, run `npx --package @galaxy-foundry/summarize-nextflow foundry summary-nextflow.json`. This checks artifact `summary-nextflow` against the summary-nextflow schema.
+- Validate `summary-nextflow.json` before returning it: run `foundry validate-summary-nextflow summary-nextflow.json` from `@galaxy-foundry/foundry`. If the command is not on PATH, run `npx --package @galaxy-foundry/foundry foundry validate-summary-nextflow summary-nextflow.json`. This checks artifact `summary-nextflow` against the summary-nextflow schema.
 
 ## Procedure
 

--- a/casts/claude/skills/summarize-nextflow/_provenance.json
+++ b/casts/claude/skills/summarize-nextflow/_provenance.json
@@ -6,11 +6,11 @@
     "path": "content/molds/summarize-nextflow/index.md",
     "revision": 13,
     "content_hash": "5c2eb98afb41c1cc58e3a22aedfe62fac75e6c6c93eb6eb6339aadda1ac7ebd0",
-    "commit": "7e21e08dee76406496df85fe6d41e5096879f55d"
+    "commit": "e90a42769ba95218355e011fe62fb6daeaef28a7"
   },
   "cast_method": "hand-cast",
   "cast_agent": "claude (manual transcription, no LLM cast prompt)",
-  "cast_at": "2026-07-01T23:46:06.523Z",
+  "cast_at": "2026-07-09T14:32:46.652Z",
   "cast_date": "2026-05-08",
   "cast_revision": 11,
   "cast_history": [

--- a/docs/EVAL_PHILOSOPHY.md
+++ b/docs/EVAL_PHILOSOPHY.md
@@ -55,6 +55,12 @@ Every eval property must have a pass/fail edge — an output you can imagine tha
 
 The four maintainer-facing files decay differently and serve different readers; keeping them separate is what lets each stay honest. `MOLD_SPEC.md` has the per-file contract.
 
+## A deterministic check is run, not emulated
+
+`eval.md` marks each property `check: deterministic` or `check: llm-judged`, and the two are scored differently. A deterministic check names a mechanical oracle — a schema validator, a structural diff, `gxwf validate` / `roundtrip`, a `planemo test` run — and it earns its verdict only by **executing that oracle**. Emulating it (describing what the validator would say, or marking it "not run" because the tool looks expensive) is not a weaker pass; it is no evaluation at all. A deterministic property is precisely the one an LLM cannot satisfy by inspection — that is why it was written deterministic rather than llm-judged. When a trial reaches a deterministic gate it genuinely cannot run, that is a *blocked* trial to report, not a property to wave through. (`llm-judged` properties are the ones scored by reasoned inspection; the split mirrors the eval/scenario split — mechanical where it can be, judgment only where it must be.)
+
+This is the rule a test-drive most easily violates: an executable Mold like `run-workflow-test` is self-bootstrapping (`planemo test` launches its own Galaxy), so "no running Galaxy" never justifies skipping its deterministic gate. See `/test-drive` step 4.
+
 ## Pipelines evaluate by composition plus a thin oracle
 
 A Pipeline is judged two ways at once:

--- a/packages/build-cli/src/commands/cast-mold.ts
+++ b/packages/build-cli/src/commands/cast-mold.ts
@@ -1141,14 +1141,18 @@ function schemaValidationRows(
     const target = resolveWikiLink(output.schema, slugMap);
     const meta = target ? metaByPath.get(target) : undefined;
     const validator = scalar(meta?.validator_bin);
-    const packageName = scalar(meta?.package);
+    const subcommand = scalar(meta?.validator_subcommand);
+    const command = validator && subcommand ? `${validator} ${subcommand}` : validator;
+    // A declared subcommand means the bin ships in the foundry CLI package; the
+    // schema's `package` only names the export source (mirrors validate.ts).
+    const validatorPackage = subcommand ? "@galaxy-foundry/foundry" : scalar(meta?.package);
     const schemaName = stripWikiLinks(output.schema);
     const file = output.default_filename
       ? `\`${output.default_filename}\``
       : "the emitted artifact";
     rows.push(
       validator
-        ? `- Validate ${file} before returning it: run \`${validator} ${output.default_filename ?? "<artifact-path>"}\`${packageName ? ` from \`${packageName}\`` : ""}. ${packageName ? `If the command is not on PATH, run \`npx --package ${packageName} ${validator} ${output.default_filename ?? "<artifact-path>"}\`. ` : ""}This checks artifact \`${output.id}\` against the ${schemaName} schema.`
+        ? `- Validate ${file} before returning it: run \`${command} ${output.default_filename ?? "<artifact-path>"}\`${validatorPackage ? ` from \`${validatorPackage}\`` : ""}. ${validatorPackage ? `If the command is not on PATH, run \`npx --package ${validatorPackage} ${command} ${output.default_filename ?? "<artifact-path>"}\`. ` : ""}This checks artifact \`${output.id}\` against the ${schemaName} schema.`
         : `- Validate ${file} for artifact \`${output.id}\` against the ${schemaName} schema when a validator is available.`,
     );
   }

--- a/scripts/cast-skill-verify.ts
+++ b/scripts/cast-skill-verify.ts
@@ -136,6 +136,7 @@ function main(): void {
     }
   }
 
+  const verifyOutputCommands: string[] = [];
   const verifyPath = path.join(bundleRoot, "_verify.json");
   if (!existsSync(verifyPath)) {
     errors.push("missing _verify.json in cast bundle");
@@ -163,6 +164,9 @@ function main(): void {
           }
           if (!Array.isArray(entry.args) || !entry.args.every((arg) => typeof arg === "string")) {
             errors.push(`_verify.json: entries[${index}].args must be a string array`);
+          } else if (entry.direction === "output" && typeof entry.validator_bin === "string") {
+            const sub = entry.args.filter((arg) => arg !== "{artifact_path}").join(" ");
+            if (sub) verifyOutputCommands.push(`${entry.validator_bin} ${sub}`);
           }
         });
       }
@@ -198,6 +202,16 @@ function main(): void {
     // Forbid raw wiki-links in SKILL.md.
     if (/\[\[[^\]]+\]\]/.test(skillBody)) {
       errors.push("SKILL.md: contains raw [[wiki-link]] (must be resolved or stripped)");
+    }
+  }
+
+  // The Validation section must name each output validator's full `bin subcommand`
+  // invocation, so the human-facing SKILL text can't drift from the machine-facing
+  // _verify.json contract (F1: the renderer once dropped the subcommand).
+  const validationSection = (skillBody.match(/## Validation[\s\S]*?(?=\n## |$)/) ?? [""])[0];
+  for (const cmd of verifyOutputCommands) {
+    if (!validationSection.includes(cmd)) {
+      errors.push(`SKILL.md: Validation section omits '${cmd}' from _verify.json (renderer dropped the validator subcommand)`);
     }
   }
 


### PR DESCRIPTION
> **Posted by Claude (AI assistant) on jmchilton's behalf** — authored by Claude, not written by jmchilton personally.

Surfaced while driving `/test-pipeline update-interview-to-galaxy` (scenario 1, the retune-param + expose-hidden-report no-loop path). Two independent bugs, plus casting the four molds that scenario exercises.

## 1. Cast Validation renderer dropped the validator subcommand (F1/F1b)

`schemaValidationRows` rendered the SKILL `## Validation` section from `validator_bin` alone, ignoring `validator_subcommand` — so it emitted a bare `foundry <file>` instead of `foundry validate-<name> <file>`. The machine-facing `_verify.json` was already correct (it combines bin + args), so text and contract had silently diverged across **7 casts**.

- Renderer now joins `bin + validator_subcommand`.
- When a subcommand is declared, the npx `--package` is `@galaxy-foundry/foundry` (where the `foundry` bin actually ships) rather than the schema's export package — this is the same rule `validate.ts` already applies (F1b: caught the `summarize-nextflow` schema, whose export package is `@galaxy-foundry/summarize-nextflow` but validator is a `foundry` subcommand).
- `cast-skill-verify.ts` now asserts each **output** validator's `bin subcommand` appears in the SKILL Validation section, so the human text can't drift from `_verify.json` again (red→green tested).
- Recast the 5 affected tracked molds.

## 2. `/test-drive` + `/test-pipeline` let executable phases be skipped

"Emulation" in these commands meant skill *dispatch* (read `SKILL.md` instead of the `Skill` tool), but it read as license to skip the actual work — so `run-workflow-test` got marked "not run / needs live Galaxy". Planemo is self-bootstrapping (`planemo test` launches its own Galaxy), so that was never a valid skip.

- `test-drive.md`: disambiguates "emulation" = dispatch only; splits authoring vs **executable** Molds (validate → `gxwf validate`, run → `planemo test`); a `check: deterministic` property is scored by running it, never emulated.
- `test-pipeline.md`: the validate/run/debug tail runs; reaching `run-workflow-test` without a green result (or a specifically-justified deferral) means the journey did not complete.
- `docs/EVAL_PHILOSOPHY.md`: new "A deterministic check is run, not emulated" section.

## 3. Cast the four UPDATE-INTERVIEW→GALAXY molds

`summarize-galaxy-workflow`, `interview-to-galaxy-workflow-changeset`, `apply-galaxy-workflow-changeset`, `changeset-to-galaxy-test-plan` were authored but uncast. Cast for the claude target; all verify clean.

**Known follow-up (F2):** `changeset-to-galaxy-test-plan`'s SKILL says `source.derived_from: mixed`, but the `galaxy-workflow-test-plan` schema enum forbids `mixed` at source level — to be fixed + recast next.

## Checks

`npm run validate` (0 errors), `npm run typecheck`, build-cli typecheck, `cast-skill-verify` on all touched casts — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)