### PR TITLE
Add CC-BY-2.5, CC-BY-2.0, Artistic-2.0, GPL-2.0-or-later to license policy

### DIFF
--- a/license-policy.yml
+++ b/license-policy.yml
@@ -99,8 +99,42 @@ licenses:
     copyleft: false
     obligations: attribution (title/author/source/license/changes)
 
+  CC-BY-2.5:
+    name: CC BY 2.5
+    policy: verbatim-ok
+    allowed_modes: [verbatim, condense, sidecar]
+    license_file: true
+    copyleft: false
+    obligations: attribution (title/author/source/license/changes)
+
+  CC-BY-2.0:
+    name: CC BY 2.0
+    policy: verbatim-ok
+    allowed_modes: [verbatim, condense, sidecar]
+    license_file: true
+    copyleft: false
+    obligations: attribution (title/author/source/license/changes)
+
+  Artistic-2.0:
+    name: Artistic License 2.0
+    policy: verbatim-ok
+    allowed_modes: [verbatim, condense, sidecar]
+    license_file: true
+    copyleft: false
+    obligations: attribution + license notice; state changes to modified content
+
   GPL-2.0-only:
     name: GPL 2.0
+    policy: verbatim-ok
+    allowed_modes: [verbatim, sidecar]
+    license_file: true
+    copyleft: true
+    obligations: >-
+      notice + same-license + source availability; isolate in its own file, do
+      not blend into permissively-licensed prose
+
+  GPL-2.0-or-later:
+    name: GPL 2.0 or later
     policy: verbatim-ok
     allowed_modes: [verbatim, sidecar]
     license_file: true

--- a/meta_schema.yml
+++ b/meta_schema.yml
@@ -332,7 +332,11 @@ properties:
           - BSD-3-Clause
           - AFL-3.0
           - CC-BY-4.0
+          - CC-BY-2.5
+          - CC-BY-2.0
+          - Artistic-2.0
           - GPL-2.0-only
+          - GPL-2.0-or-later
           - GPL-3.0-only
           - LGPL-3.0-or-later
           - CC-BY-NC-SA-2.0


### PR DESCRIPTION
> **Posted by Claude (AI assistant) on behalf of @jmchilton — not authored by them personally.**

## Why

`license-policy.yml` is a hand-mirrored copy of the shared decision in galaxyproject/foundry-pattern#4, and the [statistical-genomics-foundry](https://github.com/jmchilton/statistical-genomics-foundry) instance keeps an identical copy. Sourcing a batch-design corpus over there hit four licenses the table doesn't carry:

| License | Sources that need it |
|---|---|
| `CC-BY-2.5` | PLOS 2007-era open-access articles |
| `CC-BY-2.0` | BMC 2012-era open-access articles |
| `Artistic-2.0` | Bioconductor package docs, vignettes, workflows |
| `GPL-2.0-or-later` | GPL-2+ package sources |

Absent from the table, each resolves to the `default` row — **own-words-only + `defect: true`** — which *forbids* carrying exactly the short load-bearing verbatim quotes those sources exist to supply. That is a false negative of the policy, not a real restriction: all four are permissive-or-attribution licenses that plainly allow attributed verbatim carry.

## What

- All four rows are `verbatim-ok` with `license_file: true`.
- **`Artistic-2.0`** — non-copyleft for our purposes. We carry *docs*, not linked code; the license's copyleft-ish conditions bind modified-package redistribution, which is not what a source note does. Obligations recorded as attribution + license notice + state changes.
- **`GPL-2.0-or-later`** — same posture as the existing `GPL-2.0-only` row: `[verbatim, sidecar]`, `copyleft: true`, **no own-words launder** (per the table's `own_words_not_copyleft_launder` global rule).
- **`meta_schema.yml`'s license enum is edited in lockstep** — `tests/license-policy.test.ts` asserts the enum and the table's SPDX ids stay identical, so the schema edit is required, not incidental.

## Cross-repo

Per the file's own header this is a **cross-repo change**. The statistical-genomics-foundry copy is updated to match in the same work; its `GPL-2.0-or-later` row was reordered to sit beside `GPL-2.0-only` so the two files are now **byte-identical apart from each naming the other** in the header. foundry-pattern#4 open question 4 still tracks the eventual shared-package/sync mechanism — until then, by hand.

## Testing

- `npx vitest run tests/license-policy.test.ts` → **5 passed** (incl. the enum-lockstep test, which fails without the `meta_schema.yml` edit).
- `npm run validate` → **224 files, 0 errors** (194 pre-existing warnings).
- `npm test` → **143 tests passed**. One *suite* (`tests/cli-registry.test.ts`) fails to collect in a fresh worktree without `site/` deps installed — verified identical on a clean checkout with these changes stashed, so it is pre-existing and unrelated.

No LICENSES/ files are added here: this repo vendors license text per-*source* (`galaxy.LICENSE`), and no Foundry note redistributes content under these four licenses yet. The rows are policy, ready when one does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)