### PR TITLE
Add test-data-resolution to nextflow/cwl-to-galaxy with source-specific resolvers (#348)

### DIFF
--- a/casts/claude/skills/cwl-to-test-data/SKILL.md
+++ b/casts/claude/skills/cwl-to-test-data/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: cwl-to-test-data
+description: "Resolve a CWL workflow's own declared test cases into Galaxy workflow test-data refs."
+---
+
+# cwl-to-test-data
+
+Follow the procedure below and use the artifact/reference sections as the runtime contract.
+
+## When To Use
+
+- Resolve a CWL workflow's own declared test cases into Galaxy workflow test-data refs.
+
+## Inputs
+
+- Read artifact `summary-cwl`. Schema: summary-cwl. Produced by `summarize-cwl`. Structured CWL summary from summarize-cwl; carries the source's test cases (`tests[]`) — each a `job_path` (a CWL job file naming the test inputs) plus `expected_outputs`.
+- Read artifact `cwl-galaxy-interface`. Produced by `cwl-summary-to-galaxy-interface`. Galaxy interface brief from cwl-summary-to-galaxy-interface pinning the workflow input labels, collection shapes, and datatypes each resolved fixture must map onto.
+
+## Outputs
+
+- Write artifact `test-data-refs` as `test-data-refs.json`. Format: `json`. Test data resolved from the CWL source's declared test cases, expressed as URLs/paths plus expected shapes for downstream test authoring. Shared id with find-test-data — the branch's search fallback fills only the inputs this Mold leaves unresolved.
+
+## Required Tools
+
+- None declared. Procedure should not assume external CLIs are present.
+
+## Load Upfront
+
+- `references/schemas/summary-cwl.schema.json`: Schema file copied verbatim into the bundle. Input contract: read `tests[]` — each case's `job_path` inputs and `expected_outputs` — as the declared source of test data.
+
+## Load On Demand
+
+- `references/notes/component-cwl-workflow-anatomy.md`: Research note copied verbatim into the bundle. Interpret a CWL job file's input objects (File/Directory, secondaryFiles, arrays, inline literals) before mapping them onto Galaxy inputs. Use when: reading a `job_path`'s declared inputs to decide their Galaxy shape.
+- `references/notes/galaxy-workflow-testability-design.md`: Research note copied verbatim into the bundle. Map each declared job input to an addressable Galaxy input label and the collection shape it must populate. Use when: mapping a CWL File-array or secondaryFiles input onto a Galaxy collection shape.
+- `references/notes/iwc-test-data-conventions.md`: Research note copied verbatim into the bundle. Express each ref remote-URL-first with SHA-1 integrity and per-input collection layout when recording resolved fixtures. Use when: writing each `test-data-refs` entry.
+
+## Validation
+
+- None declared.
+
+## Procedure
+
+Resolve the CWL workflow's own declared test cases into Galaxy `test-data-refs`. The CWL summary carries the source's test cases (`tests[]`) — each a `job_path` (a CWL job file naming the test inputs) plus `expected_outputs`. Read the declared inputs and map them onto the Galaxy workflow's inputs, emitting one ref per input, ready for implement-galaxy-workflow-test to stage.
+
+This skill is the source-specific first leg of the harness's `test-data-resolution` branch. It resolves what the CWL source itself declares; any input it cannot resolve from a declared test case stays a reported gap and the harness falls through to find-test-data (search), then to `user-supplied`. Deciding to fall through is a harness concern, not this skill's — its job is an honest map of the source's own test cases.
+
+### Sequence
+
+1. **Enumerate Galaxy inputs and their required shape.** From the interface brief, list each workflow input: label, Galaxy collection shape (File / list / paired / list:paired / record), and datatype. This is the *target shape* every ref must satisfy.
+2. **Read the declared test cases.** From the summary's `tests[]`, read each case's `job_path` inputs — File/Directory objects with their `location`/`path`, `secondaryFiles`, arrays, and inline literals — plus `expected_outputs`. Prefer the case whose inputs best cover the workflow's inputs.
+3. **Map each declared input onto a Galaxy input.** Match by id and shape onto the interface's input labels. A CWL File array maps to a Galaxy list; a File carrying `secondaryFiles` may map to a record or composite datatype — record element identifiers and any prep needed to reach the Galaxy collection shape (galaxy-workflow-testability-design).
+4. **Emit refs.** Write one `test-data-refs.json` entry per resolved input: prefer a remote `location` URL when the job references one (remote-URL-first, iwc-test-data-conventions); fall back to the in-tree `path` plus provenance only when no URL is published. Carry datatype, collection element identifiers, and any subset/split prep. Each entry maps to an addressable workflow input label.
+5. **Report genuine gaps.** An input with no declared test-case input of the right shape stays `resolved: false` with a reason — this is what the harness hands to find-test-data. Do not search public sources here; searching is find-test-data's job, not this skill's.
+
+### No fabrication
+
+Never invent a URL, accession, or path, and never emit a placeholder for an input you could not resolve from a declared test case. A declared input with no published URL is recorded by its in-tree `path` plus provenance, not papered over with a guessed URL. Every emitted ref points at data the source actually declares; everything else is an honest gap for the next leg of the branch.
+
+## Runtime Notes
+
+- Do not read Foundry source files at runtime; use only files packaged in this skill bundle and user-supplied artifacts.
+- Preserve declared artifact filenames unless the user or harness supplies explicit paths.
+- Carry unresolved assumptions into the output artifact instead of silently inventing missing source evidence.

--- a/casts/claude/skills/cwl-to-test-data/_provenance.json
+++ b/casts/claude/skills/cwl-to-test-data/_provenance.json
@@ -1,0 +1,101 @@
+{
+  "provenance_schema_version": 3,
+  "cast_target": "claude",
+  "mold": {
+    "name": "cwl-to-test-data",
+    "path": "content/molds/cwl-to-test-data/index.md",
+    "revision": 1,
+    "content_hash": "7db8792d2766ea34a221a86b22f17a3e3bd167118c8e0e380d738935d639a791",
+    "commit": "c29a96b7c4d124bdad3c081ae5ece79a3d03cf22"
+  },
+  "cast_at": "2026-07-17T23:04:07.740Z",
+  "refs": [
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[component-cwl-workflow-anatomy]]",
+      "src": "content/research/component-cwl-workflow-anatomy.md",
+      "dst": "references/notes/component-cwl-workflow-anatomy.md",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Interpret a CWL job file's input objects (File/Directory, secondaryFiles, arrays, inline literals) before mapping them onto Galaxy inputs.",
+      "trigger": "When reading a `job_path`'s declared inputs to decide their Galaxy shape.",
+      "src_hash": "3322ec34115f2d12f0a72c2b9fb1fa33a06aaa6a0d004653310306f40e741f2d",
+      "dst_hash": "3322ec34115f2d12f0a72c2b9fb1fa33a06aaa6a0d004653310306f40e741f2d",
+      "source": "deterministic"
+    },
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[galaxy-workflow-testability-design]]",
+      "src": "content/research/galaxy-workflow-testability-design.md",
+      "dst": "references/notes/galaxy-workflow-testability-design.md",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Map each declared job input to an addressable Galaxy input label and the collection shape it must populate.",
+      "trigger": "When mapping a CWL File-array or secondaryFiles input onto a Galaxy collection shape.",
+      "src_hash": "e4d5991a5085e0f9ad52b8e6856f64179362334bd51b77a3302faeb96732f980",
+      "dst_hash": "e4d5991a5085e0f9ad52b8e6856f64179362334bd51b77a3302faeb96732f980",
+      "source": "deterministic"
+    },
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[iwc-test-data-conventions]]",
+      "src": "content/research/iwc-test-data-conventions.md",
+      "dst": "references/notes/iwc-test-data-conventions.md",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Express each ref remote-URL-first with SHA-1 integrity and per-input collection layout when recording resolved fixtures.",
+      "trigger": "When writing each `test-data-refs` entry.",
+      "src_hash": "2c7ef6a674b84f434ed973fe5c93156a6b368fc774a432e828257ddbde5d4993",
+      "dst_hash": "2c7ef6a674b84f434ed973fe5c93156a6b368fc774a432e828257ddbde5d4993",
+      "source": "deterministic"
+    },
+    {
+      "kind": "schema",
+      "mode": "verbatim",
+      "ref": "[[summary-cwl]]",
+      "src": "package://@galaxy-foundry/foundry#summaryCwlSchema",
+      "dst": "references/schemas/summary-cwl.schema.json",
+      "used_at": "runtime",
+      "load": "upfront",
+      "evidence": "corpus-observed",
+      "purpose": "Input contract: read `tests[]` — each case's `job_path` inputs and `expected_outputs` — as the declared source of test data.",
+      "license": "MIT",
+      "src_hash": "0bb5e164d5a7328481dc6ca1225f90666c758603566427512838bf565413c4e0",
+      "dst_hash": "0bb5e164d5a7328481dc6ca1225f90666c758603566427512838bf565413c4e0",
+      "source": "deterministic"
+    }
+  ],
+  "artifacts": {
+    "produces": [
+      {
+        "id": "test-data-refs",
+        "kind": "json",
+        "default_filename": "test-data-refs.json",
+        "description": "Test data resolved from the CWL source's declared test cases, expressed as URLs/paths plus expected shapes for downstream test authoring. Shared id with [[find-test-data]] — the branch's search fallback fills only the inputs this Mold leaves unresolved."
+      }
+    ],
+    "consumes": [
+      {
+        "id": "summary-cwl",
+        "description": "Structured CWL summary from [[summarize-cwl]]; carries the source's test cases (`tests[]`) — each a `job_path` (a CWL job file naming the test inputs) plus `expected_outputs`.",
+        "inherited_schema": "[[summary-cwl]]",
+        "producers": [
+          "summarize-cwl"
+        ]
+      },
+      {
+        "id": "cwl-galaxy-interface",
+        "description": "Galaxy interface brief from [[cwl-summary-to-galaxy-interface]] pinning the workflow input labels, collection shapes, and datatypes each resolved fixture must map onto.",
+        "producers": [
+          "cwl-summary-to-galaxy-interface"
+        ]
+      }
+    ]
+  }
+}

--- a/casts/claude/skills/cwl-to-test-data/_verify.json
+++ b/casts/claude/skills/cwl-to-test-data/_verify.json
@@ -1,0 +1,17 @@
+{
+  "verify_schema_version": 1,
+  "entries": [
+    {
+      "artifact_id": "summary-cwl",
+      "direction": "input",
+      "kind": "json",
+      "default_filename": "summary-cwl.json",
+      "schema": "[[summary-cwl]]",
+      "validator_bin": "foundry",
+      "args": [
+        "validate-summary-cwl",
+        "{artifact_path}"
+      ]
+    }
+  ]
+}

--- a/casts/claude/skills/cwl-to-test-data/references/notes/component-cwl-workflow-anatomy.md
+++ b/casts/claude/skills/cwl-to-test-data/references/notes/component-cwl-workflow-anatomy.md
@@ -1,0 +1,95 @@
+---
+type: research
+subtype: component
+title: "CWL workflow anatomy"
+tags:
+  - research/component
+  - source/cwl
+status: draft
+created: 2026-05-10
+revised: 2026-05-10
+revision: 1
+ai_generated: true
+related_notes:
+  - "[[summary-cwl]]"
+  - "[[cwl-v1.2-schemas]]"
+  - "[[galaxy-collection-semantics]]"
+related_molds:
+  - "[[summarize-cwl]]"
+  - "[[cwl-summary-to-galaxy-interface]]"
+  - "[[cwl-summary-to-galaxy-data-flow]]"
+  - "[[cwl-summary-to-galaxy-template]]"
+sources:
+  - "https://www.commonwl.org/v1.2/Workflow.html"
+  - "https://cwltool.readthedocs.io/en/stable/"
+  - "https://github.com/common-workflow-language/cwl-utils#normalize-a-cwl-document"
+  - "https://pypi.org/project/cwl-utils/"
+  - "https://github.com/common-workflow-language/cwldep"
+summary: "CWL structure relevant to summarize-cwl: normalized documents, steps, scatter, conditionals, requirements, and dependency handling."
+---
+
+# CWL Workflow Anatomy
+
+CWL is a structured workflow language, not a pipeline framework that must be inferred from ecosystem conventions. The `summarize-cwl` Mold should therefore start from CWL's own validated object model and avoid recreating the heavy Nextflow extraction stack.
+
+## Normalization Posture
+
+Use `cwltool --validate` as the first gate. If validation fails, the summary should emit provenance plus validation diagnostics and stop before producing downstream-looking graph claims.
+
+Use `cwl-normalizer` from `cwl-utils` as the default normalization surface. The cwl-utils README describes it as producing JSON CWL documents with dependencies packed together, upgrading to CWL v1.2 as needed, and optionally refactoring CWL expressions into separate steps. This is the right handoff for `summarize-cwl`: structured enough for extraction, still source-faithful, and not a Galaxy design.
+
+Use `cwl-utils` for structured extraction when implementing the cast skill: it is a maintained CWL utility package with command and Python-library surfaces for loading CWL documents, normalizing them, inspecting Docker requirements, and citation/provenance metadata.
+
+Treat `cwldep` as optional research for dependency import workflows, not the default normalizer. It can add, install, check, and update workflow dependencies, but `cwl-normalizer` plus direct document resolution is the narrower operation needed for v1.
+
+## Objects To Preserve
+
+Preserve these CWL concepts directly in [[summary-cwl]]:
+
+- `Workflow` inputs and outputs, including type expressions, `format`, `secondaryFiles`, defaults, labels, and docs.
+- `WorkflowStep` ids, `run` targets, input source wiring, output ids, `scatter`, `scatterMethod`, `when`, requirements, and hints.
+- `CommandLineTool` command surfaces: `baseCommand`, `arguments`, inputs, outputs, input/output bindings, and requirement blocks.
+- `DockerRequirement` and `SoftwareRequirement`. Capture the raw requirement object and a few easy fields (`dockerPull`, `dockerImageId`, package names/versions), but do not solve packages into Galaxy wrappers here.
+- `ExpressionTool`, `Operation`, nested `Workflow`, and extension-heavy steps as graph nodes with warnings when they are likely to affect Galaxy translation.
+
+## Graph Edges
+
+The CWL graph can be derived mechanically:
+
+- Workflow input to step input: each `WorkflowStepInput.source` pointing at a workflow input.
+- Step output to step input: each `source` pointing at `<step>/<output>`.
+- Step output to workflow output: each `WorkflowOutputParameter.outputSource`.
+
+Add `via` markers when an edge crosses a shape-affecting feature:
+
+- `scatter` when the consuming step scatters over that input.
+- `linkMerge` when multiple sources are merged.
+- `pickValue` when nullable or multi-source selection is declared.
+- `valueFrom` when an expression rewrites the value.
+- `secondaryFiles` when sidecar files are part of the value contract.
+
+Do not try to execute `valueFrom` or JavaScript expressions. Preserve them verbatim and mark the edge lower confidence for Galaxy translation.
+
+## Galaxy-Relevant Shape Signals
+
+CWL arrays are the main signal for Galaxy collections. `File[]` and scattered `File` inputs often map to Galaxy `list`; nested arrays may imply `list:list` or a review question. Records may map to Galaxy sample-sheet-like structures only when fields describe repeated per-sample metadata plus data files; otherwise keep them as workflow-level parameter grouping notes.
+
+`secondaryFiles` are not ordinary extra workflow outputs. They often mean Galaxy should preserve paired sidecars such as BAM/BAI, FASTA/FAI, VCF/TBI, or index directories through tool-step outputs and tests.
+
+`Directory` is a review trigger. Galaxy can move directories through some tools, but many IWC-style workflows prefer explicit files or collections. Keep `Directory` visible in summaries and downstream interface briefs rather than flattening it.
+
+## Tests
+
+CWL job files are good test-plan seeds when they are supplied by the user, live beside the workflow by convention, or are named in an external runner configuration. The summarizer should not invent expected outputs. It can record job inputs and expected-output files/checksums only when they are present in a discoverable test description.
+
+## Boundaries
+
+`summarize-cwl` owns validation, normalization, graph enumeration, command/tool surface extraction, requirement capture, and warnings.
+
+Downstream molds own:
+
+- Galaxy interface choices from CWL types and docs.
+- Galaxy collection and scatter/map-over semantics.
+- IWC exemplar comparison.
+- gxformat2 skeleton authoring.
+- Tool Shed discovery or new Galaxy wrapper authoring.

--- a/casts/claude/skills/cwl-to-test-data/references/notes/galaxy-workflow-testability-design.md
+++ b/casts/claude/skills/cwl-to-test-data/references/notes/galaxy-workflow-testability-design.md
@@ -1,0 +1,139 @@
+---
+type: research
+subtype: component
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-05-03
+revised: 2026-05-06
+revision: 2
+ai_generated: true
+related_notes:
+  - "[[iwc-workflow-testability-survey]]"
+  - "[[iwc-test-data-conventions]]"
+  - "[[planemo-asserts-idioms]]"
+  - "[[iwc-shortcuts-anti-patterns]]"
+  - "[[planemo-workflow-test-architecture]]"
+  - "[[implement-galaxy-workflow-test]]"
+  - "[[gxformat2-schema]]"
+  - "[[gxformat2-workflow-inputs]]"
+  - "[[galaxy-datatypes-conf]]"
+summary: "Design guidance for Galaxy workflow inputs, outputs, and checkpoints that make IWC-style workflow tests possible."
+---
+
+# Galaxy workflow testability design
+
+Use this note when authoring or translating a Galaxy workflow **before** the `-tests.yml` file exists. It covers workflow structure choices that make later IWC-style tests meaningful: labels, promoted checkpoints, collection identifiers, and fixture-compatible inputs.
+
+This is not a `content/patterns/` page. It is cross-cutting design guidance for Molds that need testable Galaxy workflows. Assertion syntax lives in [[planemo-asserts-idioms]]. Test YAML fixture shapes live in [[iwc-test-data-conventions]]. Accepted shortcut vs smell calls live in [[iwc-shortcuts-anti-patterns]]. Corpus evidence trail lives in [[iwc-workflow-testability-survey]].
+
+## 1. Treat labels as API
+
+Workflow input and output labels are not cosmetic. Planemo and IWC tests address workflow inputs and outputs by label, and the survey found exact label matches for every asserted output across 114 matched workflow/test pairs. A generated workflow should therefore pick stable, descriptive labels before test authoring starts.
+
+Rules:
+
+- Label every output that may need a test assertion.
+- Treat input/output renames as breaking changes requiring sibling `-tests.yml` updates.
+- Prefer stable domain names over tool-step defaults or positional names.
+- Do not rely on unlabeled or positional outputs for tests.
+
+Evidence:
+
+- Scanpy exposes outputs such as `Initial Anndata General Info`, `UMAP of louvain`, `Ranked genes with Wilcoxon test`, and `Dotplot of top genes on clusters` (`$IWC_FORMAT2/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy.gxwf.yml:105-147`). The sibling test keys assertions by those exact labels (`$IWC/workflows/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml:27-205`).
+- VGP scaffolding uses punctuation-heavy labels such as `Hi-C duplication stats on scaffolds: Raw`, `Hi-C duplication stats on scaffolds: MultiQc`, and `Merged Alignment stats` (`$IWC_FORMAT2/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8.gxwf.yml:170-196`). The test asserts those exact labels (`$IWC/workflows/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8-tests.yml:218-245`).
+
+## 2. Promote assertable checkpoints
+
+IWC workflow tests assert workflow-level outputs. Intermediate step results are invisible unless promoted to top-level workflow outputs. When final reports are weakly assertable, expose intermediate checkpoints that carry deterministic content or structure.
+
+Rules:
+
+- Promote intermediate outputs when they are the best deterministic or structural checkpoint.
+- Prefer a checkpoint table/text/HDF5 object that can prove content over a final plot/report that can only prove existence.
+- Accept some output-list clutter when it buys meaningful tests.
+- Do not promote every intermediate by default; expose checkpoints that map to concrete assertion intent.
+
+Evidence:
+
+- Scanpy exposes 21 workflow outputs and the sibling test asserts all 21. These include initial AnnData summaries, intermediate plots, ranked-gene tables, final AnnData, cluster-count tables, and final plots (`$IWC_FORMAT2/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy.gxwf.yml:105-147`; `$IWC/workflows/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml:27-205`).
+- RNA-seq paired-end exposes mapped reads, stranded/unstranded coverage, abundance estimates, expression tables, counts tables, and MultiQC reports (`$IWC_FORMAT2/transcriptomics/rnaseq-pe/rnaseq-pe.gxwf.yml:90-112`). The sibling test asserts sizes for coverage/read outputs and stronger regex/line checks for expression/count outputs (`$IWC/workflows/transcriptomics/rnaseq-pe/rnaseq-pe-tests.yml:48-97`).
+- MGnify complete exposes 83 workflow outputs; 38 are asserted in the sibling test, including MultiQC reports, FASTA collections, taxonomic classifications, OTU tables, and HDF5/JSON outputs (`$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/mgnify-amplicon-pipeline-v5-complete.gxwf.yml:163-329`; `$IWC/workflows/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/mgnify-amplicon-pipeline-v5-complete-tests.yml:15-120`).
+
+## 3. Stabilize collection output identifiers
+
+Collection tests key assertions by element identifier. If a workflow emits collections with unstable or opaque identifiers, the test cannot target elements cleanly.
+
+Rules:
+
+- Preserve biologically or sample-meaningful identifiers through map-over and collection reshaping.
+- When generating or relabeling collections, make the identifier derivation deterministic and visible in workflow structure.
+- For nested collections, ensure each axis has predictable identifiers.
+- Quote special identifiers in tests when YAML requires it, but do not simplify identifiers merely for YAML convenience.
+
+Evidence:
+
+- 59 of 115 IWC test files use `element_tests:`, with 227 `element_tests:` blocks in the corpus survey.
+- 10x CellPlex tests nested collection outputs by `subsample`, then inner `matrix`, `barcodes`, and `genes` elements (`$IWC/workflows/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:82-128`). The workflow exposes the corresponding collection outputs (`$IWC_FORMAT2/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex.gxwf.yml:73-91`).
+- HyPhy collection outputs are tested by generated gene identifiers such as `NC_001477.1|capsid_protein_C|95-394_DENV1` (`$IWC/workflows/comparative_genomics/hyphy/hyphy-core-tests.yml:31-71`). The workflow exposes collection outputs for MEME, PRIME, BUSTED, and FEL (`$IWC_FORMAT2/comparative_genomics/hyphy/hyphy-core.gxwf.yml:26-38`).
+
+## 4. Choose checkpoints by assertion strength
+
+Assertion choice is not only a test-file decision. It should feed back into workflow output design. If the only exposed output is a stochastic plot or binary file, the best possible test may be a weak size check. Exposing a sibling table, report, HDF5 structure, or summary line can make the same workflow much more testable.
+
+Rules:
+
+- For image-heavy workflows, expose data or summary outputs behind the plot when possible.
+- For stochastic statistical outputs, expose structural checkpoints and stable summary tokens.
+- For binary outputs, expose a text/table report or stats file when the tool can produce one.
+- Use [[planemo-asserts-idioms]] to select the assertion family after choosing the checkpoint.
+
+Evidence:
+
+- Scanpy image outputs are mostly smoke-tested with `has_size`, `has_image_width`, and `has_image_height`, but the same workflow also exposes AnnData HDF5 keys and cluster-count table checks (`$IWC/workflows/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml:33-205`).
+- RNA-seq paired-end pairs coarse size checks for coverage/mapped-read outputs with stronger regex and exact-line checks for expression/count tables (`$IWC/workflows/transcriptomics/rnaseq-pe/rnaseq-pe-tests.yml:48-97`).
+- VGP scaffolding tests combine stable text checks for scaffold/report stats with size checks for map/alignment artifacts (`$IWC/workflows/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8-tests.yml:173-245`).
+
+## 5. Design inputs with fixtures in mind
+
+Workflow input labels and types constrain the eventual `job:` block. Fixture planning is not only a test-file activity: it should influence whether the workflow exposes a file input, a collection input, a string data-table input, or a typed parameter.
+
+Rules:
+
+- Choose input labels that will be readable as test `job:` keys.
+- Match workflow input collection types to realistic fixture shapes.
+- Decide early whether reference data should be a portable remote file or a CVMFS/data-table string.
+- Keep typed parameters explicit when tests need to set them (`int`, `boolean`, `string`) rather than burying them in step defaults.
+
+Evidence:
+
+- 10x CellPlex job inputs include `fastq PE collection GEX`, `reference genome`, `gtf`, `cellranger_barcodes_3M-february-2018.txt`, `fastq PE collection CMO`, `sample name and CMO sequence collection`, and `Number of expected cells` (`$IWC/workflows/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:2-75`). The workflow declares matching collection, data, string, boolean, and int inputs (`$IWC_FORMAT2/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex.gxwf.yml:4-72`).
+- HyPhy accepts a `list` collection of unaligned sequences and preserves accession-like fixture identifiers through to output element assertions (`$IWC/workflows/comparative_genomics/hyphy/hyphy-core-tests.yml:7-30`; `$IWC_FORMAT2/comparative_genomics/hyphy/hyphy-core.gxwf.yml:14-25`).
+
+## 6. Know what a gxformat2 output entry contains
+
+Top-level gxformat2 `outputs:` is the public workflow-output surface. It is separate from per-step `out:` declarations and from step post-job actions such as `change_datatype` or `rename`.
+
+Authoring rules:
+
+- Use `label` as the stable public name tests and users will address.
+- Use `outputSource` to point at the producing step output; do not rely on positional output order.
+- Use `doc` for short user-facing context when the label is not self-explanatory.
+- Keep `type` aligned with the exposed value (`data`, `collection`, or scalar vocabulary from [[gxformat2-workflow-inputs]]) when the schema needs it.
+- Apply `change_datatype` at the producing step output when Galaxy needs a stronger datatype than the tool reports; choose values from [[galaxy-datatypes-conf]].
+- Use `rename` only for generated dataset names inside Galaxy histories. It is not a substitute for stable workflow-output `label`.
+- Treat `add_tags` and `remove_tags` as metadata helpers, not as the test API. IWC tests key by labels and collection element identifiers, not tags.
+- Avoid `hide` or `delete_intermediate_datasets` on outputs that are promoted as test checkpoints.
+
+Design inference: a workflow-output promotion decision should pick both the public `outputs:` entry and any producer-side post-job action needed to make that output useful. For example, a synthesized BED checkpoint needs a stable output `label` plus a producer-side `change_datatype: bed`; one without the other is incomplete for a testable workflow.
+
+## Cross-references
+
+- [[iwc-workflow-testability-survey]] — corpus survey and distribution rationale.
+- [[iwc-test-data-conventions]] — job/input YAML shapes, remote fixtures, hashes, collection fixture syntax.
+- [[planemo-asserts-idioms]] — assertion-family choice after an output is exposed.
+- [[iwc-shortcuts-anti-patterns]] — accepted shortcut vs smell calls for weak assertions and label coupling.
+- [[planemo-workflow-test-architecture]] — Planemo execution, output-problem ambiguity, and structured artifacts.
+- [[gxformat2-schema]] — structural vocabulary for top-level workflow outputs and step post-job actions.
+- [[galaxy-datatypes-conf]] — valid Galaxy datatype extensions for `format` and `change_datatype` choices.

