### PR TITLE
Add CC0-1.0, CC-BY-3.0, and CC-BY-NC* rows to the license policy

### DIFF
--- a/license-policy.yml
+++ b/license-policy.yml
@@ -91,8 +91,27 @@ licenses:
     copyleft: false
     obligations: attribution + notice
 
+  CC0-1.0:
+    name: CC0 1.0 (public domain dedication)
+    policy: verbatim-ok
+    allowed_modes: [verbatim, condense, sidecar]
+    license_file: true
+    copyleft: false
+    obligations: >-
+      none legally — public-domain dedication, no attribution or notice term. The
+      CC0 legalcode is still vendored on verbatim carry (uniform with every other
+      verbatim-ok row; license_file_tracks_verbatim); a citation is kept as courtesy
+
   CC-BY-4.0:
     name: CC BY 4.0
+    policy: verbatim-ok
+    allowed_modes: [verbatim, condense, sidecar]
+    license_file: true
+    copyleft: false
+    obligations: attribution (title/author/source/license/changes)
+
+  CC-BY-3.0:
+    name: CC BY 3.0
     policy: verbatim-ok
     allowed_modes: [verbatim, condense, sidecar]
     license_file: true
@@ -170,6 +189,56 @@ licenses:
     obligations: >-
       attribution + citation; verbatim carry avoided so NC + share-alike do not
       propagate into the KB
+
+  # CC BY-NC* family (any version): the license PERMITS non-commercial verbatim
+  # reproduction, but the NC condition travels with the text — a cast that embeds
+  # NC prose becomes an NC-encumbered cast, unusable commercially. We take
+  # own-words instead (functional strings stay verbatim as facts, per global
+  # rules). Same reasoning the CC-BY-NC-SA-2.0 row already applies to NC.
+  # ND ("NoDerivatives") is treated identically: a summary is itself a derivative,
+  # so short quotation rides on the quotation right (outside the license) — no
+  # reason to carry NC-encumbered prose.
+  CC-BY-NC-4.0:
+    name: CC BY-NC 4.0
+    policy: own-words-only
+    allowed_modes: [condense]
+    license_file: false
+    copyleft: false
+    obligations: attribution + citation; NC condition kept out of casts (own-words)
+
+  CC-BY-NC-3.0:
+    name: CC BY-NC 3.0
+    policy: own-words-only
+    allowed_modes: [condense]
+    license_file: false
+    copyleft: false
+    obligations: attribution + citation; NC condition kept out of casts (own-words)
+
+  CC-BY-NC-2.5:
+    name: CC BY-NC 2.5
+    policy: own-words-only
+    allowed_modes: [condense]
+    license_file: false
+    copyleft: false
+    obligations: attribution + citation; NC condition kept out of casts (own-words)
+
+  CC-BY-NC-2.0-UK:
+    name: CC BY-NC 2.0 England & Wales
+    policy: own-words-only
+    allowed_modes: [condense]
+    license_file: false
+    copyleft: false
+    obligations: attribution + citation; NC condition kept out of casts (own-words)
+
+  CC-BY-NC-ND-4.0:
+    name: CC BY-NC-ND 4.0
+    policy: own-words-only
+    allowed_modes: [condense]
+    license_file: false
+    copyleft: false
+    obligations: >-
+      attribution + citation; NC + ND kept out of casts (own-words). A summary is
+      a derivative, so no verbatim prose is carried under the ND term.
 
   LicenseRef-arXiv-nonexclusive-distrib-1.0:
     name: arXiv non-exclusive distribution 1.0

--- a/meta_schema.yml
+++ b/meta_schema.yml
@@ -331,7 +331,9 @@ properties:
           - BSD-2-Clause
           - BSD-3-Clause
           - AFL-3.0
+          - CC0-1.0
           - CC-BY-4.0
+          - CC-BY-3.0
           - CC-BY-2.5
           - CC-BY-2.0
           - Artistic-2.0
@@ -340,6 +342,11 @@ properties:
           - GPL-3.0-only
           - LGPL-3.0-or-later
           - CC-BY-NC-SA-2.0
+          - CC-BY-NC-4.0
+          - CC-BY-NC-3.0
+          - CC-BY-NC-2.5
+          - CC-BY-NC-2.0-UK
+          - CC-BY-NC-ND-4.0
       - pattern: "^LicenseRef-[A-Za-z0-9.-]+$"
     description: "SPDX license identifier (or LicenseRef-<slug>) for the note's vendored content, resolved against license-policy.yml. The Foundry's own content is covered by the root LICENSE; this field annotates third-party redistributions."
   # Repo-relative path to the upstream LICENSE under LICENSES/. The validator


### PR DESCRIPTION
> **Opened by Claude (AI assistant) on behalf of @jmchilton — not authored by them personally.**

Mirrors the `statistical-genomics-foundry` instance of the shared license → redistribution-policy table (source of truth foundry-pattern#4). That instance's source corpus turned up notes whose `license` ids resolved to the default/defect row; this adds the missing rows so both copies stay identical.

## Rows added
- **CC0-1.0**, **CC-BY-3.0** → `verbatim-ok`. CC0 is a public-domain dedication with no legal notice obligation, but the CC0 legalcode is still vendored on verbatim carry to stay uniform with every other `verbatim-ok` row and with the `license_file_tracks_verbatim` global rule (and to satisfy the `verbatim-ok ⇒ license_file: true` invariant in `tests/license-policy.test.ts`).
- **CC-BY-NC-4.0 / 3.0 / 2.5 / 2.0-UK**, **CC-BY-NC-ND-4.0** → `own-words-only`. These licenses *permit* non-commercial verbatim reproduction, but the NC condition travels with the text — a cast that embeds NC prose becomes an NC-encumbered cast, unusable commercially. This applies the same reasoning the existing `CC-BY-NC-SA-2.0` row already documents; ND is treated identically (a summary is itself a derivative, so short quotation rides on the quotation right, outside the license).

## Lockstep
`meta_schema.yml`'s `license` enum is extended with the same 7 ids. `tests/license-policy.test.ts` passes (5/5).

Pre-existing unrelated failures in `cast-mold` / CLI tests reproduce on `main` with these changes stashed (tsx/build-order environment fragility); they do not touch the license policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)