### PR TITLE
Declare build-cli's dependency on @galaxy-foundry/foundry

### DIFF
--- a/packages/build-cli/package.json
+++ b/packages/build-cli/package.json
@@ -37,6 +37,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@galaxy-foundry/foundry": "workspace:*",
     "@galaxy-foundry/note-schema": "workspace:*",
     "@galaxy-foundry/planemo-cli-meta": "workspace:*",
     "ajv": "^8.17.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
 
   packages/build-cli:
     dependencies:
+      '@galaxy-foundry/foundry':
+        specifier: workspace:*
+        version: link:../foundry
       '@galaxy-foundry/note-schema':
         specifier: workspace:*
         version: link:../note-schema


### PR DESCRIPTION
_PR description written by Claude (AI assistant) on behalf of @jmchilton._

## Symptom

`packages-build` failed on `main` ([run 29770964925](https://github.com/galaxyproject/foundry/actions/runs/29770964925/job/88448679903)), breaking the deploy:

```
packages/build-cli build: src/commands/validate.ts(9,32): error TS2307:
  Cannot find module '@galaxy-foundry/foundry/meta' or its corresponding type declarations.
packages/build-cli build: src/commands/validate.ts(45,27): error TS7006:
  Parameter 'command' implicitly has an 'any' type.
```

## Root cause

`build-cli` imports `@galaxy-foundry/foundry` — `.../foundry/meta` in `validate.ts`, the package root in `cast-mold.ts` — but never declared it as a workspace dependency. pnpm builds the workspace in topological order derived from **declared** deps, so nothing forced `foundry` to build before `build-cli`. It happened to work by scheduling luck.

#359 added `vitest` to `build-cli`, which reshuffled the parallel build scheduling. `build-cli`'s `tsc` then started before `foundry/dist` existed, and the `./meta` subpath export (`./dist/meta/index.d.ts`) couldn't resolve — hence both errors (the second is fallout: `foundryCliMeta` became `any`).

This is latent, not introduced by #359 — the missing declaration has been there since `foundry` was packaged for npm (`bf3485b`). #359 just perturbed the ordering enough to expose it.

## Fix

Declare `"@galaxy-foundry/foundry": "workspace:*"` in `build-cli`'s dependencies, matching how `note-schema` and `planemo-cli-meta` are already declared. No cycle — `foundry` does not depend on `build-cli`.

## Verification

- From a clean tree (`rm -rf packages/*/dist && npm run packages-build`) the failure reproduces on `main` and is gone with this change; `foundry build: Done` now precedes `build-cli build: Done`.
- `packages-typecheck` clean across all 6 packages.
- `packages-test`: 152 tests pass (build-cli 9, foundry 43, summarize-nextflow 87, note-schema 5, planemo-cli-meta 3, planemo-test-report-schema 5).
- Lockfile change is a single `link:../foundry` entry.

## Follow-up worth considering (not in this PR)

The build passing depended on scheduling luck for a while. A from-clean `rm -rf packages/*/dist` build in CI — or `pnpm -r exec` dependency-graph validation — would catch a missing workspace-dep declaration deterministically instead of waiting for an unrelated change to reshuffle ordering. Happy to open an issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)