--- a/casts/claude/skills/cwl-to-test-data/references/notes/iwc-test-data-conventions.md
+++ b/casts/claude/skills/cwl-to-test-data/references/notes/iwc-test-data-conventions.md
@@ -1,0 +1,311 @@
+---
+type: research
+subtype: component
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-04-30
+revised: 2026-05-03
+revision: 3
+ai_generated: true
+related_notes:
+  - "[[galaxy-workflow-testability-design]]"
+  - "[[iwc-shortcuts-anti-patterns]]"
+  - "[[planemo-asserts-idioms]]"
+  - "[[implement-galaxy-workflow-test]]"
+  - "[[tests-format]]"
+  - "[[iwc-tabular-operations-survey]]"
+summary: "How IWC workflows organize and reference test data — Zenodo-first, SHA-1 integrity, collection shapes, CVMFS gotchas."
+---
+
+# IWC test data conventions
+
+Reference for an agent implementing or editing a `<workflow>-tests.yml` in IWC style. All evidence cited from `/Users/jxc755/projects/repositories/workflow-fixtures/iwc-src/workflows/` (raw IWC clone) and `workflows/README.md`. Authoritative spec: [planemo.readthedocs.io/en/latest/test_format.html](https://planemo.readthedocs.io/en/latest/test_format.html). The companion analysis at `/Users/jxc755/projects/repositories/galaxy-brain/vault/projects/workflow_state/skills/COMPONENT_GALAXY_WORKFLOW_TESTING.md` is the synthesized source for several normative claims here.
+
+This note owns **test YAML fixture shapes**. For workflow-structure choices that make those fixtures possible before the test file exists, use [[galaxy-workflow-testability-design]].
+
+## 1. Where does test data live? Remote vs in-repo
+
+Two storage patterns. They mix freely inside one job.
+
+**Remote `location:` (default for any non-trivial input).** Strongly preferred for anything bigger than a toy fixture. Order of preference, observed in the corpus:
+
+- **Zenodo** — overwhelming default, persistent DOI-backed URL.
+  - `read-preprocessing/short-read-qc-trimming/short-read-quality-control-and-trimming-tests.yml:13,17` — `https://zenodo.org/records/11484215/files/paired_r1.fastq.gz` (note the modern `/records/` plural form; older entries use `/record/`).
+  - `metabolomics/lcms-preprocessing/Mass_spectrometry__LC-MS_preprocessing_with_XCMS-tests.yml:6,17,24,...` — 11+ mzML files all hosted at `zenodo.org/record/10130758/files/...`.
+  - `sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation-tests.yml:5` — `https://zenodo.org/record/4555735/files/NC_045512.2_reference.fasta?download=1`.
+  - `repeatmasking/RepeatMasking-Workflow-tests.yml:5` — `https://zenodo.org/record/8364146/files/eco.fasta?download=1`. The `?download=1` query suffix is acceptable but optional; both forms appear.
+- **EBI/ENA REST** — for canonical reference sequences.
+  - `virology/pox-virus-amplicon/pox-virus-half-genome-tests.yml:5` — `https://www.ebi.ac.uk/ena/browser/api/fasta/AF325528.1?download=true`.
+- **SRA / ENA FTP** — for raw read accessions where re-uploading to Zenodo is wasteful.
+  - `pox-virus-half-genome-tests.yml:27,34,49,56` — `ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR151/076/SRR15145276/SRR15145276_1.fastq.gz`.
+
+**In-repo `path: test-data/...` (toy fixtures + small expected outputs only).** Used when:
+
+- File is small enough to commit (rule of thumb from corpus: low single-digit MB or smaller).
+- File is a hand-crafted toy or trimmed reference (e.g. a 5-element FASTA for HyPhy).
+- File is the *expected output* baseline for a `file:` exact-comparison assertion: `consensus-from-variation-tests.yml:31` — `file: test-data/masked_consensus.fa`.
+
+`workflows/README.md:67` makes the contract explicit: "try to generate a toy dataset … and then publish it to zenodo to have a permanent URL." `workflows/README.md:98`: "if some outputs are large, it is better to use assertions than storing the whole output file to the iwc repository."
+
+Subdirectory layout inside `test-data/` is free-form and used to organize related fixtures, e.g. `comparative_genomics/hyphy/test-data/unaligned_seqs/`, `test-data/codon_alignments/`, `test-data/iqtree_trees/` (referenced from `hyphy-core-tests.yml:13,17,21,...`).
+
+**Decision rule for an agent:**
+
+1. Expected-output baseline that's small — commit to `test-data/`.
+2. Toy/trimmed input < ~5 MB — commit to `test-data/`.
+3. Anything else — Zenodo (or EBI/SRA for canonical accessions). Add `hashes:` SHA-1.
+4. If the input is a reference index resolvable from CVMFS (`hg38`, `dm6`, `mm10`, …), use the plain string form. See section 5.
+
+## 2. The `class: File` block — exact YAML shapes
+
+All snippets verbatim from the IWC corpus.
+
+### 2a. Single remote file (with integrity hash)
+
+`virology/pox-virus-amplicon/pox-virus-half-genome-tests.yml:3-9`:
+
+```yaml
+Reference FASTA:
+  class: File
+  location: "https://www.ebi.ac.uk/ena/browser/api/fasta/AF325528.1?download=true"
+  filetype: fasta
+  hashes:
+  - hash_function: SHA-1
+    hash_value: 927d0d00b7db6ad60524bb9e50d3ab41c4ac5ecf
+```
+
+Field order is conventional but not enforced. `filetype:` is the Galaxy datatype name (`fasta`, `fastqsanger.gz`, `mzml`, `bed`, `tabular`, `csv`, `gtf`, `vcf`, …). `location:` URLs may be quoted or bare; both forms occur.
+
+### 2b. Single local file
+
+`comparative_genomics/hyphy/hyphy-core-tests.yml:3-6`:
+
+```yaml
+reference cds:
+  class: File
+  path: test-data/denv1_ref_cds.fasta
+  filetype: fasta
+```
+
+`path:` is relative to the workflow directory (the directory containing the `-tests.yml`). Hashes are usually omitted on local files — the file is in-tree, so integrity is implicit. They are nonetheless added in some workflows: `consensus-from-variation-tests.yml:15-18` shows `path: test-data/aligned_reads_for_coverage.bam` paired with a SHA-1 hash. The pattern appears to be: hashes added when the `-tests.yml` was generated by `planemo workflow_test_init --from_invocation`, which mints them automatically.
+
+A dataset attribute can be set on a single file to force a `dbkey`, e.g. `epigenetics/consensus-peaks/consensus-peaks-chip-pe-tests.yml:7-10`:
+
+```yaml
+- class: File
+  identifier: rep1
+  path: test-data/rep1.bam
+  dbkey: mm10
+```
+
+`dbkey:` and `decompress: true` (`scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:30`) are documented per-file attributes that ride alongside `class: File`.
+
+### 2c. List collection
+
+`hyphy-core-tests.yml:7-30`:
+
+```yaml
+unaligned sequences:
+  class: Collection
+  collection_type: list
+  elements:
+  - identifier: AB178040.1|2002
+    class: File
+    path: test-data/unaligned_seqs/AB178040.1|2002.fasta
+    filetype: fasta
+  - identifier: AB195673.1|2003
+    class: File
+    path: test-data/unaligned_seqs/AB195673.1|2003.fasta
+    filetype: fasta
+  ...
+```
+
+Each element is a single-file dict with an `identifier:`. A larger remote-only example with hashes per element: `metabolomics/lcms-preprocessing/Mass_spectrometry__LC-MS_preprocessing_with_XCMS-tests.yml:11-22`:
+
+```yaml
+Mass-spectrometry Dataset Collection:
+  class: Collection
+  collection_type: list
+  elements:
+  - class: File
+    identifier: Blanc05.mzML
+    location: https://zenodo.org/record/10130758/files/Blanc05.mzML
+    filetype: mzml
+    hashes:
+    - hash_function: SHA-1
+      hash_value: e98d5a4cd8849a145a032bdc31c348ad97cb59c3
+```
+
+### 2d. Paired collection (single pair)
+
+A `paired` collection is a Collection whose two elements have identifiers `forward` and `reverse`. In IWC it is rarely used at top level — it is almost always wrapped as a single-element `list:paired` (see 2e). When it appears bare, the shape is the inner block of 2e without the outer `list:paired` wrapper.
+
+### 2e. `list:paired` collection
+
+`read-preprocessing/short-read-qc-trimming/short-read-quality-control-and-trimming-tests.yml:3-18`:
+
+```yaml
+Raw reads:
+  class: Collection
+  collection_type: list:paired
+  elements:
+  - class: Collection
+    type: paired
+    identifier: pair
+    elements:
+    - class: File
+      identifier: forward
+      location: https://zenodo.org/records/11484215/files/paired_r1.fastq.gz
+      filetype: fastqsanger.gz
+    - class: File
+      identifier: reverse
+      location: https://zenodo.org/records/11484215/files/paired_r2.fastq.gz
+      filetype: fastqsanger.gz
+```
+
+Note: outer `collection_type: list:paired`, inner `type: paired` (not `collection_type:`). Inner element identifiers are the literal strings `forward` and `reverse` — these are reserved.
+
+A multi-pair list:paired with full hashes: `virology/pox-virus-amplicon/pox-virus-half-genome-tests.yml:17-38` or `scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:3-24`.
+
+### 2f. `list:list:paired` and deeper
+
+Not directly observed in sampled IWC inputs. The shape is recursive — wrap a `list:paired` element list inside another `class: Collection, collection_type: list:list:paired`, where each outer element is `class: Collection, type: list:paired` (analogous to the `list:paired` → `paired` nesting in 2e). For deeply-nested collections planemo's [`_writing_collections.rst`](https://github.com/galaxyproject/planemo/blob/master/docs/_writing_collections.rst) is the de-facto reference.
+
+Output side: nested-collection assertions DO exist in the corpus. `scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:82-98`:
+
+```yaml
+Seurat input for gene expression (filtered):
+  attributes: {collection_type: list:list}
+  element_tests:
+    subsample:
+      elements:
+        matrix:
+          asserts:
+            has_line:
+              line: "23932 3 1171"
+        barcodes:
+          asserts:
+            has_line:
+              line: "CACATGATCATAAGGA"
+```
+
+Pattern: outer `element_tests:` keyed by outer identifier; inner `elements:` (note plural, not `element_tests:` here) keyed by inner identifier. Optional `attributes: {collection_type: ...}` asserts the shape of the produced collection.
+
+### 2g. `composite_data:`
+
+**Not observed** in the sampled IWC corpus (`grep -rln "composite\|imzml\|primary_file\|extra_files" workflows/ --include="*-tests.yml"` returns nothing). Per the planemo spec the shape is a `composite_data:` mapping listing each component file path, but an agent emitting one in IWC style has no in-corpus reference and should treat it as unproven territory — fall back to the planemo docs and verify against `galaxy.tool_util.parser.yaml`.
+
+### 2h. CWL-style shorthand (list of File dicts without identifiers)
+
+Documented in planemo; not observed in sampled IWC. IWC always supplies explicit identifiers.
+
+### 2i. `tags:` on elements (Galaxy 20.09+)
+
+Documented in planemo; not surfaced in sampled IWC `-tests.yml` files (`grep "  tags:" --include="*-tests.yml"` empty across the sampled set). Practical absence — IWC tests rely on identifier matching, not tags.
+
+## 3. SHA-1 integrity hashes — when, when not, why
+
+**Format.** Always a list under `hashes:`, even for one entry. Each entry is `{hash_function: SHA-1, hash_value: <40-hex>}`. Verbatim from `pox-virus-half-genome-tests.yml:7-9`:
+
+```yaml
+hashes:
+- hash_function: SHA-1
+  hash_value: 927d0d00b7db6ad60524bb9e50d3ab41c4ac5ecf
+```
+
+Only `SHA-1` observed in the IWC corpus. The planemo spec also accepts `MD5`, `SHA-256`, `SHA-512` as `hash_function:` values; IWC does not exercise these.
+
+**When present:**
+
+- Every remote `location:`-fetched input in the sampled corpus carries a SHA-1 (Zenodo, EBI REST, SRA FTP). The hash guards against silent upstream corruption — Zenodo records are immutable but bit-rot and CDN-edge errors do happen; ENA FASTA endpoints can quietly change line-wrap.
+- Many local `path:`-loaded inputs also carry a SHA-1. This is `--from_invocation` autogeneration leaking through (planemo emits hashes for every input it captured).
+- `consensus-from-variation-tests.yml:6-8,17-18,27-28` — every input in the test, local and remote, has a hash.
+
+**When omitted:**
+
+- Hand-written local-file fixtures often skip hashes — `hyphy-core-tests.yml:3-30` has zero `hashes:` blocks across six local-file inputs.
+- Output assertions: `file:`-comparison outputs and `location:`-comparison outputs (`RepeatMasking-Workflow-tests.yml:13`) **do not** carry `hashes:`. The integrity story for outputs is handled by `compare:` / `asserts:` instead.
+
+**Why bother on local files.** Catches accidental corruption when collaborators hand-edit `test-data/` fixtures.
+
+## 4. Element identifier conventions
+
+Identifiers are arbitrary strings, used both as the YAML key (`element_tests:`) and as the produced Galaxy collection element name. Conventions surfaced from the corpus:
+
+- **Pipes are legal** and survive YAML round-trip without quoting on the input side: `hyphy-core-tests.yml:11` — `identifier: AB178040.1|2002`. On the *output* side they're quoted because they appear as YAML mapping keys: `hyphy-core-tests.yml:34` — `"NC_001477.1|capsid_protein_C|95-394_DENV1":`. Quote when the identifier contains characters that would otherwise start a YAML flow node (`{`, `[`, `&`, `*`, `!`, `|`, `>`, `'`, `"`, `%`, `@`, `` ` ``) or look like a number/bool.
+- **Dots, hyphens, underscores** — common, no quoting needed: `Blanc05.mzML`, `HU_neg_048.mzML`, `SRR11578257`, `Rep1`, `subsample`, `pair`.
+- **Reserved inside `paired` collections:** `forward` and `reverse` (lowercase). Never use these names for outer identifiers in `list:paired`.
+- **Inline comments after identifier** are legal and used for provenance: `pox-virus-half-genome-tests.yml:23` — `identifier: 20L70   # SRR15145276`.
+- **Whitespace and special chars in workflow input *labels*** survive too — they are job-mapping keys, not collection identifiers, but the same YAML quoting rules apply. Example from the analysis doc: `Manually annotate celltypes?: true` as a job key in `Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml:23`.
+
+### 4a. Workflow-interface implications
+
+Fixture shape should feed back into workflow input design. Tests supply job inputs by workflow input label, and collection fixtures must match the workflow's declared collection type.
+
+- The 10x CellPlex test uses `fastq PE collection GEX`, `fastq PE collection CMO`, and `sample name and CMO sequence collection` as job keys with `list:paired` and `list` collection fixtures; the workflow declares matching collection inputs at `$IWC_FORMAT2/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex.gxwf.yml:4-72`.
+- CVMFS/data-table shortcuts like `reference genome: dm6` are workflow-interface choices as much as test YAML choices: they require the workflow input to be a string/data-table-backed parameter, not a file input.
+- If a fixture needs stable sample names, decide whether those names should enter through collection element identifiers, a mapping file, or a workflow parameter before writing assertions.
+
+Rule for an agent: when a new workflow input is being designed and the test fixture is already known, check [[galaxy-workflow-testability-design]] before locking the input label/type.
+
+## 5. CVMFS / `.loc` / built-in-index references
+
+When a workflow input is a Galaxy data-table-backed reference (built-in genome index, dbsnp file, kraken DB, …), the input takes a **plain string** matching the `value` column of a `.loc` file. No `class: File`, no `location:`. Examples:
+
+- `scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:25` — `reference genome: dm6 # To test on usegalaxy.eu dm6full`
+- `epigenetics/cutandrun/cutandrun-tests.yml:27` — `reference_genome: 'hg38canon'`
+- `epigenetics/atacseq/atacseq-tests.yml:25` — `reference_genome: hg19`
+- `microbiome/host-contamination-removal/host-contamination-removal-short-reads/host-or-contamination-removal-on-short-reads-tests.yml:19` — `Host/Contaminant Reference Genome: hg38`
+- `microbiome/pathogen-identification/nanopore-pre-processing/Nanopore-Pre-Processing-tests.yml:22` — `host_reference_genome: apiMel3`
+- `transcriptomics/goseq/goseq-go-kegg-enrichment-analsis-tests.yml:24` — `Select genome to use: mm10`
+
+The string is the first column of the `.loc` entry. `workflows/README.md:169-182` shows the lookup procedure: browse `http://datacache.galaxyproject.org/indexes/location/<table>.loc`, find the `.loc` row, take the value column (which column varies by tool — check the matching `tool_data_table_conf.xml.sample`).
+
+**Portability implication:** these tests **only** run on a Galaxy with CVMFS mounted at `/cvmfs/data.galaxyproject.org`. IWC CI mounts CVMFS in-runner (`setup-cvmfs: true` in `.github/workflows/test_workflows.yml`). On a plain developer laptop running `planemo test`, CVMFS-string inputs fail unresolved. An agent generating tests should either:
+
+1. Stay URL-driven: replace the CVMFS string with a `class: File` + `location:` to a Zenodo-hosted reference (portable, slower CI, larger inputs).
+2. Use the CVMFS string and document "CI-only" — the user cannot reproduce locally without a CVMFS mount.
+
+There is no `.loc`-resolution shorthand in the YAML — it is just a bare string parameter. Agents must not invent `class: DataTable` or similar.
+
+## 6. Reviewer-feedback patterns (PR-review)
+
+Recurring asks from IWC reviewers, distilled from the contribution README and community help threads:
+
+- **Move large data to Zenodo before merge.** Anything bigger than a toy fixture committed in `test-data/` will be flagged. `workflows/README.md:67`.
+- **Use assertions, not exact-file comparison, for large outputs.** `workflows/README.md:98` — "if some outputs are large, it is better to use assertions than storing the whole output file."
+- **Generate tests with `planemo workflow_test_init --from_invocation`, don't hand-write.** `workflows/README.md:88-94`. The autogenerated test will mint correct hashes, correct labels, and a working `test-data/` snapshot.
+- **Set creator `identifier:` to a full ORCID URL** (e.g. `https://orcid.org/0000-0002-1825-0097`) — `workflows/README.md:53`. The most common lint failure; enforced in [planemo#1458](https://github.com/galaxyproject/planemo/pull/1458).
+- **Don't use `compare: diff` on outputs that embed timestamps or non-deterministic ordering.** Switch to `has_text` / `has_n_lines` (with `delta:`) or `compare: sim_size`+`delta:`.
+- **Bump `release:` in the `.ga` and add a `CHANGELOG.md` entry** in the same PR — enforced by the IWC PR template; reviewers verify via `bump_version.py`.
+- **Lower-case + `-` only** in directory names — `workflows/README.md:11,72`.
+- **Element identifiers must round-trip** — quote in YAML when they contain pipes/colons/whitespace.
+
+## 7. What is *not* covered by current convention
+
+Gaps an agent should be aware of:
+
+- **`composite_data:` is unrepresented in the IWC corpus.** No working examples to imitate for imzml+ibd or other multi-file datatypes. Treat as off-trail; cite planemo docs and verify by parser.
+- **`tags:` on elements unused.** Galaxy 20.09+ supports them; IWC does not exercise them.
+- **CWL-style shorthand File lists unused.** IWC always names elements.
+- **No negative tests.** Zero `expect_failure:` across the sampled corpus. There is no IWC convention for asserting a workflow *should* fail on bad input.
+- **No checksum-based output assertion in the wild.** `checksum: "sha1$..."` is documented and used at the input side as `hashes:`, but output-side `checksum:` was not surfaced in sampled tests. The corpus prefers `file:` (exact), `compare: sim_size`+`delta:` (size only), or `asserts:` (content probes).
+- **No data-cache layer beyond pip/planemo.** Every test re-pulls remote inputs from Zenodo / EBI / SRA on every CI run. A Zenodo outage breaks many PRs simultaneously. There is no IWC-side mirror or cache.
+- **No per-test timeout / retry convention.** A hung tool blocks the whole chunk until the GitHub Actions 6-hour limit.
+- **No portable story for CVMFS-only tests.** The same `-tests.yml` either works locally (URL-driven) or works in CI (CVMFS-string-driven), not both. There is no documented switch.
+- **Hash function is de-facto SHA-1.** The spec accepts SHA-256/SHA-512/MD5; IWC does not use them. Agents that emit a stronger hash will pass planemo but break corpus convention.
+- **Local-file `hashes:` are inconsistently present.** `--from_invocation`-generated tests have them, hand-written tests usually don't. Either is accepted; don't expect uniformity.
+- **`decompress: true` and `dbkey:` are file-level attributes** but undocumented at the planemo test_format page in the same place as `class:`/`location:`/`hashes:`. Cross-reference against the `gxformat2` Schema-Salad bindings if unsure.
+- **`?download=1` query string on Zenodo URLs** is optional. Both forms appear (`/record/4555735/files/X?download=1` vs `/records/11484215/files/Y`). The newer `/records/` plural is the modern Zenodo URL form; both work.
+
+## Cross-references
+
+- [[galaxy-workflow-testability-design]] — workflow input/output structure choices that make these fixture shapes testable.
+- `/Users/jxc755/projects/repositories/galaxy-brain/vault/projects/workflow_state/skills/COMPONENT_GALAXY_WORKFLOW_TESTING.md` — full synthesis with assertion-vocabulary table, CI internals, and tooling rundown. Sections 2b, 3, 4, 5, 9 are the direct upstream of this note.
+- planemo test format spec: [planemo.readthedocs.io/en/latest/test_format.html](https://planemo.readthedocs.io/en/latest/test_format.html).
+- planemo best practices: [planemo.readthedocs.io/en/latest/best_practices_workflows.html](https://planemo.readthedocs.io/en/latest/best_practices_workflows.html).
+- planemo collections reference: [github.com/galaxyproject/planemo/blob/master/docs/_writing_collections.rst](https://github.com/galaxyproject/planemo/blob/master/docs/_writing_collections.rst).
+- IWC contribution contract: `workflows/README.md` in [github.com/galaxyproject/iwc](https://github.com/galaxyproject/iwc).
+- Galaxy datacache (CVMFS `.loc` browsing): [datacache.galaxyproject.org/indexes/location/](http://datacache.galaxyproject.org/indexes/location/).

--- a/casts/claude/skills/cwl-to-test-data/references/schemas/summary-cwl.schema.json
+++ b/casts/claude/skills/cwl-to-test-data/references/schemas/summary-cwl.schema.json
@@ -1,0 +1,901 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://galaxyproject.org/foundry/schemas/summary-cwl.schema.json",
+  "$comment": "Canonical source: packages/foundry/src/schemas/summary-cwl/summary-cwl.schema.json in galaxyproject/foundry. Mold frontmatter cites this schema via [[summary-cwl]] wiki-links; the cast pipeline imports the `summaryCwlSchema` runtime export and serializes it into cast bundles.",
+  "title": "CWL Workflow Summary",
+  "description": "Structured per-source summary emitted by the summarize-cwl Mold. CWL is already a typed workflow language, so this schema records validated and normalized workflow/tool structure rather than inferred pipeline semantics.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "summary_version",
+    "source",
+    "documents",
+    "workflow_inputs",
+    "workflow_outputs",
+    "steps",
+    "tools",
+    "graph",
+    "tests",
+    "warnings"
+  ],
+  "properties": {
+    "summary_version": {
+      "type": "string",
+      "enum": [
+        "1"
+      ],
+      "description": "Summary schema major version."
+    },
+    "source": {
+      "$ref": "#/$defs/SourceRecord"
+    },
+    "documents": {
+      "$ref": "#/$defs/DocumentSet"
+    },
+    "workflow_inputs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/WorkflowInput"
+      }
+    },
+    "workflow_outputs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/WorkflowOutput"
+      }
+    },
+    "steps": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/WorkflowStep"
+      }
+    },
+    "tools": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/CommandLineTool"
+      }
+    },
+    "graph": {
+      "$ref": "#/$defs/WorkflowGraph"
+    },
+    "tests": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/TestCase"
+      }
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Warning"
+      }
+    }
+  },
+  "$defs": {
+    "SourceRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "ecosystem",
+        "workflow",
+        "url",
+        "version",
+        "license",
+        "slug",
+        "cwl_version",
+        "entrypoint"
+      ],
+      "properties": {
+        "ecosystem": {
+          "type": "string",
+          "enum": [
+            "cwl"
+          ],
+          "description": "Source ecosystem; fixed for this per-source schema."
+        },
+        "workflow": {
+          "type": "string",
+          "description": "Human-oriented workflow name, usually the entry Workflow id or source filename stem."
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Original path or URL supplied by the user."
+        },
+        "version": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Pinned commit, tag, release, or digest when available."
+        },
+        "license": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "License identifier or detected license filename when available."
+        },
+        "slug": {
+          "type": "string",
+          "description": "Stable kebab-case run slug."
+        },
+        "cwl_version": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Declared cwlVersion after loading the entry document, commonly v1.0, v1.1, or v1.2."
+        },
+        "entrypoint": {
+          "type": "string",
+          "description": "Main workflow document/id after resolution, e.g. workflow.cwl#main."
+        }
+      }
+    },
+    "DocumentSet": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "entrypoint",
+        "normalized_path",
+        "validation"
+      ],
+      "properties": {
+        "entrypoint": {
+          "type": "string",
+          "description": "Local path or URL passed to cwl-utils/cwltool."
+        },
+        "normalized_path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Path to the cwl-utils cwl-normalizer JSON output when normalization was requested or possible."
+        },
+        "validation": {
+          "$ref": "#/$defs/ValidationResult"
+        }
+      }
+    },
+    "ValidationResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "command",
+        "status",
+        "diagnostics"
+      ],
+      "properties": {
+        "command": {
+          "type": "string",
+          "description": "Validation command or library operation used."
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "valid",
+            "warning",
+            "invalid",
+            "not-run"
+          ]
+        },
+        "diagnostics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "WorkflowInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "label",
+        "type",
+        "optional",
+        "default",
+        "doc",
+        "format",
+        "secondary_files"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "type": "string",
+          "description": "Compact CWL type expression, preserving arrays, records, enums, nullability, File, and Directory."
+        },
+        "optional": {
+          "type": "boolean"
+        },
+        "default": {
+          "description": "Verbatim default value when present.",
+          "type": [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "object",
+            "array",
+            "null"
+          ]
+        },
+        "doc": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "format": {
+          "type": [
+            "string",
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "secondary_files": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "WorkflowOutput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "label",
+        "type",
+        "output_source",
+        "doc",
+        "format",
+        "secondary_files"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "type": "string"
+        },
+        "output_source": {
+          "type": [
+            "string",
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "doc": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "format": {
+          "type": [
+            "string",
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "secondary_files": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "WorkflowStep": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "run",
+        "run_class",
+        "label",
+        "doc",
+        "in",
+        "out",
+        "scatter",
+        "scatter_method",
+        "when",
+        "requirements",
+        "hints"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "run": {
+          "type": "string",
+          "description": "Resolved run reference as it appears in the normalized document, e.g. #tool_id."
+        },
+        "run_class": {
+          "type": "string",
+          "enum": [
+            "CommandLineTool",
+            "ExpressionTool",
+            "Workflow",
+            "Operation",
+            "unknown"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "doc": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "in": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/StepInput"
+          }
+        },
+        "out": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "scatter": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "scatter_method": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "dotproduct",
+            "nested_crossproduct",
+            "flat_crossproduct",
+            null
+          ]
+        },
+        "when": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "CWL v1.2 conditional expression, preserved verbatim when present."
+        },
+        "requirements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Requirement"
+          }
+        },
+        "hints": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Requirement"
+          }
+        }
+      }
+    },
+    "StepInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "source",
+        "default",
+        "value_from",
+        "link_merge",
+        "pick_value"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "source": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "description": "Normalized CWL source links. Null means the input has no source and is driven by default or runtime binding.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "default": {
+          "description": "Verbatim WorkflowStepInput default value when present.",
+          "type": [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "object",
+            "array",
+            "null"
+          ]
+        },
+        "value_from": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Expression from valueFrom, preserved verbatim when present."
+        },
+        "link_merge": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "merge_nested",
+            "merge_flattened",
+            null
+          ],
+          "description": "CWL linkMerge setting for multiple inbound sources."
+        },
+        "pick_value": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "first_non_null",
+            "the_only_non_null",
+            "all_non_null",
+            null
+          ],
+          "description": "CWL pickValue setting for choosing non-null values among multiple sources."
+        }
+      }
+    },
+    "CommandLineTool": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "label",
+        "base_command",
+        "arguments",
+        "inputs",
+        "outputs",
+        "requirements",
+        "hints"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "base_command": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "arguments": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "inputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ToolInput"
+          }
+        },
+        "outputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ToolOutput"
+          }
+        },
+        "requirements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Requirement"
+          }
+        },
+        "hints": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Requirement"
+          }
+        }
+      }
+    },
+    "ToolInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "type",
+        "input_binding",
+        "doc",
+        "format",
+        "secondary_files"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "input_binding": {
+          "$ref": "#/$defs/BindingSummary"
+        },
+        "doc": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "format": {
+          "type": [
+            "string",
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "secondary_files": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ToolOutput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "type",
+        "output_binding",
+        "doc",
+        "format",
+        "secondary_files"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "output_binding": {
+          "$ref": "#/$defs/BindingSummary"
+        },
+        "doc": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "format": {
+          "type": [
+            "string",
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "secondary_files": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "BindingSummary": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false,
+      "required": [
+        "position",
+        "prefix",
+        "glob",
+        "value_from"
+      ],
+      "properties": {
+        "position": {
+          "type": [
+            "number",
+            "integer",
+            "null"
+          ]
+        },
+        "prefix": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "glob": {
+          "type": [
+            "string",
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "value_from": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "Requirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "class",
+        "docker_pull",
+        "docker_image_id",
+        "packages",
+        "raw"
+      ],
+      "properties": {
+        "class": {
+          "type": "string",
+          "description": "Requirement or hint class, e.g. DockerRequirement, SoftwareRequirement, ScatterFeatureRequirement."
+        },
+        "docker_pull": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "DockerRequirement.dockerPull when present."
+        },
+        "docker_image_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "DockerRequirement.dockerImageId when present."
+        },
+        "packages": {
+          "type": "array",
+          "description": "SoftwareRequirement packages as name/version/spec strings.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "raw": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Verbatim requirement/hint object for unsupported or target-specific fields."
+        }
+      }
+    },
+    "WorkflowGraph": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "nodes",
+        "edges"
+      ],
+      "properties": {
+        "nodes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GraphNode"
+          }
+        },
+        "edges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GraphEdge"
+          }
+        }
+      }
+    },
+    "GraphNode": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "kind",
+        "label"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "workflow-input",
+            "step",
+            "workflow-output"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "GraphEdge": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "from",
+        "to",
+        "via"
+      ],
+      "properties": {
+        "from": {
+          "type": "string"
+        },
+        "to": {
+          "type": "string"
+        },
+        "via": {
+          "type": "array",
+          "description": "Shape-affecting CWL features on this edge, e.g. scatter, linkMerge, pickValue, valueFrom.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "TestCase": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "job_path",
+        "expected_outputs",
+        "provenance"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "job_path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "expected_outputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ExpectedOutputRef"
+          }
+        },
+        "provenance": {
+          "type": "string"
+        }
+      }
+    },
+    "ExpectedOutputRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "path",
+        "url",
+        "filetype",
+        "checksum",
+        "assertions"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "filetype": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "checksum": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "assertions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Warning": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "message",
+        "path"
+      ],
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/casts/claude/skills/nextflow-to-test-data/SKILL.md
+++ b/casts/claude/skills/nextflow-to-test-data/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: nextflow-to-test-data
+description: "Resolve a Nextflow pipeline's own declared test fixtures into Galaxy workflow test-data refs."
+---
+
+# nextflow-to-test-data
+
+Follow the procedure below and use the artifact/reference sections as the runtime contract.
+
+## When To Use
+
+- Resolve a Nextflow pipeline's own declared test fixtures into Galaxy workflow test-data refs.
+
+## Inputs
+
+- Read artifact `summary-nextflow`. Schema: summary-nextflow. Produced by `summarize-nextflow`. Structured Nextflow summary from summarize-nextflow; carries the selected profile's `test_fixtures` and the full `nf_tests[]` enumeration — each declared input a role plus url/path, sha1, and filetype.
+- Read artifact `nextflow-galaxy-interface`. Produced by `nextflow-summary-to-galaxy-interface`. Galaxy interface brief from nextflow-summary-to-galaxy-interface pinning the workflow input labels, collection shapes, and datatypes each resolved fixture must map onto.
+
+## Outputs
+
+- Write artifact `test-data-refs` as `test-data-refs.json`. Format: `json`. Test data resolved from the pipeline's declared fixtures, expressed as URLs/paths plus expected shapes for downstream test authoring. Shared id with find-test-data — the branch's search fallback fills only the inputs this Mold leaves unresolved.
+
+## Required Tools
+
+- None declared. Procedure should not assume external CLIs are present.
+
+## Load Upfront
+
+- `references/schemas/summary-nextflow.schema.json`: Schema file copied verbatim into the bundle. Input contract: read the selected profile's `test_fixtures.inputs[]` and the `nf_tests[]` enumeration — role, url/path, sha1, filetype — as the declared source of test data.
+
+## Load On Demand
+
+- `references/notes/component-nextflow-testing.md`: Research note copied verbatim into the bundle. Interpret nf-test profiles and fixture conventions before mapping declared fixtures onto Galaxy inputs. Use when: reading `test_fixtures` / `nf_tests` to decide which profile's fixtures best cover the workflow inputs.
+- `references/notes/component-nextflow-testing.yml`: Companion file copied verbatim into the bundle. Sibling of `references/notes/component-nextflow-testing.md`; read it where that note directs.
+- `references/notes/galaxy-workflow-testability-design.md`: Research note copied verbatim into the bundle. Map each declared fixture to an addressable Galaxy input label and the collection shape it must populate. Use when: mapping a declared fixture (often a samplesheet-driven input) onto a Galaxy input's collection shape.
+- `references/notes/iwc-test-data-conventions.md`: Research note copied verbatim into the bundle. Express each ref remote-URL-first with SHA-1 integrity and per-input collection layout when recording resolved fixtures. Use when: writing each `test-data-refs` entry.
+
+## Validation
+
+- None declared.
+
+## Procedure
+
+Resolve the Nextflow pipeline's own declared test fixtures into Galaxy `test-data-refs`. The Nextflow summary already carries the `test`-profile fixtures (`test_fixtures`) and the full nf-test enumeration (`nf_tests[]`) — each declared input a `role` plus a `url`/`path`, `sha1`, and `filetype`. Map those onto the Galaxy workflow's inputs and emit one ref per input, ready for implement-galaxy-workflow-test to stage.
+
+This skill is the source-specific first leg of the harness's `test-data-resolution` branch. It resolves what the pipeline itself declares; any input it cannot resolve from a declared fixture stays a reported gap and the harness falls through to find-test-data (search), then to `user-supplied`. Deciding to fall through is a harness concern, not this skill's — its job is an honest map of the pipeline's own fixtures.
+
+### Sequence
+
+1. **Enumerate Galaxy inputs and their required shape.** From the interface brief, list each workflow input: label, Galaxy collection shape (File / list / paired / list:paired / record), and datatype. This is the *target shape* every ref must satisfy.
+2. **Read the declared fixtures.** From the summary's `test_fixtures.inputs[]` (selected profile) and `nf_tests[]` (other profiles), collect each declared input: `role`, `url`/`path`, `sha1`, `filetype`, and description. Prefer the profile whose fixtures best cover the workflow's inputs.
+3. **Map each declared fixture onto a Galaxy input.** Match by role and shape onto the interface's input labels. A samplesheet-driven Nextflow input often expands into a Galaxy collection — record the element identifiers and any split/concatenation prep needed to reach the Galaxy collection shape (galaxy-workflow-testability-design).
+4. **Emit refs.** Write one `test-data-refs.json` entry per resolved input: prefer the declared remote `url` + `sha1` (remote-URL-first, iwc-test-data-conventions); fall back to the in-tree `path` plus provenance only when no URL is published. Carry datatype, collection element identifiers, and any subset/split prep. Each entry maps to an addressable workflow input label.
+5. **Report genuine gaps.** An input with no declared fixture of the right shape stays `resolved: false` with a reason — this is what the harness hands to find-test-data. Do not search public sources here; searching is find-test-data's job, not this skill's.
+
+### No fabrication
+
+Never invent a URL, accession, or path, and never emit a placeholder for an input you could not resolve from a declared fixture. A declared fixture with no published URL is recorded by its in-tree `path` plus provenance, not papered over with a guessed URL. Every emitted ref points at data the pipeline actually declares; everything else is an honest gap for the next leg of the branch.
+
+## Runtime Notes
+
+- Do not read Foundry source files at runtime; use only files packaged in this skill bundle and user-supplied artifacts.
+- Preserve declared artifact filenames unless the user or harness supplies explicit paths.
+- Carry unresolved assumptions into the output artifact instead of silently inventing missing source evidence.

