### PR TITLE
casts: regenerate three skills against updated schemas

### DIFF
--- a/casts/claude/skills/changeset-to-galaxy-test-plan/_provenance.json
+++ b/casts/claude/skills/changeset-to-galaxy-test-plan/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/changeset-to-galaxy-test-plan/index.md",
     "revision": 1,
     "content_hash": "8523a8cc48083cf6592561c3648d32ccb90c9a2f64f8dd11103a706f8e7e3f63",
-    "commit": "6c76f40e203225bae1f8f917376141e06edcfd6a"
+    "commit": "2e8ea5a6363235576bacfa5defd11492bbab6f94"
   },
-  "cast_at": "2026-07-09T17:24:35.445Z",
+  "cast_at": "2026-07-10T18:51:39.221Z",
   "refs": [
     {
       "kind": "research",
@@ -112,8 +112,8 @@
       "evidence": "cast-validated",
       "purpose": "Input contract: read the existing workflow's `tests[]` (the regression baseline) and its resolved input/output labels so baseline assertions bind to real labels.",
       "license": "MIT",
-      "src_hash": "bc083ab266392f2c6659cfc78d74364fb5552a3d262c9f274bfb487857895ee3",
-      "dst_hash": "bc083ab266392f2c6659cfc78d74364fb5552a3d262c9f274bfb487857895ee3",
+      "src_hash": "eba7da0be524490192852b1eef112e1ab2323b21e7d738c9fe8aec602c41b63f",
+      "dst_hash": "eba7da0be524490192852b1eef112e1ab2323b21e7d738c9fe8aec602c41b63f",
       "source": "deterministic"
     },
     {

--- a/casts/claude/skills/changeset-to-galaxy-test-plan/references/schemas/summary-galaxy-workflow.schema.json
+++ b/casts/claude/skills/changeset-to-galaxy-test-plan/references/schemas/summary-galaxy-workflow.schema.json
@@ -424,9 +424,9 @@
         },
         "out": {
           "type": "array",
-          "description": "Declared output names this step produces.",
+          "description": "Declared outputs this step produces, each with any gxformat2 post-job actions preserved verbatim so a downstream change-set can address a hidden/renamed/tagged output.",
           "items": {
-            "type": "string"
+            "$ref": "#/$defs/StepOutput"
           }
         },
         "when": {
@@ -483,6 +483,28 @@
             "null"
           ],
           "description": "Runtime/expression source preserved verbatim when present."
+        }
+      }
+    },
+    "StepOutput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "actions"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Declared output name this step produces; the anchor edits and workflow outputs address."
+        },
+        "actions": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true,
+          "description": "Verbatim gxformat2 post-job actions on this output (e.g. hide, rename, add_tags, remove_tags, change_datatype, delete_intermediate), preserved uninterpreted like tool_state. Null when the output carries no actions."
         }
       }
     },

--- a/casts/claude/skills/implement-galaxy-workflow-test/_provenance.json
+++ b/casts/claude/skills/implement-galaxy-workflow-test/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/implement-galaxy-workflow-test/index.md",
     "revision": 7,
     "content_hash": "7f68fe27b39a85abaf6c15f1647809b0d28c71753a7de463a52ffcd5e440f82a",
-    "commit": "7e21e08dee76406496df85fe6d41e5096879f55d"
+    "commit": "2e8ea5a6363235576bacfa5defd11492bbab6f94"
   },
