### PR TITLE
Stop skip-flag guards becoming reference rebuilds and assets

### DIFF
--- a/packages/summarize-nextflow/src/resolver.ts
+++ b/packages/summarize-nextflow/src/resolver.ts
@@ -337,7 +337,6 @@ export async function resolveNextflowSummary(
   }
 
   const params = parseParams(pipelineRoot);
-  const paramNames = new Set(params.map((param) => param.name));
 
   const summary: Summary = {
     source: {
@@ -378,7 +377,7 @@ export async function resolveNextflowSummary(
         : [],
     },
     reference_assets: [],
-    reference_rebuilds: detectReferenceRebuilds(workflows, invocationsByCallee, paramNames),
+    reference_rebuilds: detectReferenceRebuilds(workflows, invocationsByCallee, params),
     test_fixtures: parseTestFixtures(pipelineRoot, options.profile),
     nf_tests: parseNfTests(pipelineRoot),
     warnings: [...root.warnings, ...warnings],
@@ -1217,6 +1216,9 @@ function buildReferenceAssets(
     if (!rebuildParams.has(name) && isNonReferenceParam(name)) continue;
     const param = paramsByName.get(name);
     if (!param) continue;
+    // A switch is never an asset, however it was nominated — the rebuild path
+    // must not smuggle one past the candidate filters above.
+    if (isToggleParam(name, paramsByName)) continue;
     const callers = [...(usedBy.get(name) ?? [])].sort();
     const hasRebuild = rebuildParams.has(name);
     const sourcePath = param.source_path ?? null;
@@ -1261,6 +1263,17 @@ const NON_REFERENCE_PARAMS = new Set([
 
 function isNonReferenceParam(name: string): boolean {
   return NON_REFERENCE_PARAMS.has(name);
+}
+
+function isToggleName(name: string): boolean {
+  return /^(skip|no|disable|disabled)_/u.test(name);
+}
+
+// nf-core subworkflows rename take slots (`val_skip_fastqc`), so a name test on
+// the raw guard identifier misses these; the declared type is the reliable
+// signal, with the name test covering params absent from nextflow_schema.json.
+function isToggleParam(name: string, paramsByName: Map<string, Param>): boolean {
+  return paramsByName.get(name)?.type === "boolean" || isToggleName(name);
 }
 
 function isPathTypedParam(param: Param): boolean {
@@ -1325,8 +1338,10 @@ function classifyAssetKind(name: string): string {
 function detectReferenceRebuilds(
   workflows: ParsedWorkflow[],
   invocationsByCallee: Map<string, SubworkflowInvocation[]>,
-  paramNames: Set<string>,
+  params: Param[],
 ): ReferenceRebuildRule[] {
+  const paramsByName = new Map(params.map((param) => [param.name, param]));
+  const paramNames = new Set(paramsByName.keys());
   const rules: ReferenceRebuildRule[] = [];
   for (const workflow of workflows) {
     const takeNames = new Set((workflow.inputs ?? []).map((entry) => entry.name));
@@ -1338,7 +1353,7 @@ function detectReferenceRebuilds(
       );
       if (!negation) continue;
       const negated = negation[1]!;
-      if (/^(skip|no|disable|disabled)_/u.test(negated)) continue;
+      if (isToggleName(negated)) continue;
       const rebuild = analyzeRebuildBody(block.defaultBody, negated);
       if (!rebuild) continue;
       // Compute-if-missing convention: the assignment LHS or the negated identifier
@@ -1356,6 +1371,7 @@ function detectReferenceRebuilds(
         invocations,
         paramNames,
       );
+      if (isToggleParam(assetParam.name, paramsByName)) continue;
       const guardParams = collectGuardParams(block.guard, takeNames, invocations);
       const confidence: Evidence["confidence"] =
         assetParam.resolvedFromBinding && guardParams.allFromTakes ? "high" : "medium";

--- a/packages/summarize-nextflow/test/integration/cli.test.ts
+++ b/packages/summarize-nextflow/test/integration/cli.test.ts
@@ -902,6 +902,21 @@ describe("summarize-nextflow CLI — real pipeline tree (nf-core/bacass)", () =>
     );
   });
 
+  itIfBacassFixture("rebuilds only the Bakta database, not the FASTQC/FASTP skip flags", () => {
+    const r = spawnSync("node", [CLI, BACASS_PIPELINE, "--no-with-nextflow", "--no-validate"], {
+      encoding: "utf8",
+      maxBuffer: SPAWN_MAX_BUFFER,
+    });
+    expect(r.status).toBe(0);
+
+    const data = JSON.parse(r.stdout);
+    const rebuilds = data.reference_rebuilds as { asset_param: string; builder: string }[];
+    expect(rebuilds.map((rule) => [rule.asset_param, rule.builder])).toEqual([
+      ["baktadb", "BAKTA_BAKTADBDOWNLOAD"],
+    ]);
+    expect((data.reference_assets as { param: string }[]).map((a) => a.param)).toEqual(["baktadb"]);
+  });
+
   itIfBacassFixture("extracts repeated module aliases from bacass includes", () => {
     const r = spawnSync("node", [CLI, BACASS_PIPELINE, "--no-with-nextflow", "--no-validate"], {
       encoding: "utf8",

--- a/packages/summarize-nextflow/test/resolver.test.ts
+++ b/packages/summarize-nextflow/test/resolver.test.ts
@@ -1366,6 +1366,174 @@ workflow PIPE {
     expect(summary.reference_rebuilds.map((r) => r.builder)).toEqual(["CREATE_DICT"]);
   });
 
+  test("skips skip-flag guards renamed by a subworkflow take slot", async () => {
+    const root = tempPipelineRoot();
+    write(root, "nextflow.config", "manifest { name = 'nf-core/toggle' }\n");
+    write(
+      root,
+      "nextflow_schema.json",
+      JSON.stringify({
+        $defs: {
+          ref: {
+            title: "Reference genome options",
+            properties: {
+              fasta: { type: "string", format: "file-path" },
+              fasta_fai: { type: "string", format: "file-path" },
+              skip_fastqc: { type: "boolean" },
+            },
+          },
+        },
+      }),
+    );
+    write(
+      root,
+      "modules/tools.nf",
+      `process FASTQC_RAW {\n  input:\n  path reads\n  output:\n  path "*.zip", emit: zip\n  script:\n  "x"\n}
+process SAMTOOLS_FAIDX {\n  input:\n  path fasta\n  output:\n  path "*.fai", emit: fai\n  script:\n  "x"\n}
+`,
+    );
+    // Take slot renamed `val_skip_fastqc`, as nf-core subworkflows conventionally do.
+    write(
+      root,
+      "subworkflows/nf-core/trim_qc/main.nf",
+      `include { FASTQC_RAW } from '../../../modules/tools'
+workflow TRIM_QC {
+  take:
+  ch_reads
+  val_skip_fastqc
+  main:
+  if (!val_skip_fastqc) {
+    FASTQC_RAW (
+      ch_reads
+    )
+    ch_fastqc_raw_zip = FASTQC_RAW.out.zip
+  }
+  emit:
+  done = 1
+}
+`,
+    );
+    write(
+      root,
+      "subworkflows/local/prepare_genome/main.nf",
+      `include { SAMTOOLS_FAIDX } from '../../../modules/tools'
+workflow PREPARE_GENOME {
+  take:
+  fasta
+  fasta_fai_in
+  main:
+  if (!fasta_fai_in) {
+    SAMTOOLS_FAIDX(fasta)
+    fasta_fai = SAMTOOLS_FAIDX.out.fai
+  }
+  emit:
+  done = 1
+}
+`,
+    );
+    write(
+      root,
+      "main.nf",
+      `include { TRIM_QC } from './subworkflows/nf-core/trim_qc/main'
+include { PREPARE_GENOME } from './subworkflows/local/prepare_genome/main'
+workflow PIPE {
+  main:
+  TRIM_QC (
+    ch_reads,
+    params.skip_fastqc
+  )
+  PREPARE_GENOME(
+    params.fasta,
+    params.fasta_fai
+  )
+}
+`,
+    );
+
+    const summary = (await summarize(root)) as unknown as {
+      reference_rebuilds: { asset_param: string; builder: string }[];
+      reference_assets: { param: string }[];
+    };
+
+    expect(summary.reference_rebuilds.map((r) => [r.asset_param, r.builder])).toEqual([
+      ["fasta_fai", "SAMTOOLS_FAIDX"],
+    ]);
+    expect(summary.reference_assets.map((a) => a.param).sort()).toEqual(["fasta", "fasta_fai"]);
+  });
+
+  test("keeps a boolean param out of reference_assets when a rebuild nominates it", async () => {
+    const root = tempPipelineRoot();
+    write(root, "nextflow.config", "manifest { name = 'nf-core/toggle-fallback' }\n");
+    write(
+      root,
+      "nextflow_schema.json",
+      JSON.stringify({
+        $defs: {
+          ref: {
+            title: "Reference genome options",
+            properties: {
+              fasta: { type: "string", format: "file-path" },
+              fasta_fai: { type: "string", format: "file-path" },
+              build_index: { type: "boolean" },
+            },
+          },
+        },
+      }),
+    );
+    write(
+      root,
+      "modules/tools.nf",
+      `process SAMTOOLS_FAIDX {\n  input:\n  path fasta\n  output:\n  path "*.fai", emit: fai\n  script:\n  "x"\n}\n`,
+    );
+    // Guard negates a boolean take slot while the built asset is a real path param,
+    // so the boolean reaches reference_assets only via the rule's fallback_for.
+    write(
+      root,
+      "subworkflows/local/prepare_genome/main.nf",
+      `include { SAMTOOLS_FAIDX } from '../../../modules/tools'
+workflow PREPARE_GENOME {
+  take:
+  fasta
+  fasta_fai_in
+  val_build_index
+  main:
+  if (!val_build_index) {
+    SAMTOOLS_FAIDX(fasta)
+    fasta_fai = SAMTOOLS_FAIDX.out.fai
+  }
+  emit:
+  done = 1
+}
+`,
+    );
+    write(
+      root,
+      "main.nf",
+      `include { PREPARE_GENOME } from './subworkflows/local/prepare_genome/main'
+workflow PIPE {
+  main:
+  PREPARE_GENOME(
+    params.fasta,
+    params.fasta_fai,
+    params.build_index
+  )
+}
+`,
+    );
+
+    const summary = (await summarize(root)) as unknown as {
+      reference_rebuilds: { asset_param: string; fallback_for: string | null }[];
+      reference_assets: { param: string }[];
+    };
+
+    // The rule stands and still names the boolean as its fallback...
+    expect(summary.reference_rebuilds.map((r) => [r.asset_param, r.fallback_for])).toEqual([
+      ["fasta_fai", "build_index"],
+    ]);
+    // ...but the asset inventory must not pick it up from there.
+    expect(summary.reference_assets.map((a) => a.param)).not.toContain("build_index");
+  });
+
   test("emits no rebuilds for a pipeline without compute-if-missing branches", async () => {
     const root = tempPipelineRoot();
     write(root, "nextflow.config", "manifest { name = 'adhoc/no-rebuild' }\n");


### PR DESCRIPTION
> _Posted by Claude (AI assistant) on behalf of @jmchilton — not authored by them personally._

Closes #355.

## Root cause

`detectReferenceRebuilds` filtered skip-flag guards by testing the *raw* negated identifier. nf-core subworkflows conventionally rename take slots, so bacass's `if (!val_skip_fastqc)` (`subworkflows/nf-core/fastq_trim_fastp_fastqc/main.nf:39`, take declared `val_skip_fastqc  // value: boolean`) sailed past the anchored `^(skip|no|disable|disabled)_`. `resolveAssetParam` then resolved the rule back to the real `skip_fastqc` param via the caller's positional binding in `workflows/bacass.nf:176` — with `confidence: high`. `buildReferenceAssets` admitted it unfiltered, because the rebuild path bypasses both `isNonReferenceParam` and `isPathTypedParam`.

## Fix

Both ends, as the issue asks:

- **Rule side** — `detectReferenceRebuilds` now takes `params: Param[]` rather than a bare name set, and drops a rule when the **resolved** `asset_param` is boolean-typed (or skip-named).
- **Asset side** — `buildReferenceAssets` rejects a boolean param however it was nominated.

The raw-identifier pre-filter stays. Instrumenting it across the corpus showed it fires 101 times catching the direct `!params.skip_*` and bare `!skip_*` forms — it's live, just not sufficient alone. It's also defeated in shapes no prefix-stripping would catch: domain-namespaced flags (`arg_skip_abricate`, `bgc_skip_antismash`, `mapstats_skip_preseq`), `skip` with no trailing underscore (`preprocessing_skippairmerging`, `longread_qc_skipadaptertrim`), and an adjacent class the vocabulary never covered (`!params.run_taxa_classification`, `!params.with_umi`, `!build_only_index`). Those don't currently produce rules only because they fail later gates — luck, not design. So the resolved-param type check is the durable defense; the name filter is a cheap first pass.

### Deviation from the suggested acceptance criteria

The issue suggests requiring the param be *path-typed* on the rebuild path. That would break correct output: bacass's `baktadb` is `type: string, format: null` — **not** path-typed — as are all five eager assets (`fasta_fai`, `fasta_dict`, `fasta_mapperindexdir`). Only sarek's 6 declare `file-path`/`directory-path`. A path-typed gate would drop 6 of the corpus's 11 legitimate rebuild assets, including the `baktadb` the issue's own criterion requires. Gated on **non-boolean** instead.

## Tests

Three, all verified red-to-green:

1. `resolver.test.ts` — "skips skip-flag guards renamed by a subworkflow take slot": synthetic pipeline mirroring bacass, alongside a legitimate `fasta_fai` rebuild, asserting only the legitimate rule and assets survive. Pre-fix: 2 rules.
2. `resolver.test.ts` — "keeps a boolean param out of reference_assets when a rebuild nominates it": pins the `fallback_for` path, which is **independently reachable** — the rule legitimately stands with `fallback_for: "build_index"` and the asset gate must still block it. Pre-fix assets: `['build_index', 'fasta', 'fasta_fai']`. The asset-side fix is load-bearing, not just belt-and-braces.
3. `integration/cli.test.ts` — "rebuilds only the Bakta database, not the FASTQC/FASTP skip flags": the real bacass fixture, pinning the headline criterion.

## Verification

- bacass: 4 rules / 3 assets → **1 / 1** (`baktadb` / `BAKTA_BAKTADBDOWNLOAD`).
- sarek (6 rules / 48 assets) and eager (5 / 11) unchanged; every other fixture byte-identical on both fields. Swept all 18 materialized pipelines — zero boolean rules or assets remain corpus-wide.
- `summarize-nextflow` 90/90, root `npm run test` 151/151, `packages-typecheck`, `packages-lint`, `packages-format`, `validate` (0 errors) pass. `cast summarize-nextflow --check` clean — no bundle regeneration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)