--- a/casts/claude/skills/nextflow-to-test-data/_provenance.json
+++ b/casts/claude/skills/nextflow-to-test-data/_provenance.json
@@ -1,0 +1,118 @@
+{
+  "provenance_schema_version": 3,
+  "cast_target": "claude",
+  "mold": {
+    "name": "nextflow-to-test-data",
+    "path": "content/molds/nextflow-to-test-data/index.md",
+    "revision": 1,
+    "content_hash": "d87e5f46e5680184cc586b97c946b7ee82e71b3ab85dfc9cf1b964960553e8bc",
+    "commit": "c29a96b7c4d124bdad3c081ae5ece79a3d03cf22"
+  },
+  "cast_at": "2026-07-17T23:03:53.481Z",
+  "refs": [
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[component-nextflow-testing]]",
+      "src": "content/research/component-nextflow-testing.md",
+      "dst": "references/notes/component-nextflow-testing.md",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "hypothesis",
+      "purpose": "Interpret nf-test profiles and fixture conventions before mapping declared fixtures onto Galaxy inputs.",
+      "trigger": "When reading `test_fixtures` / `nf_tests` to decide which profile's fixtures best cover the workflow inputs.",
+      "verification": "Map nf-core/bacass declared fixtures onto its Galaxy interface and confirm this note improves profile/fixture selection.",
+      "src_hash": "bb750b1abbec1c33bc3c6620594314f0f64848195ce0599d5ce5626528ea834d",
+      "dst_hash": "bb750b1abbec1c33bc3c6620594314f0f64848195ce0599d5ce5626528ea834d",
+      "source": "deterministic"
+    },
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[component-nextflow-testing]]",
+      "src": "content/research/component-nextflow-testing.yml",
+      "dst": "references/notes/component-nextflow-testing.yml",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "hypothesis",
+      "purpose": "Interpret nf-test profiles and fixture conventions before mapping declared fixtures onto Galaxy inputs.",
+      "trigger": "When reading `test_fixtures` / `nf_tests` to decide which profile's fixtures best cover the workflow inputs.",
+      "companion_of": "references/notes/component-nextflow-testing.md",
+      "src_hash": "7d4da038c82a7da9b4abf4a6cdd8480f73a235e155c8d9763d6bd3826acf818e",
+      "dst_hash": "7d4da038c82a7da9b4abf4a6cdd8480f73a235e155c8d9763d6bd3826acf818e",
+      "source": "deterministic"
+    },
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[galaxy-workflow-testability-design]]",
+      "src": "content/research/galaxy-workflow-testability-design.md",
+      "dst": "references/notes/galaxy-workflow-testability-design.md",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Map each declared fixture to an addressable Galaxy input label and the collection shape it must populate.",
+      "trigger": "When mapping a declared fixture (often a samplesheet-driven input) onto a Galaxy input's collection shape.",
+      "src_hash": "e4d5991a5085e0f9ad52b8e6856f64179362334bd51b77a3302faeb96732f980",
+      "dst_hash": "e4d5991a5085e0f9ad52b8e6856f64179362334bd51b77a3302faeb96732f980",
+      "source": "deterministic"
+    },
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[iwc-test-data-conventions]]",
+      "src": "content/research/iwc-test-data-conventions.md",
+      "dst": "references/notes/iwc-test-data-conventions.md",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Express each ref remote-URL-first with SHA-1 integrity and per-input collection layout when recording resolved fixtures.",
+      "trigger": "When writing each `test-data-refs` entry.",
+      "src_hash": "2c7ef6a674b84f434ed973fe5c93156a6b368fc774a432e828257ddbde5d4993",
+      "dst_hash": "2c7ef6a674b84f434ed973fe5c93156a6b368fc774a432e828257ddbde5d4993",
+      "source": "deterministic"
+    },
+    {
+      "kind": "schema",
+      "mode": "verbatim",
+      "ref": "[[summary-nextflow]]",
+      "src": "package://@galaxy-foundry/summarize-nextflow#summaryNextflowSchema",
+      "dst": "references/schemas/summary-nextflow.schema.json",
+      "used_at": "runtime",
+      "load": "upfront",
+      "evidence": "corpus-observed",
+      "purpose": "Input contract: read the selected profile's `test_fixtures.inputs[]` and the `nf_tests[]` enumeration — role, url/path, sha1, filetype — as the declared source of test data.",
+      "license": "MIT",
+      "src_hash": "a8d622803e5bbfd66340a1463da80ae5d1195a898411bb39cc690019d964c03b",
+      "dst_hash": "a8d622803e5bbfd66340a1463da80ae5d1195a898411bb39cc690019d964c03b",
+      "source": "deterministic"
+    }
+  ],
+  "artifacts": {
+    "produces": [
+      {
+        "id": "test-data-refs",
+        "kind": "json",
+        "default_filename": "test-data-refs.json",
+        "description": "Test data resolved from the pipeline's declared fixtures, expressed as URLs/paths plus expected shapes for downstream test authoring. Shared id with [[find-test-data]] — the branch's search fallback fills only the inputs this Mold leaves unresolved."
+      }
+    ],
+    "consumes": [
+      {
+        "id": "summary-nextflow",
+        "description": "Structured Nextflow summary from [[summarize-nextflow]]; carries the selected profile's `test_fixtures` and the full `nf_tests[]` enumeration — each declared input a role plus url/path, sha1, and filetype.",
+        "inherited_schema": "[[summary-nextflow]]",
+        "producers": [
+          "summarize-nextflow"
+        ]
+      },
+      {
+        "id": "nextflow-galaxy-interface",
+        "description": "Galaxy interface brief from [[nextflow-summary-to-galaxy-interface]] pinning the workflow input labels, collection shapes, and datatypes each resolved fixture must map onto.",
+        "producers": [
+          "nextflow-summary-to-galaxy-interface"
+        ]
+      }
+    ]
+  }
+}

--- a/casts/claude/skills/nextflow-to-test-data/_verify.json
+++ b/casts/claude/skills/nextflow-to-test-data/_verify.json
@@ -1,0 +1,17 @@
+{
+  "verify_schema_version": 1,
+  "entries": [
+    {
+      "artifact_id": "summary-nextflow",
+      "direction": "input",
+      "kind": "json",
+      "default_filename": "summary-nextflow.json",
+      "schema": "[[summary-nextflow]]",
+      "validator_bin": "foundry",
+      "args": [
+        "validate-summary-nextflow",
+        "{artifact_path}"
+      ]
+    }
+  ]
+}

