### PR TITLE
Pin gxwf to the workspace install + bump @galaxy-tool-util/cli to 1.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "vitest": "^2.1.0"
   },
   "dependencies": {
-    "@galaxy-tool-util/cli": "^1.8.1",
+    "@galaxy-tool-util/cli": "^1.10.0",
     "@galaxy-tool-util/schema": "^1.7.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@galaxy-tool-util/cli':
-        specifier: ^1.8.1
-        version: 1.8.1
+        specifier: ^1.10.0
+        version: 1.10.0
       '@galaxy-tool-util/schema':
         specifier: ^1.7.2
         version: 1.7.2
@@ -591,24 +591,24 @@ packages:
     resolution: {integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@galaxy-tool-util/cli@1.8.1':
-    resolution: {integrity: sha512-nfxOyGmkLzLRfp+hS0F+lT34GXUFrqjAv0ZMOIoXqoMxDwRlALXFTipcqdARY6+7HkNUsTQ41+igzCLt+dFV3w==}
+  '@galaxy-tool-util/cli@1.10.0':
+    resolution: {integrity: sha512-K4KDHl/AsBudimBpmIjT6u85qFExY+XKKehiWeaEJcB8CPkvZULkf5JjwW2gLvB3HVxo2bnD7bWeZmVNFMNWdQ==}
     hasBin: true
 
-  '@galaxy-tool-util/connection-validation@1.8.0':
-    resolution: {integrity: sha512-kJWC9/yPBrX155HwzbztKUPAmHHX6T9ZUM0rtfEr9fXc0bKHEih+py4q/1GCbx3IIGvJCzVVrvp/Phh4HzZWvg==}
+  '@galaxy-tool-util/connection-validation@1.10.0':
+    resolution: {integrity: sha512-Nz9CdwdnQ1+3figfAS5YW9ELOXaZk4TeGSS8XyV7+XPOfWuPBt7vhxmQZ8baf7NBUTQCCGFSB4LEX/YeJHAS+w==}
 
-  '@galaxy-tool-util/core@1.8.1':
-    resolution: {integrity: sha512-BL5gYFHszeUIe7iC+uQVcEerwdN2eZl6RpoXMOnTrTj4sZ5K31eAs9u4gkGyuMH0L0Xg70EnTzsgezgqU892hw==}
+  '@galaxy-tool-util/core@1.10.0':
+    resolution: {integrity: sha512-PtFbuKXmzuJJQKcoS0YbisR1+nEy2eyxvxSOaoXWF+EcwSzjBlGWGj6XmGjGP1Vbvc2dJau+XMdHSdyr5WeU9w==}
+
+  '@galaxy-tool-util/schema@1.10.0':
+    resolution: {integrity: sha512-X0+79uHY5Lu8mGehbhZIgDpiUONmtM6p1Tn0QWu+yFF7NNDdkxK951G9Q9QAIuNdYkobI03T8VWgz+17zvJF8g==}
 
   '@galaxy-tool-util/schema@1.7.2':
     resolution: {integrity: sha512-9udM+HHHg3jhly6dQ2FfZNg8Z8Ydi6fObFG9/Ff6OxSt1zmtieTmOFAB9YfdhlOLDuBp3qFfcvv+su5wqZD/Ww==}
 
-  '@galaxy-tool-util/schema@1.8.0':
-    resolution: {integrity: sha512-aFkaG/tde24nfY7XgjHouSGHwdi2wGlOuGNoIdxWssxbDwqkCg902DabkL8L4fVnj3JKjrduGz/FzgE/t66p+A==}
-
-  '@galaxy-tool-util/search@1.8.1':
-    resolution: {integrity: sha512-R/qxwzPK/a99rof8ZtNFKvHVZtcOo6Z3Tw+d4JRCD2nf2hmW40Q/wCQsXnZQL5K8xcWJAh1AWNfVGZihrqeOvQ==}
+  '@galaxy-tool-util/search@1.10.0':
+    resolution: {integrity: sha512-zMPHrrUpRRaVldKjZwYEmV9dzoM8nN2BDasQvjTutLl7vK6fomuWaFem6HqLiou43qe9Y7+X0LBQElKGhEQMfA==}
 
   '@galaxy-tool-util/workflow-graph@1.2.0':
     resolution: {integrity: sha512-S3a/2lHaNcKoE9pYWSZXPL6DPFh+DXU5JhMdVMMzYRx4BHDbpK0aqVPcwyq+uAlNP+PqwmhD6WLgdsVwBSDotQ==}
@@ -2051,12 +2051,12 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@galaxy-tool-util/cli@1.8.1':
+  '@galaxy-tool-util/cli@1.10.0':
     dependencies:
-      '@galaxy-tool-util/connection-validation': 1.8.0
-      '@galaxy-tool-util/core': 1.8.1
-      '@galaxy-tool-util/schema': 1.8.0
-      '@galaxy-tool-util/search': 1.8.1
+      '@galaxy-tool-util/connection-validation': 1.10.0
+      '@galaxy-tool-util/core': 1.10.0
+      '@galaxy-tool-util/schema': 1.10.0
+      '@galaxy-tool-util/search': 1.10.0
       ajv: 8.20.0
       commander: 14.0.3
       effect: 3.21.2
@@ -2065,14 +2065,21 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@galaxy-tool-util/connection-validation@1.8.0':
+  '@galaxy-tool-util/connection-validation@1.10.0':
     dependencies:
-      '@galaxy-tool-util/schema': 1.8.0
+      '@galaxy-tool-util/schema': 1.10.0
       '@galaxy-tool-util/workflow-graph': 1.2.0
 
-  '@galaxy-tool-util/core@1.8.1':
+  '@galaxy-tool-util/core@1.10.0':
     dependencies:
-      '@galaxy-tool-util/schema': 1.8.0
+      '@galaxy-tool-util/schema': 1.10.0
+      effect: 3.21.2
+      yaml: 2.8.3
+
+  '@galaxy-tool-util/schema@1.10.0':
+    dependencies:
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
       effect: 3.21.2
       yaml: 2.8.3
 
@@ -2083,17 +2090,10 @@ snapshots:
       effect: 3.21.2
       yaml: 2.8.3
 
-  '@galaxy-tool-util/schema@1.8.0':
+  '@galaxy-tool-util/search@1.10.0':
     dependencies:
-      ajv: 8.20.0
-      ajv-formats: 3.0.1(ajv@8.20.0)
-      effect: 3.21.2
-      yaml: 2.8.3
-
-  '@galaxy-tool-util/search@1.8.1':
-    dependencies:
-      '@galaxy-tool-util/core': 1.8.1
-      '@galaxy-tool-util/schema': 1.8.0
+      '@galaxy-tool-util/core': 1.10.0
+      '@galaxy-tool-util/schema': 1.10.0
 
   '@galaxy-tool-util/workflow-graph@1.2.0': {}
 

--- a/workflow-fixtures/scripts/build-iwc.sh
+++ b/workflow-fixtures/scripts/build-iwc.sh
@@ -34,8 +34,9 @@ if [ "${VERIFY:-0}" = "1" ]; then
   [ "$head" = "$sha" ] || { echo "!! HEAD $head != pinned $sha" >&2; exit 1; }
 fi
 
-# gxwf via npx (cached after first run). Pin to a major.
-GXWF=(npx --yes -p '@galaxy-tool-util/cli' gxwf)
+# gxwf from the workspace install, so the version tracks the pin in the repo
+# root package.json + pnpm-lock.yaml (bump there, run pnpm install, no edit here).
+GXWF=(pnpm exec gxwf)
 
 echo ">> cleaning workflows -> $cleaned"
 rm -rf "$cleaned"


### PR DESCRIPTION
## Why

`workflow-fixtures/scripts/build-iwc.sh` invoked `npx -p '@galaxy-tool-util/cli' gxwf` **with no version**, so the generated IWC format2 corpus tracked whatever gxwf `npx` happened to resolve at build time — not the version pinned in `package.json`. An old gxwf leaked non-canonical output into all 120 fixtures:

- a top-level `unique_tools:` block (an in-memory-only derived field — not part of on-disk gxformat2; current gxwf strips it on serialize), and
- unquoted YAML-1.1 word-scalars (`use_guide: no`, which PyYAML decodes to boolean `False` instead of the string `"no"`).

Current gxwf (1.8.2+) no longer emits either, so any re-serialization "changed" untouched regions — which shows up as spurious byte-stability churn for the update-in-place pipeline whose whole value prop is byte-stable untouched regions.

## What

- **`build-iwc.sh`**: `npx -p @galaxy-tool-util/cli gxwf` → `pnpm exec gxwf`. Fixture-gen now runs the workspace-installed gxwf, so it tracks the `package.json` + `pnpm-lock.yaml` pin. Future bumps are edit-the-pin + `pnpm install`; no script edit.
- **`package.json`**: `@galaxy-tool-util/cli` `^1.8.1` → `^1.10.0` (latest); lockfile updated.

`package.json` is now the single source of truth for the gxwf version.

## Verification

- `npm run test` — 145/145 pass on the bump.
- Regenerating `iwc-format2` with 1.10.0: `unique_tools` present in **120/120 → 0/120**; `use_guide` canonically quoted.
- `draft-extract` on a regenerated fixture is now a **byte-identical round-trip** (was dropping `unique_tools` / re-quoting before, purely because the on-disk fixture was stale).

## Follow-ups (not in this PR)

- `content/cli/gxwf/index.md` and `content/cli/galaxy-tool-cache/index.md` still pin `@1.8.1` in their `invoke_fallback` + prose (one line now falsely says it "tracks the `^1.8.1` devDependency"). These feed the runtime fallback baked into cast bundles — reconciling them means editing the notes → bump → recast the affected molds.
- The shared fixture mirror (`~/projects/repositories/workflow-fixtures`) is still on the old corpus; only local worktree fixtures were regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)