-  "cast_at": "2026-07-01T23:45:59.070Z",
+  "cast_at": "2026-07-10T18:51:40.524Z",
   "refs": [
     {
       "kind": "cli-command",
@@ -126,8 +126,8 @@
       "purpose": "Input contract: read the schema-valid Galaxy test plan (job inputs, expected outputs, assertion intent, tolerances, label assumptions, unresolved mappings, omissions) and convert it into tests-format output, reconciling assumed labels and fixtures against the real draft.",
       "verification": "Consume a cast test plan from a *-test-to-galaxy-test-plan Mold and confirm tests-format output can be authored from it without re-reading the source summary.",
       "license": "MIT",
-      "src_hash": "7bf899c777cb2757cbde359e86c481ef4b1a35b6a8270ed9f678c461226fd96b",
-      "dst_hash": "7bf899c777cb2757cbde359e86c481ef4b1a35b6a8270ed9f678c461226fd96b",
+      "src_hash": "7378ea527dd18279bd0c2426ed189cb2975dff7948ba1fc98796ac5bc9ce6bc0",
+      "dst_hash": "7378ea527dd18279bd0c2426ed189cb2975dff7948ba1fc98796ac5bc9ce6bc0",
       "source": "deterministic"
     },
     {

--- a/casts/claude/skills/implement-galaxy-workflow-test/references/schemas/galaxy-workflow-test-plan.schema.json
+++ b/casts/claude/skills/implement-galaxy-workflow-test/references/schemas/galaxy-workflow-test-plan.schema.json
@@ -3,7 +3,7 @@
   "$id": "https://galaxyproject.org/foundry/schemas/galaxy-workflow-test-plan.schema.json",
   "$comment": "Canonical source: packages/foundry/src/schemas/galaxy-workflow-test-plan/galaxy-workflow-test-plan.schema.json in galaxyproject/foundry. Mold frontmatter cites this schema via [[galaxy-workflow-test-plan]] wiki-links; the cast pipeline imports the `galaxyWorkflowTestPlanSchema` runtime export and serializes it into cast bundles. The on-disk artifact is YAML; validate it with `foundry validate-galaxy-workflow-test-plan`.",
   "title": "Galaxy Workflow Test Plan",
-  "description": "Intermediate, reviewable Galaxy workflow test-plan handoff produced by a *-test-to-galaxy-test-plan Mold (nextflow, cwl, or freeform) and consumed by implement-galaxy-workflow-test. It preserves test intent, fixture provenance, assertion intent, tolerances, label assumptions, unresolved mappings, and intentional omissions before any concrete tests-format `*-tests.yml` is authored. It is NOT the final test artifact: assertion vocabulary is referenced by family name from the tests-format schema, not duplicated here.",
+  "description": "Intermediate, reviewable Galaxy workflow test-plan handoff produced by a *-test-to-galaxy-test-plan Mold (nextflow, cwl, freeform, or galaxy) and consumed by implement-galaxy-workflow-test. It preserves test intent, fixture provenance, assertion intent, tolerances, label assumptions, unresolved mappings, and intentional omissions before any concrete tests-format `*-tests.yml` is authored. It is NOT the final test artifact: assertion vocabulary is referenced by family name from the tests-format schema, not duplicated here.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -74,9 +74,10 @@
           "enum": [
             "nextflow",
             "cwl",
-            "freeform"
+            "freeform",
+            "galaxy"
           ],
-          "description": "Source family of the Galaxy-targeting translator that produced this plan."
+          "description": "Source family of the Galaxy-targeting translator that produced this plan. galaxy denotes a Galaxy→Galaxy update plan carried forward from an existing Galaxy workflow's own tests (the changeset-to-galaxy-test-plan case)."
         },
         "name": {
           "type": "string",

--- a/casts/claude/skills/interview-to-galaxy-workflow-changeset/_provenance.json
+++ b/casts/claude/skills/interview-to-galaxy-workflow-changeset/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/interview-to-galaxy-workflow-changeset/index.md",
     "revision": 1,
     "content_hash": "3d6d8fc9dd09c98125a3ab4c0f7ae5972e85b5afc1707e2922c2e4132d2871a3",
-    "commit": "e90a42769ba95218355e011fe62fb6daeaef28a7"
+    "commit": "2e8ea5a6363235576bacfa5defd11492bbab6f94"
   },
-  "cast_at": "2026-07-07T19:12:25.508Z",
+  "cast_at": "2026-07-10T18:51:37.939Z",
   "refs": [
     {
       "kind": "research",
@@ -36,8 +36,8 @@
       "evidence": "cast-validated",
       "purpose": "Input contract: read the existing-workflow summary to anchor every change-set entry to a real step/input/output.",
       "license": "MIT",
-      "src_hash": "bc083ab266392f2c6659cfc78d74364fb5552a3d262c9f274bfb487857895ee3",
-      "dst_hash": "bc083ab266392f2c6659cfc78d74364fb5552a3d262c9f274bfb487857895ee3",
+      "src_hash": "eba7da0be524490192852b1eef112e1ab2323b21e7d738c9fe8aec602c41b63f",
+      "dst_hash": "eba7da0be524490192852b1eef112e1ab2323b21e7d738c9fe8aec602c41b63f",
       "source": "deterministic"
     }
   ],

--- a/casts/claude/skills/interview-to-galaxy-workflow-changeset/references/schemas/summary-galaxy-workflow.schema.json
+++ b/casts/claude/skills/interview-to-galaxy-workflow-changeset/references/schemas/summary-galaxy-workflow.schema.json
@@ -424,9 +424,9 @@
         },
         "out": {
           "type": "array",
-          "description": "Declared output names this step produces.",
+          "description": "Declared outputs this step produces, each with any gxformat2 post-job actions preserved verbatim so a downstream change-set can address a hidden/renamed/tagged output.",
           "items": {
-            "type": "string"
+            "$ref": "#/$defs/StepOutput"
           }
         },
         "when": {
@@ -483,6 +483,28 @@
             "null"
           ],
           "description": "Runtime/expression source preserved verbatim when present."
+        }
+      }
+    },
+    "StepOutput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "actions"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Declared output name this step produces; the anchor edits and workflow outputs address."
+        },
+        "actions": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true,
+          "description": "Verbatim gxformat2 post-job actions on this output (e.g. hide, rename, add_tags, remove_tags, change_datatype, delete_intermediate), preserved uninterpreted like tool_state. Null when the output carries no actions."
         }
       }
     },


### PR DESCRIPTION
> [!NOTE]
> Opened by Claude (AI assistant) on behalf of @jmchilton.

Re-casts three skill bundles that drifted from their schema sources after recent commits landed the source changes without re-casting:

- **changeset-to-galaxy-test-plan**
- **implement-galaxy-workflow-test**
- **interview-to-galaxy-workflow-changeset**

They pick up:
- per-output post-job actions in `summary-galaxy-workflow` (`a0c1cf0`)
- `galaxy-workflow-test-plan` schema changes — `source.kind`, `derived_from` fix (`84f76f0`)

## Verification
- `foundry-build cast <mold> --check` → `clean: no drift, no errors` for all three (bundles are exactly the deterministic regeneration).
- `npm run validate` → 0 errors.

Generated-only change; no source or logic edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)