--- a/casts/claude/skills/nextflow-to-test-data/references/notes/component-nextflow-testing.md
+++ b/casts/claude/skills/nextflow-to-test-data/references/notes/component-nextflow-testing.md
@@ -1,0 +1,94 @@
+---
+type: research
+subtype: component
+tags:
+  - research/component
+  - source/nextflow
+component: "Nextflow Testing and Test Fixtures"
+status: draft
+created: 2026-05-01
+revised: 2026-05-05
+revision: 2
+ai_generated: true
+summary: "nf-test patterns mapped to Galaxy planemo asserts and CWL test equivalents — backs nextflow-test-to-target-tests Mold and summarize-nextflow §7."
+companions:
+  - "component-nextflow-testing.yml"
+sources:
+  - "https://www.nf-test.com/"
+  - "https://www.nf-test.com/docs/assertions/"
+  - "https://www.nf-test.com/docs/assertions/snapshots/"
+  - "https://www.nf-test.com/docs/configuration/"
+  - "https://nf-co.re/docs/contributing/nf-test/assertions"
+  - "https://nf-co.re/docs/developing/testing/overview"
+  - "https://github.com/nf-core/test-datasets"
+  - "https://www.nextflow.io/docs/latest/config.html#config-profiles"
+  - "https://nf-co.re/docs/contributing/pipelines#test-data"
+related_molds:
+  - "[[summarize-nextflow]]"
+  - "[[nextflow-test-to-target-tests]]"
+  - "[[implement-galaxy-workflow-test]]"
+related_notes:
+  - "[[planemo-asserts-idioms]]"
+  - "[[tests-format]]"
+  - "[[iwc-test-data-conventions]]"
+  - "[[component-nf-core-tools]]"
+---
+
+# Nextflow Testing and Test Fixtures
+
+Operational grounding for two Molds:
+
+- [[summarize-nextflow]] §7 — extract `nf_tests[]` and `test_fixtures` from a real nf-core or DSL2 pipeline.
+- [[nextflow-test-to-target-tests]] — translate nf-test fixtures + assertions into Galaxy / CWL equivalents.
+
+The summarize side is mostly *enumeration*: walk `tests/*.nf.test`, extract structured fields per the Mold §7 spec. The translation side is *mapping*: each nf-test assertion pattern has a (sometimes lossy) Galaxy or CWL equivalent.
+
+Companion structured form: `component-nextflow-testing.yml`. Per-pattern entries with `nf_test_pattern`, `description`, `galaxy_equivalent`, `cwl_equivalent`, `notes`, plus `assertion` (the precise nf-test syntax) and `target_link` (deep-links into [[tests-format]] or planemo idioms when applicable).
+
+## What `summarize-nextflow` §7 already encodes
+
+The Mold body's §7 lists the structural fields per nf-test file: `name`, `path`, `profiles[]`, `params_overrides`, `assert_workflow_success`, `snapshot` (with `captures`, `helpers`, `ignore_files`, `ignore_globs`, `snap_path`), `prose_assertions[]`. The schema is `summary-nextflow.schema.json`'s `NfTest` and `SnapshotFixture`.
+
+This note's contribution: the *interpretation* layer that turns those structured fields into target-shaped tests.
+
+## The nf-core snapshot idiom
+
+Templated nf-core modules and pipelines use a near-uniform snapshot pattern:
+
+```groovy
+assert snapshot(
+    workflow.trace.succeeded().size(),
+    versions_yml,
+    getAllFilesFromDir(...).list().sort(),    // stable names
+    getAllFilesFromDir(...)*.path.collect{ ... }  // stable paths or md5
+).match()
+```
+
+Four logical captures: succeeded-task count, version YAML, stable file-name list, stable file-path / md5 list. The pruning happens through `ignoreFile: 'tests/.nftignore'` arguments to `getAllFilesFromDir(...)` plus `ignore: [glob1, glob2]` lists.
+
+The translation table in the YAML maps each capture to a Galaxy or CWL assertion. Some are direct (succeeded count → workflow execution success); some are lossy (stable_paths → has_text per output, no md5 chain).
+
+## Source-of-truth chain
+
+1. **nf-test framework** (askimed/nf-test, MIT) — the assertion DSL and snapshot semantics: [www.nf-test.com/docs/assertions/](https://www.nf-test.com/docs/assertions/).
+2. **nf-core conventions** — how nf-core pipelines use nf-test: [nf-co.re/docs/contributing/nf-test/assertions](https://nf-co.re/docs/contributing/nf-test/assertions).
+3. **planemo / tests-format** — the Galaxy target side. Vocabulary in [[tests-format]]; idiom guide in [[planemo-asserts-idioms]].
+4. **cwltest** — the CWL target side. JSON-schema validated YAML test job + expected outputs; cited inline per pattern in the YAML.
+
+## Test-data fixtures
+
+Separate from assertions: where the input data lives.
+
+- `conf/<profile>.config` (default `conf/test.config`) — declares `params.input` (samplesheet URL) and other URL-shaped params per profile. nf-core templates resolve runtime URLs via `params.pipelines_testdata_base_path + 'foo.csv'`.
+- [`nf-core/test-datasets`](https://github.com/nf-core/test-datasets) — branch-per-pipeline; the canonical location for samplesheet content. The cast skill follows samplesheet URLs into the appropriate branch when a single fetch enumerates the referenced files.
+- The `Mold §7` rule: emit the resolved samplesheet URL plus referenced data files as `TestDataRef` entries; do *not* download for content validation.
+
+## Cross-references
+
+- [[planemo-asserts-idioms]] — Galaxy-side idiom guide; the YAML's `target_link` fields deep-link into this.
+- [[tests-format]] — vendored JSON Schema for `<workflow>-tests.yml`; deep-link target for the Galaxy assertion column.
+- [[component-nf-core-tools]] — wider tool ecosystem (nf-core's `test_datasets_utils`, branch listings).
+
+## Open gaps
+
+_Updated when a real pipeline exposes an nf-test pattern not mapped here. Each entry names the motivating pipeline._

--- a/casts/claude/skills/nextflow-to-test-data/references/notes/component-nextflow-testing.yml
+++ b/casts/claude/skills/nextflow-to-test-data/references/notes/component-nextflow-testing.yml
@@ -1,0 +1,197 @@
+# nf-test patterns → Galaxy / CWL test equivalents.
+# Companion to component-nextflow-testing.md.
+#
+# Rows ordered by frequency in real nf-core pipelines (snapshot block first).
+
+mappings:
+
+  # ---- Snapshot block (nf-core canonical idiom) ----
+
+  - id: snapshot.match
+    nf_test_pattern: "assert snapshot(...).match()"
+    description: "Top-level snapshot assertion comparing serialized form of N captured values to a stored .nf.test.snap file."
+    galaxy_equivalent: "Per-output assertion block in <workflow>-tests.yml; no single-line analog. Decompose into per-capture assertions (rows below)."
+    cwl_equivalent: "cwltest expected_outputs entries per output; no single-line analog. Decompose."
+    target_link: "[[tests-format]]"
+    notes: "The whole-snapshot idiom is lossy on translation; explode into N per-capture assertions and accept the surface-area increase."
+
+  - id: snapshot.succeeded_task_count
+    nf_test_pattern: "workflow.trace.succeeded().size()"
+    description: "Count of successfully completed tasks. nf-core canonical first capture; brittle across pipeline versions but stable per release."
+    galaxy_equivalent: "Implicit in workflow execution success. Galaxy workflow tests pass iff the workflow completes; per-step success surfaces via has_text on log outputs."
+    cwl_equivalent: "Implicit in cwltest's `should_succeed` / `should_fail` boolean. No per-task count."
+    target_link: "[[planemo-asserts-idioms]] §1 (Plain text reports / logs)"
+    notes: "Drop on translation; targets verify success implicitly."
+
+  - id: snapshot.versions_yml
+    nf_test_pattern: "ch_versions or path('versions.yml')"
+    description: "The `versions` topic channel collected per process and dumped to versions.yml at workflow end. nf-core canonical second capture."
+    galaxy_equivalent: "has_text on the workflow's versions output (or the multiqc report's software-versions section). Galaxy versions surface via tool-shed metadata, not a unified versions.yml."
+    cwl_equivalent: "has_text or contains_string on the versions.yml output if produced; CWL doesn't enforce a versions topic."
+    target_link: "[[tests-format#has_text_model]]"
+    notes: "Galaxy assertion targets stable tool-name strings rather than version numbers (versions drift across Bioconda releases)."
+
+  - id: snapshot.stable_names
+    nf_test_pattern: "getAllFilesFromDir(params.outdir).list().sort()"
+    description: "Sorted list of file names produced under outdir; ignores content. nf-core canonical third capture."
+    galaxy_equivalent: "Tabular has_n_lines + has_text per known canonical filename; or a directory-listing collection with element_identifiers asserted."
+    cwl_equivalent: "expected_outputs with explicit listing on the output directory (Directory type)."
+    target_link: "[[tests-format#has_text_model]]"
+    notes: "nf-test's stable_names is a list comparison; Galaxy/CWL comparable via per-name has_text."
+
+  - id: snapshot.stable_paths
+    nf_test_pattern: "getAllFilesFromDir(...) with md5 hashing or path tuples"
+    description: "Per-file fingerprint (md5 or path tuple) of files under outdir. nf-core canonical fourth capture."
+    galaxy_equivalent: "Per-output `compare: diff` for byte-stable outputs; `compare: sim_size` for non-deterministic; has_text or has_archive_member for binary archives. See planemo-asserts-idioms by output type."
+    cwl_equivalent: "expected_outputs with `checksum` field (sha1 or sha256) per file."
+    target_link: "[[planemo-asserts-idioms]] §1 (decision table by output type)"
+    notes: "The richest translation surface; per-file decisions required. Cast skill should consult planemo-asserts-idioms for the right Galaxy assertion per file format."
+
+  - id: snapshot.helpers.getAllFilesFromDir
+    nf_test_pattern: "getAllFilesFromDir(<dir>, ignoreFile: <path>, ignore: [<globs>])"
+    description: "nf-test helper that recursively lists files, applying .nftignore / inline glob filters."
+    galaxy_equivalent: "No single-helper analog. Galaxy tests assert on individual outputs; the ignore pattern is implicit (tests don't reference filtered files)."
+    cwl_equivalent: "expected_outputs by file path; CWL has no `ignore` analog."
+    notes: "On translation, the cast skill records ignore_files/ignore_globs in summary-nextflow's SnapshotFixture but doesn't propagate them to the target test (the target is per-file, not per-tree)."
+
+  - id: snapshot.helpers.removeNextflowVersion
+    nf_test_pattern: "removeNextflowVersion(<file>)"
+    description: "nf-test helper that strips the Nextflow version line from a file before snapshotting."
+    galaxy_equivalent: "compare: diff with lines_diff: 1-2 (header tolerance); or has_text on stable rows only."
+    cwl_equivalent: "checksum on a sed-postprocessed copy."
+    target_link: "[[planemo-asserts-idioms]] §2 (compare operators)"
+
+  # ---- Workflow / process success assertions ----
+
+  - id: assert.workflow_success
+    nf_test_pattern: "assert workflow.success"
+    description: "Workflow completed without error."
+    galaxy_equivalent: "Implicit. planemo workflow test fails if any step errors."
+    cwl_equivalent: "should_succeed: true (default)."
+    notes: "Drop on translation."
+
+  - id: assert.workflow_failed
+    nf_test_pattern: "assert workflow.failed"
+    description: "Workflow expected to fail (negative test)."
+    galaxy_equivalent: "Galaxy workflow tests don't directly support expected-failure; encode as a separate negative test or skip."
+    cwl_equivalent: "should_fail: true."
+    notes: "Galaxy translation requires either skipping or reframing as a non-test (unusual)."
+
+  - id: assert.process_succeeded
+    nf_test_pattern: "assert process.success"
+    description: "Module-level test: the wrapped process succeeded."
+    galaxy_equivalent: "Implicit (process is a tool; tool failure → test failure)."
+    cwl_equivalent: "Implicit (CommandLineTool zero-exit)."
+    notes: "Module tests translate to Galaxy <tests> blocks (single-tool tests), not workflow tests."
+
+  - id: assert.process_failed
+    nf_test_pattern: "assert process.failed"
+    description: "Module-level test: process expected to fail."
+    galaxy_equivalent: "Galaxy <test expect_failure='true'>."
+    cwl_equivalent: "should_fail at job level."
+
+  # ---- Output assertions (file/channel) ----
+
+  - id: assert.output_path_equals
+    nf_test_pattern: "assert path(process.out.<name>[0]).equals(...)"
+    description: "Byte-exact file equality."
+    galaxy_equivalent: "compare: diff with file: fixture path."
+    cwl_equivalent: "expected_outputs with checksum (sha1 of fixture)."
+    target_link: "[[tests-format]]"
+
+  - id: assert.output_path_md5
+    nf_test_pattern: "assert path(process.out.<name>[0]).md5 == '<hash>'"
+    description: "MD5-pinned file equality."
+    galaxy_equivalent: "compare: diff with sim_size fallback if upstream tool is non-deterministic."
+    cwl_equivalent: "expected_outputs checksum: 'sha1$<hash>' (CWL prefers sha1; conversion needed)."
+    notes: "CWL conversion lossy: nf-test md5 must be re-derived as sha1 over the same fixture."
+
+  - id: assert.output_text_contains
+    nf_test_pattern: "assert path(out).text.contains('substring')"
+    description: "Substring match on file content."
+    galaxy_equivalent: "has_text: text: 'substring'."
+    cwl_equivalent: "expected_outputs partial-content match (cwltest doesn't support substring directly; checksum a normalized form or use a wrapper)."
+    target_link: "[[tests-format#has_text_model]]"
+
+  - id: assert.output_text_matches_regex
+    nf_test_pattern: "assert path(out).text =~ /<regex>/"
+    description: "Regex match on file content."
+    galaxy_equivalent: "has_text_matching: expression: '<regex>'."
+    cwl_equivalent: "Not supported natively; checksum a normalized form."
+    target_link: "[[tests-format#has_text_matching_model]]"
+
+  - id: assert.output_lines_count
+    nf_test_pattern: "assert path(out).readLines().size() == N"
+    description: "Line count equality."
+    galaxy_equivalent: "has_n_lines: n: N (with optional delta:)."
+    cwl_equivalent: "Not supported natively."
+    target_link: "[[tests-format#has_n_lines_model]]"
+
+  - id: assert.output_size
+    nf_test_pattern: "assert path(out).size() in <range>"
+    description: "File size assertion."
+    galaxy_equivalent: "has_size: value: <bytes> with delta: or delta_frac:."
+    cwl_equivalent: "Not supported natively; check via wrapper."
+    target_link: "[[tests-format#has_size_model]]"
+
+  - id: assert.output_channel_size
+    nf_test_pattern: "assert process.out.<name>.size() == N"
+    description: "Number of items in an output channel (e.g., scatter results)."
+    galaxy_equivalent: "Galaxy collection element count via element_count or has_collection_element."
+    cwl_equivalent: "expected_outputs array length on a Directory listing or output array."
+    notes: "Cardinality assertion translates to collection-shape tests in Galaxy; CWL needs an explicit listing."
+
+  # ---- File comparison via cmp/diff ----
+
+  - id: assert.cmp_files
+    nf_test_pattern: "assert path(out).bytes == path(fixture).bytes"
+    description: "Byte-exact comparison via Path API."
+    galaxy_equivalent: "compare: diff."
+    cwl_equivalent: "checksum match."
+
+  - id: assert.snapshot_file_md5
+    nf_test_pattern: "assert snapshot(path(out)).match() (single-file snapshot, md5 fingerprint)"
+    description: "Single-file snapshot. nf-test fingerprints by md5; the .snap file stores the hash."
+    galaxy_equivalent: "compare: diff or has_text per output type (per planemo-asserts-idioms decision table)."
+    cwl_equivalent: "expected_outputs checksum."
+    target_link: "[[planemo-asserts-idioms]] §1"
+
+  # ---- Workflow-level assertions ----
+
+  - id: workflow.trace_outputs
+    nf_test_pattern: "workflow.out.<name>"
+    description: "Reference a published-via-emit channel from a workflow."
+    galaxy_equivalent: "Galaxy workflow output dataset (named by output_name in <output>)."
+    cwl_equivalent: "Workflow output port with explicit type."
+    notes: "Map nf-test output names to Galaxy output_name 1:1; CWL output ports get the same names."
+
+  - id: workflow.publishDir_outputs
+    nf_test_pattern: "Files under params.outdir checked via getAllFilesFromDir"
+    description: "Files written by publishDir directives, asserted via tree walk."
+    galaxy_equivalent: "Galaxy History / collection assertions per output dataset."
+    cwl_equivalent: "Directory output with explicit listing."
+    notes: "publishDir is pipeline-level; module tests typically don't use this idiom."
+
+  # ---- Setup / teardown ----
+
+  - id: setup.test_data_path
+    nf_test_pattern: "setup { ... } block with file fetch from nf-core/test-datasets"
+    description: "Test fixture preparation; pulls files from a versioned test-datasets branch."
+    galaxy_equivalent: "Test fixtures under test_data/ in the workflow repo, or referenced by URL."
+    cwl_equivalent: "Job file referencing fixtures with location: URLs or relative paths."
+    target_link: "[[iwc-test-data-conventions]]"
+    notes: "Translation requires resolving the runtime URL (params.pipelines_testdata_base_path + ...) into a static fixture reference."
+
+  # ---- Configuration ----
+
+  - id: config.profile_test
+    nf_test_pattern: "-profile test (or test_full, test_dfast, ...)"
+    description: "Activates a conf/<profile>.config selecting test-sized inputs."
+    galaxy_equivalent: "Galaxy workflow tests have a single fixture set per test; multi-profile equivalent is multiple test entries."
+    cwl_equivalent: "Multiple cwltest test entries with different job files."
+
+  - id: config.params_file
+    nf_test_pattern: "-params-file <yaml>"
+    description: "Override params.* from a YAML file."
+    galaxy_equivalent: "<test><param name='X' value='Y'/></test> entries."
+    cwl_equivalent: "Job file in YAML; same as default."

--- a/casts/claude/skills/nextflow-to-test-data/references/notes/galaxy-workflow-testability-design.md
+++ b/casts/claude/skills/nextflow-to-test-data/references/notes/galaxy-workflow-testability-design.md
@@ -1,0 +1,139 @@
+---
+type: research
+subtype: component
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-05-03
+revised: 2026-05-06
+revision: 2
+ai_generated: true
+related_notes:
+  - "[[iwc-workflow-testability-survey]]"
+  - "[[iwc-test-data-conventions]]"
+  - "[[planemo-asserts-idioms]]"
+  - "[[iwc-shortcuts-anti-patterns]]"
+  - "[[planemo-workflow-test-architecture]]"
+  - "[[implement-galaxy-workflow-test]]"
+  - "[[gxformat2-schema]]"
+  - "[[gxformat2-workflow-inputs]]"
+  - "[[galaxy-datatypes-conf]]"
+summary: "Design guidance for Galaxy workflow inputs, outputs, and checkpoints that make IWC-style workflow tests possible."
+---
+
+# Galaxy workflow testability design
+
+Use this note when authoring or translating a Galaxy workflow **before** the `-tests.yml` file exists. It covers workflow structure choices that make later IWC-style tests meaningful: labels, promoted checkpoints, collection identifiers, and fixture-compatible inputs.
+
+This is not a `content/patterns/` page. It is cross-cutting design guidance for Molds that need testable Galaxy workflows. Assertion syntax lives in [[planemo-asserts-idioms]]. Test YAML fixture shapes live in [[iwc-test-data-conventions]]. Accepted shortcut vs smell calls live in [[iwc-shortcuts-anti-patterns]]. Corpus evidence trail lives in [[iwc-workflow-testability-survey]].
+
+## 1. Treat labels as API
+
+Workflow input and output labels are not cosmetic. Planemo and IWC tests address workflow inputs and outputs by label, and the survey found exact label matches for every asserted output across 114 matched workflow/test pairs. A generated workflow should therefore pick stable, descriptive labels before test authoring starts.
+
+Rules:
+
+- Label every output that may need a test assertion.
+- Treat input/output renames as breaking changes requiring sibling `-tests.yml` updates.
+- Prefer stable domain names over tool-step defaults or positional names.
+- Do not rely on unlabeled or positional outputs for tests.
+
+Evidence:
+
+- Scanpy exposes outputs such as `Initial Anndata General Info`, `UMAP of louvain`, `Ranked genes with Wilcoxon test`, and `Dotplot of top genes on clusters` (`$IWC_FORMAT2/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy.gxwf.yml:105-147`). The sibling test keys assertions by those exact labels (`$IWC/workflows/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml:27-205`).
+- VGP scaffolding uses punctuation-heavy labels such as `Hi-C duplication stats on scaffolds: Raw`, `Hi-C duplication stats on scaffolds: MultiQc`, and `Merged Alignment stats` (`$IWC_FORMAT2/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8.gxwf.yml:170-196`). The test asserts those exact labels (`$IWC/workflows/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8-tests.yml:218-245`).
+
+## 2. Promote assertable checkpoints
+
+IWC workflow tests assert workflow-level outputs. Intermediate step results are invisible unless promoted to top-level workflow outputs. When final reports are weakly assertable, expose intermediate checkpoints that carry deterministic content or structure.
+
+Rules:
+
+- Promote intermediate outputs when they are the best deterministic or structural checkpoint.
+- Prefer a checkpoint table/text/HDF5 object that can prove content over a final plot/report that can only prove existence.
+- Accept some output-list clutter when it buys meaningful tests.
+- Do not promote every intermediate by default; expose checkpoints that map to concrete assertion intent.
+
+Evidence:
+
+- Scanpy exposes 21 workflow outputs and the sibling test asserts all 21. These include initial AnnData summaries, intermediate plots, ranked-gene tables, final AnnData, cluster-count tables, and final plots (`$IWC_FORMAT2/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy.gxwf.yml:105-147`; `$IWC/workflows/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml:27-205`).
+- RNA-seq paired-end exposes mapped reads, stranded/unstranded coverage, abundance estimates, expression tables, counts tables, and MultiQC reports (`$IWC_FORMAT2/transcriptomics/rnaseq-pe/rnaseq-pe.gxwf.yml:90-112`). The sibling test asserts sizes for coverage/read outputs and stronger regex/line checks for expression/count outputs (`$IWC/workflows/transcriptomics/rnaseq-pe/rnaseq-pe-tests.yml:48-97`).
+- MGnify complete exposes 83 workflow outputs; 38 are asserted in the sibling test, including MultiQC reports, FASTA collections, taxonomic classifications, OTU tables, and HDF5/JSON outputs (`$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/mgnify-amplicon-pipeline-v5-complete.gxwf.yml:163-329`; `$IWC/workflows/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/mgnify-amplicon-pipeline-v5-complete-tests.yml:15-120`).
+
+## 3. Stabilize collection output identifiers
+
+Collection tests key assertions by element identifier. If a workflow emits collections with unstable or opaque identifiers, the test cannot target elements cleanly.
+
+Rules:
+
+- Preserve biologically or sample-meaningful identifiers through map-over and collection reshaping.
+- When generating or relabeling collections, make the identifier derivation deterministic and visible in workflow structure.
+- For nested collections, ensure each axis has predictable identifiers.
+- Quote special identifiers in tests when YAML requires it, but do not simplify identifiers merely for YAML convenience.
+
+Evidence:
+
+- 59 of 115 IWC test files use `element_tests:`, with 227 `element_tests:` blocks in the corpus survey.
+- 10x CellPlex tests nested collection outputs by `subsample`, then inner `matrix`, `barcodes`, and `genes` elements (`$IWC/workflows/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:82-128`). The workflow exposes the corresponding collection outputs (`$IWC_FORMAT2/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex.gxwf.yml:73-91`).
+- HyPhy collection outputs are tested by generated gene identifiers such as `NC_001477.1|capsid_protein_C|95-394_DENV1` (`$IWC/workflows/comparative_genomics/hyphy/hyphy-core-tests.yml:31-71`). The workflow exposes collection outputs for MEME, PRIME, BUSTED, and FEL (`$IWC_FORMAT2/comparative_genomics/hyphy/hyphy-core.gxwf.yml:26-38`).
+
+## 4. Choose checkpoints by assertion strength
+
+Assertion choice is not only a test-file decision. It should feed back into workflow output design. If the only exposed output is a stochastic plot or binary file, the best possible test may be a weak size check. Exposing a sibling table, report, HDF5 structure, or summary line can make the same workflow much more testable.
+
+Rules:
+
+- For image-heavy workflows, expose data or summary outputs behind the plot when possible.
+- For stochastic statistical outputs, expose structural checkpoints and stable summary tokens.
+- For binary outputs, expose a text/table report or stats file when the tool can produce one.
+- Use [[planemo-asserts-idioms]] to select the assertion family after choosing the checkpoint.
+
+Evidence:
+
+- Scanpy image outputs are mostly smoke-tested with `has_size`, `has_image_width`, and `has_image_height`, but the same workflow also exposes AnnData HDF5 keys and cluster-count table checks (`$IWC/workflows/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml:33-205`).
+- RNA-seq paired-end pairs coarse size checks for coverage/mapped-read outputs with stronger regex and exact-line checks for expression/count tables (`$IWC/workflows/transcriptomics/rnaseq-pe/rnaseq-pe-tests.yml:48-97`).
+- VGP scaffolding tests combine stable text checks for scaffold/report stats with size checks for map/alignment artifacts (`$IWC/workflows/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8-tests.yml:173-245`).
+
+## 5. Design inputs with fixtures in mind
+
+Workflow input labels and types constrain the eventual `job:` block. Fixture planning is not only a test-file activity: it should influence whether the workflow exposes a file input, a collection input, a string data-table input, or a typed parameter.
+
+Rules:
+
+- Choose input labels that will be readable as test `job:` keys.
+- Match workflow input collection types to realistic fixture shapes.
+- Decide early whether reference data should be a portable remote file or a CVMFS/data-table string.
+- Keep typed parameters explicit when tests need to set them (`int`, `boolean`, `string`) rather than burying them in step defaults.
+
+Evidence:
+
+- 10x CellPlex job inputs include `fastq PE collection GEX`, `reference genome`, `gtf`, `cellranger_barcodes_3M-february-2018.txt`, `fastq PE collection CMO`, `sample name and CMO sequence collection`, and `Number of expected cells` (`$IWC/workflows/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:2-75`). The workflow declares matching collection, data, string, boolean, and int inputs (`$IWC_FORMAT2/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex.gxwf.yml:4-72`).
+- HyPhy accepts a `list` collection of unaligned sequences and preserves accession-like fixture identifiers through to output element assertions (`$IWC/workflows/comparative_genomics/hyphy/hyphy-core-tests.yml:7-30`; `$IWC_FORMAT2/comparative_genomics/hyphy/hyphy-core.gxwf.yml:14-25`).
+
+## 6. Know what a gxformat2 output entry contains
+
+Top-level gxformat2 `outputs:` is the public workflow-output surface. It is separate from per-step `out:` declarations and from step post-job actions such as `change_datatype` or `rename`.
+
+Authoring rules:
+
+- Use `label` as the stable public name tests and users will address.
+- Use `outputSource` to point at the producing step output; do not rely on positional output order.
+- Use `doc` for short user-facing context when the label is not self-explanatory.
+- Keep `type` aligned with the exposed value (`data`, `collection`, or scalar vocabulary from [[gxformat2-workflow-inputs]]) when the schema needs it.
+- Apply `change_datatype` at the producing step output when Galaxy needs a stronger datatype than the tool reports; choose values from [[galaxy-datatypes-conf]].
+- Use `rename` only for generated dataset names inside Galaxy histories. It is not a substitute for stable workflow-output `label`.
+- Treat `add_tags` and `remove_tags` as metadata helpers, not as the test API. IWC tests key by labels and collection element identifiers, not tags.
+- Avoid `hide` or `delete_intermediate_datasets` on outputs that are promoted as test checkpoints.
+
+Design inference: a workflow-output promotion decision should pick both the public `outputs:` entry and any producer-side post-job action needed to make that output useful. For example, a synthesized BED checkpoint needs a stable output `label` plus a producer-side `change_datatype: bed`; one without the other is incomplete for a testable workflow.
+
+## Cross-references
+
+- [[iwc-workflow-testability-survey]] — corpus survey and distribution rationale.
+- [[iwc-test-data-conventions]] — job/input YAML shapes, remote fixtures, hashes, collection fixture syntax.
+- [[planemo-asserts-idioms]] — assertion-family choice after an output is exposed.
+- [[iwc-shortcuts-anti-patterns]] — accepted shortcut vs smell calls for weak assertions and label coupling.
+- [[planemo-workflow-test-architecture]] — Planemo execution, output-problem ambiguity, and structured artifacts.
+- [[gxformat2-schema]] — structural vocabulary for top-level workflow outputs and step post-job actions.
+- [[galaxy-datatypes-conf]] — valid Galaxy datatype extensions for `format` and `change_datatype` choices.

--- a/casts/claude/skills/nextflow-to-test-data/references/notes/iwc-test-data-conventions.md
+++ b/casts/claude/skills/nextflow-to-test-data/references/notes/iwc-test-data-conventions.md
@@ -1,0 +1,311 @@
+---
+type: research
+subtype: component
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-04-30
+revised: 2026-05-03
+revision: 3
+ai_generated: true
+related_notes:
+  - "[[galaxy-workflow-testability-design]]"
+  - "[[iwc-shortcuts-anti-patterns]]"
+  - "[[planemo-asserts-idioms]]"
+  - "[[implement-galaxy-workflow-test]]"
+  - "[[tests-format]]"
+  - "[[iwc-tabular-operations-survey]]"
+summary: "How IWC workflows organize and reference test data — Zenodo-first, SHA-1 integrity, collection shapes, CVMFS gotchas."
+---
+
+# IWC test data conventions
+
+Reference for an agent implementing or editing a `<workflow>-tests.yml` in IWC style. All evidence cited from `/Users/jxc755/projects/repositories/workflow-fixtures/iwc-src/workflows/` (raw IWC clone) and `workflows/README.md`. Authoritative spec: [planemo.readthedocs.io/en/latest/test_format.html](https://planemo.readthedocs.io/en/latest/test_format.html). The companion analysis at `/Users/jxc755/projects/repositories/galaxy-brain/vault/projects/workflow_state/skills/COMPONENT_GALAXY_WORKFLOW_TESTING.md` is the synthesized source for several normative claims here.
+
+This note owns **test YAML fixture shapes**. For workflow-structure choices that make those fixtures possible before the test file exists, use [[galaxy-workflow-testability-design]].
+
+## 1. Where does test data live? Remote vs in-repo
+
+Two storage patterns. They mix freely inside one job.
+
+**Remote `location:` (default for any non-trivial input).** Strongly preferred for anything bigger than a toy fixture. Order of preference, observed in the corpus:
+
+- **Zenodo** — overwhelming default, persistent DOI-backed URL.
+  - `read-preprocessing/short-read-qc-trimming/short-read-quality-control-and-trimming-tests.yml:13,17` — `https://zenodo.org/records/11484215/files/paired_r1.fastq.gz` (note the modern `/records/` plural form; older entries use `/record/`).
+  - `metabolomics/lcms-preprocessing/Mass_spectrometry__LC-MS_preprocessing_with_XCMS-tests.yml:6,17,24,...` — 11+ mzML files all hosted at `zenodo.org/record/10130758/files/...`.
+  - `sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation-tests.yml:5` — `https://zenodo.org/record/4555735/files/NC_045512.2_reference.fasta?download=1`.
+  - `repeatmasking/RepeatMasking-Workflow-tests.yml:5` — `https://zenodo.org/record/8364146/files/eco.fasta?download=1`. The `?download=1` query suffix is acceptable but optional; both forms appear.
+- **EBI/ENA REST** — for canonical reference sequences.
+  - `virology/pox-virus-amplicon/pox-virus-half-genome-tests.yml:5` — `https://www.ebi.ac.uk/ena/browser/api/fasta/AF325528.1?download=true`.
+- **SRA / ENA FTP** — for raw read accessions where re-uploading to Zenodo is wasteful.
+  - `pox-virus-half-genome-tests.yml:27,34,49,56` — `ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR151/076/SRR15145276/SRR15145276_1.fastq.gz`.
+
+**In-repo `path: test-data/...` (toy fixtures + small expected outputs only).** Used when:
+
+- File is small enough to commit (rule of thumb from corpus: low single-digit MB or smaller).
+- File is a hand-crafted toy or trimmed reference (e.g. a 5-element FASTA for HyPhy).
+- File is the *expected output* baseline for a `file:` exact-comparison assertion: `consensus-from-variation-tests.yml:31` — `file: test-data/masked_consensus.fa`.
+
+`workflows/README.md:67` makes the contract explicit: "try to generate a toy dataset … and then publish it to zenodo to have a permanent URL." `workflows/README.md:98`: "if some outputs are large, it is better to use assertions than storing the whole output file to the iwc repository."
+
+Subdirectory layout inside `test-data/` is free-form and used to organize related fixtures, e.g. `comparative_genomics/hyphy/test-data/unaligned_seqs/`, `test-data/codon_alignments/`, `test-data/iqtree_trees/` (referenced from `hyphy-core-tests.yml:13,17,21,...`).
+
+**Decision rule for an agent:**
+
+1. Expected-output baseline that's small — commit to `test-data/`.
+2. Toy/trimmed input < ~5 MB — commit to `test-data/`.
+3. Anything else — Zenodo (or EBI/SRA for canonical accessions). Add `hashes:` SHA-1.
+4. If the input is a reference index resolvable from CVMFS (`hg38`, `dm6`, `mm10`, …), use the plain string form. See section 5.
+
+## 2. The `class: File` block — exact YAML shapes
+
+All snippets verbatim from the IWC corpus.
+
+### 2a. Single remote file (with integrity hash)
+
+`virology/pox-virus-amplicon/pox-virus-half-genome-tests.yml:3-9`:
+
+```yaml
+Reference FASTA:
+  class: File
+  location: "https://www.ebi.ac.uk/ena/browser/api/fasta/AF325528.1?download=true"
+  filetype: fasta
+  hashes:
+  - hash_function: SHA-1
+    hash_value: 927d0d00b7db6ad60524bb9e50d3ab41c4ac5ecf
+```
+
+Field order is conventional but not enforced. `filetype:` is the Galaxy datatype name (`fasta`, `fastqsanger.gz`, `mzml`, `bed`, `tabular`, `csv`, `gtf`, `vcf`, …). `location:` URLs may be quoted or bare; both forms occur.
+
+### 2b. Single local file
+
+`comparative_genomics/hyphy/hyphy-core-tests.yml:3-6`:
+
+```yaml
+reference cds:
+  class: File
+  path: test-data/denv1_ref_cds.fasta
+  filetype: fasta
+```
+
+`path:` is relative to the workflow directory (the directory containing the `-tests.yml`). Hashes are usually omitted on local files — the file is in-tree, so integrity is implicit. They are nonetheless added in some workflows: `consensus-from-variation-tests.yml:15-18` shows `path: test-data/aligned_reads_for_coverage.bam` paired with a SHA-1 hash. The pattern appears to be: hashes added when the `-tests.yml` was generated by `planemo workflow_test_init --from_invocation`, which mints them automatically.
+
+A dataset attribute can be set on a single file to force a `dbkey`, e.g. `epigenetics/consensus-peaks/consensus-peaks-chip-pe-tests.yml:7-10`:
+
+```yaml
+- class: File
+  identifier: rep1
+  path: test-data/rep1.bam
+  dbkey: mm10
+```
+
+`dbkey:` and `decompress: true` (`scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:30`) are documented per-file attributes that ride alongside `class: File`.
+
+### 2c. List collection
+
+`hyphy-core-tests.yml:7-30`:
+
+```yaml
+unaligned sequences:
+  class: Collection
+  collection_type: list
+  elements:
+  - identifier: AB178040.1|2002
+    class: File
+    path: test-data/unaligned_seqs/AB178040.1|2002.fasta
+    filetype: fasta
+  - identifier: AB195673.1|2003
+    class: File
+    path: test-data/unaligned_seqs/AB195673.1|2003.fasta
+    filetype: fasta
+  ...
+```
+
+Each element is a single-file dict with an `identifier:`. A larger remote-only example with hashes per element: `metabolomics/lcms-preprocessing/Mass_spectrometry__LC-MS_preprocessing_with_XCMS-tests.yml:11-22`:
+
+```yaml
+Mass-spectrometry Dataset Collection:
+  class: Collection
+  collection_type: list
+  elements:
+  - class: File
+    identifier: Blanc05.mzML
+    location: https://zenodo.org/record/10130758/files/Blanc05.mzML
+    filetype: mzml
+    hashes:
+    - hash_function: SHA-1
+      hash_value: e98d5a4cd8849a145a032bdc31c348ad97cb59c3
+```
+
+### 2d. Paired collection (single pair)
+
+A `paired` collection is a Collection whose two elements have identifiers `forward` and `reverse`. In IWC it is rarely used at top level — it is almost always wrapped as a single-element `list:paired` (see 2e). When it appears bare, the shape is the inner block of 2e without the outer `list:paired` wrapper.
+
+### 2e. `list:paired` collection
+
+`read-preprocessing/short-read-qc-trimming/short-read-quality-control-and-trimming-tests.yml:3-18`:
+
+```yaml
+Raw reads:
+  class: Collection
+  collection_type: list:paired
+  elements:
+  - class: Collection
+    type: paired
+    identifier: pair
+    elements:
+    - class: File
+      identifier: forward
+      location: https://zenodo.org/records/11484215/files/paired_r1.fastq.gz
+      filetype: fastqsanger.gz
+    - class: File
+      identifier: reverse
+      location: https://zenodo.org/records/11484215/files/paired_r2.fastq.gz
+      filetype: fastqsanger.gz
+```
+
+Note: outer `collection_type: list:paired`, inner `type: paired` (not `collection_type:`). Inner element identifiers are the literal strings `forward` and `reverse` — these are reserved.
+
+A multi-pair list:paired with full hashes: `virology/pox-virus-amplicon/pox-virus-half-genome-tests.yml:17-38` or `scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:3-24`.
+
+### 2f. `list:list:paired` and deeper
+
+Not directly observed in sampled IWC inputs. The shape is recursive — wrap a `list:paired` element list inside another `class: Collection, collection_type: list:list:paired`, where each outer element is `class: Collection, type: list:paired` (analogous to the `list:paired` → `paired` nesting in 2e). For deeply-nested collections planemo's [`_writing_collections.rst`](https://github.com/galaxyproject/planemo/blob/master/docs/_writing_collections.rst) is the de-facto reference.
+
+Output side: nested-collection assertions DO exist in the corpus. `scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:82-98`:
+
+```yaml
+Seurat input for gene expression (filtered):
+  attributes: {collection_type: list:list}
+  element_tests:
+    subsample:
+      elements:
+        matrix:
+          asserts:
+            has_line:
+              line: "23932 3 1171"
+        barcodes:
+          asserts:
+            has_line:
+              line: "CACATGATCATAAGGA"
+```
+
+Pattern: outer `element_tests:` keyed by outer identifier; inner `elements:` (note plural, not `element_tests:` here) keyed by inner identifier. Optional `attributes: {collection_type: ...}` asserts the shape of the produced collection.
+
+### 2g. `composite_data:`
+
+**Not observed** in the sampled IWC corpus (`grep -rln "composite\|imzml\|primary_file\|extra_files" workflows/ --include="*-tests.yml"` returns nothing). Per the planemo spec the shape is a `composite_data:` mapping listing each component file path, but an agent emitting one in IWC style has no in-corpus reference and should treat it as unproven territory — fall back to the planemo docs and verify against `galaxy.tool_util.parser.yaml`.
+
+### 2h. CWL-style shorthand (list of File dicts without identifiers)
+
+Documented in planemo; not observed in sampled IWC. IWC always supplies explicit identifiers.
+
+### 2i. `tags:` on elements (Galaxy 20.09+)
+
+Documented in planemo; not surfaced in sampled IWC `-tests.yml` files (`grep "  tags:" --include="*-tests.yml"` empty across the sampled set). Practical absence — IWC tests rely on identifier matching, not tags.
+
+## 3. SHA-1 integrity hashes — when, when not, why
+
+**Format.** Always a list under `hashes:`, even for one entry. Each entry is `{hash_function: SHA-1, hash_value: <40-hex>}`. Verbatim from `pox-virus-half-genome-tests.yml:7-9`:
+
+```yaml
+hashes:
+- hash_function: SHA-1
+  hash_value: 927d0d00b7db6ad60524bb9e50d3ab41c4ac5ecf
+```
+
+Only `SHA-1` observed in the IWC corpus. The planemo spec also accepts `MD5`, `SHA-256`, `SHA-512` as `hash_function:` values; IWC does not exercise these.
+
+**When present:**
+
+- Every remote `location:`-fetched input in the sampled corpus carries a SHA-1 (Zenodo, EBI REST, SRA FTP). The hash guards against silent upstream corruption — Zenodo records are immutable but bit-rot and CDN-edge errors do happen; ENA FASTA endpoints can quietly change line-wrap.
+- Many local `path:`-loaded inputs also carry a SHA-1. This is `--from_invocation` autogeneration leaking through (planemo emits hashes for every input it captured).
+- `consensus-from-variation-tests.yml:6-8,17-18,27-28` — every input in the test, local and remote, has a hash.
+
+**When omitted:**
+
+- Hand-written local-file fixtures often skip hashes — `hyphy-core-tests.yml:3-30` has zero `hashes:` blocks across six local-file inputs.
+- Output assertions: `file:`-comparison outputs and `location:`-comparison outputs (`RepeatMasking-Workflow-tests.yml:13`) **do not** carry `hashes:`. The integrity story for outputs is handled by `compare:` / `asserts:` instead.
+
+**Why bother on local files.** Catches accidental corruption when collaborators hand-edit `test-data/` fixtures.
+
+## 4. Element identifier conventions
+
+Identifiers are arbitrary strings, used both as the YAML key (`element_tests:`) and as the produced Galaxy collection element name. Conventions surfaced from the corpus:
+
+- **Pipes are legal** and survive YAML round-trip without quoting on the input side: `hyphy-core-tests.yml:11` — `identifier: AB178040.1|2002`. On the *output* side they're quoted because they appear as YAML mapping keys: `hyphy-core-tests.yml:34` — `"NC_001477.1|capsid_protein_C|95-394_DENV1":`. Quote when the identifier contains characters that would otherwise start a YAML flow node (`{`, `[`, `&`, `*`, `!`, `|`, `>`, `'`, `"`, `%`, `@`, `` ` ``) or look like a number/bool.
+- **Dots, hyphens, underscores** — common, no quoting needed: `Blanc05.mzML`, `HU_neg_048.mzML`, `SRR11578257`, `Rep1`, `subsample`, `pair`.
+- **Reserved inside `paired` collections:** `forward` and `reverse` (lowercase). Never use these names for outer identifiers in `list:paired`.
+- **Inline comments after identifier** are legal and used for provenance: `pox-virus-half-genome-tests.yml:23` — `identifier: 20L70   # SRR15145276`.
+- **Whitespace and special chars in workflow input *labels*** survive too — they are job-mapping keys, not collection identifiers, but the same YAML quoting rules apply. Example from the analysis doc: `Manually annotate celltypes?: true` as a job key in `Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml:23`.
+
+### 4a. Workflow-interface implications
+
+Fixture shape should feed back into workflow input design. Tests supply job inputs by workflow input label, and collection fixtures must match the workflow's declared collection type.
+
+- The 10x CellPlex test uses `fastq PE collection GEX`, `fastq PE collection CMO`, and `sample name and CMO sequence collection` as job keys with `list:paired` and `list` collection fixtures; the workflow declares matching collection inputs at `$IWC_FORMAT2/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex.gxwf.yml:4-72`.
+- CVMFS/data-table shortcuts like `reference genome: dm6` are workflow-interface choices as much as test YAML choices: they require the workflow input to be a string/data-table-backed parameter, not a file input.
+- If a fixture needs stable sample names, decide whether those names should enter through collection element identifiers, a mapping file, or a workflow parameter before writing assertions.
+
+Rule for an agent: when a new workflow input is being designed and the test fixture is already known, check [[galaxy-workflow-testability-design]] before locking the input label/type.
+
+## 5. CVMFS / `.loc` / built-in-index references
+
+When a workflow input is a Galaxy data-table-backed reference (built-in genome index, dbsnp file, kraken DB, …), the input takes a **plain string** matching the `value` column of a `.loc` file. No `class: File`, no `location:`. Examples:
+
+- `scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:25` — `reference genome: dm6 # To test on usegalaxy.eu dm6full`
+- `epigenetics/cutandrun/cutandrun-tests.yml:27` — `reference_genome: 'hg38canon'`
+- `epigenetics/atacseq/atacseq-tests.yml:25` — `reference_genome: hg19`
+- `microbiome/host-contamination-removal/host-contamination-removal-short-reads/host-or-contamination-removal-on-short-reads-tests.yml:19` — `Host/Contaminant Reference Genome: hg38`
+- `microbiome/pathogen-identification/nanopore-pre-processing/Nanopore-Pre-Processing-tests.yml:22` — `host_reference_genome: apiMel3`
+- `transcriptomics/goseq/goseq-go-kegg-enrichment-analsis-tests.yml:24` — `Select genome to use: mm10`
+
+The string is the first column of the `.loc` entry. `workflows/README.md:169-182` shows the lookup procedure: browse `http://datacache.galaxyproject.org/indexes/location/<table>.loc`, find the `.loc` row, take the value column (which column varies by tool — check the matching `tool_data_table_conf.xml.sample`).
+
+**Portability implication:** these tests **only** run on a Galaxy with CVMFS mounted at `/cvmfs/data.galaxyproject.org`. IWC CI mounts CVMFS in-runner (`setup-cvmfs: true` in `.github/workflows/test_workflows.yml`). On a plain developer laptop running `planemo test`, CVMFS-string inputs fail unresolved. An agent generating tests should either:
+
+1. Stay URL-driven: replace the CVMFS string with a `class: File` + `location:` to a Zenodo-hosted reference (portable, slower CI, larger inputs).
+2. Use the CVMFS string and document "CI-only" — the user cannot reproduce locally without a CVMFS mount.
+
+There is no `.loc`-resolution shorthand in the YAML — it is just a bare string parameter. Agents must not invent `class: DataTable` or similar.
+
+## 6. Reviewer-feedback patterns (PR-review)
+
+Recurring asks from IWC reviewers, distilled from the contribution README and community help threads:
+
+- **Move large data to Zenodo before merge.** Anything bigger than a toy fixture committed in `test-data/` will be flagged. `workflows/README.md:67`.
+- **Use assertions, not exact-file comparison, for large outputs.** `workflows/README.md:98` — "if some outputs are large, it is better to use assertions than storing the whole output file."
+- **Generate tests with `planemo workflow_test_init --from_invocation`, don't hand-write.** `workflows/README.md:88-94`. The autogenerated test will mint correct hashes, correct labels, and a working `test-data/` snapshot.
+- **Set creator `identifier:` to a full ORCID URL** (e.g. `https://orcid.org/0000-0002-1825-0097`) — `workflows/README.md:53`. The most common lint failure; enforced in [planemo#1458](https://github.com/galaxyproject/planemo/pull/1458).
+- **Don't use `compare: diff` on outputs that embed timestamps or non-deterministic ordering.** Switch to `has_text` / `has_n_lines` (with `delta:`) or `compare: sim_size`+`delta:`.
+- **Bump `release:` in the `.ga` and add a `CHANGELOG.md` entry** in the same PR — enforced by the IWC PR template; reviewers verify via `bump_version.py`.
+- **Lower-case + `-` only** in directory names — `workflows/README.md:11,72`.
+- **Element identifiers must round-trip** — quote in YAML when they contain pipes/colons/whitespace.
+
+## 7. What is *not* covered by current convention
+
+Gaps an agent should be aware of:
+
+- **`composite_data:` is unrepresented in the IWC corpus.** No working examples to imitate for imzml+ibd or other multi-file datatypes. Treat as off-trail; cite planemo docs and verify by parser.
+- **`tags:` on elements unused.** Galaxy 20.09+ supports them; IWC does not exercise them.
+- **CWL-style shorthand File lists unused.** IWC always names elements.
+- **No negative tests.** Zero `expect_failure:` across the sampled corpus. There is no IWC convention for asserting a workflow *should* fail on bad input.
+- **No checksum-based output assertion in the wild.** `checksum: "sha1$..."` is documented and used at the input side as `hashes:`, but output-side `checksum:` was not surfaced in sampled tests. The corpus prefers `file:` (exact), `compare: sim_size`+`delta:` (size only), or `asserts:` (content probes).
+- **No data-cache layer beyond pip/planemo.** Every test re-pulls remote inputs from Zenodo / EBI / SRA on every CI run. A Zenodo outage breaks many PRs simultaneously. There is no IWC-side mirror or cache.
+- **No per-test timeout / retry convention.** A hung tool blocks the whole chunk until the GitHub Actions 6-hour limit.
+- **No portable story for CVMFS-only tests.** The same `-tests.yml` either works locally (URL-driven) or works in CI (CVMFS-string-driven), not both. There is no documented switch.
+- **Hash function is de-facto SHA-1.** The spec accepts SHA-256/SHA-512/MD5; IWC does not use them. Agents that emit a stronger hash will pass planemo but break corpus convention.
+- **Local-file `hashes:` are inconsistently present.** `--from_invocation`-generated tests have them, hand-written tests usually don't. Either is accepted; don't expect uniformity.
+- **`decompress: true` and `dbkey:` are file-level attributes** but undocumented at the planemo test_format page in the same place as `class:`/`location:`/`hashes:`. Cross-reference against the `gxformat2` Schema-Salad bindings if unsure.
+- **`?download=1` query string on Zenodo URLs** is optional. Both forms appear (`/record/4555735/files/X?download=1` vs `/records/11484215/files/Y`). The newer `/records/` plural is the modern Zenodo URL form; both work.
+
+## Cross-references
+
+- [[galaxy-workflow-testability-design]] — workflow input/output structure choices that make these fixture shapes testable.
+- `/Users/jxc755/projects/repositories/galaxy-brain/vault/projects/workflow_state/skills/COMPONENT_GALAXY_WORKFLOW_TESTING.md` — full synthesis with assertion-vocabulary table, CI internals, and tooling rundown. Sections 2b, 3, 4, 5, 9 are the direct upstream of this note.
+- planemo test format spec: [planemo.readthedocs.io/en/latest/test_format.html](https://planemo.readthedocs.io/en/latest/test_format.html).
+- planemo best practices: [planemo.readthedocs.io/en/latest/best_practices_workflows.html](https://planemo.readthedocs.io/en/latest/best_practices_workflows.html).
+- planemo collections reference: [github.com/galaxyproject/planemo/blob/master/docs/_writing_collections.rst](https://github.com/galaxyproject/planemo/blob/master/docs/_writing_collections.rst).
+- IWC contribution contract: `workflows/README.md` in [github.com/galaxyproject/iwc](https://github.com/galaxyproject/iwc).
+- Galaxy datacache (CVMFS `.loc` browsing): [datacache.galaxyproject.org/indexes/location/](http://datacache.galaxyproject.org/indexes/location/).

--- a/casts/claude/skills/nextflow-to-test-data/references/schemas/summary-nextflow.schema.json
+++ b/casts/claude/skills/nextflow-to-test-data/references/schemas/summary-nextflow.schema.json
@@ -1,0 +1,1499 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://galaxyproject.org/foundry/schemas/summary-nextflow.schema.json",
+  "$comment": "Canonical source: packages/summarize-nextflow/src/schema/summary-nextflow.schema.json in galaxyproject/foundry. Mold frontmatter cites this schema via [[summary-nextflow]] wiki-links; the cast pipeline imports the `summaryNextflowSchema` runtime export and serializes it into cast bundles.",
+  "title": "Nextflow Pipeline Summary",
+  "description": "Structured per-source summary emitted by the summarize-nextflow Mold.\n\nPer-source schema by design — paper, Nextflow, and CWL each have their own summary shape; downstream Molds (data flow, templates, tool wrappers) consume any source's summary and handle the polymorphism.\n\nField names mirror gxy-sketches' SketchSource / ToolSpec / TestDataRef / ExpectedOutputRef where parity exists; see content/research/gxy-sketches-alignment.md.",
+  "$ref": "#/$defs/Summary",
+  "$defs": {
+    "Summary": {
+      "title": "Summary",
+      "description": "Top-level shape. Every Nextflow summary is exactly this object.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source",
+        "params",
+        "sample_sheets",
+        "profiles",
+        "tools",
+        "processes",
+        "subworkflows",
+        "workflow",
+        "reference_assets",
+        "reference_rebuilds",
+        "test_fixtures",
+        "nf_tests"
+      ],
+      "properties": {
+        "source": {
+          "$ref": "#/$defs/SourceRecord"
+        },
+        "params": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Param"
+          }
+        },
+        "sample_sheets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SampleSheet"
+          },
+          "description": "Structured sample-sheet inputs. Each entry binds one `params[]` parameter to a row schema (column names, types, path-vs-meta classification, required flags, enums, patterns). Promoted from prose inside `params[].description` so downstream target translations (Galaxy `sample_sheet*` collections, CWL records-of-arrays) can choose collection variants without re-parsing the source pipeline. Empty array when no sample-sheet idiom is detected. Discovery sources: nf-schema `schema:` references, `samplesheetToList()` calls, and `splitCsv(header: true)` materializations."
+        },
+        "profiles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Tool"
+          }
+        },
+        "processes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Process"
+          }
+        },
+        "subworkflows": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Subworkflow"
+          }
+        },
+        "workflow": {
+          "$ref": "#/$defs/Workflow"
+        },
+        "reference_assets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ReferenceAsset"
+          },
+          "description": "Curated, target-agnostic view of reference-data inputs the source pipeline consumes (FASTAs, indexes, dictionaries, annotation tables, …). Each entry is a foreign-key projection onto `params[]` plus source-side metadata (asset kind, format hint, source expression, schema group, callers). Empty array when no reference assets are detected. Downstream Molds (e.g. nextflow-summary-to-galaxy-reference-data) classify these against Galaxy translation rungs; classification decisions are not encoded here."
+        },
+        "reference_rebuilds": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ReferenceRebuildRule"
+          },
+          "description": "Compute-if-missing rebuild branches detected in workflow/subworkflow bodies. Each entry binds an asset param to the guard and builder process that recomputes it when absent. Empty when no rebuild idioms are found. Source evidence only — Galaxy in-tool-rebuild decisions live downstream."
+        },
+        "test_fixtures": {
+          "$ref": "#/$defs/TestFixtures",
+          "description": "Test-input data shape for the *selected* profile (the cast's `profile` argument, default `test`). For pipelines with multiple test profiles, see `nf_tests[]` for the full enumeration."
+        },
+        "nf_tests": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/NfTest"
+          },
+          "description": "All `tests/*.nf.test` files in the pipeline. Each entry captures one test-program — its profile, params overrides, and structured assertions. Empty array when the pipeline has no nf-test fixtures."
+        },
+        "warnings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Cast-skill-emitted advisory messages (e.g. DSL1 detected, meta.yml/script disagreement, lossy assertion summarization). Empty array on a clean run."
+        }
+      }
+    },
+    "SourceRecord": {
+      "title": "SourceRecord",
+      "description": "Provenance block. Mirrors gxy-sketches SketchSource field names so a Foundry summary is structurally consumable by anyone using that shape.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "ecosystem",
+        "workflow",
+        "url",
+        "version",
+        "slug"
+      ],
+      "properties": {
+        "ecosystem": {
+          "type": "string",
+          "enum": [
+            "nf-core",
+            "nextflow"
+          ],
+          "description": "Pipeline flavor. `nf-core` when `manifest.name` is `nf-core/<slug>` and the canonical layout is present; `nextflow` for ad-hoc DSL2 pipelines. Superset of gxy-sketches' enum (which adds `iwc`, `snakemake-workflows`, `wdl` for its other ingestors)."
+        },
+        "workflow": {
+          "type": "string",
+          "description": "Pipeline name (typically the part after `nf-core/`)."
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Git remote URL of the pipeline repository."
+        },
+        "version": {
+          "type": "string",
+          "description": "Tag, branch, or commit SHA the summary was derived from."
+        },
+        "license": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "SPDX license identifier when detectable from a LICENSE file."
+        },
+        "slug": {
+          "type": "string",
+          "description": "Kebab-case identifier; `<owner>-<repo>` for nf-core, repo basename otherwise."
+        }
+      }
+    },
+    "Param": {
+      "title": "Param",
+      "description": "One pipeline parameter. Sourced from `nextflow.config`'s `params { ... }` block, augmented from `nextflow_schema.json` when present (nf-core).",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "type",
+        "required"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "description": "JSON Schema-style type when nextflow_schema.json supplies it (string, integer, number, boolean, path); free-form when inferred from a default value."
+        },
+        "default": {
+          "description": "Default value verbatim from the source. May be null."
+        },
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "enum": {
+          "type": "array",
+          "items": {},
+          "description": "Allowed values when nextflow_schema.json declares them."
+        },
+        "format": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "JSON Schema `format` keyword from nextflow_schema.json. nf-schema vocabulary: `file-path`, `directory-path`, `path`, `file-path-pattern`. Distinguishes path-typed params (datasets/collections) from plain strings without re-reading the source schema. Null when undeclared."
+        },
+        "hidden": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "nf-schema `hidden` keyword. True for CLI-plumbing params (e.g. `validate_params`, `pipelines_testdata_base_path`, `version`) that shouldn't surface in user-facing target interfaces. Null when undeclared."
+        },
+        "mimetype": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "nf-schema `mimetype` keyword (e.g. `text/csv`, `text/plain`, `application/gzip`). Useful for seeding Galaxy `format` on path-typed params. Null when undeclared."
+        },
+        "schema_group": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Human-readable group label from the parent nextflow_schema.json `$defs` section's `title` (e.g. `Input/output options`, `Reference genome options`). Preserves nf-schema sectioning so target interfaces can group inputs without re-parsing the source. Null when the param is not under a titled section."
+        },
+        "fa_icon": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Font Awesome icon class from the parent `$defs` section's `fa_icon` (e.g. `fas fa-terminal`). Optional UI hint; null when undeclared."
+        },
+        "source_kind": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "nextflow_schema",
+            "params_block",
+            "getGenomeAttribute",
+            "computed",
+            null
+          ],
+          "description": "How this param entry was derived. `nextflow_schema`: declared in `nextflow_schema.json`. `params_block`: declared (or defaulted) in `nextflow.config`'s `params { ... }` block. `getGenomeAttribute`: synthesized from `params.X = getGenomeAttribute('X')` assignments in `nextflow.config` (nf-core key-expanded bundle pattern). `computed`: derived from another non-getGenomeAttribute expression. Null when provenance was not classified."
+        },
+        "source_expression": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Verbatim right-hand-side expression when the param was assigned in Groovy (e.g. `getGenomeAttribute('fasta_fai')`). Null when the param comes from a JSON Schema entry only."
+        },
+        "source_path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Repo-relative path of the source file where the assignment lives (e.g. `nextflow.config`, `conf/igenomes.config`). Null when undefined or when the param comes only from `nextflow_schema.json`."
+        }
+      }
+    },
+    "SampleSheet": {
+      "title": "SampleSheet",
+      "description": "One sample-sheet-shaped pipeline input. Captures the row schema, path-vs-meta column classification, and discovery provenance so downstream Molds can map onto Galaxy `sample_sheet[:variant]` collections, CWL records-of-arrays, or other target shapes without re-reading the source.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "param",
+        "discovered_via",
+        "columns"
+      ],
+      "properties": {
+        "param": {
+          "type": "string",
+          "description": "Foreign key into `params[].name` — the parameter whose value points at the sample-sheet file."
+        },
+        "schema_path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Repo-relative path of the JSON Schema file describing rows (e.g. `assets/schema_input.json`), resolved from the param's nf-schema entry's `schema:` keyword. Null when discovered via `samplesheetToList` without a schema reference, or via `splitCsv(header: true)` ad-hoc parsing."
+        },
+        "discovered_via": {
+          "type": "string",
+          "enum": [
+            "nf-schema",
+            "samplesheetToList",
+            "splitCsv",
+            "ad-hoc"
+          ],
+          "description": "How the sample-sheet shape was detected. `nf-schema`: nextflow_schema.json entry has `schema:` keyword. `samplesheetToList`: workflow imports nf-schema's helper and calls it on the param. `splitCsv`: workflow uses `splitCsv(header: true)` on the param's path. `ad-hoc`: pipeline-specific CSV/TSV parsing inferred from script bodies."
+        },
+        "format": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "csv",
+            "tsv",
+            "csv-or-tsv",
+            null
+          ],
+          "description": "Tabular format declared by the param's `mimetype` or inferred from `samplesheetToList` / `splitCsv` semantics. Null when undeclared."
+        },
+        "header": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Whether the file is expected to have a header row. Null when the discovery source doesn't pin it."
+        },
+        "columns": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SampleSheetColumn"
+          },
+          "description": "Row schema in declaration order. nf-schema's `samplesheetToList` emits columns in property order, not source-column order — preserve property order here so downstream translations match runtime channel item layout."
+        }
+      }
+    },
+    "SampleSheetColumn": {
+      "title": "SampleSheetColumn",
+      "description": "One column in a sample-sheet row schema. Type vocabulary is JSON Schema-style scalar; `kind` separates dataset-reference columns from per-row metadata. Validation hints (`pattern`, `enum`, `exists`, `mimetype`) are preserved verbatim — target Molds decide which of them survive translation (e.g. Galaxy's `sample_sheet` validator allowlist is regex/in_range/length).",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "type",
+        "kind",
+        "required"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "integer",
+            "number",
+            "boolean"
+          ],
+          "description": "JSON Schema-style scalar type. Path columns are typed `string` with a `format: file-path|directory-path|path` qualifier — see `format` and `kind`."
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "data",
+            "meta"
+          ],
+          "description": "`data`: path-typed column whose values are dataset references (becomes element/inner-collection slot in Galaxy `sample_sheet`). `meta`: scalar metadata column (becomes a `column_definitions` entry, populated per row in `columns[]`). Includes the nf-schema `meta:` annotation when present; in its absence inferred from `format` (`file-path`/`directory-path`/`path` → `data`, anything else → `meta`)."
+        },
+        "format": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "JSON Schema `format` keyword. nf-schema vocabulary: `file-path`, `directory-path`, `path`, `file-path-pattern`. Null for scalar metadata columns without a format hint."
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "default": {
+          "description": "Default value verbatim from the sample-sheet schema. May be null."
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "enum": {
+          "type": "array",
+          "items": {},
+          "description": "Allowed values when the column schema declares an `enum`. Empty array when absent."
+        },
+        "pattern": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "JSON Schema regex `pattern` when present."
+        },
+        "exists": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "nf-schema `exists` flag for path columns. True when the parser must verify the file exists."
+        },
+        "mimetype": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "nf-schema `mimetype` keyword (e.g. `text/csv`, `application/gzip`). Useful for target datatypes."
+        }
+      }
+    },
+    "Tool": {
+      "title": "Tool",
+      "description": "One tool/dependency the pipeline runs. Mirrors gxy-sketches ToolSpec (name + version) and augments it with the resolved container/conda strings the bridge to author-galaxy-tool-wrapper needs.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "version"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Canonical tool name (e.g. `fastp`, `samtools`). Used as the foreign key from `processes[].tool`."
+        },
+        "version": {
+          "type": "string"
+        },
+        "biocontainer": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "BioContainers image reference when one was found. Includes both `quay.io/biocontainers/<name>:<version>--<build>` and the docker.io alias `biocontainers/<name>:<version>--<build>` (modern nf-core modules typically use the docker.io form in the docker branch and the depot.galaxyproject.org form in the singularity branch)."
+        },
+        "bioconda": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "`bioconda::<name>=<version>` spec when a `conda` directive provides one — directly or by reference to a `${moduleDir}/environment.yml` whose `dependencies:` list contains a single bioconda entry. The latter is the modern nf-core convention."
+        },
+        "docker": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Non-biocontainer Docker registry image string when present."
+        },
+        "singularity": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Singularity image reference when present (e.g. `https://depot.galaxyproject.org/singularity/...`)."
+        },
+        "wave": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Seqera Wave / community-cr registry reference (e.g. `community.wave.seqera.io/library/<name>:<version>--<digest>` or `https://community-cr-prod.seqera.io/.../sha256/<digest>/data`). Wave-built containers are increasingly common in nf-core; kept distinct from `docker` because the resolution rules and provenance differ."
+        },
+        "mulled_components": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ToolSpec"
+          },
+          "description": "Constituent Bioconda packages for an opaque `mulled-v2-*` multi-package container when resolved from a cached BioContainers multi-package-containers TSV. Omitted when no matching cached row is available."
+        }
+      }
+    },
+    "ToolSpec": {
+      "title": "ToolSpec",
+      "description": "One constituent package in a decomposed multi-package container.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "version",
+        "bioconda"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "bioconda": {
+          "type": "string",
+          "description": "Exact Bioconda requirement spec, e.g. `bioconda::samtools=1.20`."
+        }
+      }
+    },
+    "ChannelIO": {
+      "title": "ChannelIO",
+      "description": "One declared input or output channel of a process. Channel shape is a string, not a structured type — `tuple(meta, [path,path])` is enough for downstream Molds and avoids a research project on NF channel typing.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "shape"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "shape": {
+          "type": "string",
+          "description": "String-encoded channel shape, e.g. `tuple(meta, [path,path])`, `path`, `val(integer)`."
+        },
+        "description": {
+          "type": "string"
+        },
+        "topic": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Nextflow channel-topic name when this output is bound to a topic (e.g. `versions` for the standard nf-core version-aggregation topic). Topics are a Nextflow 24+ feature; the module-level `topic: <name>` annotation on a process output emits to a global named channel that any consumer can `channel.topic('<name>')` to read. Null for non-topic outputs and for all inputs."
+        }
+      }
+    },
+    "Process": {
+      "title": "Process",
+      "description": "One Nextflow `process { ... }` block.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "module_path",
+        "meta",
+        "module_tests",
+        "inputs",
+        "outputs"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Canonical process name (uppercase NF convention) as declared by the `process <NAME>` line in `module_path`."
+        },
+        "aliases": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Alias names this process is imported as in workflow scopes via `include { <NAME> as <ALIAS> }`. Real nf-core pipelines re-import a single module multiple times under different aliases to invoke it with distinct runtime args (e.g. `MINIMAP2_ALIGN as MINIMAP2_CONSENSUS`, `MINIMAP2_ALIGN as MINIMAP2_POLISH`). Each alias appears in `workflow.edges[].from`/`.to` exactly as written; the canonical `name` does not appear in edges unless an unaliased import exists. Default `[]` when the process is only imported under its canonical name."
+        },
+        "in_subworkflows": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Denormalized FK: names of `subworkflows[]` whose `calls[]` invoke this process (canonical name or any alias). Empty `[]` when the process is only invoked from the primary `workflow` body. Useful for grouping the flat process-tier DAG into a subworkflow-tier view client-side. Multi-entry when the same module is invoked from several subworkflows (typically via aliases)."
+        },
+        "module_path": {
+          "type": "string",
+          "description": "Relative path from the pipeline root to the file declaring the process."
+        },
+        "meta": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ModuleMeta"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Normalized `meta.yml` from the module directory when present. Null for local/ad-hoc processes without module metadata."
+        },
+        "module_tests": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/NfTest"
+          },
+          "description": "Module-scoped nf-test files under the module's `tests/` directory. Empty for local/ad-hoc modules without unit tests."
+        },
+        "tool": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Foreign key into `tools[].name` when the process runs a single recognizable tool; null for multi-tool or pure-Groovy processes."
+        },
+        "container": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Verbatim text of the process's `container` directive (or null). Modern nf-core modules use a ternary expression `\"${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ? '<singularity-uri>' : '<docker-uri>' }\"` — keep that text intact here. The two resolved branches are split out into `tools[].docker` / `tools[].singularity` (and `tools[].wave` / `tools[].biocontainer` as appropriate)."
+        },
+        "conda": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Verbatim text of the process's `conda` directive (or null). Two common shapes: a literal `bioconda::<name>=<version>` (legacy) or a file reference `${moduleDir}/environment.yml` (modern nf-core convention). Either way the resolved bioconda spec lands in `tools[].bioconda`."
+        },
+        "inputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ChannelIO"
+          }
+        },
+        "outputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ChannelIO"
+          }
+        },
+        "when": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Verbatim `when:` guard expression, or null if absent."
+        },
+        "script_summary": {
+          "type": "string",
+          "description": "One-line LLM-derived summary of what the `script:` body does. Free text."
+        },
+        "publish_dir": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "`publishDir` value when the process publishes outputs (or null)."
+        }
+      }
+    },
+    "ModuleMeta": {
+      "title": "ModuleMeta",
+      "description": "Normalized subset of nf-core module `meta.yml`, captured next to a process so module-scoped downstream Molds can consume `processes[i]` without reading the full pipeline summary.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "keywords",
+        "authors",
+        "maintainers",
+        "tools",
+        "input",
+        "output"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "keywords": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "authors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "maintainers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ModuleMetaEntry"
+          }
+        },
+        "input": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ModuleMetaEntry"
+          }
+        },
+        "output": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ModuleMetaEntry"
+          }
+        }
+      }
+    },
+    "ModuleMetaEntry": {
+      "title": "ModuleMetaEntry",
+      "description": "One named entry from a module `meta.yml` section, normalized from nf-core's single-key YAML maps into `{ name, ...fields }` objects.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "homepage": {
+          "type": "string"
+        },
+        "documentation": {
+          "type": "string"
+        },
+        "tool_dev_url": {
+          "type": "string"
+        },
+        "doi": {
+          "type": "string"
+        },
+        "licence": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "identifier": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "pattern": {
+          "type": "string"
+        }
+      }
+    },
+    "Subworkflow": {
+      "title": "Subworkflow",
+      "description": "One named `workflow <NAME> { ... }` block other than the primary workflow. Includes nf-core utility wrappers (PIPELINE_INITIALISATION, PIPELINE_COMPLETION, UTILS_NFCORE_PIPELINE) which exist to compose helper-function calls rather than to invoke processes.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "path",
+        "kind",
+        "calls",
+        "tests"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string",
+          "description": "Relative path from the pipeline root."
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "pipeline",
+            "utility"
+          ],
+          "description": "`pipeline` when the subworkflow invokes pipeline processes (data-flow contributor). `utility` when it composes helper functions only — common nf-core template subworkflows like PIPELINE_INITIALISATION (which calls `paramsHelp`, `samplesheetToList`, `UTILS_NFSCHEMA_PLUGIN`) and PIPELINE_COMPLETION (`completionEmail`, `completionSummary`). Utility subworkflows have empty `calls[]` for processes but may still expose channel outputs the primary workflow consumes."
+        },
+        "calls": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Names of processes and nested subworkflows this subworkflow invokes. Free-function calls (e.g. `paramsHelp`, `completionEmail`) are NOT recorded here; they're implied by `kind = utility`."
+        },
+        "inputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ChannelIO"
+          },
+          "description": "Parsed entries of the subworkflow's `take:` block. `name` is the take name, `description` carries any adjacent `// ...` comment, `shape` carries the verbatim source line."
+        },
+        "outputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ChannelIO"
+          }
+        },
+        "invocations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SubworkflowInvocation"
+          },
+          "description": "Call-sites where this subworkflow was invoked. Each entry records the calling workflow/subworkflow, the verbatim positional arguments, and a per-argument binding onto this subworkflow's `inputs[].name` (take names). Drives reference-asset attribution (`reference_assets[].used_by`) without re-parsing call sites. Empty when uncalled or when the call could not be positionally aligned."
+        },
+        "tests": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/NfTest"
+          },
+          "description": "Subworkflow-scoped nf-test files under the subworkflow's `tests/` directory. Empty when absent."
+        }
+      }
+    },
+    "SubworkflowInvocation": {
+      "title": "SubworkflowInvocation",
+      "description": "One call-site of a subworkflow, with positional arguments bound to its `take:` names.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "caller",
+        "arguments",
+        "bindings"
+      ],
+      "properties": {
+        "caller": {
+          "type": "string",
+          "description": "Name of the calling workflow or subworkflow."
+        },
+        "caller_path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Repo-relative path of the file the caller is defined in. Null when not resolvable."
+        },
+        "arguments": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Verbatim positional argument expressions in source order (e.g. `params.fasta`, `PREPARE_GENOME.out.fai`)."
+        },
+        "bindings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/InvocationBinding"
+          },
+          "description": "Per-argument binding onto the callee's `inputs[].name` (take names), in source order. Length matches `arguments[]` when the call positionally aligns to the callee's take block; shorter when only a prefix aligns."
+        }
+      }
+    },
+    "InvocationBinding": {
+      "title": "InvocationBinding",
+      "description": "Binding of one positional argument to a callee `take:` name.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "take",
+        "argument"
+      ],
+      "properties": {
+        "take": {
+          "type": "string",
+          "description": "Callee `take:` name (FK into the callee subworkflow's `inputs[].name`)."
+        },
+        "argument": {
+          "type": "string",
+          "description": "Verbatim caller-side argument expression."
+        }
+      }
+    },
+    "Channel": {
+      "title": "Channel",
+      "description": "One top-level channel constructed in the workflow. Sources include `Channel.fromPath`, `Channel.fromFilePairs`, `samplesheetToList`-driven `Channel.fromList`, `splitCsv`, `file`/`files`, and plain `params.*` references.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "source",
+        "shape",
+        "construct",
+        "from_param",
+        "required_runtime"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string",
+          "description": "Verbatim channel-construction expression."
+        },
+        "shape": {
+          "type": "string",
+          "description": "String-encoded channel shape; same convention as ChannelIO."
+        },
+        "construct": {
+          "type": "string",
+          "enum": [
+            "fromPath",
+            "fromFilePairs",
+            "fromList",
+            "samplesheetToList",
+            "splitCsv",
+            "file",
+            "files",
+            "of",
+            "value",
+            "empty",
+            "topic",
+            "other"
+          ],
+          "description": "Classifies the channel's primary materialization factory or shape-determining operator. Selection precedence: (1) `samplesheetToList` when the chain contains `samplesheetToList(...)` (typically wrapped in `Channel.fromList`); (2) `splitCsv` when the chain ends in `.splitCsv(header: true)` over a path; (3) otherwise the outermost factory (`Channel.fromPath` → `fromPath`, `Channel.fromFilePairs` → `fromFilePairs`, `file(...)` → `file`, etc.); (4) `other` for unrecognized constructions. The verbatim `source` retains the full chain — `construct` is the typed lookup the converter would otherwise re-parse."
+        },
+        "from_param": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Foreign key into `params[].name` when the construction expression directly references `params.X` (e.g. `Channel.fromPath(params.reads)`, `samplesheetToList(params.input, ...)`, `file(params.fasta)`). Null for literal-glob construction, expressions that compose multiple params, and channels derived from other channels. v1 resolution is direct-only; one-hop Groovy bindings (`def reads = params.reads; Channel.fromPath(reads)`) are not chased — see galaxyproject/foundry#211."
+        },
+        "required_runtime": {
+          "type": "boolean",
+          "description": "True when the construction chain ends in `.ifEmpty { error ... }` (or an equivalent imperative emptiness-throw guard). Captures runtime requiredness even when the param's nf-schema entry does not mark it required. Combine with `params[].required` and any imperative pre-construction `error` checks for the full requiredness picture."
+        }
+      }
+    },
+    "Edge": {
+      "title": "Edge",
+      "description": "One edge in the workflow's call graph. The deterministic parser records the literal operator chain in `via`; reconciliation of the source and target shapes is the LLM step.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "from",
+        "to"
+      ],
+      "properties": {
+        "from": {
+          "type": "string",
+          "description": "Channel name or `<PROCESS>.out.<chan>` reference."
+        },
+        "to": {
+          "type": "string",
+          "description": "Process or subworkflow name receiving this channel."
+        },
+        "via": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Operators on the path between source and target, in order (e.g. `[\"map\", \"join\", \"groupTuple\"]`). Empty for a direct edge."
+        },
+        "notes": {
+          "type": "string",
+          "description": "LLM-emitted note when the reconciliation is low-confidence (e.g. deeply nested closures)."
+        }
+      }
+    },
+    "Conditional": {
+      "title": "Conditional",
+      "description": "One workflow-level conditional that gates a subgraph.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "guard",
+        "branch",
+        "affects"
+      ],
+      "properties": {
+        "guard": {
+          "type": "string",
+          "description": "Verbatim guard expression, e.g. `params.skip_alignment`."
+        },
+        "branch": {
+          "type": "string",
+          "enum": [
+            "default",
+            "alternate"
+          ],
+          "description": "Which side of the conditional this entry describes. `default` is the truthy branch; `alternate` is the else branch."
+        },
+        "affects": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Process or subworkflow names whose execution is gated by this conditional."
+        }
+      }
+    },
+    "Workflow": {
+      "title": "Workflow",
+      "description": "Primary workflow: channel construction plus the call-graph DAG. Real nf-core pipelines have multiple named `workflow` blocks (an anonymous entrypoint `workflow {}` in main.nf that wires PIPELINE_INITIALISATION → NFCORE_<NAME> → PIPELINE_COMPLETION; a named NFCORE_<NAME> wrapper; a substantive named workflow under workflows/<name>.nf). The summary collapses this into one primary `workflow` plus `subworkflows[]`. Selection rule: pick the workflow that invokes the most pipeline processes — typically the one under `workflows/<name>.nf`. The anonymous `workflow {}` glue and the NFCORE_<NAME> wrapper land in `subworkflows[]`.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "channels",
+        "edges"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the selected primary workflow (uppercase NF convention). The anonymous `workflow {}` entrypoint is never the primary; if it is the only workflow block, the pipeline is too small to summarize and the cast skill should emit a warning."
+        },
+        "channels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Channel"
+          }
+        },
+        "edges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Edge"
+          }
+        },
+        "conditionals": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Conditional"
+          }
+        }
+      }
+    },
+    "TestDataRef": {
+      "title": "TestDataRef",
+      "description": "One test-fixture input. Field names mirror gxy-sketches' TestDataRef verbatim. The sketch-bundle constraint that `path` must live under `test_data/` is intentionally dropped; the Foundry summary describes fixtures as data, it does not bundle them.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "role"
+      ],
+      "properties": {
+        "role": {
+          "type": "string",
+          "description": "Logical role of the input (e.g. `samplesheet`, `reference_fasta`)."
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Repo-relative path when the fixture lives in-tree, or local filesystem path when the CLI fetched the remote fixture into a caller-provided test-data directory."
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uri"
+        },
+        "sha1": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "SHA-1 integrity hash when published alongside the fixture."
+        },
+        "filetype": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "File format, e.g. `fastq.gz`, `csv`."
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "path"
+          ]
+        },
+        {
+          "required": [
+            "url"
+          ]
+        }
+      ]
+    },
+    "ExpectedOutputRef": {
+      "title": "ExpectedOutputRef",
+      "description": "One expected output. Field names mirror gxy-sketches' ExpectedOutputRef verbatim. At least one of path / url / assertions is required.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "role"
+      ],
+      "properties": {
+        "role": {
+          "type": "string"
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uri"
+        },
+        "kind": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Coarse output kind: `report`, `tabular`, `image`, `archive`, `sequence`, `other`."
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "assertions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Assertion strings. Simple equality / regex / contains-string checks are preserved verbatim; complex Groovy assertions are summarized to prose with a `warnings[]` flag in the parent Summary."
+        }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "path"
+          ]
+        },
+        {
+          "required": [
+            "url"
+          ]
+        },
+        {
+          "required": [
+            "assertions"
+          ]
+        }
+      ]
+    },
+    "TestFixtures": {
+      "title": "TestFixtures",
+      "description": "Test fixtures derived from a `conf/<profile>.config` for the cast's selected profile. Pipelines with multiple test profiles (bacass has 11) record only the selected profile here; the full nf-test enumeration lives in `nf_tests[]`.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "profile",
+        "inputs",
+        "outputs"
+      ],
+      "properties": {
+        "profile": {
+          "type": "string",
+          "description": "Which `conf/<profile>.config` produced these fixtures (typically `test`)."
+        },
+        "inputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TestDataRef"
+          }
+        },
+        "outputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ExpectedOutputRef"
+          }
+        }
+      }
+    },
+    "NfTest": {
+      "title": "NfTest",
+      "description": "One `tests/*.nf.test` file. nf-core templates use a near-uniform shape: a `nextflow_pipeline { test(\"<desc>\") { when { params { ... } } then { assertAll(...) } } }` block, with one test() per profile, asserting `workflow.success` plus a snapshot match. This shape captures the data so downstream test-conversion molds (e.g. nextflow-test-to-target-tests) don't have to re-parse Groovy.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "path",
+        "profiles",
+        "assert_workflow_success",
+        "prose_assertions"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Description string passed to `test(\"...\")`. Often duplicates the profile name."
+        },
+        "path": {
+          "type": "string",
+          "description": "Repo-relative path of the .nf.test file (e.g. `tests/dfast.nf.test`)."
+        },
+        "profiles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Profile name(s) the test runs under, from the file-level `profile \"<name>\"` declaration and/or per-test config overrides. Usually a single profile."
+        },
+        "params_overrides": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "The `when { params { ... } }` block as a key→value map. Most templates set only `outdir`; pipeline-specific overrides land here."
+        },
+        "assert_workflow_success": {
+          "type": "boolean",
+          "description": "Whether the test asserts `workflow.success`. Almost always true for nf-core templates."
+        },
+        "snapshot": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SnapshotFixture"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Structured representation of the `assert snapshot(...).match()` clause when present; null when the test uses no snapshot."
+        },
+        "prose_assertions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Other assertions (regex matches, count checks, content equality on specific files) summarized to prose strings. Empty for snapshot-only tests, which is the common nf-core case."
+        }
+      }
+    },
+    "SnapshotFixture": {
+      "title": "SnapshotFixture",
+      "description": "Structured shape of an nf-test `snapshot(...).match()` assertion. nf-core templates pass a small set of values into snapshot() — succeeded-task count, version YAML (with Nextflow version stripped), stable file-name list, stable file-content list — and prune the comparison via `getAllFilesFromDir(..., ignoreFile: ..., ignore: [...])` helpers. This breakdown lets downstream consumers reconstruct equivalent assertions in target test frameworks without re-parsing Groovy.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "captures",
+        "helpers",
+        "ignore_files",
+        "ignore_globs"
+      ],
+      "properties": {
+        "captures": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Logical names of values passed to snapshot(), in order. Common set: `succeeded_task_count`, `versions_yml`, `stable_names`, `stable_paths`. Free-form strings rather than an enum because pipelines can pass other values."
+        },
+        "helpers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "nf-test helper functions invoked in the snapshot expression (e.g. `getAllFilesFromDir`, `removeNextflowVersion`). Used to detect whether a target framework can replicate the comparison."
+        },
+        "ignore_files": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Repo-relative paths passed as `ignoreFile:` to helpers (e.g. `tests/.nftignore`, `tests/.nftignore_files_entirely`). The files themselves are line-delimited globs."
+        },
+        "ignore_globs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Inline `ignore: [...]` glob list passed to helpers (e.g. `['Prokka/**', '**/multiqc_busco.yaml']`). Distinct from ignore_files which references on-disk lists."
+        },
+        "snap_path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Repo-relative path of the corresponding `.nf.test.snap` file when present."
+        },
+        "parsed_content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SnapshotContent"
+          },
+          "description": "Parsed entries from the `.nf.test.snap` JSON sidecar. Empty when the sidecar is absent, too large for compact summary output, or not valid JSON. Each entry preserves the snapshot name plus channel-keyed file md5 assertions and non-file scalar values."
+        }
+      }
+    },
+    "SnapshotContent": {
+      "title": "SnapshotContent",
+      "description": "One top-level snapshot entry from an nf-test `.snap` JSON sidecar.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "channels"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Top-level key in the `.snap` file, usually the `test(\"...\")` name."
+        },
+        "channels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SnapshotChannel"
+          },
+          "description": "Channel-keyed snapshot values. Pipeline-template flat file lists use `key: null`."
+        }
+      }
+    },
+    "SnapshotChannel": {
+      "title": "SnapshotChannel",
+      "description": "One output channel or flat snapshot list inside a `.snap` entry.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "key",
+        "files",
+        "values"
+      ],
+      "properties": {
+        "key": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Channel key from the snapshot object, e.g. `0`, `1`, or `genome_gtf`; null for flat file-list snapshots."
+        },
+        "files": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SnapshotFile"
+          },
+          "description": "File md5 assertions parsed from `<path>:md5,<hex>` strings."
+        },
+        "values": {
+          "type": "array",
+          "items": {},
+          "description": "Non-file snapshot values preserved verbatim for consumers that need versions, counts, or scalar tuple emissions."
+        }
+      }
+    },
+    "Evidence": {
+      "title": "Evidence",
+      "description": "Shared provenance block for source-detected facts. `source_path` localizes the finding; `confidence` is a coarse self-assessment; `evidence[]` carries free-form snippets (matched lines, normalized expressions, detector notes). Reused by ReferenceAsset and ReferenceRebuildRule.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_path",
+        "confidence",
+        "evidence"
+      ],
+      "properties": {
+        "source_path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Repo-relative path of the source file where the finding was detected (e.g. `subworkflows/local/prepare_genome/main.nf`, `nextflow.config`). Null when the finding spans files or cannot be localized."
+        },
+        "confidence": {
+          "type": "string",
+          "enum": [
+            "high",
+            "medium",
+            "low"
+          ],
+          "description": "Detector self-assessment. `high`: all signals match the expected idiom; `medium`: some signals match but the guard or builder is partial / mixes non-param locals; `low`: heuristic match, downstream should treat as a hint."
+        },
+        "evidence": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Free-form evidence snippets (matched source lines, normalized expressions, detector notes). Empty when none."
+        }
+      }
+    },
+    "ReferenceAsset": {
+      "title": "ReferenceAsset",
+      "description": "Curated source-side view of one reference-data input the pipeline consumes. A foreign-key projection onto `params[].name` plus the metadata downstream classification Molds need. Target-agnostic: no Galaxy translation decisions are encoded here.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "param",
+        "asset_kind",
+        "required",
+        "used_by",
+        "evidence"
+      ],
+      "properties": {
+        "param": {
+          "type": "string",
+          "description": "FK into `params[].name`."
+        },
+        "asset_kind": {
+          "type": "string",
+          "description": "Coarse asset classification (e.g. `fasta`, `fasta_index`, `sequence_dictionary`, `bwa_index`, `bwamem2_index`, `tabix_index`, `gtf`, `gff`, `bed`, `vcf`, `database`, `other`). Free-form string; downstream Molds choose how to map onto target datatypes."
+        },
+        "format_hint": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Format hint, often the nf-schema `format` keyword (`file-path`, `directory-path`, `path`, `file-path-pattern`) or a domain hint like `fai`, `dict`. Null when undetermined."
+        },
+        "required": {
+          "type": "boolean",
+          "description": "True when the source pipeline treats this asset as required (no compute-if-missing branch, no optional guard). When false, see `reference_rebuilds[]` for any rebuild branch covering this param."
+        },
+        "source_kind": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "nextflow_schema",
+            "params_block",
+            "getGenomeAttribute",
+            "computed",
+            null
+          ],
+          "description": "Mirrors `params[<this>].source_kind`. Duplicated here so reference-data consumers don't have to dereference."
+        },
+        "source_expression": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Mirrors `params[<this>].source_expression`. Duplicated for the same reason."
+        },
+        "schema_group": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Mirrors `params[<this>].schema_group`. Useful for grouping (`Reference genome options`)."
+        },
+        "used_by": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Names of processes / subworkflows that receive this param as an argument (via direct invocation binding or channel construction). Empty when no caller could be attributed."
+        },
+        "evidence": {
+          "$ref": "#/$defs/Evidence"
+        }
+      }
+    },
+    "ReferenceRebuildRule": {
+      "title": "ReferenceRebuildRule",
+      "description": "One compute-if-missing rebuild branch detected in a workflow or subworkflow body. Binds an asset param to the guard expression and builder process that produces it when absent. Source evidence only; in-tool-rebuild decisions live downstream.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "asset_param",
+        "guard",
+        "builder",
+        "builder_outputs",
+        "evidence"
+      ],
+      "properties": {
+        "asset_param": {
+          "type": "string",
+          "description": "FK into `params[].name` — the asset this branch reconstitutes when missing."
+        },
+        "guard": {
+          "type": "string",
+          "description": "Verbatim guard expression, e.g. `!fasta_fai_in && step != \"annotate\"`."
+        },
+        "guard_params": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Param names referenced by the guard. Empty when the guard binds only non-param locals."
+        },
+        "builder": {
+          "type": "string",
+          "description": "Builder process or subworkflow name invoked inside the branch (e.g. `SAMTOOLS_FAIDX`, `BWA_INDEX`)."
+        },
+        "builder_outputs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Output channel names from the builder that are assigned to the asset (e.g. `fai`, `dict`)."
+        },
+        "fallback_for": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Name of the `<asset>_in`-style param that, when present, supplies the asset directly and skips the rebuild. Null when no such pairing was detected."
+        },
+        "evidence": {
+          "$ref": "#/$defs/Evidence"
+        }
+      }
+    },
+    "SnapshotFile": {
+      "title": "SnapshotFile",
+      "description": "One file digest assertion from a `.snap` sidecar.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "basename",
+        "md5",
+        "stub"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Path portion before `:md5,` exactly as stored in the sidecar."
+        },
+        "basename": {
+          "type": "string",
+          "description": "Final path segment, suitable for Galaxy test `file:` assertions when the snapshot stores only basenames."
+        },
+        "md5": {
+          "type": "string",
+          "pattern": "^[a-fA-F0-9]{32}$",
+          "description": "MD5 digest from the sidecar."
+        },
+        "stub": {
+          "type": "boolean",
+          "description": "True when the digest is the empty-file md5 emitted by many `-stub` tests."
+        }
+      }
+    }
+  }
+}

