### PR TITLE
Keep cast --check from creating the bundle dir

### DIFF
--- a/packages/build-cli/src/commands/cast-mold.ts
+++ b/packages/build-cli/src/commands/cast-mold.ts
@@ -1264,7 +1264,8 @@ export async function runCastMoldCommand(argv = process.argv.slice(2)): Promise<
     args.target === "claude"
       ? path.join(repoRoot, "casts", args.target, "skills", args.moldName)
       : path.join(repoRoot, "casts", args.target, args.moldName);
-  mkdirSync(bundleRoot, { recursive: true });
+  // --check is read-only: never materialize the bundle dir for a never-cast Mold.
+  if (!args.check) mkdirSync(bundleRoot, { recursive: true });
   const provenancePath = path.join(bundleRoot, "_provenance.json");
   const carry = readExistingProvenance(provenancePath);
 

--- a/tests/cast-mold.test.ts
+++ b/tests/cast-mold.test.ts
@@ -855,6 +855,57 @@ describe("cast-mold negative cases", () => {
     expect(r.code).not.toBe(0);
     expect(r.stderr).toContain("mold source missing");
   });
+
+  it("--check on a never-cast mold leaves no bundle directory behind", () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "foundry-cast-check-"));
+    try {
+      mkdirSync(path.join(dir, "content/molds/m"), { recursive: true });
+      mkdirSync(path.join(dir, "casts/claude"), { recursive: true });
+      writeFileSync(
+        path.join(dir, "casts/claude/_target.yml"),
+        [
+          "name: claude",
+          "provenance_schema_version: 3",
+          "required_outputs: [SKILL.md, _provenance.json]",
+          "kinds: {}",
+          "condense_prompts: {}",
+          "skill_constraints:",
+          "  frontmatter_required: [name, description]",
+          "  forbidden_runtime_paths: []",
+          "  forbid_packaged_files: []",
+          "",
+        ].join("\n"),
+      );
+      writeFileSync(
+        path.join(dir, "content/molds/m/index.md"),
+        `---
+type: mold
+name: m
+axis: generic
+tags: [mold]
+status: draft
+created: 2026-05-07
+revised: 2026-05-07
+revision: 1
+ai_generated: false
+summary: Never-cast mold used to check that --check stays read-only.
+references: []
+---
+
+# m
+
+Body.
+`,
+      );
+
+      const r = runTsx(foundryBuild, ["cast", "m", "--target=claude", "--root", dir, "--check"]);
+      expect(r.code).not.toBe(0);
+      expect(r.stderr).toContain("SKILL.md");
+      expect(existsSync(path.join(dir, "casts/claude/skills/m"))).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("cast-mold license → redistribution-policy enforcement", () => {


### PR DESCRIPTION
> _Posted by Claude (AI assistant) on behalf of @jmchilton — not authored by them personally._

Closes #360.

`runCastMoldCommand` called `mkdirSync(bundleRoot, { recursive: true })` before anything branched on `args.check`, so a read-only drift check against a never-cast Mold left an empty `casts/claude/skills/<mold>/` behind. Git doesn't track empty dirs, so these were invisible in `git status` but broke `tests/plugin-packaging.test.ts`'s SKILL.md-per-skill assertion.

Every other write in the check path (`castOneRef`, `reconcileSkillMarkdown`, `_required_tools.json`, `_verify.json`) was already guarded — the mkdir was the sole leak.

## Regression test

`tests/cast-mold.test.ts` — "`--check` on a never-cast mold leaves no bundle directory behind": temp repo, minimal Mold with no refs, `cast m --check` → nonzero exit, `SKILL.md` drift reported, `casts/claude/skills/m` absent. Confirmed red-to-green.

## Verification

- Issue's reproduction: `cast validate-cwl --check` reports both drifts, exit 1, no dir created.
- Repo-wide `--check` scan over all `content/molds/*/index.md`: `find casts/claude/skills -type d -empty` returns nothing.
- `npm run test` 151/151, `typecheck` 0 errors, `packages-test`, `packages-format`, `packages-lint`, `validate` (0 errors) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)