--- a/casts/claude/skills/pipeline-cwl-to-galaxy/SKILL.md
+++ b/casts/claude/skills/pipeline-cwl-to-galaxy/SKILL.md
@@ -64,7 +64,8 @@ Run these phases in order. After each, confirm the expected artifact exists in t
 5. **cwl-summary-to-galaxy-template** — invoke the `cwl-summary-to-galaxy-template` skill. gxformat2 skeleton with per-step TODOs from a CWL summary and prior Galaxy design briefs.
 6. **advance-galaxy-draft-step** (loop) — invoke the `advance-galaxy-draft-step` skill, once per step. It owns its own endstate oracle (`gxwf draft-next-step`) and concretizes one drafty step per call; re-invoke until it reports `draft: false`, then it extracts the concrete `galaxy-workflow.gxwf.yml` (via `gxwf draft-extract`) and continues.
 7. **test-data-resolution** (branch) — resolve in order; stop at the first that yields acceptable output:
-   - Try `find-test-data` — Search IWC fixtures and public sources for test data matching a data-flow shape.
+   - Try `cwl-to-test-data` — Resolve a CWL workflow's own declared test cases into Galaxy workflow test-data refs.
+   - Otherwise try `find-test-data` — Search IWC fixtures and public sources for test data matching a data-flow shape.
    - **user-supplied** — if nothing above yields acceptable output, ask the user to supply it directly.
 8. **cwl-test-to-galaxy-test-plan** — MANUAL — `cwl-test-to-galaxy-test-plan` is not yet cast. Translate CWL test fixtures into a Galaxy workflow test plan. Do this by hand and confirm before continuing.
 9. **implement-galaxy-workflow-test** — invoke the `implement-galaxy-workflow-test` skill. Assemble Galaxy workflow test fixtures and assertions.

--- a/casts/claude/skills/pipeline-cwl-to-galaxy/SKILL.md
+++ b/casts/claude/skills/pipeline-cwl-to-galaxy/SKILL.md
@@ -63,11 +63,14 @@ Run these phases in order. After each, confirm the expected artifact exists in t
 4. **compare-against-iwc-exemplar** — invoke the `compare-against-iwc-exemplar` skill. Find nearest IWC exemplar(s) and surface a structural diff against the upstream Galaxy design briefs to guide template authoring.
 5. **cwl-summary-to-galaxy-template** — invoke the `cwl-summary-to-galaxy-template` skill. gxformat2 skeleton with per-step TODOs from a CWL summary and prior Galaxy design briefs.
 6. **advance-galaxy-draft-step** (loop) — invoke the `advance-galaxy-draft-step` skill, once per step. It owns its own endstate oracle (`gxwf draft-next-step`) and concretizes one drafty step per call; re-invoke until it reports `draft: false`, then it extracts the concrete `galaxy-workflow.gxwf.yml` (via `gxwf draft-extract`) and continues.
-7. **cwl-test-to-galaxy-test-plan** — MANUAL — `cwl-test-to-galaxy-test-plan` is not yet cast. Translate CWL test fixtures into a Galaxy workflow test plan. Do this by hand and confirm before continuing.
-8. **implement-galaxy-workflow-test** — invoke the `implement-galaxy-workflow-test` skill. Assemble Galaxy workflow test fixtures and assertions.
-9. **validate-galaxy-workflow** — invoke the `validate-galaxy-workflow` skill. Run terminal gxwf validation on an assembled Galaxy workflow and classify workflow-level failures.
-10. **run-workflow-test** — invoke the `run-workflow-test` skill. Execute a workflow's tests via Planemo; emit structured pass/fail and outputs.
-11. **debug-galaxy-workflow-output** — invoke the `debug-galaxy-workflow-output` skill. Triage failing Galaxy run outputs; classify the failure surface and capture evidence before recommending repairs.
+7. **test-data-resolution** (branch) — resolve in order; stop at the first that yields acceptable output:
+   - Try `find-test-data` — Search IWC fixtures and public sources for test data matching a data-flow shape.
+   - **user-supplied** — if nothing above yields acceptable output, ask the user to supply it directly.
+8. **cwl-test-to-galaxy-test-plan** — MANUAL — `cwl-test-to-galaxy-test-plan` is not yet cast. Translate CWL test fixtures into a Galaxy workflow test plan. Do this by hand and confirm before continuing.
+9. **implement-galaxy-workflow-test** — invoke the `implement-galaxy-workflow-test` skill. Assemble Galaxy workflow test fixtures and assertions.
+10. **validate-galaxy-workflow** — invoke the `validate-galaxy-workflow` skill. Run terminal gxwf validation on an assembled Galaxy workflow and classify workflow-level failures.
+11. **run-workflow-test** — invoke the `run-workflow-test` skill. Execute a workflow's tests via Planemo; emit structured pass/fail and outputs.
+12. **debug-galaxy-workflow-output** — invoke the `debug-galaxy-workflow-output` skill. Triage failing Galaxy run outputs; classify the failure surface and capture evidence before recommending repairs.
 
 ## Done
 

--- a/casts/claude/skills/pipeline-cwl-to-galaxy/_assembly.json
+++ b/casts/claude/skills/pipeline-cwl-to-galaxy/_assembly.json
@@ -17,7 +17,7 @@
     { "phase": 4, "kind": "mold", "skill": "compare-against-iwc-exemplar", "cast_present": true, "loop": false },
     { "phase": 5, "kind": "mold", "skill": "cwl-summary-to-galaxy-template", "cast_present": true, "loop": false },
     { "phase": 6, "kind": "mold", "skill": "advance-galaxy-draft-step", "cast_present": true, "loop": true },
-    { "phase": 7, "kind": "branch", "pattern": "test-data-resolution", "chain": ["find-test-data", "user-supplied"], "cast_present": [true, null] },
+    { "phase": 7, "kind": "branch", "pattern": "test-data-resolution", "chain": ["cwl-to-test-data", "find-test-data", "user-supplied"], "cast_present": [true, true, null] },
     { "phase": 8, "kind": "mold", "skill": "cwl-test-to-galaxy-test-plan", "cast_present": false, "loop": false },
     { "phase": 9, "kind": "mold", "skill": "implement-galaxy-workflow-test", "cast_present": true, "loop": false },
     { "phase": 10, "kind": "mold", "skill": "validate-galaxy-workflow", "cast_present": true, "loop": false },

--- a/casts/claude/skills/pipeline-cwl-to-galaxy/_assembly.json
+++ b/casts/claude/skills/pipeline-cwl-to-galaxy/_assembly.json
@@ -17,10 +17,11 @@
     { "phase": 4, "kind": "mold", "skill": "compare-against-iwc-exemplar", "cast_present": true, "loop": false },
     { "phase": 5, "kind": "mold", "skill": "cwl-summary-to-galaxy-template", "cast_present": true, "loop": false },
     { "phase": 6, "kind": "mold", "skill": "advance-galaxy-draft-step", "cast_present": true, "loop": true },
-    { "phase": 7, "kind": "mold", "skill": "cwl-test-to-galaxy-test-plan", "cast_present": false, "loop": false },
-    { "phase": 8, "kind": "mold", "skill": "implement-galaxy-workflow-test", "cast_present": true, "loop": false },
-    { "phase": 9, "kind": "mold", "skill": "validate-galaxy-workflow", "cast_present": true, "loop": false },
-    { "phase": 10, "kind": "mold", "skill": "run-workflow-test", "cast_present": true, "loop": false },
-    { "phase": 11, "kind": "mold", "skill": "debug-galaxy-workflow-output", "cast_present": true, "loop": false }
+    { "phase": 7, "kind": "branch", "pattern": "test-data-resolution", "chain": ["find-test-data", "user-supplied"], "cast_present": [true, null] },
+    { "phase": 8, "kind": "mold", "skill": "cwl-test-to-galaxy-test-plan", "cast_present": false, "loop": false },
+    { "phase": 9, "kind": "mold", "skill": "implement-galaxy-workflow-test", "cast_present": true, "loop": false },
+    { "phase": 10, "kind": "mold", "skill": "validate-galaxy-workflow", "cast_present": true, "loop": false },
+    { "phase": 11, "kind": "mold", "skill": "run-workflow-test", "cast_present": true, "loop": false },
+    { "phase": 12, "kind": "mold", "skill": "debug-galaxy-workflow-output", "cast_present": true, "loop": false }
   ]
 }

--- a/casts/claude/skills/pipeline-nextflow-to-galaxy/SKILL.md
+++ b/casts/claude/skills/pipeline-nextflow-to-galaxy/SKILL.md
@@ -56,11 +56,14 @@ Run these phases in order. After each, confirm the expected artifact exists in t
 5. **compare-against-iwc-exemplar** — invoke the `compare-against-iwc-exemplar` skill. Find nearest IWC exemplar(s) and surface a structural diff against the upstream Galaxy design briefs to guide template authoring.
 6. **nextflow-summary-to-galaxy-template** — invoke the `nextflow-summary-to-galaxy-template` skill. gxformat2 skeleton with per-step TODOs from a Nextflow summary and prior Galaxy design briefs.
 7. **advance-galaxy-draft-step** (loop) — invoke the `advance-galaxy-draft-step` skill, once per step. It owns its own endstate oracle (`gxwf draft-next-step`) and concretizes one drafty step per call; re-invoke until it reports `draft: false`, then it extracts the concrete `galaxy-workflow.gxwf.yml` (via `gxwf draft-extract`) and continues.
-8. **nextflow-test-to-galaxy-test-plan** — MANUAL — `nextflow-test-to-galaxy-test-plan` is not yet cast. Translate Nextflow test evidence into a Galaxy workflow test plan. Do this by hand and confirm before continuing.
-9. **implement-galaxy-workflow-test** — invoke the `implement-galaxy-workflow-test` skill. Assemble Galaxy workflow test fixtures and assertions.
-10. **validate-galaxy-workflow** — invoke the `validate-galaxy-workflow` skill. Run terminal gxwf validation on an assembled Galaxy workflow and classify workflow-level failures.
-11. **run-workflow-test** — invoke the `run-workflow-test` skill. Execute a workflow's tests via Planemo; emit structured pass/fail and outputs.
-12. **debug-galaxy-workflow-output** — invoke the `debug-galaxy-workflow-output` skill. Triage failing Galaxy run outputs; classify the failure surface and capture evidence before recommending repairs.
+8. **test-data-resolution** (branch) — resolve in order; stop at the first that yields acceptable output:
+   - Try `find-test-data` — Search IWC fixtures and public sources for test data matching a data-flow shape.
+   - **user-supplied** — if nothing above yields acceptable output, ask the user to supply it directly.
+9. **nextflow-test-to-galaxy-test-plan** — MANUAL — `nextflow-test-to-galaxy-test-plan` is not yet cast. Translate Nextflow test evidence into a Galaxy workflow test plan. Do this by hand and confirm before continuing.
+10. **implement-galaxy-workflow-test** — invoke the `implement-galaxy-workflow-test` skill. Assemble Galaxy workflow test fixtures and assertions.
+11. **validate-galaxy-workflow** — invoke the `validate-galaxy-workflow` skill. Run terminal gxwf validation on an assembled Galaxy workflow and classify workflow-level failures.
+12. **run-workflow-test** — invoke the `run-workflow-test` skill. Execute a workflow's tests via Planemo; emit structured pass/fail and outputs.
+13. **debug-galaxy-workflow-output** — invoke the `debug-galaxy-workflow-output` skill. Triage failing Galaxy run outputs; classify the failure surface and capture evidence before recommending repairs.
 
 ## Done
 

--- a/casts/claude/skills/pipeline-nextflow-to-galaxy/SKILL.md
+++ b/casts/claude/skills/pipeline-nextflow-to-galaxy/SKILL.md
@@ -57,7 +57,8 @@ Run these phases in order. After each, confirm the expected artifact exists in t
 6. **nextflow-summary-to-galaxy-template** — invoke the `nextflow-summary-to-galaxy-template` skill. gxformat2 skeleton with per-step TODOs from a Nextflow summary and prior Galaxy design briefs.
 7. **advance-galaxy-draft-step** (loop) — invoke the `advance-galaxy-draft-step` skill, once per step. It owns its own endstate oracle (`gxwf draft-next-step`) and concretizes one drafty step per call; re-invoke until it reports `draft: false`, then it extracts the concrete `galaxy-workflow.gxwf.yml` (via `gxwf draft-extract`) and continues.
 8. **test-data-resolution** (branch) — resolve in order; stop at the first that yields acceptable output:
-   - Try `find-test-data` — Search IWC fixtures and public sources for test data matching a data-flow shape.
+   - Try `nextflow-to-test-data` — Resolve a Nextflow pipeline's own declared test fixtures into Galaxy workflow test-data refs.
+   - Otherwise try `find-test-data` — Search IWC fixtures and public sources for test data matching a data-flow shape.
    - **user-supplied** — if nothing above yields acceptable output, ask the user to supply it directly.
 9. **nextflow-test-to-galaxy-test-plan** — MANUAL — `nextflow-test-to-galaxy-test-plan` is not yet cast. Translate Nextflow test evidence into a Galaxy workflow test plan. Do this by hand and confirm before continuing.
 10. **implement-galaxy-workflow-test** — invoke the `implement-galaxy-workflow-test` skill. Assemble Galaxy workflow test fixtures and assertions.

--- a/casts/claude/skills/pipeline-nextflow-to-galaxy/_assembly.json
+++ b/casts/claude/skills/pipeline-nextflow-to-galaxy/_assembly.json
@@ -16,7 +16,7 @@
     { "phase": 5, "kind": "mold", "skill": "compare-against-iwc-exemplar", "cast_present": true, "loop": false },
     { "phase": 6, "kind": "mold", "skill": "nextflow-summary-to-galaxy-template", "cast_present": true, "loop": false },
     { "phase": 7, "kind": "mold", "skill": "advance-galaxy-draft-step", "cast_present": true, "loop": true },
-    { "phase": 8, "kind": "branch", "pattern": "test-data-resolution", "chain": ["find-test-data", "user-supplied"], "cast_present": [true, null] },
+    { "phase": 8, "kind": "branch", "pattern": "test-data-resolution", "chain": ["nextflow-to-test-data", "find-test-data", "user-supplied"], "cast_present": [true, true, null] },
     { "phase": 9, "kind": "mold", "skill": "nextflow-test-to-galaxy-test-plan", "cast_present": false, "loop": false },
     { "phase": 10, "kind": "mold", "skill": "implement-galaxy-workflow-test", "cast_present": true, "loop": false },
     { "phase": 11, "kind": "mold", "skill": "validate-galaxy-workflow", "cast_present": true, "loop": false },

--- a/casts/claude/skills/pipeline-nextflow-to-galaxy/_assembly.json
+++ b/casts/claude/skills/pipeline-nextflow-to-galaxy/_assembly.json
@@ -16,10 +16,11 @@
     { "phase": 5, "kind": "mold", "skill": "compare-against-iwc-exemplar", "cast_present": true, "loop": false },
     { "phase": 6, "kind": "mold", "skill": "nextflow-summary-to-galaxy-template", "cast_present": true, "loop": false },
     { "phase": 7, "kind": "mold", "skill": "advance-galaxy-draft-step", "cast_present": true, "loop": true },
-    { "phase": 8, "kind": "mold", "skill": "nextflow-test-to-galaxy-test-plan", "cast_present": false, "loop": false },
-    { "phase": 9, "kind": "mold", "skill": "implement-galaxy-workflow-test", "cast_present": true, "loop": false },
-    { "phase": 10, "kind": "mold", "skill": "validate-galaxy-workflow", "cast_present": true, "loop": false },
-    { "phase": 11, "kind": "mold", "skill": "run-workflow-test", "cast_present": true, "loop": false },
-    { "phase": 12, "kind": "mold", "skill": "debug-galaxy-workflow-output", "cast_present": true, "loop": false }
+    { "phase": 8, "kind": "branch", "pattern": "test-data-resolution", "chain": ["find-test-data", "user-supplied"], "cast_present": [true, null] },
+    { "phase": 9, "kind": "mold", "skill": "nextflow-test-to-galaxy-test-plan", "cast_present": false, "loop": false },
+    { "phase": 10, "kind": "mold", "skill": "implement-galaxy-workflow-test", "cast_present": true, "loop": false },
+    { "phase": 11, "kind": "mold", "skill": "validate-galaxy-workflow", "cast_present": true, "loop": false },
+    { "phase": 12, "kind": "mold", "skill": "run-workflow-test", "cast_present": true, "loop": false },
+    { "phase": 13, "kind": "mold", "skill": "debug-galaxy-workflow-output", "cast_present": true, "loop": false }
   ]
 }

--- a/content/Dashboard.md
+++ b/content/Dashboard.md
@@ -18,7 +18,10 @@ Generated from `dashboard_sections.json` and content frontmatter. Do not edit by
 
 | Name | Summary | Status | Revised | Rev |
 | --- | --- | --- | --- | --- |
+| [[cwl-to-test-data]] | Resolve a CWL workflow's own declared test cases into Galaxy workflow test-data refs. | draft | 2026-07-17 | 1 |
+| [[nextflow-to-test-data]] | Resolve a Nextflow pipeline's own declared test fixtures into Galaxy workflow test-data refs. | draft | 2026-07-17 | 1 |
 | [[apply-galaxy-workflow-changeset]] | Apply a reviewed change-set to a concrete Galaxy workflow: untouched regions preserved, tool-introducing edits injected as drafty steps. | draft | 2026-07-01 | 1 |
+| [[changeset-to-galaxy-test-plan]] | Carry an existing Galaxy workflow's tests forward as a regression baseline and augment them for a change-set's deltas, emitting a Galaxy test plan. | draft | 2026-07-01 | 1 |
 | [[interview-to-galaxy-workflow-changeset]] | Interview a user against an existing Galaxy workflow summary and emit a reviewable, step-anchored change-set. | draft | 2026-07-01 | 1 |
 | [[summarize-galaxy-workflow]] | Read an existing Galaxy gxformat2 (or .ga) workflow and emit a structured summary for interview and change-set steps. | draft | 2026-07-01 | 1 |
 | [[convert-nfcore-module-to-galaxy-tool]] | Convert one nf-core module dir into a Galaxy tool wrapper (tool.xml + macros.xml + _provenance.yml + remote-URL <test> blocks). | draft | 2026-06-19 | 4 |

--- a/content/Index.md
+++ b/content/Index.md
@@ -17,12 +17,14 @@ Generated from content frontmatter. Do not edit by hand.
 - [[advance-galaxy-draft-step]] — Advance the gxformat2 draft by one step: pick the next drafty step, resolve a wrapper, implement the step, and validate.
 - [[apply-galaxy-workflow-changeset]] — Apply a reviewed change-set to a concrete Galaxy workflow: untouched regions preserved, tool-introducing edits injected as drafty steps.
 - [[author-galaxy-tool-wrapper]] — Author a new Galaxy user-defined tool YAML definition when discovery yields nothing acceptable.
+- [[changeset-to-galaxy-test-plan]] — Carry an existing Galaxy workflow's tests forward as a regression baseline and augment them for a change-set's deltas, emitting a Galaxy test plan.
 - [[compare-against-iwc-exemplar]] — Find nearest IWC exemplar(s) and surface a structural diff against the upstream Galaxy design briefs to guide template authoring.
 - [[convert-nfcore-module-to-galaxy-tool]] — Convert one nf-core module dir into a Galaxy tool wrapper (tool.xml + macros.xml + _provenance.yml + remote-URL <test> blocks).
 - [[cwl-summary-to-galaxy-data-flow]] — Translate a CWL summary into a Galaxy data-flow design brief.
 - [[cwl-summary-to-galaxy-interface]] — Map a CWL summary into a Galaxy workflow interface design brief.
 - [[cwl-summary-to-galaxy-template]] — gxformat2 skeleton with per-step TODOs from a CWL summary and prior Galaxy design briefs.
 - [[cwl-test-to-galaxy-test-plan]] — Translate CWL test fixtures into a Galaxy workflow test plan.
+- [[cwl-to-test-data]] — Resolve a CWL workflow's own declared test cases into Galaxy workflow test-data refs.
 - [[debug-cwl-workflow-output]] — Triage failing CWL run outputs; classify failure modes; propose fixes.
 - [[debug-galaxy-workflow-output]] — Triage failing Galaxy run outputs; classify the failure surface and capture evidence before recommending repairs.
 - [[discover-shed-tool]] — Search the Tool Shed for an existing wrapper, drill from hit to a pinnable changeset, classify candidates, and recommend or fall through.
@@ -46,6 +48,7 @@ Generated from content frontmatter. Do not edit by hand.
 - [[nextflow-summary-to-galaxy-template]] — gxformat2 skeleton with per-step TODOs from a Nextflow summary and prior Galaxy design briefs.
 - [[nextflow-test-to-cwl-test-plan]] — Translate Nextflow test evidence into a CWL workflow test plan.
 - [[nextflow-test-to-galaxy-test-plan]] — Translate Nextflow test evidence into a Galaxy workflow test plan.
+- [[nextflow-to-test-data]] — Resolve a Nextflow pipeline's own declared test fixtures into Galaxy workflow test-data refs.
 - [[paper-to-test-data]] — Derive workflow test inputs and expected outputs from a paper.
 - [[repair-galaxy-draft-topology]] — Re-wire a Galaxy draft region when a step's declared output can't be computed from its wired inputs.
 - [[run-workflow-test]] — Execute a workflow's tests via Planemo; emit structured pass/fail and outputs.

--- a/content/molds/cwl-to-test-data/index.md
+++ b/content/molds/cwl-to-test-data/index.md
@@ -1,0 +1,74 @@
+---
+type: mold
+name: cwl-to-test-data
+axis: source-specific
+source: cwl
+tags:
+  - mold
+  - source/cwl
+status: draft
+created: 2026-07-17
+revised: 2026-07-17
+revision: 1
+ai_generated: true
+summary: "Resolve a CWL workflow's own declared test cases into Galaxy workflow test-data refs."
+input_artifacts:
+  - id: summary-cwl
+    description: "Structured CWL summary from [[summarize-cwl]]; carries the source's test cases (`tests[]`) — each a `job_path` (a CWL job file naming the test inputs) plus `expected_outputs`."
+  - id: cwl-galaxy-interface
+    description: "Galaxy interface brief from [[cwl-summary-to-galaxy-interface]] pinning the workflow input labels, collection shapes, and datatypes each resolved fixture must map onto."
+output_artifacts:
+  - id: test-data-refs
+    kind: json
+    default_filename: test-data-refs.json
+    description: "Test data resolved from the CWL source's declared test cases, expressed as URLs/paths plus expected shapes for downstream test authoring. Shared id with [[find-test-data]] — the branch's search fallback fills only the inputs this Mold leaves unresolved."
+references:
+  - kind: schema
+    ref: "[[summary-cwl]]"
+    used_at: runtime
+    load: upfront
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Input contract: read `tests[]` — each case's `job_path` inputs and `expected_outputs` — as the declared source of test data."
+  - kind: research
+    ref: "[[component-cwl-workflow-anatomy]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Interpret a CWL job file's input objects (File/Directory, secondaryFiles, arrays, inline literals) before mapping them onto Galaxy inputs."
+    trigger: "When reading a `job_path`'s declared inputs to decide their Galaxy shape."
+  - kind: research
+    ref: "[[galaxy-workflow-testability-design]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Map each declared job input to an addressable Galaxy input label and the collection shape it must populate."
+    trigger: "When mapping a CWL File-array or secondaryFiles input onto a Galaxy collection shape."
+  - kind: research
+    ref: "[[iwc-test-data-conventions]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Express each ref remote-URL-first with SHA-1 integrity and per-input collection layout when recording resolved fixtures."
+    trigger: "When writing each `test-data-refs` entry."
+---
+# cwl-to-test-data
+
+Resolve the CWL workflow's own declared test cases into Galaxy `test-data-refs`. The CWL summary carries the source's test cases (`tests[]`) — each a `job_path` (a CWL job file naming the test inputs) plus `expected_outputs`. Read the declared inputs and map them onto the Galaxy workflow's inputs, emitting one ref per input, ready for [[implement-galaxy-workflow-test]] to stage.
+
+This Mold is the source-specific first leg of the harness's `test-data-resolution` branch. It resolves what the CWL source itself declares; any input it cannot resolve from a declared test case stays a reported gap and the harness falls through to [[find-test-data]] (search), then to `user-supplied`. Deciding to fall through is a harness concern, not this Mold's — its job is an honest map of the source's own test cases.
+
+## Sequence
+
+1. **Enumerate Galaxy inputs and their required shape.** From the interface brief, list each workflow input: label, Galaxy collection shape (File / list / paired / list:paired / record), and datatype. This is the *target shape* every ref must satisfy.
+2. **Read the declared test cases.** From the summary's `tests[]`, read each case's `job_path` inputs — File/Directory objects with their `location`/`path`, `secondaryFiles`, arrays, and inline literals — plus `expected_outputs`. Prefer the case whose inputs best cover the workflow's inputs.
+3. **Map each declared input onto a Galaxy input.** Match by id and shape onto the interface's input labels. A CWL File array maps to a Galaxy list; a File carrying `secondaryFiles` may map to a record or composite datatype — record element identifiers and any prep needed to reach the Galaxy collection shape ([[galaxy-workflow-testability-design]]).
+4. **Emit refs.** Write one `test-data-refs.json` entry per resolved input: prefer a remote `location` URL when the job references one (remote-URL-first, [[iwc-test-data-conventions]]); fall back to the in-tree `path` plus provenance only when no URL is published. Carry datatype, collection element identifiers, and any subset/split prep. Each entry maps to an addressable workflow input label.
+5. **Report genuine gaps.** An input with no declared test-case input of the right shape stays `resolved: false` with a reason — this is what the harness hands to [[find-test-data]]. Do not search public sources here; searching is find-test-data's job, not this Mold's.
+
+## No fabrication
+
+Never invent a URL, accession, or path, and never emit a placeholder for an input you could not resolve from a declared test case. A declared input with no published URL is recorded by its in-tree `path` plus provenance, not papered over with a guessed URL. Every emitted ref points at data the source actually declares; everything else is an honest gap for the next leg of the branch.

--- a/content/molds/nextflow-to-test-data/index.md
+++ b/content/molds/nextflow-to-test-data/index.md
@@ -1,0 +1,75 @@
+---
+type: mold
+name: nextflow-to-test-data
+axis: source-specific
+source: nextflow
+tags:
+  - mold
+  - source/nextflow
+status: draft
+created: 2026-07-17
+revised: 2026-07-17
+revision: 1
+ai_generated: true
+summary: "Resolve a Nextflow pipeline's own declared test fixtures into Galaxy workflow test-data refs."
+input_artifacts:
+  - id: summary-nextflow
+    description: "Structured Nextflow summary from [[summarize-nextflow]]; carries the selected profile's `test_fixtures` and the full `nf_tests[]` enumeration — each declared input a role plus url/path, sha1, and filetype."
+  - id: nextflow-galaxy-interface
+    description: "Galaxy interface brief from [[nextflow-summary-to-galaxy-interface]] pinning the workflow input labels, collection shapes, and datatypes each resolved fixture must map onto."
+output_artifacts:
+  - id: test-data-refs
+    kind: json
+    default_filename: test-data-refs.json
+    description: "Test data resolved from the pipeline's declared fixtures, expressed as URLs/paths plus expected shapes for downstream test authoring. Shared id with [[find-test-data]] — the branch's search fallback fills only the inputs this Mold leaves unresolved."
+references:
+  - kind: schema
+    ref: "[[summary-nextflow]]"
+    used_at: runtime
+    load: upfront
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Input contract: read the selected profile's `test_fixtures.inputs[]` and the `nf_tests[]` enumeration — role, url/path, sha1, filetype — as the declared source of test data."
+  - kind: research
+    ref: "[[component-nextflow-testing]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: hypothesis
+    purpose: "Interpret nf-test profiles and fixture conventions before mapping declared fixtures onto Galaxy inputs."
+    trigger: "When reading `test_fixtures` / `nf_tests` to decide which profile's fixtures best cover the workflow inputs."
+    verification: "Map nf-core/bacass declared fixtures onto its Galaxy interface and confirm this note improves profile/fixture selection."
+  - kind: research
+    ref: "[[galaxy-workflow-testability-design]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Map each declared fixture to an addressable Galaxy input label and the collection shape it must populate."
+    trigger: "When mapping a declared fixture (often a samplesheet-driven input) onto a Galaxy input's collection shape."
+  - kind: research
+    ref: "[[iwc-test-data-conventions]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: corpus-observed
+    purpose: "Express each ref remote-URL-first with SHA-1 integrity and per-input collection layout when recording resolved fixtures."
+    trigger: "When writing each `test-data-refs` entry."
+---
+# nextflow-to-test-data
+
+Resolve the Nextflow pipeline's own declared test fixtures into Galaxy `test-data-refs`. The Nextflow summary already carries the `test`-profile fixtures (`test_fixtures`) and the full nf-test enumeration (`nf_tests[]`) — each declared input a `role` plus a `url`/`path`, `sha1`, and `filetype`. Map those onto the Galaxy workflow's inputs and emit one ref per input, ready for [[implement-galaxy-workflow-test]] to stage.
+
+This Mold is the source-specific first leg of the harness's `test-data-resolution` branch. It resolves what the pipeline itself declares; any input it cannot resolve from a declared fixture stays a reported gap and the harness falls through to [[find-test-data]] (search), then to `user-supplied`. Deciding to fall through is a harness concern, not this Mold's — its job is an honest map of the pipeline's own fixtures.
+
+## Sequence
+
+1. **Enumerate Galaxy inputs and their required shape.** From the interface brief, list each workflow input: label, Galaxy collection shape (File / list / paired / list:paired / record), and datatype. This is the *target shape* every ref must satisfy.
+2. **Read the declared fixtures.** From the summary's `test_fixtures.inputs[]` (selected profile) and `nf_tests[]` (other profiles), collect each declared input: `role`, `url`/`path`, `sha1`, `filetype`, and description. Prefer the profile whose fixtures best cover the workflow's inputs.
+3. **Map each declared fixture onto a Galaxy input.** Match by role and shape onto the interface's input labels. A samplesheet-driven Nextflow input often expands into a Galaxy collection — record the element identifiers and any split/concatenation prep needed to reach the Galaxy collection shape ([[galaxy-workflow-testability-design]]).
+4. **Emit refs.** Write one `test-data-refs.json` entry per resolved input: prefer the declared remote `url` + `sha1` (remote-URL-first, [[iwc-test-data-conventions]]); fall back to the in-tree `path` plus provenance only when no URL is published. Carry datatype, collection element identifiers, and any subset/split prep. Each entry maps to an addressable workflow input label.
+5. **Report genuine gaps.** An input with no declared fixture of the right shape stays `resolved: false` with a reason — this is what the harness hands to [[find-test-data]]. Do not search public sources here; searching is find-test-data's job, not this Mold's.
+
+## No fabrication
+
+Never invent a URL, accession, or path, and never emit a placeholder for an input you could not resolve from a declared fixture. A declared fixture with no published URL is recorded by its in-tree `path` plus provenance, not papered over with a guessed URL. Every emitted ref points at data the pipeline actually declares; everything else is an honest gap for the next leg of the branch.

--- a/content/pipelines/cwl-to-galaxy/index.md
+++ b/content/pipelines/cwl-to-galaxy/index.md
@@ -19,6 +19,10 @@ phases:
   - mold: "[[cwl-summary-to-galaxy-template]]"
   - mold: "[[advance-galaxy-draft-step]]"
     loop: true
+  - branch: test-data-resolution
+    chain:
+      - "[[find-test-data]]"
+      - user-supplied
   - mold: "[[cwl-test-to-galaxy-test-plan]]"
   - mold: "[[implement-galaxy-workflow-test]]"
   - mold: "[[validate-galaxy-workflow]]"

--- a/content/pipelines/cwl-to-galaxy/index.md
+++ b/content/pipelines/cwl-to-galaxy/index.md
@@ -21,6 +21,7 @@ phases:
     loop: true
   - branch: test-data-resolution
     chain:
+      - "[[cwl-to-test-data]]"
       - "[[find-test-data]]"
       - user-supplied
   - mold: "[[cwl-test-to-galaxy-test-plan]]"

--- a/content/pipelines/nextflow-to-galaxy/index.md
+++ b/content/pipelines/nextflow-to-galaxy/index.md
@@ -22,6 +22,10 @@ phases:
   - mold: "[[nextflow-summary-to-galaxy-template]]"
   - mold: "[[advance-galaxy-draft-step]]"
     loop: true
+  - branch: test-data-resolution
+    chain:
+      - "[[find-test-data]]"
+      - user-supplied
   - mold: "[[nextflow-test-to-galaxy-test-plan]]"
   - mold: "[[implement-galaxy-workflow-test]]"
   - mold: "[[validate-galaxy-workflow]]"

--- a/content/pipelines/nextflow-to-galaxy/index.md
+++ b/content/pipelines/nextflow-to-galaxy/index.md
@@ -24,6 +24,7 @@ phases:
     loop: true
   - branch: test-data-resolution
     chain:
+      - "[[nextflow-to-test-data]]"
       - "[[find-test-data]]"
       - user-supplied
   - mold: "[[nextflow-test-to-galaxy-test-plan]]"

--- a/docs/HARNESS_PIPELINES.md
+++ b/docs/HARNESS_PIPELINES.md
@@ -103,11 +103,12 @@ Other inline phase annotations may be coined as needs surface — e.g., `[gate]`
 5. `compare-against-iwc-exemplar` — structural diff of the design briefs against nearest IWC exemplar(s); guidance feeds template authoring.
 6. `nextflow-summary-to-galaxy-template`
 7. `[loop]` `advance-galaxy-draft-step` — one full iteration (pick → discover-or-author → summarize → implement → `gxwf draft-validate --concrete`). Loop terminates on `draft: false`.
-8. `nextflow-test-to-galaxy-test-plan` — translate NF test data and expectations into a Galaxy workflow test plan.
-9. `implement-galaxy-workflow-test` — assemble test fixtures and assertions from the translated test plan.
-10. `validate-galaxy-workflow` — terminal pass on the assembled workflow.
-11. `run-workflow-test` — execute via Planemo.
-12. `debug-galaxy-workflow-output`
+8. `[branch]` test-data resolution chain: try `nextflow-to-test-data` → on failure, `find-test-data` → on failure, harness gates to user-supplied data.
+9. `nextflow-test-to-galaxy-test-plan` — translate NF test data and expectations into a Galaxy workflow test plan.
+10. `implement-galaxy-workflow-test` — assemble test fixtures and assertions from the translated test plan.
+11. `validate-galaxy-workflow` — terminal pass on the assembled workflow.
+12. `run-workflow-test` — execute via Planemo.
+13. `debug-galaxy-workflow-output`
 
 ### CWL → GALAXY
 
@@ -119,11 +120,12 @@ CWL is already structured; the upstream extraction work is much lighter.
 4. `compare-against-iwc-exemplar` — structural diff of the design briefs against nearest IWC exemplar(s); guidance feeds template authoring.
 5. `cwl-summary-to-galaxy-template`
 6. `[loop]` `advance-galaxy-draft-step` — one full iteration (pick → discover-or-author → summarize → implement → `gxwf draft-validate --concrete`). Loop terminates on `draft: false`.
-7. `cwl-test-to-galaxy-test-plan` — translate CWL test fixtures into a Galaxy workflow test plan.
-8. `implement-galaxy-workflow-test` — assemble test fixtures and assertions from the translated test plan.
-9. `validate-galaxy-workflow` — terminal pass on the assembled workflow.
-10. `run-workflow-test` — execute via Planemo.
-11. `debug-galaxy-workflow-output`
+7. `[branch]` test-data resolution chain: try `cwl-to-test-data` → on failure, `find-test-data` → on failure, harness gates to user-supplied data.
+8. `cwl-test-to-galaxy-test-plan` — translate CWL test fixtures into a Galaxy workflow test plan.
+9. `implement-galaxy-workflow-test` — assemble test fixtures and assertions from the translated test plan.
+10. `validate-galaxy-workflow` — terminal pass on the assembled workflow.
+11. `run-workflow-test` — execute via Planemo.
+12. `debug-galaxy-workflow-output`
 
 ### INTERVIEW → GALAXY
 
@@ -174,7 +176,7 @@ Test-plan handoff: like every Galaxy-targeting pipeline, this one places a dedic
   - Debug: `debug-galaxy-workflow-output`, `debug-cwl-workflow-output`.
 - **Cross-target (Planemo-backed)**: `run-workflow-test`.
 - **Source × target (test-plan translation)**: `nextflow-test-to-galaxy-test-plan`, `cwl-test-to-galaxy-test-plan`, `nextflow-test-to-cwl-test-plan`. These produce reviewable test plans, not final test artifacts.
-- **Test data extraction (source-specific, target-agnostic)**: `paper-to-test-data` derives fixtures from a paper-origin `freeform-summary`; interview starts skip directly to `find-test-data` / user-supplied data until a real interview-specific fixture derivation Mold exists.
+- **Test data extraction (source-specific, target-agnostic)**: `paper-to-test-data` derives fixtures from a paper-origin `freeform-summary`; `nextflow-to-test-data` and `cwl-to-test-data` resolve the source's own declared fixtures (`test_fixtures` / `tests[]`) into `test-data-refs`. Each is the first leg of its pipeline's `test-data-resolution` chain, falling through to `find-test-data` (search) then user-supplied data. Interview starts skip directly to `find-test-data` / user-supplied data until a real interview-specific fixture derivation Mold exists.
 
 ## Pattern pages, not Molds
 

--- a/docs/MOLDS.md
+++ b/docs/MOLDS.md
@@ -75,6 +75,8 @@ Two-step shape (translation/derivation, then assembly):
 
 **Derivation** (gets the raw fixtures):
 - `paper-to-test-data` — derive workflow test inputs from a paper (sample data, expected outputs, parameter values). Source-specific (paper), target-agnostic. Fails often because papers rarely ship usable fixtures; falls through to `find-test-data`.
+- `nextflow-to-test-data` — resolve the Nextflow pipeline's own declared `test_fixtures` / `nf_tests` (role, url, sha1, filetype) into Galaxy `test-data-refs`. Source-specific (nextflow), target-agnostic. First leg of the chain; falls through to `find-test-data` for inputs it can't resolve.
+- `cwl-to-test-data` — resolve the CWL source's own declared `tests[]` (job-file inputs, expected outputs) into Galaxy `test-data-refs`. Source-specific (cwl), target-agnostic. First leg of the chain; falls through to `find-test-data`.
 - `find-test-data` — fallback when derivation from a source fails. Search IWC test fixtures, public databases, sibling workflows for usable test data matching a data-flow description (input shapes, expected output shapes, organism / data type). Source-agnostic, target-agnostic. The harness escalates to a user-supplied-data gate if `find-test-data` also fails.
 - `nextflow-test-to-galaxy-test-plan` — translate NF test fixtures, profiles, params, expected outputs, and snapshot evidence into a Galaxy workflow test plan. Source × target.
 - `cwl-test-to-galaxy-test-plan` — translate CWL test fixtures into a Galaxy workflow test plan. Source × target.


### PR DESCRIPTION
_Opened by Claude (AI assistant) on behalf of @jmchilton._

Fixes #348.

## Problem

`implement-galaxy-workflow-test` requires `test-data-refs`, but the `nextflow-to-galaxy` and `cwl-to-galaxy` spines had no phase producing it — the phase was uncompletable by composition (the Pipeline validator warned on the unproduced consumed artifact).

## Design

Rather than wire these spines straight to the generic `find-test-data` **search** mold, this restores the pattern `paper-to-galaxy` already uses (`paper-to-test-data → find-test-data → user-supplied`). `find-test-data` searches IWC/public sources — the wrong *first* move for nextflow/cwl, whose summaries already **declare** their own test fixtures:

- `summary-nextflow.test_fixtures` / `nf_tests[]` — each input a `role` + `url`/`path` + `sha1` + `filetype`
- `summary-cwl.tests[]` — each case a `job_path` (naming inputs) + `expected_outputs`

So two new **source-specific** resolvers map those declared fixtures onto the Galaxy interface and emit `test-data-refs`, deferring to `find-test-data` (search) only for inputs they can't resolve:

- **`nextflow-to-test-data`** (`axis: source-specific, source: nextflow`)
- **`cwl-to-test-data`** (`axis: source-specific, source: cwl`)

`test-data-resolution` chains become:
```
nextflow-to-test-data → find-test-data → user-supplied
cwl-to-test-data      → find-test-data → user-supplied
```

This also dissolves a diamond-overlap: the resolver reads declared fixtures for **data**, the test-plan mold reads them for **assertions** — orthogonal, and exactly how paper already works.

## Changes

- New molds `nextflow-to-test-data`, `cwl-to-test-data` (+ casts).
- Both `test-data-resolution` branch chains fronted with the source-specific resolver.
- Regenerated the two assembled harnesses + `Index.md`/`Dashboard.md`.
- Updated `docs/HARNESS_PIPELINES.md` and `docs/MOLDS.md`.

## Verification

- `npm run validate` → 0 errors; the `test-data-refs` unproduced-artifact warning is gone for both spines.
- `make check-generated` → clean.
- `assemble-pipeline --check` for both spines → clean against committed cast state.

## Notes

- New molds ship `index.md` + cast only (no `eval.md`/`scenarios.md` yet), matching the `paper-to-test-data` precedent; those come with first test-drives.
- `update-interview-to-galaxy` shows the same validator warning but is intentionally left out of scope — its `harness_notes` document `test-data-refs` coming from the edited workflow's baseline fixtures.
- Pre-existing doc staleness noted but not touched: `docs/MOLDS.md`'s "34 candidate Molds total" is a frozen design-era count (actual dirs: 47), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)