### PR TITLE
Seed empty stub molds and cast every mold

### DIFF
--- a/casts/claude/skills/cwl-test-to-galaxy-test-plan/SKILL.md
+++ b/casts/claude/skills/cwl-test-to-galaxy-test-plan/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: cwl-test-to-galaxy-test-plan
+description: "Translate CWL test fixtures into a Galaxy workflow test plan."
+---
+
+# cwl-test-to-galaxy-test-plan
+
+Follow the procedure below and use the artifact/reference sections as the runtime contract.
+
+## When To Use
+
+- Translate CWL test fixtures into a Galaxy workflow test plan.
+
+## Inputs
+
+- Read artifact `summary-cwl`. Schema: summary-cwl. Produced by `summarize-cwl`. Structured CWL summary from summarize-cwl; carries test fixtures, job inputs, expected outputs.
+
+## Outputs
+
+- Write artifact `galaxy-test-plan` as `galaxy-test-plan.yml`. Format: `yaml`. Schema: galaxy-workflow-test-plan. Reviewable Galaxy workflow test plan (see galaxy-workflow-test-plan) derived from CWL test fixtures, job inputs, expected outputs, and assertion evidence.
+
+## Required Tools
+
+- None declared. Procedure should not assume external CLIs are present.
+
+## Load Upfront
+
+- `references/schemas/galaxy-workflow-test-plan.schema.json`: Schema file copied verbatim into the bundle. Output contract: the emitted plan conforms to galaxy-workflow-test-plan. Cast bundles the JSON Schema; validate with `foundry validate-galaxy-workflow-test-plan`.
+- `references/schemas/summary-cwl.schema.json`: Schema file copied verbatim into the bundle. Read the CWL summary's test cases, job inputs, expected outputs, and assertion evidence.
+
+## Load On Demand
+
+- `references/notes/galaxy-workflow-testability-design.md`: Research note copied verbatim into the bundle. Choose which workflow outputs and promoted checkpoints make meaningful assertions. Use when: deciding which outputs to assert and which labels the plan should bind to.
+- `references/notes/iwc-shortcuts-anti-patterns.md`: Research note copied verbatim into the bundle. Distinguish accepted IWC-style test shortcuts from assertion smells while translating tests. Use when: deciding whether to use existence-only, size-only, image-dimension, or tolerant output checks.
+- `references/notes/iwc-test-data-conventions.md`: Research note copied verbatim into the bundle. Emit Galaxy/IWC-style job input fixtures, remote locations, hashes, and collection input shapes. Use when: writing job inputs or deciding whether fixtures belong in test-data, Zenodo, ENA/SRA, or CVMFS.
+- `references/notes/planemo-asserts-idioms.md`: Research note copied verbatim into the bundle. Describe Galaxy workflow-test assertion intent and tolerances for translated expected outputs. Use when: turning CWL expected outputs into Galaxy test-plan assertions.
+- `references/notes/planemo-workflow-test-architecture.md`: Research note copied verbatim into the bundle. Keep the plan addressable by stable labels and artifacts Planemo can connect back to invocations, jobs, and outputs. Use when: recording the labels and checkpoints the downstream test must address.
+- `references/schemas/tests-format.schema.json`: Schema file copied verbatim into the bundle. Use the Galaxy workflow tests schema as the assertion-family vocabulary when translating CWL test evidence into a Galaxy test plan. Use when: mapping expected outputs, tolerances, or fixture assertions into Galaxy workflow-test assertion intent.
+
+## Validation
+
+- Validate `galaxy-test-plan.yml` before returning it: run `foundry validate-galaxy-workflow-test-plan galaxy-test-plan.yml` from `@galaxy-foundry/foundry`. If the command is not on PATH, run `npx --package @galaxy-foundry/foundry foundry validate-galaxy-workflow-test-plan galaxy-test-plan.yml`. This checks artifact `galaxy-test-plan` against the galaxy-workflow-test-plan schema.
+
+## Procedure
+
+Translate CWL test fixtures, job inputs, expected outputs, and assertion evidence into a Galaxy workflow test plan. The output is a reviewable YAML handoff conforming to galaxy-workflow-test-plan, not a concrete `tests-format` file; implement-galaxy-workflow-test owns final YAML authoring and static validation. Because this plan is translated from real CWL test fixtures, set `source.derived_from: test-evidence` and prefer `evidence: test-evidence` on the assertions it carries.
+
+## Runtime Notes
+
+- Do not read Foundry source files at runtime; use only files packaged in this skill bundle and user-supplied artifacts.
+- Preserve declared artifact filenames unless the user or harness supplies explicit paths.
+- Carry unresolved assumptions into the output artifact instead of silently inventing missing source evidence.

--- a/casts/claude/skills/cwl-test-to-galaxy-test-plan/_provenance.json
+++ b/casts/claude/skills/cwl-test-to-galaxy-test-plan/_provenance.json
@@ -1,0 +1,159 @@
+{
+  "provenance_schema_version": 3,
+  "cast_target": "claude",
+  "mold": {
+    "name": "cwl-test-to-galaxy-test-plan",
+    "path": "content/molds/cwl-test-to-galaxy-test-plan/index.md",
+    "revision": 2,
+    "content_hash": "274a902cb9327e4d0a88ee73485d9e7950400f8ec668b7bca7fd0561776af0d1",
+    "commit": "e487fe785f468afdf25f2b6bd140c3a115a12021"
+  },
+  "cast_at": "2026-07-24T13:51:11.720Z",
+  "refs": [
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[galaxy-workflow-testability-design]]",
+      "src": "content/research/galaxy-workflow-testability-design.md",
+      "dst": "references/notes/galaxy-workflow-testability-design.md",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Choose which workflow outputs and promoted checkpoints make meaningful assertions.",
+      "trigger": "When deciding which outputs to assert and which labels the plan should bind to.",
+      "src_hash": "e4d5991a5085e0f9ad52b8e6856f64179362334bd51b77a3302faeb96732f980",
+      "dst_hash": "e4d5991a5085e0f9ad52b8e6856f64179362334bd51b77a3302faeb96732f980",
+      "source": "deterministic"
+    },
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[iwc-shortcuts-anti-patterns]]",
+      "src": "content/research/iwc-shortcuts-anti-patterns.md",
+      "dst": "references/notes/iwc-shortcuts-anti-patterns.md",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Distinguish accepted IWC-style test shortcuts from assertion smells while translating tests.",
+      "trigger": "When deciding whether to use existence-only, size-only, image-dimension, or tolerant output checks.",
+      "src_hash": "69269abd774152694053f0b9922f88dfcd175ba8c3697b2c530d911740c7fcc6",
+      "dst_hash": "69269abd774152694053f0b9922f88dfcd175ba8c3697b2c530d911740c7fcc6",
+      "source": "deterministic"
+    },
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[iwc-test-data-conventions]]",
+      "src": "content/research/iwc-test-data-conventions.md",
+      "dst": "references/notes/iwc-test-data-conventions.md",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Emit Galaxy/IWC-style job input fixtures, remote locations, hashes, and collection input shapes.",
+      "trigger": "When writing job inputs or deciding whether fixtures belong in test-data, Zenodo, ENA/SRA, or CVMFS.",
+      "src_hash": "2c7ef6a674b84f434ed973fe5c93156a6b368fc774a432e828257ddbde5d4993",
+      "dst_hash": "2c7ef6a674b84f434ed973fe5c93156a6b368fc774a432e828257ddbde5d4993",
+      "source": "deterministic"
+    },
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[planemo-asserts-idioms]]",
+      "src": "content/research/planemo-asserts-idioms.md",
+      "dst": "references/notes/planemo-asserts-idioms.md",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Describe Galaxy workflow-test assertion intent and tolerances for translated expected outputs.",
+      "trigger": "When turning CWL expected outputs into Galaxy test-plan assertions.",
+      "src_hash": "9d87cd37efcc3f5e3a378011892f3846c8fdecec7a5765193044d71edb746ed9",
+      "dst_hash": "9d87cd37efcc3f5e3a378011892f3846c8fdecec7a5765193044d71edb746ed9",
+      "source": "deterministic"
+    },
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[planemo-workflow-test-architecture]]",
+      "src": "content/research/planemo-workflow-test-architecture.md",
+      "dst": "references/notes/planemo-workflow-test-architecture.md",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Keep the plan addressable by stable labels and artifacts Planemo can connect back to invocations, jobs, and outputs.",
+      "trigger": "When recording the labels and checkpoints the downstream test must address.",
+      "src_hash": "41845074f48e96f268c6a2668f751868f9502399818c3c0fe3265b3b594dbb24",
+      "dst_hash": "41845074f48e96f268c6a2668f751868f9502399818c3c0fe3265b3b594dbb24",
+      "source": "deterministic"
+    },
+    {
+      "kind": "schema",
+      "mode": "verbatim",
+      "ref": "[[galaxy-workflow-test-plan]]",
+      "src": "package://@galaxy-foundry/foundry#galaxyWorkflowTestPlanSchema",
+      "dst": "references/schemas/galaxy-workflow-test-plan.schema.json",
+      "used_at": "runtime",
+      "load": "upfront",
+      "evidence": "hypothesis",
+      "purpose": "Output contract: the emitted plan conforms to [[galaxy-workflow-test-plan]]. Cast bundles the JSON Schema; validate with `foundry validate-galaxy-workflow-test-plan`.",
+      "verification": "Cast the skill on a CWL summary carrying tests and confirm the emitted YAML validates and downstream [[implement-galaxy-workflow-test]] consumes it.",
+      "license": "MIT",
+      "src_hash": "7378ea527dd18279bd0c2426ed189cb2975dff7948ba1fc98796ac5bc9ce6bc0",
+      "dst_hash": "7378ea527dd18279bd0c2426ed189cb2975dff7948ba1fc98796ac5bc9ce6bc0",
+      "source": "deterministic"
+    },
+    {
+      "kind": "schema",
+      "mode": "verbatim",
+      "ref": "[[summary-cwl]]",
+      "src": "package://@galaxy-foundry/foundry#summaryCwlSchema",
+      "dst": "references/schemas/summary-cwl.schema.json",
+      "used_at": "runtime",
+      "load": "upfront",
+      "evidence": "corpus-observed",
+      "purpose": "Read the CWL summary's test cases, job inputs, expected outputs, and assertion evidence.",
+      "license": "MIT",
+      "src_hash": "0bb5e164d5a7328481dc6ca1225f90666c758603566427512838bf565413c4e0",
+      "dst_hash": "0bb5e164d5a7328481dc6ca1225f90666c758603566427512838bf565413c4e0",
+      "source": "deterministic"
+    },
+    {
+      "kind": "schema",
+      "mode": "verbatim",
+      "ref": "[[tests-format]]",
+      "src": "package://@galaxy-foundry/foundry#testsFormatSchema",
+      "dst": "references/schemas/tests-format.schema.json",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Use the Galaxy workflow tests schema as the assertion-family vocabulary when translating CWL test evidence into a Galaxy test plan.",
+      "trigger": "When mapping expected outputs, tolerances, or fixture assertions into Galaxy workflow-test assertion intent.",
+      "license": "MIT",
+      "license_file": "LICENSES/galaxy-tool-util-ts.LICENSE",
+      "src_hash": "ff0de5041f4c3de0ab7abe9e7555c5a7120665b077f42661461301b0fb26f372",
+      "dst_hash": "ff0de5041f4c3de0ab7abe9e7555c5a7120665b077f42661461301b0fb26f372",
+      "source": "deterministic",
+      "license_file_hash": "383450c494c01c466bcf22df102540a39ac89da50563fd7be686ba06772f96b3"
+    }
+  ],
+  "artifacts": {
+    "produces": [
+      {
+        "id": "galaxy-test-plan",
+        "kind": "yaml",
+        "default_filename": "galaxy-test-plan.yml",
+        "schema": "[[galaxy-workflow-test-plan]]",
+        "description": "Reviewable Galaxy workflow test plan (see [[galaxy-workflow-test-plan]]) derived from CWL test fixtures, job inputs, expected outputs, and assertion evidence."
+      }
+    ],
+    "consumes": [
+      {
+        "id": "summary-cwl",
+        "description": "Structured CWL summary from [[summarize-cwl]]; carries test fixtures, job inputs, expected outputs.",
+        "inherited_schema": "[[summary-cwl]]",
+        "producers": [
+          "summarize-cwl"
+        ]
+      }
+    ]
+  }
+}

--- a/casts/claude/skills/cwl-test-to-galaxy-test-plan/_verify.json
+++ b/casts/claude/skills/cwl-test-to-galaxy-test-plan/_verify.json
@@ -1,0 +1,29 @@
+{
+  "verify_schema_version": 1,
+  "entries": [
+    {
+      "artifact_id": "summary-cwl",
+      "direction": "input",
+      "kind": "json",
+      "default_filename": "summary-cwl.json",
+      "schema": "[[summary-cwl]]",
+      "validator_bin": "foundry",
+      "args": [
+        "validate-summary-cwl",
+        "{artifact_path}"
+      ]
+    },
+    {
+      "artifact_id": "galaxy-test-plan",
+      "direction": "output",
+      "kind": "yaml",
+      "default_filename": "galaxy-test-plan.yml",
+      "schema": "[[galaxy-workflow-test-plan]]",
+      "validator_bin": "foundry",
+      "args": [
+        "validate-galaxy-workflow-test-plan",
+        "{artifact_path}"
+      ]
+    }
+  ]
+}

--- a/casts/claude/skills/cwl-test-to-galaxy-test-plan/references/notes/galaxy-workflow-testability-design.md
+++ b/casts/claude/skills/cwl-test-to-galaxy-test-plan/references/notes/galaxy-workflow-testability-design.md
@@ -1,0 +1,139 @@
+---
+type: research
+subtype: component
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-05-03
+revised: 2026-05-06
+revision: 2
+ai_generated: true
+related_notes:
+  - "[[iwc-workflow-testability-survey]]"
+  - "[[iwc-test-data-conventions]]"
+  - "[[planemo-asserts-idioms]]"
+  - "[[iwc-shortcuts-anti-patterns]]"
+  - "[[planemo-workflow-test-architecture]]"
+  - "[[implement-galaxy-workflow-test]]"
+  - "[[gxformat2-schema]]"
+  - "[[gxformat2-workflow-inputs]]"
+  - "[[galaxy-datatypes-conf]]"
+summary: "Design guidance for Galaxy workflow inputs, outputs, and checkpoints that make IWC-style workflow tests possible."
+---
+
+# Galaxy workflow testability design
+
+Use this note when authoring or translating a Galaxy workflow **before** the `-tests.yml` file exists. It covers workflow structure choices that make later IWC-style tests meaningful: labels, promoted checkpoints, collection identifiers, and fixture-compatible inputs.
+
+This is not a `content/patterns/` page. It is cross-cutting design guidance for Molds that need testable Galaxy workflows. Assertion syntax lives in [[planemo-asserts-idioms]]. Test YAML fixture shapes live in [[iwc-test-data-conventions]]. Accepted shortcut vs smell calls live in [[iwc-shortcuts-anti-patterns]]. Corpus evidence trail lives in [[iwc-workflow-testability-survey]].
+
+## 1. Treat labels as API
+
+Workflow input and output labels are not cosmetic. Planemo and IWC tests address workflow inputs and outputs by label, and the survey found exact label matches for every asserted output across 114 matched workflow/test pairs. A generated workflow should therefore pick stable, descriptive labels before test authoring starts.
+
+Rules:
+
+- Label every output that may need a test assertion.
+- Treat input/output renames as breaking changes requiring sibling `-tests.yml` updates.
+- Prefer stable domain names over tool-step defaults or positional names.
+- Do not rely on unlabeled or positional outputs for tests.
+
+Evidence:
+
+- Scanpy exposes outputs such as `Initial Anndata General Info`, `UMAP of louvain`, `Ranked genes with Wilcoxon test`, and `Dotplot of top genes on clusters` (`$IWC_FORMAT2/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy.gxwf.yml:105-147`). The sibling test keys assertions by those exact labels (`$IWC/workflows/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml:27-205`).
+- VGP scaffolding uses punctuation-heavy labels such as `Hi-C duplication stats on scaffolds: Raw`, `Hi-C duplication stats on scaffolds: MultiQc`, and `Merged Alignment stats` (`$IWC_FORMAT2/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8.gxwf.yml:170-196`). The test asserts those exact labels (`$IWC/workflows/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8-tests.yml:218-245`).
+
+## 2. Promote assertable checkpoints
+
+IWC workflow tests assert workflow-level outputs. Intermediate step results are invisible unless promoted to top-level workflow outputs. When final reports are weakly assertable, expose intermediate checkpoints that carry deterministic content or structure.
+
+Rules:
+
+- Promote intermediate outputs when they are the best deterministic or structural checkpoint.
+- Prefer a checkpoint table/text/HDF5 object that can prove content over a final plot/report that can only prove existence.
+- Accept some output-list clutter when it buys meaningful tests.
+- Do not promote every intermediate by default; expose checkpoints that map to concrete assertion intent.
+
+Evidence:
+
+- Scanpy exposes 21 workflow outputs and the sibling test asserts all 21. These include initial AnnData summaries, intermediate plots, ranked-gene tables, final AnnData, cluster-count tables, and final plots (`$IWC_FORMAT2/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy.gxwf.yml:105-147`; `$IWC/workflows/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml:27-205`).
+- RNA-seq paired-end exposes mapped reads, stranded/unstranded coverage, abundance estimates, expression tables, counts tables, and MultiQC reports (`$IWC_FORMAT2/transcriptomics/rnaseq-pe/rnaseq-pe.gxwf.yml:90-112`). The sibling test asserts sizes for coverage/read outputs and stronger regex/line checks for expression/count outputs (`$IWC/workflows/transcriptomics/rnaseq-pe/rnaseq-pe-tests.yml:48-97`).
+- MGnify complete exposes 83 workflow outputs; 38 are asserted in the sibling test, including MultiQC reports, FASTA collections, taxonomic classifications, OTU tables, and HDF5/JSON outputs (`$IWC_FORMAT2/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/mgnify-amplicon-pipeline-v5-complete.gxwf.yml:163-329`; `$IWC/workflows/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/mgnify-amplicon-pipeline-v5-complete-tests.yml:15-120`).
+
+## 3. Stabilize collection output identifiers
+
+Collection tests key assertions by element identifier. If a workflow emits collections with unstable or opaque identifiers, the test cannot target elements cleanly.
+
+Rules:
+
+- Preserve biologically or sample-meaningful identifiers through map-over and collection reshaping.
+- When generating or relabeling collections, make the identifier derivation deterministic and visible in workflow structure.
+- For nested collections, ensure each axis has predictable identifiers.
+- Quote special identifiers in tests when YAML requires it, but do not simplify identifiers merely for YAML convenience.
+
+Evidence:
+
+- 59 of 115 IWC test files use `element_tests:`, with 227 `element_tests:` blocks in the corpus survey.
+- 10x CellPlex tests nested collection outputs by `subsample`, then inner `matrix`, `barcodes`, and `genes` elements (`$IWC/workflows/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:82-128`). The workflow exposes the corresponding collection outputs (`$IWC_FORMAT2/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex.gxwf.yml:73-91`).
+- HyPhy collection outputs are tested by generated gene identifiers such as `NC_001477.1|capsid_protein_C|95-394_DENV1` (`$IWC/workflows/comparative_genomics/hyphy/hyphy-core-tests.yml:31-71`). The workflow exposes collection outputs for MEME, PRIME, BUSTED, and FEL (`$IWC_FORMAT2/comparative_genomics/hyphy/hyphy-core.gxwf.yml:26-38`).
+
+## 4. Choose checkpoints by assertion strength
+
+Assertion choice is not only a test-file decision. It should feed back into workflow output design. If the only exposed output is a stochastic plot or binary file, the best possible test may be a weak size check. Exposing a sibling table, report, HDF5 structure, or summary line can make the same workflow much more testable.
+
+Rules:
+
+- For image-heavy workflows, expose data or summary outputs behind the plot when possible.
+- For stochastic statistical outputs, expose structural checkpoints and stable summary tokens.
+- For binary outputs, expose a text/table report or stats file when the tool can produce one.
+- Use [[planemo-asserts-idioms]] to select the assertion family after choosing the checkpoint.
+
+Evidence:
+
+- Scanpy image outputs are mostly smoke-tested with `has_size`, `has_image_width`, and `has_image_height`, but the same workflow also exposes AnnData HDF5 keys and cluster-count table checks (`$IWC/workflows/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml:33-205`).
+- RNA-seq paired-end pairs coarse size checks for coverage/mapped-read outputs with stronger regex and exact-line checks for expression/count tables (`$IWC/workflows/transcriptomics/rnaseq-pe/rnaseq-pe-tests.yml:48-97`).
+- VGP scaffolding tests combine stable text checks for scaffold/report stats with size checks for map/alignment artifacts (`$IWC/workflows/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8-tests.yml:173-245`).
+
+## 5. Design inputs with fixtures in mind
+
+Workflow input labels and types constrain the eventual `job:` block. Fixture planning is not only a test-file activity: it should influence whether the workflow exposes a file input, a collection input, a string data-table input, or a typed parameter.
+
+Rules:
+
+- Choose input labels that will be readable as test `job:` keys.
+- Match workflow input collection types to realistic fixture shapes.
+- Decide early whether reference data should be a portable remote file or a CVMFS/data-table string.
+- Keep typed parameters explicit when tests need to set them (`int`, `boolean`, `string`) rather than burying them in step defaults.
+
+Evidence:
+
+- 10x CellPlex job inputs include `fastq PE collection GEX`, `reference genome`, `gtf`, `cellranger_barcodes_3M-february-2018.txt`, `fastq PE collection CMO`, `sample name and CMO sequence collection`, and `Number of expected cells` (`$IWC/workflows/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:2-75`). The workflow declares matching collection, data, string, boolean, and int inputs (`$IWC_FORMAT2/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex.gxwf.yml:4-72`).
+- HyPhy accepts a `list` collection of unaligned sequences and preserves accession-like fixture identifiers through to output element assertions (`$IWC/workflows/comparative_genomics/hyphy/hyphy-core-tests.yml:7-30`; `$IWC_FORMAT2/comparative_genomics/hyphy/hyphy-core.gxwf.yml:14-25`).
+
+## 6. Know what a gxformat2 output entry contains
+
+Top-level gxformat2 `outputs:` is the public workflow-output surface. It is separate from per-step `out:` declarations and from step post-job actions such as `change_datatype` or `rename`.
+
+Authoring rules:
+
+- Use `label` as the stable public name tests and users will address.
+- Use `outputSource` to point at the producing step output; do not rely on positional output order.
+- Use `doc` for short user-facing context when the label is not self-explanatory.
+- Keep `type` aligned with the exposed value (`data`, `collection`, or scalar vocabulary from [[gxformat2-workflow-inputs]]) when the schema needs it.
+- Apply `change_datatype` at the producing step output when Galaxy needs a stronger datatype than the tool reports; choose values from [[galaxy-datatypes-conf]].
+- Use `rename` only for generated dataset names inside Galaxy histories. It is not a substitute for stable workflow-output `label`.
+- Treat `add_tags` and `remove_tags` as metadata helpers, not as the test API. IWC tests key by labels and collection element identifiers, not tags.
+- Avoid `hide` or `delete_intermediate_datasets` on outputs that are promoted as test checkpoints.
+
+Design inference: a workflow-output promotion decision should pick both the public `outputs:` entry and any producer-side post-job action needed to make that output useful. For example, a synthesized BED checkpoint needs a stable output `label` plus a producer-side `change_datatype: bed`; one without the other is incomplete for a testable workflow.
+
+## Cross-references
+
+- [[iwc-workflow-testability-survey]] — corpus survey and distribution rationale.
+- [[iwc-test-data-conventions]] — job/input YAML shapes, remote fixtures, hashes, collection fixture syntax.
+- [[planemo-asserts-idioms]] — assertion-family choice after an output is exposed.
+- [[iwc-shortcuts-anti-patterns]] — accepted shortcut vs smell calls for weak assertions and label coupling.
+- [[planemo-workflow-test-architecture]] — Planemo execution, output-problem ambiguity, and structured artifacts.
+- [[gxformat2-schema]] — structural vocabulary for top-level workflow outputs and step post-job actions.
+- [[galaxy-datatypes-conf]] — valid Galaxy datatype extensions for `format` and `change_datatype` choices.

--- a/casts/claude/skills/cwl-test-to-galaxy-test-plan/references/notes/iwc-shortcuts-anti-patterns.md
+++ b/casts/claude/skills/cwl-test-to-galaxy-test-plan/references/notes/iwc-shortcuts-anti-patterns.md
@@ -1,0 +1,360 @@
+---
+type: research
+subtype: component
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-04-30
+revised: 2026-05-03
+revision: 2
+ai_generated: true
+related_notes:
+  - "[[galaxy-workflow-testability-design]]"
+  - "[[iwc-test-data-conventions]]"
+  - "[[planemo-asserts-idioms]]"
+  - "[[implement-galaxy-workflow-test]]"
+  - "[[tests-format]]"
+  - "[[iwc-conditionals-survey]]"
+  - "[[iwc-map-over-lifecycle-survey]]"
+  - "[[iwc-tabular-operations-survey]]"
+  - "[[iwc-transformations-survey]]"
+summary: "What IWC test suites cut corners on (accepted) vs what's a code smell — existence-only probes, sim_size deltas, image dim checks, label coupling."
+---
+
+# IWC test-suite shortcuts and anti-patterns
+
+## Purpose
+
+When an agent translates or authors a Galaxy workflow for IWC submission, the test suite it writes will be reviewed against IWC's *de facto* style — not against an idealized assertion ladder. That style routinely tolerates assertions that look weak in isolation. This note distinguishes the corner-cutting that is **normal and accepted** in the corpus from the patterns that an agent should treat as **smells** worth flagging.
+
+This note owns accepted-vs-smell calls. For positive workflow-structure guidance behind label stability, checkpoint promotion, and collection identifier design, use [[galaxy-workflow-testability-design]].
+
+Grounding: 115 `*-tests.yml` files under `workflow-fixtures/iwc-src/workflows/` (mirror of `galaxyproject/iwc`), prior synthesis in `galaxy-brain/vault/projects/workflow_state/skills/COMPONENT_GALAXY_WORKFLOW_TESTING.md`. Path citations below are relative to `iwc-src/workflows/` unless absolute.
+
+## TL;DR rules of thumb
+
+1. **Default to tolerant assertions.** `compare: sim_size` + `delta:`, `has_image_*` + `delta:`, `has_text` substring, `has_h5_keys`, `has_n_lines` + `delta:` are *the IWC vocabulary*. Strict `compare: diff` or exact-`file:` is the exception, used only when the upstream tool is fully deterministic on fixed inputs.
+2. **No negative tests.** `expect_failure:` does not appear in the corpus. Don't author one.
+3. **No checksums.** `md5:` / `checksum:` do not appear on outputs in the corpus. SHA-1 hashes are used on **inputs** (integrity of remote fetch), never on output assertions.
+4. **Preserve labels.** Inputs and outputs are referenced by label. Renaming silently breaks tests; treat label changes as breaking changes that require a sibling `-tests.yml` update.
+5. **Big data goes to Zenodo.** In-repo `test-data/` is for toy fixtures and expected outputs only.
+
+---
+
+## 1. Existence-only content probes
+
+### Accepted
+
+The HyPhy test files reduce JSON output validation to "starts with `{`":
+
+- `comparative_genomics/hyphy/hyphy-core-tests.yml:32-71` — four output collections (`meme_output`, `prime_output`, `busted_output`, `fel_output`), each gene element asserts `has_text: text: "{"` and nothing else.
+- `comparative_genomics/hyphy/hyphy-compare-tests.yml`, `capheine-core-and-compare-tests.yml` — same pattern across the rest of the family.
+
+This is **accepted** because:
+- HyPhy's MEME/PRIME/BUSTED/FEL/CFEL/RELAX statistical outputs embed run-dependent floats throughout (likelihoods, AIC, posterior probabilities). Substring assertions on numeric fields would fail intermittently.
+- Selecting any specific gene name or category in the JSON would couple the test to internal HyPhy keying that the wrapper has changed across versions.
+- The assertion does verify "the tool ran, produced JSON, did not crash, and the collection structure matches expected element identifiers" — which is genuinely useful given HyPhy's history of opaque failures.
+
+A quick scan finds **298 lines** matching the existence-style `has_text:` pattern across the corpus (`grep "has_text:\s*$\|text: \"{\"$"` yields 298 hits across many files). It is widespread, not a HyPhy quirk.
+
+Other variants in the same accepted-shortcut family:
+
+- **First-line-of-header probes**: `amplicon/amplicon-mgnify/.../mgnify-amplicon-pipeline-v5-rrna-prediction-tests.yml:46-49` asserts `has_text: "# mapseq v1.2.6 (Jan 20 2023)"` — version banner only.
+- **`has_n_columns` schema probes**: same file lines 50-52, 67-69 — "the table has 15 columns" / "4 columns" with no row-content check.
+- **`has_h5_keys` structure probes**: `scRNAseq/scanpy-clustering/.../Preprocessing-...-Scanpy-tests.yml:27-32, 159-166` — confirms AnnData has `obs/louvain`, `var/highly_variable`, `uns/rank_genes_groups`, etc., but says nothing about cluster labels or values. Also `imaging/tissue-microarray-analysis/multiplex-tissue-microarray-analysis/multiplex-tma-tests.yml` for Merged anndata.
+
+### Smell
+
+Existence probes on **deterministic** outputs. If the underlying tool is deterministic on fixed inputs (alignment, simple QC stats, well-defined transformations), reducing to `has_text: "{"` is laziness — agent should at least pull a known stable substring from the expected JSON.
+
+Heuristic for an agent: **if the source workflow's tool is on the "stochastic / floating-point heavy / version-fragile" list (HyPhy, RepeatModeler, scanpy plots, MCMC samplers, ML inference), existence probes are accepted. Otherwise, prefer `has_text` against a stable token from a real output.**
+
+---
+
+## 2. Size-only comparisons (`compare: sim_size` + `delta:`)
+
+### Accepted
+
+Canonical example: `repeatmasking/RepeatMasking-Workflow-tests.yml:11-46` — every output is `compare: sim_size` with `delta: 30000` (30 KB) on small outputs and `delta: 90000000` (90 MB!) on the Stockholm seed-alignment file. RepeatModeler's discovered repeat families differ run-to-run; only output magnitude is reproducible.
+
+`grep "compare: sim_size"` returns 9 files using this pattern:
+- `repeatmasking/RepeatMasking-Workflow-tests.yml`, `repeatmasking/Repeat-masking-with-RepeatModeler-and-RepeatMasker-tests.yml` (RepeatModeler — large delta band)
+- `epigenetics/hic-hicup-cooler/chic-fastq-to-cool-hicup-cooler-tests.yml`, `epigenetics/hic-hicup-cooler/hic-fastq-to-cool-hicup-cooler-tests.yml` (HiC matrices)
+- `genome_annotation/functional-annotation/functional-annotation-of-sequences/Functional_annotation_of_sequences-tests.yml`
+- `VGP-assembly-v2/kmer-profiling-hifi-trio-VGP2/kmer-profiling-hifi-trio-VGP2-tests.yml`
+- `genome-assembly/polish-with-long-reads/Assembly-polishing-with-long-reads-tests.yml`
+- `scRNAseq/baredsc/baredSC-1d-logNorm-tests.yml`, `scRNAseq/baredsc/baredSC-2d-logNorm-tests.yml` (Bayesian sampling — uses `delta_frac:` here)
+
+### Delta-magnitude survey
+
+From `grep "delta: [0-9]+"` distribution across the corpus:
+
+| Delta band | Count | Typical use |
+|---|---|---|
+| 4–100 (tiny) | ~20 | image pixel dimensions, line counts |
+| 1K–10K | ~40 | small text/tabular outputs, plot PNGs |
+| 25K–100K | ~25 | mid-size reports, multi-page plots |
+| 200K–1M | ~10 | report HTML, BAM stats |
+| 1M–10M | ~10 | medium BAM/BCF/cool files |
+| 10M+ (up to 90M) | ~7 | RepeatModeler libraries, large alignments |
+
+The 90 MB delta on `RepeatMasking-Workflow-tests.yml:20` is at the extreme. It says "this output is somewhere between zero bytes and 180 MB" — effectively only catches the empty-output failure mode. Accepted because RepeatModeler's seed alignments are known to vary by tens of MB across runs.
+
+### `delta_frac:`
+
+Used in 3 files (`scRNAseq/baredsc/*`, `genome-assembly/polish-with-long-reads/*`). Preferred over absolute `delta:` when the expected output size scales with input. An agent translating a workflow whose output size depends on input volume should consider `delta_frac:` over `delta:`.
+
+### Smell
+
+`compare: sim_size` on outputs from a **deterministic** tool. If the tool is bwa/bowtie2/samtools-sort with fixed seeds and pinned versions, there's no excuse for size-only — `compare: diff` (with modest `lines_diff:`) or content assertions are appropriate.
+
+Also a smell: stacking size + `has_image_*` checks on a PNG without any content assertion when the workflow's claim is *about the data shown* (e.g., a clustering plot). The corpus does this routinely (Scanpy file below) — accepted, but a translated workflow that has a more deterministic plotter should do better.
+
+---
+
+## 3. Image plot assertions
+
+### Accepted
+
+`scRNAseq/scanpy-clustering/.../Preprocessing-...-Scanpy-tests.yml:33-205` is the dense example. ~15 PNG outputs each get the same triple:
+
+```yaml
+UMAP of louvain:
+  has_size:
+    size: 68416
+    delta: 6000
+  has_image_width:
+    width: 601
+    delta: 30
+  has_image_height:
+    height: 429
+    delta: 25
+```
+
+What this catches:
+- Plot was rendered (non-zero size).
+- Render dimensions are stable (matplotlib defaults didn't drift, theme didn't change).
+- Approximate file size hasn't shifted by an order of magnitude (no catastrophic content change like all-white or all-noise).
+
+What this **misses**: cluster assignments wrong, axes mislabeled, points in wrong positions, colors swapped, the wrong subset plotted, NaN handling regression. Two visually different UMAPs can have identical width/height/size-within-10%.
+
+Other observed image-assertion users (`grep "has_image"`):
+- `imaging/tissue-microarray-analysis/tissue-microarray-analysis/tissue-micro-array-analysis-tests.yml`
+- `imaging/tissue-microarray-analysis/multiplex-tissue-microarray-analysis/multiplex-tma-tests.yml`
+
+The TMA tests use a friendlier shorthand: `has_size: size: 181K, delta: 50K` (human-readable units).
+
+### Smell
+
+Asserting `has_image_width`/`has_image_height` with **zero delta** on a tool that re-encodes (PNG round-trips through matplotlib) is brittle. The corpus uses 5–10% deltas; an agent emitting `delta: 0` should be flagged unless the renderer is byte-stable.
+
+Note `has_image_channels`, `has_image_center_of_mass` are documented (galaxy XSD) but **not observed** in the sampled corpus. An agent with a deterministic mask/segmentation output could use `has_image_center_of_mass` to actually verify spatial correctness — this would be an *upgrade* over the current corpus norm, not a smell.
+
+---
+
+## 4. Happy-path-only culture (`expect_failure:`)
+
+`grep -r "expect_failure"` over all 115 tests files returns **zero hits**. The IWC corpus has no negative tests. Period.
+
+This is a structural property of IWC: the workflows are published artifacts intended to *succeed* on canonical inputs. Adversarial / error-path testing happens in tool wrappers, not in workflow tests.
+
+**Implication for an agent:** Do not author `expect_failure:` cases when translating a workflow. If the source pipeline (e.g., nf-core) had a "fail on bad reference" test, drop it — it doesn't belong in IWC. If the validation logic is important, it should be in a wrapper-level tool test, not a workflow test.
+
+---
+
+## 5. `md5:` / `checksum:` rarity
+
+`grep -r "md5:\|checksum:"` over `*-tests.yml`: **zero hits**.
+
+SHA-1 `hashes:` blocks are pervasive — but exclusively on **inputs** (`hash_function: SHA-1` paired with a remote `location:`), to guard against silent corruption of the fetched fixture. Output assertions never use them.
+
+Accepted. The reason is empirical: outputs of real bioinformatics tools (BAM with PG headers and timestamps, VCFs with command-line provenance, JSON with run dates) are almost never byte-stable across runs. A `checksum:` would fail intermittently.
+
+**Smell:** an agent emitting `checksum:` or `md5:` on a workflow output. Even for "fully deterministic" tools, embedded provenance breaks checksums. Use `compare: diff` + `lines_diff:` instead, or content assertions.
+
+---
+
+## 6. Output label coupling
+
+Test files key outputs by **workflow label**, with spaces, capitals, punctuation preserved verbatim. Examples:
+
+- `scanpy-clustering/.../Preprocessing-...-Scanpy-tests.yml:27` — `Anndata with Celltype Annotation:` (spaces, mixed case)
+- `scanpy-clustering/.../Preprocessing-...-Scanpy-tests.yml:33` — `UMAP of louvain and top ranked genes:`
+- `imaging/tissue-microarray-analysis/multiplex-tissue-microarray-analysis/multiplex-tma-tests.yml` — `Merged anndata:`, `Spatial Scatterplot Montage:`
+- `consensus-from-variation-tests.yml:30` — `multisample_consensus_fasta:` (snake-case style)
+
+**Both styles coexist.** Snake-case (older / SARS-CoV-2 family) and natural-language-with-spaces (newer / scanpy / TMA) are equally valid. Reviewers do not enforce a single convention.
+
+### Coupling consequences
+
+Renaming an output label in the `.ga` without updating the sibling `-tests.yml` is a silent breakage:
+- Test references the old label → key not present in invocation outputs → assertion mismatch surfaces as an opaque "output not found" error in planemo.
+- `planemo workflow_lint --iwc` enforces that workflow outputs are *labeled*, not that test labels match.
+
+**Discipline observed:** every output a test asserts on is a labeled workflow output. The corpus does not assert on positional / unlabeled outputs.
+
+**Smell:** a translated workflow with unlabeled outputs that later need test coverage. Agent should label every output it intends to assert on, before writing assertions.
+
+Positive design guidance now lives in [[galaxy-workflow-testability-design]]: pick stable labels before test authoring and treat renames as test-breaking API changes.
+
+---
+
+## 7. Intermediate-step output gap
+
+`-tests.yml` can only assert on workflow-level **outputs** (entries in the `.ga`'s top-level outputs). Intermediate step results are inaccessible to assertions.
+
+Observed workaround across the corpus: **promote the intermediate to a workflow output**. This is visible indirectly — many workflows expose what would naturally be intermediates as labeled outputs solely for testability:
+
+- `scanpy-clustering` exposes `Initial Anndata General Info`, `Anndata with raw attribute`, `Plot highly variable`, `Elbow plot of PCs and variance` — these are mid-pipeline checkpoints surfaced specifically to be assertable. Compare counts: 22 outputs asserted vs the 7-or-so "user-meaningful" final artifacts.
+- `MAGs-generation-tests.yml` exposes a `Full MultiQC Report` even though MultiQC is logically intermediate to MAG annotation.
+
+**Cost:** "test-only" outputs clutter the workflow's user-facing output list. Reviewers tolerate this in exchange for testability.
+
+**Accepted shortcut:** promoting an intermediate to a workflow output for test purposes. Not a smell.
+
+**Smell:** asserting on a step output via some side-channel (e.g., relying on Galaxy collection ordering, indexing into `tool_state`). The corpus does not do this and an agent should not invent it.
+
+Positive design guidance now lives in [[galaxy-workflow-testability-design]]: promote assertable checkpoints deliberately, especially when final reports or plots can only support weak smoke tests.
+
+---
+
+## 8. Remote-data fragility
+
+### Pattern
+
+Overwhelming preference for **Zenodo** as the input store. Every remote `location:` is paired with a SHA-1 `hashes:` block. Examples already cited in nearly every snippet above.
+
+Non-Zenodo remote sources observed (from `grep "ftp.sra.ebi\|ftp://\|figshare\|github.com"`):
+- `virology/pox-virus-amplicon/pox-virus-half-genome-tests.yml:27,34,48,55` — `ftp://ftp.sra.ebi.ac.uk/...` SRA fastqs
+- `amplicon/amplicon-mgnify/.../mgnify-amplicon-pipeline-v5-rrna-prediction-tests.yml:21` — `ftp://ftp.ebi.ac.uk/...` reference DB
+- `data-fetching/parallel-accession-download/parallel-accession-download-tests.yml`, `VGP-assembly-v2/Plot-Nx-Size/...` — accession-driven
+- `variant-calling/generic-variant-calling-wgs-pe/Generic-variation-analysis-on-WGS-PE-data-tests.yml` — github raw URLs
+
+### The fragility
+
+- **Zenodo is a single point of failure across CI.** A Zenodo outage breaks every IWC PR concurrently. SHA-1 hashes guard against silent corruption but provide no mitigation for outages or HTTP 503s.
+- **EBI/SRA FTP is even less reliable** — observed flake-prone in the broader Galaxy CI history.
+- No retry / backoff configured at the test-format level; planemo-ci-action's defaults handle transient failures only via re-running the chunk job manually.
+
+### Accepted
+
+This is just life in the IWC. Don't try to "fix" it in a translated workflow by inlining large data — reviewers will push back (see §10).
+
+### Smell
+
+Inputs hosted on a contributor's personal endpoint, S3 bucket, or Dropbox. Reviewers ask for migration to Zenodo before merge.
+
+---
+
+## 9. `compare: diff` on timestamped outputs
+
+`compare: diff` usage from `grep`:
+
+- `sars-cov-2-variant-calling/sars-cov-2-ont-artic-variant-calling/ont-artic-variation-tests.yml:32` — `compare: diff, lines_diff: 6` on annotated VCF
+- `sars-cov-2-variant-calling/sars-cov-2-pe-illumina-wgs-variant-calling/pe-wgs-variation-tests.yml:35` — same
+- `imaging/fluorescence-nuclei-segmentation-and-counting/segmentation-and-counting-tests.yml:16` — `lines_diff: 0`
+- `variant-calling/variation-reporting/Generic-variation-analysis-reporting-tests.yml:21,25,29,33` — `lines_diff: 6`
+- `variant-calling/generic-variant-calling-wgs-pe/Generic-variation-analysis-on-WGS-PE-data-tests.yml:39,45,55` — `lines_diff: 6`
+
+The `lines_diff: 6` constant is suspicious — 6 lines is the typical VCF header preamble that embeds `##fileDate=...` and `##source=...`. The use is **defensible**: tolerance window matches the known mutable header lines, content lines are diffed strictly.
+
+### Smell
+
+- `compare: diff` with `lines_diff: 0` on a file that contains *any* timestamp, command-line capture, version banner, or random tie-break (hash-ordered dictionaries in Python output, etc.). The single observed `lines_diff: 0` case (`segmentation-and-counting-tests.yml:16`) appears to be on a numeric tabular output where it's defensible — verify content type before flagging.
+- `compare: diff` on a BAM. BAM headers include `@PG` lines with full command lines and Galaxy job IDs. Use `has_size` + content extracts via `has_archive_member` or `samtools view`-piped XML asserts — not byte-level diff.
+
+**Recommended replacement** when timestamps appear:
+- For VCF: `compare: diff, lines_diff: <header-line-count>` (corpus convention is 6).
+- For tabular reports: `has_text` against stable column headers + `has_n_columns`.
+- For HTML reports (MultiQC etc.): `has_text` substring on stable section names — example `short-read-qc-trimming/short-read-quality-control-and-trimming-tests.yml:25-28` asserts `"Filtered Reads"` substring on the MultiQC HTML report rather than diffing.
+
+---
+
+## 10. Reviewer-feedback recurring asks
+
+Synthesized from the COMPONENT_GALAXY_WORKFLOW_TESTING.md analysis (sections 9 and the "Common PR-review feedback" subsection) plus structural observation of what every accepted workflow has and rejected drafts apparently lack:
+
+| Reviewer ask | Where it bites | Source |
+|---|---|---|
+| **Creator `identifier:` must be a full ORCID URI** (`https://orcid.org/...`), not bare ID. | `.ga` frontmatter `creator:` block. Most common lint failure. | planemo PR #1458; `consensus-from-variation.ga:4-10` shows the conformant shape. |
+| **Move large inputs to Zenodo.** Inline `path: test-data/big.bam` for >1 MB inputs gets pushback. | `-tests.yml` job inputs. | `iwc/workflows/README.md` (per prior analysis). |
+| **Bump `release` + add CHANGELOG.md entry in the same PR.** | `.ga` `release:` and sibling `CHANGELOG.md`. Enforced by `bump_version.py`. | `iwc/workflows/README.md:217-247`. |
+| **Generate tests via `planemo workflow_test_init --from_invocation <id>`**, not by hand. Reviewers push back on hand-authored job blocks. | Any new test contribution. | help.galaxyproject.org thread 13903. |
+| **Don't use `compare: diff` on outputs that embed timestamps.** Switch to `has_text`/`has_n_lines` with `delta:`. | See §9. | Recurring review comment. |
+| **Add labeled outputs for any output you assert on.** Unlabeled outputs caught by `planemo workflow_lint --iwc`. | `.ga` outputs. | §6 above. |
+| **Hashes on every remote `location:`.** SHA-1 block paired with the URL. Reviewers spot-check. | `-tests.yml` job inputs. | Universal in the corpus; missing hashes get flagged. |
+
+### Smell to flag for an agent submission
+
+- Bare ORCID ID (`0000-0002-...`) in `creator:` instead of full URL.
+- Test job referencing >1 MB local fixture instead of a Zenodo URL.
+- PR that bumps a workflow without CHANGELOG / `release:` bump.
+- Hand-authored `-tests.yml` that reads "too clean" — reviewers know `--from_invocation` output has a recognizable fingerprint.
+
+---
+
+## Summary cheatsheet for the implement-galaxy-workflow-test mold
+
+**Use these freely (accepted shortcuts):**
+- `has_text: text: "{"` for stochastic JSON outputs.
+- `compare: sim_size, delta:` for non-deterministic file outputs; pick delta from §2 distribution by tool family.
+- `has_image_width/height/has_size` triple with 5–10% delta for matplotlib plots.
+- `has_h5_keys` for AnnData/HDF5 — assert structure not values.
+- Promoting intermediates to workflow outputs to make them assertable.
+- Labels with spaces, mixed case, punctuation as the output key.
+- SHA-1 hashes on every input `location:`.
+
+**Avoid (smells reviewers or future-you will catch):**
+- `expect_failure:` — not an IWC pattern.
+- `md5:` / `checksum:` on outputs.
+- `compare: diff, lines_diff: 0` on anything containing timestamps, BAM `@PG` lines, or Python dict ordering.
+- `has_image_*` with zero delta.
+- Existence-only `has_text: "{"` on outputs from a deterministic tool.
+- Asserting on positional/unlabeled outputs.
+- Inlining >1 MB binary fixtures in `test-data/`.
+- Bare ORCID identifier in `.ga` frontmatter.
+
+**Review-time checklist before submission:**
+1. Every output asserted on has a label in the `.ga`.
+2. Every remote `location:` has a `hashes: SHA-1` block.
+3. Inputs >1 MB live on Zenodo, not in `test-data/`.
+4. `release:` bumped and `CHANGELOG.md` updated if `.ga` changed.
+5. `creator.identifier:` is a full `https://orcid.org/...` URL.
+6. Test was generated by `planemo workflow_test_init --from_invocation`, not hand-written.
+
+---
+
+## Sources
+
+- Positive workflow-structure guidance: [[galaxy-workflow-testability-design]].
+- Prior synthesis: `/Users/jxc755/projects/repositories/galaxy-brain/vault/projects/workflow_state/skills/COMPONENT_GALAXY_WORKFLOW_TESTING.md` (sections 2c, 2d, 2e, 9).
+- Corpus root: `/Users/jxc755/projects/repositories/workflow-fixtures/iwc-src/workflows/` (115 `*-tests.yml` files across 22 categories).
+- Specific files cited:
+  - `comparative_genomics/hyphy/hyphy-core-tests.yml`, `hyphy-compare-tests.yml`, `capheine-core-and-compare-tests.yml`
+  - `repeatmasking/RepeatMasking-Workflow-tests.yml`, `Repeat-masking-with-RepeatModeler-and-RepeatMasker-tests.yml`
+  - `scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml`
+  - `read-preprocessing/short-read-qc-trimming/short-read-quality-control-and-trimming-tests.yml`
+  - `virology/pox-virus-amplicon/pox-virus-half-genome-tests.yml`
+  - `metabolomics/lcms-preprocessing/Mass_spectrometry__LC-MS_preprocessing_with_XCMS-tests.yml`
+  - `sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation-tests.yml`
+  - `sars-cov-2-variant-calling/sars-cov-2-pe-illumina-wgs-variant-calling/pe-wgs-variation-tests.yml`
+  - `sars-cov-2-variant-calling/sars-cov-2-ont-artic-variant-calling/ont-artic-variation-tests.yml`
+  - `variant-calling/variation-reporting/Generic-variation-analysis-reporting-tests.yml`
+  - `variant-calling/generic-variant-calling-wgs-pe/Generic-variation-analysis-on-WGS-PE-data-tests.yml`
+  - `imaging/fluorescence-nuclei-segmentation-and-counting/segmentation-and-counting-tests.yml`
+  - `imaging/tissue-microarray-analysis/multiplex-tissue-microarray-analysis/multiplex-tma-tests.yml`
+  - `amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction-tests.yml`
+  - `epigenetics/atacseq/atacseq-tests.yml`
+  - `epigenetics/hic-hicup-cooler/chic-fastq-to-cool-hicup-cooler-tests.yml`, `hic-fastq-to-cool-hicup-cooler-tests.yml`
+  - `microbiome/mags-building/MAGs-generation-tests.yml`
+  - `genome-assembly/polish-with-long-reads/Assembly-polishing-with-long-reads-tests.yml`
+  - `scRNAseq/baredsc/baredSC-1d-logNorm-tests.yml`, `baredSC-2d-logNorm-tests.yml`
+- Corpus-wide grep tallies:
+  - `expect_failure`: 0 hits.
+  - `md5:|checksum:` on outputs: 0 hits.
+  - `compare: sim_size`: 9 files.
+  - `compare: diff`: 5 files (variant-calling and imaging).
+  - `has_image_*`: 3 files.
+  - Existence-style `has_text:` patterns: ~298 line matches.
+  - `delta_frac:`: 3 files.

--- a/casts/claude/skills/cwl-test-to-galaxy-test-plan/references/notes/iwc-test-data-conventions.md
+++ b/casts/claude/skills/cwl-test-to-galaxy-test-plan/references/notes/iwc-test-data-conventions.md
@@ -1,0 +1,311 @@
+---
+type: research
+subtype: component
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-04-30
+revised: 2026-05-03
+revision: 3
+ai_generated: true
+related_notes:
+  - "[[galaxy-workflow-testability-design]]"
+  - "[[iwc-shortcuts-anti-patterns]]"
+  - "[[planemo-asserts-idioms]]"
+  - "[[implement-galaxy-workflow-test]]"
+  - "[[tests-format]]"
+  - "[[iwc-tabular-operations-survey]]"
+summary: "How IWC workflows organize and reference test data — Zenodo-first, SHA-1 integrity, collection shapes, CVMFS gotchas."
+---
+
+# IWC test data conventions
+
+Reference for an agent implementing or editing a `<workflow>-tests.yml` in IWC style. All evidence cited from `/Users/jxc755/projects/repositories/workflow-fixtures/iwc-src/workflows/` (raw IWC clone) and `workflows/README.md`. Authoritative spec: [planemo.readthedocs.io/en/latest/test_format.html](https://planemo.readthedocs.io/en/latest/test_format.html). The companion analysis at `/Users/jxc755/projects/repositories/galaxy-brain/vault/projects/workflow_state/skills/COMPONENT_GALAXY_WORKFLOW_TESTING.md` is the synthesized source for several normative claims here.
+
+This note owns **test YAML fixture shapes**. For workflow-structure choices that make those fixtures possible before the test file exists, use [[galaxy-workflow-testability-design]].
+
+## 1. Where does test data live? Remote vs in-repo
+
+Two storage patterns. They mix freely inside one job.
+
+**Remote `location:` (default for any non-trivial input).** Strongly preferred for anything bigger than a toy fixture. Order of preference, observed in the corpus:
+
+- **Zenodo** — overwhelming default, persistent DOI-backed URL.
+  - `read-preprocessing/short-read-qc-trimming/short-read-quality-control-and-trimming-tests.yml:13,17` — `https://zenodo.org/records/11484215/files/paired_r1.fastq.gz` (note the modern `/records/` plural form; older entries use `/record/`).
+  - `metabolomics/lcms-preprocessing/Mass_spectrometry__LC-MS_preprocessing_with_XCMS-tests.yml:6,17,24,...` — 11+ mzML files all hosted at `zenodo.org/record/10130758/files/...`.
+  - `sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation-tests.yml:5` — `https://zenodo.org/record/4555735/files/NC_045512.2_reference.fasta?download=1`.
+  - `repeatmasking/RepeatMasking-Workflow-tests.yml:5` — `https://zenodo.org/record/8364146/files/eco.fasta?download=1`. The `?download=1` query suffix is acceptable but optional; both forms appear.
+- **EBI/ENA REST** — for canonical reference sequences.
+  - `virology/pox-virus-amplicon/pox-virus-half-genome-tests.yml:5` — `https://www.ebi.ac.uk/ena/browser/api/fasta/AF325528.1?download=true`.
+- **SRA / ENA FTP** — for raw read accessions where re-uploading to Zenodo is wasteful.
+  - `pox-virus-half-genome-tests.yml:27,34,49,56` — `ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR151/076/SRR15145276/SRR15145276_1.fastq.gz`.
+
+**In-repo `path: test-data/...` (toy fixtures + small expected outputs only).** Used when:
+
+- File is small enough to commit (rule of thumb from corpus: low single-digit MB or smaller).
+- File is a hand-crafted toy or trimmed reference (e.g. a 5-element FASTA for HyPhy).
+- File is the *expected output* baseline for a `file:` exact-comparison assertion: `consensus-from-variation-tests.yml:31` — `file: test-data/masked_consensus.fa`.
+
+`workflows/README.md:67` makes the contract explicit: "try to generate a toy dataset … and then publish it to zenodo to have a permanent URL." `workflows/README.md:98`: "if some outputs are large, it is better to use assertions than storing the whole output file to the iwc repository."
+
+Subdirectory layout inside `test-data/` is free-form and used to organize related fixtures, e.g. `comparative_genomics/hyphy/test-data/unaligned_seqs/`, `test-data/codon_alignments/`, `test-data/iqtree_trees/` (referenced from `hyphy-core-tests.yml:13,17,21,...`).
+
+**Decision rule for an agent:**
+
+1. Expected-output baseline that's small — commit to `test-data/`.
+2. Toy/trimmed input < ~5 MB — commit to `test-data/`.
+3. Anything else — Zenodo (or EBI/SRA for canonical accessions). Add `hashes:` SHA-1.
+4. If the input is a reference index resolvable from CVMFS (`hg38`, `dm6`, `mm10`, …), use the plain string form. See section 5.
+
+## 2. The `class: File` block — exact YAML shapes
+
+All snippets verbatim from the IWC corpus.
+
+### 2a. Single remote file (with integrity hash)
+
+`virology/pox-virus-amplicon/pox-virus-half-genome-tests.yml:3-9`:
+
+```yaml
+Reference FASTA:
+  class: File
+  location: "https://www.ebi.ac.uk/ena/browser/api/fasta/AF325528.1?download=true"
+  filetype: fasta
+  hashes:
+  - hash_function: SHA-1
+    hash_value: 927d0d00b7db6ad60524bb9e50d3ab41c4ac5ecf
+```
+
+Field order is conventional but not enforced. `filetype:` is the Galaxy datatype name (`fasta`, `fastqsanger.gz`, `mzml`, `bed`, `tabular`, `csv`, `gtf`, `vcf`, …). `location:` URLs may be quoted or bare; both forms occur.
+
+### 2b. Single local file
+
+`comparative_genomics/hyphy/hyphy-core-tests.yml:3-6`:
+
+```yaml
+reference cds:
+  class: File
+  path: test-data/denv1_ref_cds.fasta
+  filetype: fasta
+```
+
+`path:` is relative to the workflow directory (the directory containing the `-tests.yml`). Hashes are usually omitted on local files — the file is in-tree, so integrity is implicit. They are nonetheless added in some workflows: `consensus-from-variation-tests.yml:15-18` shows `path: test-data/aligned_reads_for_coverage.bam` paired with a SHA-1 hash. The pattern appears to be: hashes added when the `-tests.yml` was generated by `planemo workflow_test_init --from_invocation`, which mints them automatically.
+
+A dataset attribute can be set on a single file to force a `dbkey`, e.g. `epigenetics/consensus-peaks/consensus-peaks-chip-pe-tests.yml:7-10`:
+
+```yaml
+- class: File
+  identifier: rep1
+  path: test-data/rep1.bam
+  dbkey: mm10
+```
+
+`dbkey:` and `decompress: true` (`scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:30`) are documented per-file attributes that ride alongside `class: File`.
+
+### 2c. List collection
+
+`hyphy-core-tests.yml:7-30`:
+
+```yaml
+unaligned sequences:
+  class: Collection
+  collection_type: list
+  elements:
+  - identifier: AB178040.1|2002
+    class: File
+    path: test-data/unaligned_seqs/AB178040.1|2002.fasta
+    filetype: fasta
+  - identifier: AB195673.1|2003
+    class: File
+    path: test-data/unaligned_seqs/AB195673.1|2003.fasta
+    filetype: fasta
+  ...
+```
+
+Each element is a single-file dict with an `identifier:`. A larger remote-only example with hashes per element: `metabolomics/lcms-preprocessing/Mass_spectrometry__LC-MS_preprocessing_with_XCMS-tests.yml:11-22`:
+
+```yaml
+Mass-spectrometry Dataset Collection:
+  class: Collection
+  collection_type: list
+  elements:
+  - class: File
+    identifier: Blanc05.mzML
+    location: https://zenodo.org/record/10130758/files/Blanc05.mzML
+    filetype: mzml
+    hashes:
+    - hash_function: SHA-1
+      hash_value: e98d5a4cd8849a145a032bdc31c348ad97cb59c3
+```
+
+### 2d. Paired collection (single pair)
+
+A `paired` collection is a Collection whose two elements have identifiers `forward` and `reverse`. In IWC it is rarely used at top level — it is almost always wrapped as a single-element `list:paired` (see 2e). When it appears bare, the shape is the inner block of 2e without the outer `list:paired` wrapper.
+
+### 2e. `list:paired` collection
+
+`read-preprocessing/short-read-qc-trimming/short-read-quality-control-and-trimming-tests.yml:3-18`:
+
+```yaml
+Raw reads:
+  class: Collection
+  collection_type: list:paired
+  elements:
+  - class: Collection
+    type: paired
+    identifier: pair
+    elements:
+    - class: File
+      identifier: forward
+      location: https://zenodo.org/records/11484215/files/paired_r1.fastq.gz
+      filetype: fastqsanger.gz
+    - class: File
+      identifier: reverse
+      location: https://zenodo.org/records/11484215/files/paired_r2.fastq.gz
+      filetype: fastqsanger.gz
+```
+
+Note: outer `collection_type: list:paired`, inner `type: paired` (not `collection_type:`). Inner element identifiers are the literal strings `forward` and `reverse` — these are reserved.
+
+A multi-pair list:paired with full hashes: `virology/pox-virus-amplicon/pox-virus-half-genome-tests.yml:17-38` or `scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:3-24`.
+
+### 2f. `list:list:paired` and deeper
+
+Not directly observed in sampled IWC inputs. The shape is recursive — wrap a `list:paired` element list inside another `class: Collection, collection_type: list:list:paired`, where each outer element is `class: Collection, type: list:paired` (analogous to the `list:paired` → `paired` nesting in 2e). For deeply-nested collections planemo's [`_writing_collections.rst`](https://github.com/galaxyproject/planemo/blob/master/docs/_writing_collections.rst) is the de-facto reference.
+
+Output side: nested-collection assertions DO exist in the corpus. `scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:82-98`:
+
+```yaml
+Seurat input for gene expression (filtered):
+  attributes: {collection_type: list:list}
+  element_tests:
+    subsample:
+      elements:
+        matrix:
+          asserts:
+            has_line:
+              line: "23932 3 1171"
+        barcodes:
+          asserts:
+            has_line:
+              line: "CACATGATCATAAGGA"
+```
+
+Pattern: outer `element_tests:` keyed by outer identifier; inner `elements:` (note plural, not `element_tests:` here) keyed by inner identifier. Optional `attributes: {collection_type: ...}` asserts the shape of the produced collection.
+
+### 2g. `composite_data:`
+
+**Not observed** in the sampled IWC corpus (`grep -rln "composite\|imzml\|primary_file\|extra_files" workflows/ --include="*-tests.yml"` returns nothing). Per the planemo spec the shape is a `composite_data:` mapping listing each component file path, but an agent emitting one in IWC style has no in-corpus reference and should treat it as unproven territory — fall back to the planemo docs and verify against `galaxy.tool_util.parser.yaml`.
+
+### 2h. CWL-style shorthand (list of File dicts without identifiers)
+
+Documented in planemo; not observed in sampled IWC. IWC always supplies explicit identifiers.
+
+### 2i. `tags:` on elements (Galaxy 20.09+)
+
+Documented in planemo; not surfaced in sampled IWC `-tests.yml` files (`grep "  tags:" --include="*-tests.yml"` empty across the sampled set). Practical absence — IWC tests rely on identifier matching, not tags.
+
+## 3. SHA-1 integrity hashes — when, when not, why
+
+**Format.** Always a list under `hashes:`, even for one entry. Each entry is `{hash_function: SHA-1, hash_value: <40-hex>}`. Verbatim from `pox-virus-half-genome-tests.yml:7-9`:
+
+```yaml
+hashes:
+- hash_function: SHA-1
+  hash_value: 927d0d00b7db6ad60524bb9e50d3ab41c4ac5ecf
+```
+
+Only `SHA-1` observed in the IWC corpus. The planemo spec also accepts `MD5`, `SHA-256`, `SHA-512` as `hash_function:` values; IWC does not exercise these.
+
+**When present:**
+
+- Every remote `location:`-fetched input in the sampled corpus carries a SHA-1 (Zenodo, EBI REST, SRA FTP). The hash guards against silent upstream corruption — Zenodo records are immutable but bit-rot and CDN-edge errors do happen; ENA FASTA endpoints can quietly change line-wrap.
+- Many local `path:`-loaded inputs also carry a SHA-1. This is `--from_invocation` autogeneration leaking through (planemo emits hashes for every input it captured).
+- `consensus-from-variation-tests.yml:6-8,17-18,27-28` — every input in the test, local and remote, has a hash.
+
+**When omitted:**
+
+- Hand-written local-file fixtures often skip hashes — `hyphy-core-tests.yml:3-30` has zero `hashes:` blocks across six local-file inputs.
+- Output assertions: `file:`-comparison outputs and `location:`-comparison outputs (`RepeatMasking-Workflow-tests.yml:13`) **do not** carry `hashes:`. The integrity story for outputs is handled by `compare:` / `asserts:` instead.
+
+**Why bother on local files.** Catches accidental corruption when collaborators hand-edit `test-data/` fixtures.
+
+## 4. Element identifier conventions
+
+Identifiers are arbitrary strings, used both as the YAML key (`element_tests:`) and as the produced Galaxy collection element name. Conventions surfaced from the corpus:
+
+- **Pipes are legal** and survive YAML round-trip without quoting on the input side: `hyphy-core-tests.yml:11` — `identifier: AB178040.1|2002`. On the *output* side they're quoted because they appear as YAML mapping keys: `hyphy-core-tests.yml:34` — `"NC_001477.1|capsid_protein_C|95-394_DENV1":`. Quote when the identifier contains characters that would otherwise start a YAML flow node (`{`, `[`, `&`, `*`, `!`, `|`, `>`, `'`, `"`, `%`, `@`, `` ` ``) or look like a number/bool.
+- **Dots, hyphens, underscores** — common, no quoting needed: `Blanc05.mzML`, `HU_neg_048.mzML`, `SRR11578257`, `Rep1`, `subsample`, `pair`.
+- **Reserved inside `paired` collections:** `forward` and `reverse` (lowercase). Never use these names for outer identifiers in `list:paired`.
+- **Inline comments after identifier** are legal and used for provenance: `pox-virus-half-genome-tests.yml:23` — `identifier: 20L70   # SRR15145276`.
+- **Whitespace and special chars in workflow input *labels*** survive too — they are job-mapping keys, not collection identifiers, but the same YAML quoting rules apply. Example from the analysis doc: `Manually annotate celltypes?: true` as a job key in `Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml:23`.
+
+### 4a. Workflow-interface implications
+
+Fixture shape should feed back into workflow input design. Tests supply job inputs by workflow input label, and collection fixtures must match the workflow's declared collection type.
+
+- The 10x CellPlex test uses `fastq PE collection GEX`, `fastq PE collection CMO`, and `sample name and CMO sequence collection` as job keys with `list:paired` and `list` collection fixtures; the workflow declares matching collection inputs at `$IWC_FORMAT2/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex.gxwf.yml:4-72`.
+- CVMFS/data-table shortcuts like `reference genome: dm6` are workflow-interface choices as much as test YAML choices: they require the workflow input to be a string/data-table-backed parameter, not a file input.
+- If a fixture needs stable sample names, decide whether those names should enter through collection element identifiers, a mapping file, or a workflow parameter before writing assertions.
+
+Rule for an agent: when a new workflow input is being designed and the test fixture is already known, check [[galaxy-workflow-testability-design]] before locking the input label/type.
+
+## 5. CVMFS / `.loc` / built-in-index references
+
+When a workflow input is a Galaxy data-table-backed reference (built-in genome index, dbsnp file, kraken DB, …), the input takes a **plain string** matching the `value` column of a `.loc` file. No `class: File`, no `location:`. Examples:
+
+- `scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml:25` — `reference genome: dm6 # To test on usegalaxy.eu dm6full`
+- `epigenetics/cutandrun/cutandrun-tests.yml:27` — `reference_genome: 'hg38canon'`
+- `epigenetics/atacseq/atacseq-tests.yml:25` — `reference_genome: hg19`
+- `microbiome/host-contamination-removal/host-contamination-removal-short-reads/host-or-contamination-removal-on-short-reads-tests.yml:19` — `Host/Contaminant Reference Genome: hg38`
+- `microbiome/pathogen-identification/nanopore-pre-processing/Nanopore-Pre-Processing-tests.yml:22` — `host_reference_genome: apiMel3`
+- `transcriptomics/goseq/goseq-go-kegg-enrichment-analsis-tests.yml:24` — `Select genome to use: mm10`
+
+The string is the first column of the `.loc` entry. `workflows/README.md:169-182` shows the lookup procedure: browse `http://datacache.galaxyproject.org/indexes/location/<table>.loc`, find the `.loc` row, take the value column (which column varies by tool — check the matching `tool_data_table_conf.xml.sample`).
+
+**Portability implication:** these tests **only** run on a Galaxy with CVMFS mounted at `/cvmfs/data.galaxyproject.org`. IWC CI mounts CVMFS in-runner (`setup-cvmfs: true` in `.github/workflows/test_workflows.yml`). On a plain developer laptop running `planemo test`, CVMFS-string inputs fail unresolved. An agent generating tests should either:
+
+1. Stay URL-driven: replace the CVMFS string with a `class: File` + `location:` to a Zenodo-hosted reference (portable, slower CI, larger inputs).
+2. Use the CVMFS string and document "CI-only" — the user cannot reproduce locally without a CVMFS mount.
+
+There is no `.loc`-resolution shorthand in the YAML — it is just a bare string parameter. Agents must not invent `class: DataTable` or similar.
+
+## 6. Reviewer-feedback patterns (PR-review)
+
+Recurring asks from IWC reviewers, distilled from the contribution README and community help threads:
+
+- **Move large data to Zenodo before merge.** Anything bigger than a toy fixture committed in `test-data/` will be flagged. `workflows/README.md:67`.
+- **Use assertions, not exact-file comparison, for large outputs.** `workflows/README.md:98` — "if some outputs are large, it is better to use assertions than storing the whole output file."
+- **Generate tests with `planemo workflow_test_init --from_invocation`, don't hand-write.** `workflows/README.md:88-94`. The autogenerated test will mint correct hashes, correct labels, and a working `test-data/` snapshot.
+- **Set creator `identifier:` to a full ORCID URL** (e.g. `https://orcid.org/0000-0002-1825-0097`) — `workflows/README.md:53`. The most common lint failure; enforced in [planemo#1458](https://github.com/galaxyproject/planemo/pull/1458).
+- **Don't use `compare: diff` on outputs that embed timestamps or non-deterministic ordering.** Switch to `has_text` / `has_n_lines` (with `delta:`) or `compare: sim_size`+`delta:`.
+- **Bump `release:` in the `.ga` and add a `CHANGELOG.md` entry** in the same PR — enforced by the IWC PR template; reviewers verify via `bump_version.py`.
+- **Lower-case + `-` only** in directory names — `workflows/README.md:11,72`.
+- **Element identifiers must round-trip** — quote in YAML when they contain pipes/colons/whitespace.
+
+## 7. What is *not* covered by current convention
+
+Gaps an agent should be aware of:
+
+- **`composite_data:` is unrepresented in the IWC corpus.** No working examples to imitate for imzml+ibd or other multi-file datatypes. Treat as off-trail; cite planemo docs and verify by parser.
+- **`tags:` on elements unused.** Galaxy 20.09+ supports them; IWC does not exercise them.
+- **CWL-style shorthand File lists unused.** IWC always names elements.
+- **No negative tests.** Zero `expect_failure:` across the sampled corpus. There is no IWC convention for asserting a workflow *should* fail on bad input.
+- **No checksum-based output assertion in the wild.** `checksum: "sha1$..."` is documented and used at the input side as `hashes:`, but output-side `checksum:` was not surfaced in sampled tests. The corpus prefers `file:` (exact), `compare: sim_size`+`delta:` (size only), or `asserts:` (content probes).
+- **No data-cache layer beyond pip/planemo.** Every test re-pulls remote inputs from Zenodo / EBI / SRA on every CI run. A Zenodo outage breaks many PRs simultaneously. There is no IWC-side mirror or cache.
+- **No per-test timeout / retry convention.** A hung tool blocks the whole chunk until the GitHub Actions 6-hour limit.
+- **No portable story for CVMFS-only tests.** The same `-tests.yml` either works locally (URL-driven) or works in CI (CVMFS-string-driven), not both. There is no documented switch.
+- **Hash function is de-facto SHA-1.** The spec accepts SHA-256/SHA-512/MD5; IWC does not use them. Agents that emit a stronger hash will pass planemo but break corpus convention.
+- **Local-file `hashes:` are inconsistently present.** `--from_invocation`-generated tests have them, hand-written tests usually don't. Either is accepted; don't expect uniformity.
+- **`decompress: true` and `dbkey:` are file-level attributes** but undocumented at the planemo test_format page in the same place as `class:`/`location:`/`hashes:`. Cross-reference against the `gxformat2` Schema-Salad bindings if unsure.
+- **`?download=1` query string on Zenodo URLs** is optional. Both forms appear (`/record/4555735/files/X?download=1` vs `/records/11484215/files/Y`). The newer `/records/` plural is the modern Zenodo URL form; both work.
+
+## Cross-references
+
+- [[galaxy-workflow-testability-design]] — workflow input/output structure choices that make these fixture shapes testable.
+- `/Users/jxc755/projects/repositories/galaxy-brain/vault/projects/workflow_state/skills/COMPONENT_GALAXY_WORKFLOW_TESTING.md` — full synthesis with assertion-vocabulary table, CI internals, and tooling rundown. Sections 2b, 3, 4, 5, 9 are the direct upstream of this note.
+- planemo test format spec: [planemo.readthedocs.io/en/latest/test_format.html](https://planemo.readthedocs.io/en/latest/test_format.html).
+- planemo best practices: [planemo.readthedocs.io/en/latest/best_practices_workflows.html](https://planemo.readthedocs.io/en/latest/best_practices_workflows.html).
+- planemo collections reference: [github.com/galaxyproject/planemo/blob/master/docs/_writing_collections.rst](https://github.com/galaxyproject/planemo/blob/master/docs/_writing_collections.rst).
+- IWC contribution contract: `workflows/README.md` in [github.com/galaxyproject/iwc](https://github.com/galaxyproject/iwc).
+- Galaxy datacache (CVMFS `.loc` browsing): [datacache.galaxyproject.org/indexes/location/](http://datacache.galaxyproject.org/indexes/location/).

--- a/casts/claude/skills/cwl-test-to-galaxy-test-plan/references/notes/planemo-asserts-idioms.md
+++ b/casts/claude/skills/cwl-test-to-galaxy-test-plan/references/notes/planemo-asserts-idioms.md
@@ -1,0 +1,249 @@
+---
+type: research
+subtype: component
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-04-30
+revised: 2026-05-11
+revision: 6
+ai_generated: true
+related_notes:
+  - "[[galaxy-workflow-testability-design]]"
+  - "[[iwc-test-data-conventions]]"
+  - "[[iwc-shortcuts-anti-patterns]]"
+  - "[[implement-galaxy-workflow-test]]"
+  - "[[tests-format]]"
+  - "[[planemo-workflow-test-architecture]]"
+  - "[[validate-tests]]"
+  - "[[iwc-tabular-operations-survey]]"
+  - "[[galaxy-discover-datasets]]"
+summary: "Decision and idiom guide for picking planemo workflow-test assertions: which family per output type, how to size tolerances, when to validate."
+---
+
+# Planemo asserts: idiom and decision guide
+
+Companion to [[iwc-test-data-conventions]] (input shapes), [[galaxy-workflow-testability-design]] (workflow structure before test YAML exists), and [[iwc-shortcuts-anti-patterns]] (what's accepted vs smell). This note is forward-looking: when authoring a new `<workflow>-tests.yml`, which assertion family fits which output, and what the recommended tolerances and operators are.
+
+The **vocabulary itself is not restated here** — every assertion's parameter list, types, defaults, required fields, and Python docstring is rendered from the test-format JSON Schema at [[tests-format]]. Assertion names below deep-link into that page (e.g. [[tests-format#has_text_model|has_text]] jumps straight to that `$def`).
+
+## 1. Choose by output type
+
+The single most useful decision table. Pick the row that matches the file format the workflow emits; default to the recommended assertion family.
+
+| Output type | Default assertion family | Why | Fallback |
+|---|---|---|---|
+| **Plain text reports / logs** (FastQC summary, MultiQC text section) | [[tests-format#has_text_model|has_text]] (substring on a known stable token) + [[tests-format#has_n_lines_model|has_n_lines]] with `delta:` | Substring is robust across versions; line count catches truncation | [[tests-format#has_text_matching_model|has_text_matching]] (regex) when token text changes per run |
+| **HTML reports** (MultiQC HTML, custom dashboards) | [[tests-format#has_text_model|has_text]] against stable section names | HTML embeds timestamps and asset hashes; byte-diff is hopeless | [[tests-format#has_size_model|has_size]] + large `delta` as last resort |
+| **Tabular** (TSV, CSV, BED-like) | [[tests-format#has_n_columns_model|has_n_columns]] + [[tests-format#has_text_model|has_text]] for headers + [[tests-format#has_n_lines_model|has_n_lines]] with `delta:` | Schema-shape + content probes; tolerant to row reordering | [[tests-format#has_line_matching_model|has_line_matching]] for a known canonical row |
+| **VCF** | `compare: diff` with `lines_diff: 6` | The `lines_diff: 6` constant matches the typical VCF header preamble that embeds `##fileDate=` and `##source=` | [[tests-format#has_text_matching_model|has_text_matching]] for known variants |
+| **BAM** | [[tests-format#has_size_model|has_size]] + [[tests-format#has_archive_member_model|has_archive_member]] (BAM is a gzipped block format) | Headers contain `@PG` lines with command lines and Galaxy job IDs; never byte-diff | Convert to SAM in a downstream step and assert on text |
+| **FASTA** (deterministic — assemblies, consensus) | `file:` exact comparison or [[tests-format#has_text_model|has_text]] for known sequence | Output is byte-stable when the upstream tool is deterministic | [[tests-format#has_n_lines_model|has_n_lines]] if line wrapping varies |
+| **FASTA** (non-deterministic — RepeatModeler libraries) | `compare: sim_size` with large `delta:` | Family content varies run-to-run | [[tests-format#has_n_lines_model|has_n_lines]] with `delta:` |
+| **FASTQ** (rare as workflow output) | [[tests-format#has_n_lines_model|has_n_lines]] (must be multiple of 4) | Quality scores are read-id-dependent | `compare: sim_size` |
+| **JSON** (deterministic — config dumps, params) | [[tests-format#has_json_property_with_value_model|has_json_property_with_value]] / [[tests-format#has_json_property_with_text_model|has_json_property_with_text]] | Surgical: assert on the property you care about, ignore the rest | `compare: diff` if the JSON is fully canonical |
+| **JSON** (stochastic — HyPhy stats, MCMC results) | `has_text: text: "{"` (existence-only) | Embedded floats break any structural assertion; see [[iwc-shortcuts-anti-patterns]] §1 | [[tests-format#has_h5_keys_model|has_h5_keys]]-equivalent for top-level structural keys |
+| **HDF5 / AnnData** | [[tests-format#has_h5_keys_model|has_h5_keys]] + [[tests-format#has_h5_attribute_model|has_h5_attribute]] for known structure | Asserts shape, not values — values are float-noisy | [[tests-format#has_size_model|has_size]] with `delta:` |
+| **XML** | [[tests-format#is_valid_xml_model|is_valid_xml]] + [[tests-format#has_element_with_path_model|has_element_with_path]] + `element_text_is`/`element_text_matches` | Surgical structural probes; byte-diff fails on whitespace/attribute-order | [[tests-format#has_n_elements_with_path_model|has_n_elements_with_path]] for cardinality |
+| **PNG / image plots** | [[tests-format#has_image_width_model|has_image_width]] + [[tests-format#has_image_height_model|has_image_height]] + [[tests-format#has_size_model|has_size]] with `delta:` (5–10%) | Catches "rendered something with the right dimensions"; corpus norm | [[tests-format#has_image_center_of_mass_model|has_image_center_of_mass]] if mask/segmentation outputs are deterministic |
+| **TIFF / multipage images** | [[tests-format#has_image_frames_model|has_image_frames]] + [[tests-format#has_image_channels_model|has_image_channels]] + [[tests-format#has_size_model|has_size]] with `delta:` | Same logic, channel/frame structure matters | — |
+| **Archives** (zip, tar.gz) | `has_archive_member: path: "regex"` with nested `asserts:` | Asserts on a specific member; archive timestamps never byte-stable | [[tests-format#has_size_model|has_size]] with `delta:` |
+| **GFF / GTF** | [[tests-format#has_n_lines_model|has_n_lines]] with `delta:` + [[tests-format#has_text_model|has_text]] for known feature | Tools reorder freely; hard to byte-diff | `has_n_columns: 9` (GFF spec) |
+| **Cool / HiC matrices** | `compare: sim_size` with multi-MB `delta:` | Binary, run-to-run variance | [[tests-format#has_archive_member_model|has_archive_member]] for HDF5 component |
+
+When in doubt: start with [[tests-format#has_size_model|has_size]] + `delta_frac: 0.1`. It catches the catastrophic failure mode (empty / 10x bigger output). Then add a content probe.
+
+### 1a. If the assertion is too weak, revisit the workflow output
+
+Assertion choice sometimes reveals a workflow-design problem. If the only available output can support only a size check or image-dimension smoke test, check whether the workflow should expose a stronger checkpoint before settling for the weak assertion.
+
+- Scanpy's plot outputs use size and image-dimension assertions, but the same workflow also exposes AnnData HDF5 checkpoints and a cluster-count table (`$IWC/workflows/scRNAseq/scanpy-clustering/Preprocessing-and-Clustering-of-single-cell-RNA-seq-data-with-Scanpy-tests.yml:33-205`).
+- RNA-seq paired-end uses coarse size bands for coverage/mapped-read outputs, but expression/count tables get stronger regex and exact-line checks (`$IWC/workflows/transcriptomics/rnaseq-pe/rnaseq-pe-tests.yml:48-97`).
+
+Rule: if a translated workflow exposes only weakly assertable final reports, consult [[galaxy-workflow-testability-design]] and consider promoting a table/text/HDF5 checkpoint before writing the final assertions.
+
+## 2. The `compare:` operators
+
+Top-level on a `file:` output assertion. Vocabulary, in decreasing strictness:
+
+- **`diff`** (default). Byte-for-byte equality with optional `lines_diff:` tolerance for a fixed number of header lines. Use only when the upstream tool is deterministic on fixed inputs *and* the output has no embedded timestamps, command lines, version banners, or hash-ordered Python-dict-style keys.
+- **`re_match` / `re_match_multiline`**. Each line of the expected fixture is a regex that must match the corresponding output line. Useful when a few fields per row are timestamped but the rest is canonical. Rare in the corpus.
+- **`contains`**. The expected fixture is a substring of the output. Cheap; weak. Prefer `asserts: has_text` for new code unless you genuinely have a multi-line block to assert as a whole.
+- **`sim_size`**. Output file size matches the fixture's size within `delta:` (bytes) or `delta_frac:` (fraction). Use when the output is necessarily non-deterministic but its rough size is reproducible (RepeatModeler libraries, HiC matrices, Bayesian sampler outputs).
+
+Picking `lines_diff:`: count the mutable header lines in the output format. VCF: ~6 (`##fileformat`, `##fileDate`, `##source`, `##reference`, contig/info lines vary). SAM/text headers: count `@HD`/`@PG`/`@CO` lines. Set `lines_diff:` to the count exactly — looser values mask real diffs.
+
+## 3. Tolerance picking
+
+**`delta:`** is bytes (for [[tests-format#has_size_model|has_size]] and `compare: sim_size`) or absolute count (for [[tests-format#has_n_lines_model|has_n_lines]], [[tests-format#has_n_columns_model|has_n_columns]], [[tests-format#has_image_width_model|has_image_width]], etc.). Suffix multipliers documented in the schema — `1K`, `1M`, `1G` work.
+
+**`delta_frac:`** is a fraction (0.1 = 10%). Use when expected size scales with input volume. Three IWC tests use it (`scRNAseq/baredsc/*`, `genome-assembly/polish-with-long-reads/*`); the rest use absolute `delta:`.
+
+**Picking magnitudes** (from corpus survey in [[iwc-shortcuts-anti-patterns]] §2):
+
+- Image dimensions: `delta: 25–30` pixels (5% of typical matplotlib defaults).
+- Image file size: `delta: 5K–60K` (5–10% of file size).
+- Small text reports: `delta: 1K–10K`.
+- HTML reports: `delta: 25K–100K`.
+- BAM files: `delta: 1M–10M`.
+- RepeatModeler / Bayesian sampler outputs: `delta: 30K–90M` (extreme, but justified by the underlying nondeterminism).
+
+**Heuristic for new outputs:** `delta_frac: 0.1` is a defensible default. Tighten if the output proves more deterministic than expected.
+
+## 4. Text family — [[tests-format#has_text_model|has_text]] vs [[tests-format#has_text_matching_model|has_text_matching]] vs [[tests-format#has_line_model|has_line]] vs [[tests-format#has_line_matching_model|has_line_matching]] vs [[tests-format#has_n_lines_model|has_n_lines]]
+
+All five are common; choose by what you're verifying.
+
+- **[[tests-format#has_text_model|has_text]]** — output contains the substring `text:`. Anywhere in the output, any number of times. Add `n:` / `min:` / `max:` to constrain occurrence count. Add `delta:` to allow slack on the count.
+- **[[tests-format#has_text_matching_model|has_text_matching]]** — output matches the regex `expression:`. Use sparingly; prefer literal [[tests-format#has_text_model|has_text]] when you can.
+- **[[tests-format#has_line_model|has_line]]** — output has at least one *line* matching `line:` exactly. Use when line boundaries matter (e.g. asserting on a specific row in a table).
+- **[[tests-format#has_line_matching_model|has_line_matching]]** — same but with regex.
+- **[[tests-format#has_n_lines_model|has_n_lines]]** — assert the line count is `n:` ± `delta:`.
+
+A common combination in IWC: `has_n_lines: n: 100, delta: 5` + `has_text: text: "expected_token"` — line-count sanity-check plus a content marker. This catches both truncation and content drift in one assertion pair.
+
+`negate: true` is supported on every assertion. Used for the "this output should NOT contain X" case.
+
+## 5. Collection output assertions (`element_tests:`)
+
+For Galaxy collection outputs, the test format keys element assertions by element identifier:
+
+```yaml
+my_collection_output:
+  element_tests:
+    sample_1:
+      asserts:
+        has_text:
+          text: "expected"
+    sample_2:
+      file: test-data/expected_sample_2.txt
+```
+
+Optional `attributes:` at the collection level can assert on the produced collection shape:
+
+```yaml
+my_collection_output:
+  attributes: {collection_type: list:list}
+  element_tests:
+    ...
+```
+
+Nested collections: outer `element_tests:` keyed by outer identifier; inner uses `elements:` (note plural, no `_tests` suffix on the inner). See [[iwc-test-data-conventions]] §2f for the live example.
+
+For a list-of-files where every element should pass the same minimal check, the existence-probe pattern (`has_text: "{"` for JSON; `has_size: min: 100` for any non-empty binary) is widely used and accepted in IWC.
+
+## 6. The validate-against-workflow inner loop
+
+A `-tests.yml` file can be **structurally invalid** in two distinct ways:
+
+1. **Schema-invalid** — wrong field names, wrong nesting, wrong types. Caught by the test-format JSON Schema.
+2. **Workflow-incoherent** — schema-valid YAML, but the input/output labels don't match the actual workflow. Renaming an output in the `.ga` and forgetting to update its sibling `-tests.yml` produces this case. Planemo will surface it as an "output not found" error at test-runtime, but only after a full workflow run.
+
+The `@galaxy-tool-util/schema` npm package ships **two** validators that catch both cases statically — no Galaxy or Planemo invocation needed:
+
+- **`validateTestsFile(yaml)`** — runs the file against `tests.schema.json` (AJV). Reports schema violations with paths.
+- **`checkTestsAgainstWorkflow(workflow, tests)`** — cross-checks a `.ga` / format2 workflow against a tests file: missing input labels, missing output labels, type incompatibilities (e.g. test supplies a `File` for a parameter typed `int`).
+
+Both are pure-JS, take milliseconds, and have no Galaxy dependency. Wire them into the inner authoring loop:
+
+```
+edit -tests.yml
+  → validateTestsFile()                    # schema gate
+  → checkTestsAgainstWorkflow(.ga, tests)  # coherence gate
+  → planemo workflow_test_on_invocation    # assertion gate (no full re-run)
+  → planemo test                           # full integration (slow)
+```
+
+The first two gates short-circuit cheap mistakes before a slow planemo run. They are the static-validation equivalent of `gxwf` for tests, and the `implement-galaxy-workflow-test` mold should reference them as its primary inner-loop tooling. Source: galaxy-tool-util-ts package, `src/test-format/index.ts` exports.
+
+## 7. Authoring loop — generation, then refinement
+
+Reviewer convention is to **generate** the initial `-tests.yml` rather than hand-write it. Two planemo subcommands cover this:
+
+- **`planemo workflow_test_init --from_invocation <invocation_id>`** ([[planemo-workflow_test_init]]) — given a successful Galaxy invocation ID, emit a `-tests.yml` with a `job:` block that captures all inputs (with SHA-1 hashes) and an `outputs:` block with `file:` references to the actual outputs (downloaded into `test-data/`). Hand-tighten the assertions afterward.
+- **`planemo workflow_test_on_invocation <tests.yml> <invocation_id>`** ([[planemo-workflow_test_on_invocation]]) — re-evaluate an edited `-tests.yml` against a saved invocation without re-running the workflow. The fast inner loop for assertion iteration; complements the static gates in §6.
+
+Together these cut the assertion-iteration cost dramatically. An agent should:
+
+1. Run the workflow once on usegalaxy.* (or local) to get a known-good invocation.
+2. `--from_invocation` to bootstrap the test file.
+3. Replace the autogenerated `file:` exact-comparison assertions with assertion-family-appropriate alternatives per §1.
+4. [[planemo-workflow_test_on_invocation]] after each edit; full [[planemo-test]] at the end.
+
+## 8. What the schema gives you for free
+
+When the test-format schema lands as a Foundry-rendered note, the agent can consult any assertion's `$def` directly for: parameter types, defaults, required fields, the `that` discriminator constant, and the original Python docstring (carried through as `description`). This note does **not** restate that vocabulary — it complements it with the corpus-grounded *which-and-when*.
+
+What's still missing from the schema and worth keeping in research notes:
+
+- This decision table (§1) — output-type → assertion family.
+- Tolerance magnitudes (§3) — corpus-derived defaults.
+- The `validateTestsFile` / `checkTestsAgainstWorkflow` integration story (§6).
+- Anti-pattern flags — see [[iwc-shortcuts-anti-patterns]].
+
+## 9. Common combinations (recipes)
+
+Six recipes worth memorizing.
+
+**Stable text report (FastQC summary, simple stats).**
+```yaml
+my_report:
+  asserts:
+    has_n_lines: { n: 12, delta: 2 }
+    has_text: { text: "Total Sequences" }
+```
+
+**MultiQC HTML report.**
+```yaml
+multiqc_report:
+  asserts:
+    has_text: { text: "Filtered Reads" }
+    has_text: { text: "FastQC" }
+```
+
+**VCF (pinned tool, fixed reference).**
+```yaml
+called_variants:
+  file: test-data/expected.vcf
+  compare: diff
+  lines_diff: 6
+```
+
+**Stochastic JSON (HyPhy-style).**
+```yaml
+hyphy_meme:
+  element_tests:
+    geneA: { asserts: { has_text: { text: "{" } } }
+    geneB: { asserts: { has_text: { text: "{" } } }
+```
+
+**Matplotlib plot.**
+```yaml
+umap_plot:
+  asserts:
+    has_size: { size: 68416, delta: 6000 }
+    has_image_width: { width: 601, delta: 30 }
+    has_image_height: { height: 429, delta: 25 }
+```
+
+**AnnData (HDF5).**
+```yaml
+clustered_anndata:
+  asserts:
+    has_h5_keys: { keys: "obs/louvain" }
+    has_h5_keys: { keys: "var/highly_variable" }
+    has_h5_keys: { keys: "uns/rank_genes_groups" }
+    has_size: { size: 12000000, delta: 1500000 }
+```
+
+## 10. Cross-references
+
+- [[galaxy-workflow-testability-design]] — decide which workflow outputs and checkpoints to expose before choosing assertions.
+- [[iwc-test-data-conventions]] — input-side conventions (job inputs, collection shapes, `hashes:`, CVMFS).
+- [[iwc-shortcuts-anti-patterns]] — accepted-vs-smell catalog and corpus prevalence; this note's mirror image.
+- Test-format schema (`@galaxy-tool-util/schema` npm package) — authoritative vocabulary; will be vendored into a Foundry-rendered schema note. See `docs/COMPILATION_PIPELINE.md` for the casting story.
+- Planemo test-format spec: [planemo.readthedocs.io/en/latest/test_format.html](https://planemo.readthedocs.io/en/latest/test_format.html).
+- [[galaxy-xsd]] — Galaxy XSD assertion source of truth, vendored from upstream.
+- Tightening of the schema and Pydantic source: [galaxyproject/galaxy#22566](https://github.com/galaxyproject/galaxy/pull/22566).
+- TS schema sync into npm: [jmchilton/galaxy-tool-util-ts#75](https://github.com/jmchilton/galaxy-tool-util-ts/pull/75).

--- a/casts/claude/skills/cwl-test-to-galaxy-test-plan/references/notes/planemo-workflow-test-architecture.md
+++ b/casts/claude/skills/cwl-test-to-galaxy-test-plan/references/notes/planemo-workflow-test-architecture.md
@@ -1,0 +1,154 @@
+---
+type: research
+subtype: component
+title: "Planemo workflow-test architecture"
+tags:
+  - research/component
+  - tool/planemo
+  - target/galaxy
+status: draft
+created: 2026-05-02
+revised: 2026-05-11
+revision: 3
+ai_generated: true
+related_notes:
+  - "[[galaxy-workflow-testability-design]]"
+  - "[[galaxy-tool-job-failure-reference]]"
+  - "[[galaxy-workflow-invocation-failure-reference]]"
+  - "[[planemo-asserts-idioms]]"
+related_molds:
+  - "[[run-workflow-test]]"
+  - "[[debug-galaxy-workflow-output]]"
+  - "[[implement-galaxy-workflow-test]]"
+sources:
+  - "~/projects/repositories/planemo/planemo/commands/cmd_test.py"
+  - "~/projects/repositories/planemo/planemo/commands/cmd_run.py"
+  - "~/projects/repositories/planemo/planemo/galaxy/activity.py"
+  - "~/projects/repositories/planemo/planemo/galaxy/invocations"
+  - "~/projects/repositories/planemo/planemo/galaxy/config.py"
+summary: "Reference for Planemo workflow test/run architecture, Galaxy modes, API polling, and noisy failure boundaries."
+---
+
+# Planemo Workflow-Test Architecture
+
+This note describes Planemo architecture relevant to workflow tests and workflow runs. It is reference material for Molds that need to run tests or interpret Planemo artifacts, not a command-selection recipe.
+
+## Main Commands
+
+| User action | Command | Core behavior |
+|---|---|---|
+| Full workflow test | `planemo test <workflow>` ([[planemo-test]]) | Finds test definitions, starts or targets Galaxy, stages inputs, invokes workflow, checks assertions, writes reports. |
+| Direct run | `planemo run <workflow> <job.yml>` | Runs one workflow/job pair and can download outputs without assertion checks. |
+| Recheck assertions | `planemo workflow_test_on_invocation <tests.yml> <invocation_id>` ([[planemo-workflow_test_on_invocation]]) | Runs test assertions against an existing invocation without rerunning the workflow. |
+| Track invocation | `planemo workflow_track <invocation_id>` | Polls an existing invocation and displays progress. |
+| Generate test from invocation | `planemo workflow_test_init --from_invocation <id>` ([[planemo-workflow_test_init]]) | Builds a test template from a completed invocation and its outputs. |
+| Generate job template | `planemo workflow_job_init <workflow>` | Creates a job-input template for a workflow. |
+
+Observed code paths live under `~/projects/repositories/planemo/planemo/commands/`, `planemo/engine/`, and `planemo/galaxy/`.
+
+## Engine Selection
+
+Planemo chooses between engines early:
+
+- CWL runnables can use CWL-specific engines.
+- Supplying `--galaxy_url` implies an external running Galaxy unless an engine is explicitly selected.
+- Default Galaxy workflow testing uses a managed local Galaxy engine.
+- `--engine docker_galaxy` uses a managed Dockerized Galaxy.
+- `--engine external_galaxy` uses an existing running Galaxy.
+
+“Existing Galaxy” can mean two different things:
+
+- Existing local Galaxy source tree, still managed by Planemo for this run.
+- Existing running Galaxy server, addressed through URL and API keys.
+
+Mold output and eval logs should record which meaning applies.
+
+## Managed Galaxy Configuration
+
+For managed Galaxy, Planemo builds a temporary configuration directory and generated Galaxy config. It can configure tool config, shed tool config, job config, file sources, object store paths, dependency config, SQLite database by default, admin users, API keys, and environment overrides.
+
+Important managed-mode behavior:
+
+- Planemo may find a local Galaxy root or install/use a cached Galaxy source tree.
+- `--galaxy_branch` selects which Galaxy branch is cloned when no Galaxy root is supplied; it defaults to `master`. Omitting it therefore tests against the newest Galaxy. Naming an older `release_*` branch narrows what workflow syntax Galaxy will accept, and the resulting rejection surfaces as an invocation-time error rather than as a version mismatch.
+- Managed Galaxy defaults are convenient but may not match production Galaxy behavior.
+- Planemo can install workflow tool dependencies through Tool Shed metadata when configured.
+- Test histories are created automatically unless a history id is supplied.
+
+## External Galaxy Configuration
+
+For external Galaxy, Planemo uses supplied Galaxy URL and API keys. A user key runs workflows; an admin key may be needed for installing missing repositories or creating a user key.
+
+External Galaxy mode is useful when the target environment matters, but failure surfaces can include server configuration, installed tools, permissions, and existing history state. Eval logs should preserve URL/key mode without storing secrets.
+
+## API Interaction
+
+Planemo primarily talks to Galaxy through BioBlend-backed clients.
+
+Important operations:
+
+- Import workflows into Galaxy.
+- Stage datasets and collections into histories.
+- Invoke workflows by input names.
+- Poll invocations and jobs.
+- Fetch job details with full detail when needed.
+- Download outputs and output collections.
+- Run assertion checks and write structured reports.
+
+For workflows, Planemo invokes Galaxy using input labels/names. Stable generated labels are therefore important for both test execution and debugging.
+
+Workflow testability design guidance lives in [[galaxy-workflow-testability-design]]. This architecture note only records why Planemo makes labels and workflow-level outputs operationally important.
+
+## Structured Artifacts
+
+Useful Planemo artifacts and fields:
+
+| Artifact or field | Use |
+|---|---|
+| `tool_test_output.json` | Primary structured result artifact for tests. |
+| invocation id | Key for Galaxy invocation API follow-up. |
+| history id | Key for history contents and output inspection. |
+| workflow id | Key for workflow invocation aliases and reruns. |
+| output problems | Assertion and missing-output failures. |
+| execution problem | Staging, invocation, API, or other execution-level failure. |
+| invocation details | Step/job/output details Planemo collected from Galaxy. |
+| job details | Tool id, state, exit code, command, stdout/stderr when collected. |
+
+Terminal output is not enough for durable failure analysis. Preserve structured output whenever possible.
+
+## Noisy Boundaries
+
+Planemo transforms and summarizes Galaxy failure information. These are likely information-loss boundaries:
+
+- Exceptions during execution can become stringified `ErrorRunResponse` values.
+- Polling may summarize “at least one job is in error” while detailed job evidence is printed elsewhere or stored separately.
+- Missing outputs become assertion/output problems, which can conflate label mismatch, workflow output omission, optional output absence, failed invocation, or output download issue.
+- Output download failures may be logged but not always propagated as the most specific failure.
+- External Galaxy without an admin key may defer missing-tool problems until runtime.
+- `allow_tool_state_corrections=True` can let Galaxy adjust tool state during invocation, which is useful but can mask definition drift.
+- `--no_wait` is not suitable for debug conclusions because invocation creation can succeed before jobs fail.
+
+## Reference Use For Molds
+
+For [[run-workflow-test]]:
+
+- Preserve structured Planemo result output, invocation id, history id, workflow id, and Galaxy mode.
+- Record whether the run used managed local Galaxy, Docker Galaxy, or external Galaxy.
+- Do not treat terminal output as the primary failure artifact.
+
+For [[debug-galaxy-workflow-output]]:
+
+- Start from structured Planemo output.
+- For missing-output failures, check label drift and omitted workflow-level outputs before assuming tool failure.
+- If the failure is job-level, inspect Galaxy job APIs described in [[galaxy-tool-job-failure-reference]].
+- If the failure is invocation-level, inspect Galaxy invocation APIs described in [[galaxy-workflow-invocation-failure-reference]].
+- If only assertions failed, use [[planemo-asserts-idioms]] before deciding to rerun.
+
+## Verification Gaps
+
+Actual runs should verify:
+
+- Which invocation messages Planemo exposes directly.
+- Whether target Planemo/Galaxy versions populate `completed`, `/completion`, and step job summaries.
+- How `workflow_test_on_invocation` behaves for failed, warning-only, mapped collection, and subworkflow invocations.
+- Whether generated test cases from invocation preserve nested output collection structure correctly.

--- a/casts/claude/skills/cwl-test-to-galaxy-test-plan/references/schemas/galaxy-workflow-test-plan.schema.json
+++ b/casts/claude/skills/cwl-test-to-galaxy-test-plan/references/schemas/galaxy-workflow-test-plan.schema.json
@@ -1,0 +1,552 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://galaxyproject.org/foundry/schemas/galaxy-workflow-test-plan.schema.json",
+  "$comment": "Canonical source: packages/foundry/src/schemas/galaxy-workflow-test-plan/galaxy-workflow-test-plan.schema.json in galaxyproject/foundry. Mold frontmatter cites this schema via [[galaxy-workflow-test-plan]] wiki-links; the cast pipeline imports the `galaxyWorkflowTestPlanSchema` runtime export and serializes it into cast bundles. The on-disk artifact is YAML; validate it with `foundry validate-galaxy-workflow-test-plan`.",
+  "title": "Galaxy Workflow Test Plan",
+  "description": "Intermediate, reviewable Galaxy workflow test-plan handoff produced by a *-test-to-galaxy-test-plan Mold (nextflow, cwl, freeform, or galaxy) and consumed by implement-galaxy-workflow-test. It preserves test intent, fixture provenance, assertion intent, tolerances, label assumptions, unresolved mappings, and intentional omissions before any concrete tests-format `*-tests.yml` is authored. It is NOT the final test artifact: assertion vocabulary is referenced by family name from the tests-format schema, not duplicated here.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "plan_version",
+    "source",
+    "workflow",
+    "test_cases",
+    "unresolved",
+    "omissions",
+    "warnings"
+  ],
+  "properties": {
+    "plan_version": {
+      "type": "string",
+      "enum": [
+        "1"
+      ],
+      "description": "Test-plan schema major version."
+    },
+    "source": {
+      "$ref": "#/$defs/SourceRecord"
+    },
+    "workflow": {
+      "$ref": "#/$defs/WorkflowRef"
+    },
+    "test_cases": {
+      "type": "array",
+      "description": "One entry per planned Galaxy workflow test (each becomes one tests-format test entry downstream).",
+      "items": {
+        "$ref": "#/$defs/TestCase"
+      }
+    },
+    "unresolved": {
+      "type": "array",
+      "description": "Mappings the plan could not resolve and that implement-galaxy-workflow-test (or a reviewer) must settle before authoring the final test file.",
+      "items": {
+        "$ref": "#/$defs/UnresolvedItem"
+      }
+    },
+    "omissions": {
+      "type": "array",
+      "description": "Outputs or behaviors deliberately left unasserted, with rationale, so the gap is a recorded decision rather than an oversight.",
+      "items": {
+        "$ref": "#/$defs/Omission"
+      }
+    },
+    "warnings": {
+      "type": "array",
+      "description": "Plan-construction warnings: source-test evidence that could not be translated, expression-derived shapes, missing fixtures, and similar.",
+      "items": {
+        "$ref": "#/$defs/Warning"
+      }
+    }
+  },
+  "$defs": {
+    "SourceRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "name",
+        "derived_from",
+        "notes"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "nextflow",
+            "cwl",
+            "freeform",
+            "galaxy"
+          ],
+          "description": "Source family of the Galaxy-targeting translator that produced this plan. galaxy denotes a Galaxy→Galaxy update plan carried forward from an existing Galaxy workflow's own tests (the changeset-to-galaxy-test-plan case)."
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-oriented workflow or source name the plan was derived from."
+        },
+        "derived_from": {
+          "type": "string",
+          "enum": [
+            "test-evidence",
+            "intent"
+          ],
+          "description": "Dominant basis for the plan: test-evidence means it was translated from existing upstream test fixtures/snapshots/job files (nf-test, CWL jobs); intent means it was synthesized from workflow intent and scenario-level expected outputs without upstream test evidence (freeform paper/interview sources)."
+        },
+        "notes": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Free-text provenance about the source and how test evidence was (or was not) available."
+        }
+      }
+    },
+    "WorkflowRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "How the plan relates to the Galaxy workflow it tests, and where its input/output labels came from.",
+      "required": [
+        "title",
+        "label_source",
+        "notes"
+      ],
+      "properties": {
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Galaxy workflow title/name when known."
+        },
+        "label_source": {
+          "type": "string",
+          "enum": [
+            "draft",
+            "interface-brief",
+            "assumed"
+          ],
+          "description": "Provenance of the input/output labels this plan references: draft means they were read from a concrete gxformat2 workflow draft (verifiable); interface-brief means they came from an upstream Galaxy interface brief; assumed means they were inferred and are unconfirmed against any workflow."
+        },
+        "notes": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Free-text notes about label confidence and workflow-binding assumptions."
+        }
+      }
+    },
+    "TestCase": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "doc",
+        "derived_from",
+        "provenance",
+        "job_inputs",
+        "expected_outputs"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Stable identifier for this planned test case."
+        },
+        "doc": {
+          "type": "string",
+          "description": "What this test exercises, in plain language; becomes the tests-format test `doc`."
+        },
+        "derived_from": {
+          "type": "string",
+          "enum": [
+            "test-evidence",
+            "intent",
+            "mixed"
+          ],
+          "description": "Basis for this case: translated from upstream test evidence, synthesized from intent, or a mix."
+        },
+        "provenance": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Where this case came from, e.g. an nf-test name, a CWL job file, a paper section, or an interview answer."
+        },
+        "job_inputs": {
+          "type": "array",
+          "description": "Planned workflow job inputs for this case.",
+          "items": {
+            "$ref": "#/$defs/JobInput"
+          }
+        },
+        "expected_outputs": {
+          "type": "array",
+          "description": "Planned workflow outputs to assert for this case.",
+          "items": {
+            "$ref": "#/$defs/ExpectedOutput"
+          }
+        }
+      }
+    },
+    "JobInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "workflow_label",
+        "label_status",
+        "description",
+        "collection_shape",
+        "datatype",
+        "fixture"
+      ],
+      "properties": {
+        "workflow_label": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Workflow input label this job entry binds to; null when the label is not yet known."
+        },
+        "label_status": {
+          "type": "string",
+          "enum": [
+            "resolved",
+            "assumed",
+            "unresolved"
+          ],
+          "description": "resolved means the label matches a concrete workflow draft input; assumed means it is inferred from a brief; unresolved means the binding label is not yet decided."
+        },
+        "description": {
+          "type": "string",
+          "description": "What this input is and the role it plays in the test."
+        },
+        "collection_shape": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Galaxy collection shape when the input is a collection, e.g. list, paired, list:paired, list:list; null for a single dataset or when unknown."
+        },
+        "datatype": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Galaxy datatype/extension hint, e.g. fastqsanger.gz, fasta, tabular; null when undecided."
+        },
+        "fixture": {
+          "$ref": "#/$defs/Fixture"
+        }
+      }
+    },
+    "Fixture": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "storage",
+        "location",
+        "checksum",
+        "provenance"
+      ],
+      "properties": {
+        "storage": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "remote-url",
+            "in-repo",
+            "cvmfs-string",
+            "generated-toy",
+            "unresolved",
+            null
+          ],
+          "description": "Where the fixture data lives or should live: remote-url (Zenodo/EBI/SRA location), in-repo (committed test-data path), cvmfs-string (data-table/built-in-index bare string), generated-toy (to be synthesized), or unresolved (not yet sourced)."
+        },
+        "location": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Concrete URL, repo-relative path, or data-table string when known; null when the fixture still needs resolution."
+        },
+        "checksum": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Integrity hash when available, e.g. SHA-1:<hex>; null when unknown."
+        },
+        "provenance": {
+          "type": "string",
+          "description": "Where this fixture comes from or how it was chosen, e.g. a translated source test-data reference, a Zenodo record, or a note that test-data-resolution must supply it."
+        }
+      }
+    },
+    "ExpectedOutput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "workflow_label",
+        "label_status",
+        "description",
+        "output_kind",
+        "collection_shape",
+        "assertion_intent"
+      ],
+      "properties": {
+        "workflow_label": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Workflow output label to assert against; null when the output label is not yet known."
+        },
+        "label_status": {
+          "type": "string",
+          "enum": [
+            "resolved",
+            "assumed",
+            "unresolved"
+          ],
+          "description": "resolved means the label matches a concrete workflow draft output; assumed means it is inferred from a brief; unresolved means the output label is not yet decided."
+        },
+        "description": {
+          "type": "string",
+          "description": "What this output is and why it is worth asserting."
+        },
+        "output_kind": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "dataset",
+            "collection",
+            null
+          ],
+          "description": "Whether the output is a single dataset or a collection; null when undecided. Collection outputs carry element-level assertion intent via assertion_intent[].element_identifier."
+        },
+        "collection_shape": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Galaxy collection shape for collection outputs, e.g. list, list:paired, list:list; null otherwise."
+        },
+        "assertion_intent": {
+          "type": "array",
+          "description": "Assertion intent for this output. May be empty when the output is intentionally unasserted (record the reason in omissions). Each entry names a tests-format assertion family by name rather than duplicating its full parameter object.",
+          "items": {
+            "$ref": "#/$defs/AssertionIntent"
+          }
+        }
+      }
+    },
+    "AssertionIntent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "family",
+        "intent",
+        "expected_value",
+        "tolerance",
+        "element_identifier",
+        "evidence",
+        "confidence"
+      ],
+      "properties": {
+        "family": {
+          "type": "string",
+          "description": "tests-format assertion family or compare operator this intent maps to, by name, e.g. has_text, has_n_lines, has_n_columns, has_size, has_image_width, has_h5_keys, file, compare:diff, compare:sim_size. Names reference the tests-format schema vocabulary; this plan does not restate parameter shapes."
+        },
+        "intent": {
+          "type": "string",
+          "description": "What this assertion verifies, in plain language, so implement-galaxy-workflow-test can materialize the concrete assertion without re-reading the source tests."
+        },
+        "expected_value": {
+          "type": [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "null"
+          ],
+          "description": "Concrete expected token, count, size, or comparison fixture when known; null when synthesized from intent without a concrete value."
+        },
+        "tolerance": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Tolerance"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Tolerance for the expected value when applicable; null for exact or existence-only assertions."
+        },
+        "element_identifier": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Collection element identifier this assertion targets, for element-level (element_tests) assertions; null for top-level dataset assertions."
+        },
+        "evidence": {
+          "type": "string",
+          "enum": [
+            "test-evidence",
+            "intent"
+          ],
+          "description": "Whether this assertion was translated from upstream test evidence or synthesized from intent."
+        },
+        "confidence": {
+          "type": "string",
+          "enum": [
+            "high",
+            "medium",
+            "low"
+          ],
+          "description": "How firmly the expected value and family are believed correct; synthesized assertions are typically medium or low."
+        }
+      }
+    },
+    "Tolerance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "magnitude",
+        "rationale"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "delta",
+            "delta_frac",
+            "lines_diff",
+            "none"
+          ],
+          "description": "Tolerance operator: delta (absolute count/bytes, suffixes like 1K/1M allowed as strings), delta_frac (fraction such as 0.1), lines_diff (number of mutable header lines for compare:diff), or none."
+        },
+        "magnitude": {
+          "type": [
+            "string",
+            "number",
+            "integer",
+            "null"
+          ],
+          "description": "Tolerance magnitude, e.g. 6, \"10K\", or 0.1; null when kind is none or the magnitude is undecided."
+        },
+        "rationale": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Why this magnitude was chosen, e.g. mutable VCF header line count, percentage of typical file size, or nondeterministic output."
+        }
+      }
+    },
+    "UnresolvedItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "description",
+        "blocking",
+        "suggested_resolution"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "input-label",
+            "output-label",
+            "fixture",
+            "assertion",
+            "datatype",
+            "collection-shape",
+            "other"
+          ],
+          "description": "Category of the unresolved mapping."
+        },
+        "description": {
+          "type": "string",
+          "description": "What could not be resolved and why."
+        },
+        "blocking": {
+          "type": "boolean",
+          "description": "Whether implement-galaxy-workflow-test must resolve this before authoring a runnable test."
+        },
+        "suggested_resolution": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "A proposed way to resolve it when one is apparent; null otherwise."
+        }
+      }
+    },
+    "Omission": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "target",
+        "reason",
+        "category"
+      ],
+      "properties": {
+        "target": {
+          "type": "string",
+          "description": "What is intentionally left unasserted, e.g. a workflow output label or a class of outputs."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Why it is omitted, e.g. nondeterministic content, no stable checkpoint, or asserted only weakly elsewhere."
+        },
+        "category": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "nondeterministic",
+            "no-stable-checkpoint",
+            "weak-output",
+            "out-of-scope",
+            "other",
+            null
+          ],
+          "description": "Coarse omission category; null when none fits."
+        }
+      }
+    },
+    "Warning": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "message",
+        "path"
+      ],
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "Stable warning code, e.g. untranslatable-snapshot, missing-fixture, expression-derived-shape."
+        },
+        "message": {
+          "type": "string",
+          "description": "Human-readable warning detail."
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Pointer into the source or plan the warning refers to; null when not applicable."
+        }
+      }
+    }
+  }
+}

--- a/casts/claude/skills/cwl-test-to-galaxy-test-plan/references/schemas/summary-cwl.schema.json
+++ b/casts/claude/skills/cwl-test-to-galaxy-test-plan/references/schemas/summary-cwl.schema.json
@@ -1,0 +1,901 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://galaxyproject.org/foundry/schemas/summary-cwl.schema.json",
+  "$comment": "Canonical source: packages/foundry/src/schemas/summary-cwl/summary-cwl.schema.json in galaxyproject/foundry. Mold frontmatter cites this schema via [[summary-cwl]] wiki-links; the cast pipeline imports the `summaryCwlSchema` runtime export and serializes it into cast bundles.",
+  "title": "CWL Workflow Summary",
+  "description": "Structured per-source summary emitted by the summarize-cwl Mold. CWL is already a typed workflow language, so this schema records validated and normalized workflow/tool structure rather than inferred pipeline semantics.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "summary_version",
+    "source",
+    "documents",
+    "workflow_inputs",
+    "workflow_outputs",
+    "steps",
+    "tools",
+    "graph",
+    "tests",
+    "warnings"
+  ],
+  "properties": {
+    "summary_version": {
+      "type": "string",
+      "enum": [
+        "1"
+      ],
+      "description": "Summary schema major version."
+    },
+    "source": {
+      "$ref": "#/$defs/SourceRecord"
+    },
+    "documents": {
+      "$ref": "#/$defs/DocumentSet"
+    },
+    "workflow_inputs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/WorkflowInput"
+      }
+    },
+    "workflow_outputs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/WorkflowOutput"
+      }
+    },
+    "steps": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/WorkflowStep"
+      }
+    },
+    "tools": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/CommandLineTool"
+      }
+    },
+    "graph": {
+      "$ref": "#/$defs/WorkflowGraph"
+    },
+    "tests": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/TestCase"
+      }
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Warning"
+      }
+    }
+  },
+  "$defs": {
+    "SourceRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "ecosystem",
+        "workflow",
+        "url",
+        "version",
+        "license",
+        "slug",
+        "cwl_version",
+        "entrypoint"
+      ],
+      "properties": {
+        "ecosystem": {
+          "type": "string",
+          "enum": [
+            "cwl"
+          ],
+          "description": "Source ecosystem; fixed for this per-source schema."
+        },
+        "workflow": {
+          "type": "string",
+          "description": "Human-oriented workflow name, usually the entry Workflow id or source filename stem."
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Original path or URL supplied by the user."
+        },
+        "version": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Pinned commit, tag, release, or digest when available."
+        },
+        "license": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "License identifier or detected license filename when available."
+        },
+        "slug": {
+          "type": "string",
+          "description": "Stable kebab-case run slug."
+        },
+        "cwl_version": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Declared cwlVersion after loading the entry document, commonly v1.0, v1.1, or v1.2."
+        },
+        "entrypoint": {
+          "type": "string",
+          "description": "Main workflow document/id after resolution, e.g. workflow.cwl#main."
+        }
+      }
+    },
+    "DocumentSet": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "entrypoint",
+        "normalized_path",
+        "validation"
+      ],
+      "properties": {
+        "entrypoint": {
+          "type": "string",
+          "description": "Local path or URL passed to cwl-utils/cwltool."
+        },
+        "normalized_path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Path to the cwl-utils cwl-normalizer JSON output when normalization was requested or possible."
+        },
+        "validation": {
+          "$ref": "#/$defs/ValidationResult"
+        }
+      }
+    },
+    "ValidationResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "command",
+        "status",
+        "diagnostics"
+      ],
+      "properties": {
+        "command": {
+          "type": "string",
+          "description": "Validation command or library operation used."
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "valid",
+            "warning",
+            "invalid",
+            "not-run"
+          ]
+        },
+        "diagnostics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "WorkflowInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "label",
+        "type",
+        "optional",
+        "default",
+        "doc",
+        "format",
+        "secondary_files"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "type": "string",
+          "description": "Compact CWL type expression, preserving arrays, records, enums, nullability, File, and Directory."
+        },
+        "optional": {
+          "type": "boolean"
+        },
+        "default": {
+          "description": "Verbatim default value when present.",
+          "type": [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "object",
+            "array",
+            "null"
+          ]
+        },
+        "doc": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "format": {
+          "type": [
+            "string",
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "secondary_files": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "WorkflowOutput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "label",
+        "type",
+        "output_source",
+        "doc",
+        "format",
+        "secondary_files"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "type": "string"
+        },
+        "output_source": {
+          "type": [
+            "string",
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "doc": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "format": {
+          "type": [
+            "string",
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "secondary_files": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "WorkflowStep": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "run",
+        "run_class",
+        "label",
+        "doc",
+        "in",
+        "out",
+        "scatter",
+        "scatter_method",
+        "when",
+        "requirements",
+        "hints"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "run": {
+          "type": "string",
+          "description": "Resolved run reference as it appears in the normalized document, e.g. #tool_id."
+        },
+        "run_class": {
+          "type": "string",
+          "enum": [
+            "CommandLineTool",
+            "ExpressionTool",
+            "Workflow",
+            "Operation",
+            "unknown"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "doc": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "in": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/StepInput"
+          }
+        },
+        "out": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "scatter": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "scatter_method": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "dotproduct",
+            "nested_crossproduct",
+            "flat_crossproduct",
+            null
+          ]
+        },
+        "when": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "CWL v1.2 conditional expression, preserved verbatim when present."
+        },
+        "requirements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Requirement"
+          }
+        },
+        "hints": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Requirement"
+          }
+        }
+      }
+    },
+    "StepInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "source",
+        "default",
+        "value_from",
+        "link_merge",
+        "pick_value"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "source": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "description": "Normalized CWL source links. Null means the input has no source and is driven by default or runtime binding.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "default": {
+          "description": "Verbatim WorkflowStepInput default value when present.",
+          "type": [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "object",
+            "array",
+            "null"
+          ]
+        },
+        "value_from": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Expression from valueFrom, preserved verbatim when present."
+        },
+        "link_merge": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "merge_nested",
+            "merge_flattened",
+            null
+          ],
+          "description": "CWL linkMerge setting for multiple inbound sources."
+        },
+        "pick_value": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "first_non_null",
+            "the_only_non_null",
+            "all_non_null",
+            null
+          ],
+          "description": "CWL pickValue setting for choosing non-null values among multiple sources."
+        }
+      }
+    },
+    "CommandLineTool": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "label",
+        "base_command",
+        "arguments",
+        "inputs",
+        "outputs",
+        "requirements",
+        "hints"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "base_command": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "arguments": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "inputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ToolInput"
+          }
+        },
+        "outputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ToolOutput"
+          }
+        },
+        "requirements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Requirement"
+          }
+        },
+        "hints": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Requirement"
+          }
+        }
+      }
+    },
+    "ToolInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "type",
+        "input_binding",
+        "doc",
+        "format",
+        "secondary_files"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "input_binding": {
+          "$ref": "#/$defs/BindingSummary"
+        },
+        "doc": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "format": {
+          "type": [
+            "string",
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "secondary_files": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ToolOutput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "type",
+        "output_binding",
+        "doc",
+        "format",
+        "secondary_files"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "output_binding": {
+          "$ref": "#/$defs/BindingSummary"
+        },
+        "doc": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "format": {
+          "type": [
+            "string",
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "secondary_files": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "BindingSummary": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false,
+      "required": [
+        "position",
+        "prefix",
+        "glob",
+        "value_from"
+      ],
+      "properties": {
+        "position": {
+          "type": [
+            "number",
+            "integer",
+            "null"
+          ]
+        },
+        "prefix": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "glob": {
+          "type": [
+            "string",
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "value_from": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "Requirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "class",
+        "docker_pull",
+        "docker_image_id",
+        "packages",
+        "raw"
+      ],
+      "properties": {
+        "class": {
+          "type": "string",
+          "description": "Requirement or hint class, e.g. DockerRequirement, SoftwareRequirement, ScatterFeatureRequirement."
+        },
+        "docker_pull": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "DockerRequirement.dockerPull when present."
+        },
+        "docker_image_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "DockerRequirement.dockerImageId when present."
+        },
+        "packages": {
+          "type": "array",
+          "description": "SoftwareRequirement packages as name/version/spec strings.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "raw": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Verbatim requirement/hint object for unsupported or target-specific fields."
+        }
+      }
+    },
+    "WorkflowGraph": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "nodes",
+        "edges"
+      ],
+      "properties": {
+        "nodes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GraphNode"
+          }
+        },
+        "edges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GraphEdge"
+          }
+        }
+      }
+    },
+    "GraphNode": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "kind",
+        "label"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "workflow-input",
+            "step",
+            "workflow-output"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "GraphEdge": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "from",
+        "to",
+        "via"
+      ],
+      "properties": {
+        "from": {
+          "type": "string"
+        },
+        "to": {
+          "type": "string"
+        },
+        "via": {
+          "type": "array",
+          "description": "Shape-affecting CWL features on this edge, e.g. scatter, linkMerge, pickValue, valueFrom.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "TestCase": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "job_path",
+        "expected_outputs",
+        "provenance"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "job_path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "expected_outputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ExpectedOutputRef"
+          }
+        },
+        "provenance": {
+          "type": "string"
+        }
+      }
+    },
+    "ExpectedOutputRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "path",
+        "url",
+        "filetype",
+        "checksum",
+        "assertions"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "filetype": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "checksum": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "assertions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Warning": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "message",
+        "path"
+      ],
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/casts/claude/skills/cwl-test-to-galaxy-test-plan/references/schemas/tests-format.schema.json
+++ b/casts/claude/skills/cwl-test-to-galaxy-test-plan/references/schemas/tests-format.schema.json
@@ -1,0 +1,7328 @@
+{
+  "$defs": {
+    "Collection": {
+      "additionalProperties": false,
+      "properties": {
+        "class": {
+          "const": "Collection",
+          "title": "Class",
+          "type": "string"
+        },
+        "collection_type": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Collection Type"
+        },
+        "elements": {
+          "anyOf": [
+            {
+              "items": {
+                "oneOf": [
+                  {
+                    "oneOf": [
+                      {
+                        "$ref": "#/$defs/LocationFile"
+                      },
+                      {
+                        "$ref": "#/$defs/PathFile"
+                      },
+                      {
+                        "$ref": "#/$defs/ContentsFile"
+                      },
+                      {
+                        "$ref": "#/$defs/CompositeDataFile"
+                      }
+                    ]
+                  },
+                  {
+                    "$ref": "#/$defs/Collection"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Elements"
+        },
+        "identifier": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Identifier"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Name"
+        },
+        "rows": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "items": {},
+                "type": "array"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rows"
+        }
+      },
+      "required": [
+        "class"
+      ],
+      "title": "Collection",
+      "type": "object"
+    },
+    "CollectionAttributes": {
+      "additionalProperties": false,
+      "properties": {
+        "collection_type": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Collection Type"
+        }
+      },
+      "title": "CollectionAttributes",
+      "type": "object"
+    },
+    "CompositeDataFile": {
+      "additionalProperties": false,
+      "properties": {
+        "class": {
+          "const": "File",
+          "title": "Class",
+          "type": "string"
+        },
+        "composite_data": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Composite Data",
+          "type": "array"
+        },
+        "contents": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Contents"
+        },
+        "dbkey": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Dbkey"
+        },
+        "decompress": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Decompress"
+        },
+        "deferred": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Deferred"
+        },
+        "filetype": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "File Type"
+        },
+        "hashes": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/HashEntry"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Hashes"
+        },
+        "identifier": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Identifier"
+        },
+        "info": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Info"
+        },
+        "location": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Location"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Name"
+        },
+        "path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Path"
+        },
+        "space_to_tab": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Space To Tab"
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tags"
+        },
+        "to_posix_lines": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "To POSIX Lines"
+        }
+      },
+      "required": [
+        "class",
+        "composite_data"
+      ],
+      "title": "CompositeDataFile",
+      "type": "object"
+    },
+    "ContentsFile": {
+      "additionalProperties": false,
+      "description": "CWL File literal — content inlined as a string.",
+      "properties": {
+        "class": {
+          "const": "File",
+          "title": "Class",
+          "type": "string"
+        },
+        "composite_data": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Composite Data"
+        },
+        "contents": {
+          "title": "Contents",
+          "type": "string"
+        },
+        "dbkey": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Dbkey"
+        },
+        "decompress": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Decompress"
+        },
+        "deferred": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Deferred"
+        },
+        "filetype": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "File Type"
+        },
+        "hashes": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/HashEntry"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Hashes"
+        },
+        "identifier": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Identifier"
+        },
+        "info": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Info"
+        },
+        "location": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Location"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Name"
+        },
+        "path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Path"
+        },
+        "space_to_tab": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Space To Tab"
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tags"
+        },
+        "to_posix_lines": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "To POSIX Lines"
+        }
+      },
+      "required": [
+        "class",
+        "contents"
+      ],
+      "title": "ContentsFile",
+      "type": "object"
+    },
+    "Directory": {
+      "additionalProperties": false,
+      "description": "CWL-style directory input. Supported by stage_inputs for directory-typed\ndatasets (e.g. bwa_mem2_index test fixtures). Rare in workflow tests; IWC\ndoes not use it.",
+      "properties": {
+        "class": {
+          "const": "Directory",
+          "title": "Class",
+          "type": "string"
+        },
+        "filetype": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "File Type"
+        },
+        "location": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Location"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Name"
+        },
+        "path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Path"
+        }
+      },
+      "required": [
+        "class"
+      ],
+      "title": "Directory",
+      "type": "object"
+    },
+    "HashEntry": {
+      "additionalProperties": false,
+      "properties": {
+        "hash_function": {
+          "enum": [
+            "MD5",
+            "SHA-1",
+            "SHA-256",
+            "SHA-512"
+          ],
+          "title": "Hash Function",
+          "type": "string"
+        },
+        "hash_value": {
+          "title": "Hash Value",
+          "type": "string"
+        }
+      },
+      "required": [
+        "hash_function",
+        "hash_value"
+      ],
+      "title": "HashEntry",
+      "type": "object"
+    },
+    "Job": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "oneOf": [
+              {
+                "$ref": "#/$defs/LocationFile"
+              },
+              {
+                "$ref": "#/$defs/PathFile"
+              },
+              {
+                "$ref": "#/$defs/ContentsFile"
+              },
+              {
+                "$ref": "#/$defs/CompositeDataFile"
+              }
+            ]
+          },
+          {
+            "$ref": "#/$defs/Collection"
+          },
+          {
+            "$ref": "#/$defs/Directory"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "integer"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "boolean"
+          },
+          {
+            "items": {
+              "anyOf": [
+                {
+                  "oneOf": [
+                    {
+                      "$ref": "#/$defs/LocationFile"
+                    },
+                    {
+                      "$ref": "#/$defs/PathFile"
+                    },
+                    {
+                      "$ref": "#/$defs/ContentsFile"
+                    },
+                    {
+                      "$ref": "#/$defs/CompositeDataFile"
+                    }
+                  ]
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "title": "Job",
+      "type": "object"
+    },
+    "LocationFile": {
+      "additionalProperties": false,
+      "properties": {
+        "class": {
+          "const": "File",
+          "title": "Class",
+          "type": "string"
+        },
+        "composite_data": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Composite Data"
+        },
+        "contents": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Contents"
+        },
+        "dbkey": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Dbkey"
+        },
+        "decompress": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Decompress"
+        },
+        "deferred": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Deferred"
+        },
+        "filetype": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "File Type"
+        },
+        "hashes": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/HashEntry"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Hashes"
+        },
+        "identifier": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Identifier"
+        },
+        "info": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Info"
+        },
+        "location": {
+          "title": "Location",
+          "type": "string"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Name"
+        },
+        "path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Path"
+        },
+        "space_to_tab": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Space To Tab"
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tags"
+        },
+        "to_posix_lines": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "To POSIX Lines"
+        }
+      },
+      "required": [
+        "class",
+        "location"
+      ],
+      "title": "LocationFile",
+      "type": "object"
+    },
+    "OutputCompareType": {
+      "enum": [
+        "diff",
+        "re_match",
+        "sim_size",
+        "re_match_multiline",
+        "contains",
+        "image_diff"
+      ],
+      "title": "OutputCompareType",
+      "type": "string"
+    },
+    "PathFile": {
+      "additionalProperties": false,
+      "properties": {
+        "class": {
+          "const": "File",
+          "title": "Class",
+          "type": "string"
+        },
+        "composite_data": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Composite Data"
+        },
+        "contents": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Contents"
+        },
+        "dbkey": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Dbkey"
+        },
+        "decompress": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Decompress"
+        },
+        "deferred": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Deferred"
+        },
+        "filetype": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "File Type"
+        },
+        "hashes": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/HashEntry"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Hashes"
+        },
+        "identifier": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Identifier"
+        },
+        "info": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Info"
+        },
+        "location": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Location"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Name"
+        },
+        "path": {
+          "title": "Path",
+          "type": "string"
+        },
+        "space_to_tab": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Space To Tab"
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tags"
+        },
+        "to_posix_lines": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "To POSIX Lines"
+        }
+      },
+      "required": [
+        "class",
+        "path"
+      ],
+      "title": "PathFile",
+      "type": "object"
+    },
+    "TestCollectionCollectionElementAssertions": {
+      "additionalProperties": false,
+      "properties": {
+        "class": {
+          "anyOf": [
+            {
+              "const": "Collection",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "Collection",
+          "title": "Class"
+        },
+        "element_tests": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "else": {
+                  "$ref": "#/$defs/TestCollectionDatasetElementAssertions"
+                },
+                "if": {
+                  "properties": {
+                    "class": {
+                      "const": "Collection"
+                    }
+                  },
+                  "required": [
+                    "class"
+                  ],
+                  "type": "object"
+                },
+                "then": {
+                  "$ref": "#/$defs/TestCollectionCollectionElementAssertions"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Element Tests"
+        },
+        "elements": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "else": {
+                  "$ref": "#/$defs/TestCollectionDatasetElementAssertions"
+                },
+                "if": {
+                  "properties": {
+                    "class": {
+                      "const": "Collection"
+                    }
+                  },
+                  "required": [
+                    "class"
+                  ],
+                  "type": "object"
+                },
+                "then": {
+                  "$ref": "#/$defs/TestCollectionCollectionElementAssertions"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Elements"
+        }
+      },
+      "title": "TestCollectionCollectionElementAssertions",
+      "type": "object"
+    },
+    "TestCollectionDatasetElementAssertions": {
+      "additionalProperties": false,
+      "properties": {
+        "asserts": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "$ref": "#/$defs/assertion_dict"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Assertions about the content of the output.",
+          "title": "Asserts"
+        },
+        "checksum": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The target output's checksum should match the value specified here, in the form `hash_type$hash_value` (e.g. `sha1$8156d7ca0f46ed7abac98f82e36cfaddb2aca041`). Useful for large static files where uploading the whole file is inconvenient.",
+          "title": "Checksum"
+        },
+        "class": {
+          "anyOf": [
+            {
+              "const": "File",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "File",
+          "title": "Class"
+        },
+        "compare": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OutputCompareType"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Comparison mode used when matching the output against the reference file.",
+          "title": "Compare"
+        },
+        "decompress": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "If true, decompress files before comparison. Applies to assertions expressed with `assert_contents` or `compare` set to anything but `sim_size`. Useful for testing compressed outputs that are non-deterministic despite having deterministic decompressed contents. By default, only files compressed with bz2, gzip and zip are automatically decompressed.",
+          "title": "Decompress"
+        },
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "If `compare` is set to `sim_size`, the maximum allowed absolute size difference (in bytes) between the generated data set and the reference file in `test-data/`. Default is 10000 bytes. Can be combined with `delta_frac`.",
+          "title": "Delta"
+        },
+        "delta_frac": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "If `compare` is set to `sim_size`, the maximum allowed relative size difference between the generated data set and the reference file in `test-data/`. 0.1 means the generated file can differ by at most 10%. Default is not to check for relative size difference. Can be combined with `delta`.",
+          "title": "Delta Frac"
+        },
+        "file": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Name of the output file stored in the target `test-data` directory that will be used to compare against the results of executing the tool via the functional test framework.",
+          "title": "File"
+        },
+        "ftype": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "If specified, this value is checked against the corresponding output's data type. If these do not match, the test will fail.",
+          "title": "File Type"
+        },
+        "lines_diff": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Applies when `compare` is set to `diff`, `re_match`, or `contains`. For `diff`, the number of lines of difference to allow (a modified line counts as two: one added, one removed).",
+          "title": "Lines Diff"
+        },
+        "location": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "URL that points to a remote output file that will be downloaded and used for output comparison. Use only when the file cannot be included in the `test-data` folder. May be combined with `file` (downloads when missing on disk) or used alone (filename inferred from the URL). A `checksum` is also used to verify the download when provided.",
+          "title": "Location"
+        },
+        "metadata": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Mapping of metadata keys to expected values for this output.",
+          "title": "Metadata"
+        },
+        "path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Filesystem path to a local output file used for comparison.",
+          "title": "Path"
+        },
+        "sort": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Applies only if `compare` is `diff`, `re_match` or `re_match_multiline`. Sorts the lines of the history data set before comparison; for `diff` and `re_match` the local file is also sorted. Useful for non-deterministic output.",
+          "title": "Sort"
+        }
+      },
+      "title": "TestCollectionDatasetElementAssertions",
+      "type": "object"
+    },
+    "TestCollectionOutputAssertions": {
+      "additionalProperties": false,
+      "properties": {
+        "attributes": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CollectionAttributes"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Attributes"
+        },
+        "class": {
+          "anyOf": [
+            {
+              "const": "Collection",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "Collection",
+          "title": "Class"
+        },
+        "collection_type": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Collection Type"
+        },
+        "element_count": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Element Count"
+        },
+        "element_tests": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "else": {
+                  "$ref": "#/$defs/TestCollectionDatasetElementAssertions"
+                },
+                "if": {
+                  "properties": {
+                    "class": {
+                      "const": "Collection"
+                    }
+                  },
+                  "required": [
+                    "class"
+                  ],
+                  "type": "object"
+                },
+                "then": {
+                  "$ref": "#/$defs/TestCollectionCollectionElementAssertions"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Element Tests"
+        },
+        "elements": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "else": {
+                  "$ref": "#/$defs/TestCollectionDatasetElementAssertions"
+                },
+                "if": {
+                  "properties": {
+                    "class": {
+                      "const": "Collection"
+                    }
+                  },
+                  "required": [
+                    "class"
+                  ],
+                  "type": "object"
+                },
+                "then": {
+                  "$ref": "#/$defs/TestCollectionCollectionElementAssertions"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Elements"
+        }
+      },
+      "title": "TestCollectionOutputAssertions",
+      "type": "object"
+    },
+    "TestDataOutputAssertions": {
+      "additionalProperties": false,
+      "properties": {
+        "asserts": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "$ref": "#/$defs/assertion_dict"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Assertions about the content of the output.",
+          "title": "Asserts"
+        },
+        "checksum": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The target output's checksum should match the value specified here, in the form `hash_type$hash_value` (e.g. `sha1$8156d7ca0f46ed7abac98f82e36cfaddb2aca041`). Useful for large static files where uploading the whole file is inconvenient.",
+          "title": "Checksum"
+        },
+        "class": {
+          "anyOf": [
+            {
+              "const": "File",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "File",
+          "title": "Class"
+        },
+        "compare": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OutputCompareType"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Comparison mode used when matching the output against the reference file.",
+          "title": "Compare"
+        },
+        "decompress": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "If true, decompress files before comparison. Applies to assertions expressed with `assert_contents` or `compare` set to anything but `sim_size`. Useful for testing compressed outputs that are non-deterministic despite having deterministic decompressed contents. By default, only files compressed with bz2, gzip and zip are automatically decompressed.",
+          "title": "Decompress"
+        },
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "If `compare` is set to `sim_size`, the maximum allowed absolute size difference (in bytes) between the generated data set and the reference file in `test-data/`. Default is 10000 bytes. Can be combined with `delta_frac`.",
+          "title": "Delta"
+        },
+        "delta_frac": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "If `compare` is set to `sim_size`, the maximum allowed relative size difference between the generated data set and the reference file in `test-data/`. 0.1 means the generated file can differ by at most 10%. Default is not to check for relative size difference. Can be combined with `delta`.",
+          "title": "Delta Frac"
+        },
+        "file": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Name of the output file stored in the target `test-data` directory that will be used to compare against the results of executing the tool via the functional test framework.",
+          "title": "File"
+        },
+        "ftype": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "If specified, this value is checked against the corresponding output's data type. If these do not match, the test will fail.",
+          "title": "File Type"
+        },
+        "lines_diff": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Applies when `compare` is set to `diff`, `re_match`, or `contains`. For `diff`, the number of lines of difference to allow (a modified line counts as two: one added, one removed).",
+          "title": "Lines Diff"
+        },
+        "location": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "URL that points to a remote output file that will be downloaded and used for output comparison. Use only when the file cannot be included in the `test-data` folder. May be combined with `file` (downloads when missing on disk) or used alone (filename inferred from the URL). A `checksum` is also used to verify the download when provided.",
+          "title": "Location"
+        },
+        "metadata": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Mapping of metadata keys to expected values for this output.",
+          "title": "Metadata"
+        },
+        "path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Filesystem path to a local output file used for comparison.",
+          "title": "Path"
+        },
+        "sort": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Applies only if `compare` is `diff`, `re_match` or `re_match_multiline`. Sorts the lines of the history data set before comparison; for `diff` and `re_match` the local file is also sorted. Useful for non-deterministic output.",
+          "title": "Sort"
+        }
+      },
+      "title": "TestDataOutputAssertions",
+      "type": "object"
+    },
+    "TestJob": {
+      "additionalProperties": false,
+      "properties": {
+        "doc": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Describes the purpose of the test.",
+          "title": "Doc"
+        },
+        "expect_failure": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": false,
+          "description": "If true, the workflow is expected to produce an error.",
+          "title": "Expect Failure"
+        },
+        "job": {
+          "$ref": "#/$defs/Job",
+          "description": "Defines the job to execute. Can be a path to a file or an inline dictionary describing the job inputs."
+        },
+        "outputs": {
+          "additionalProperties": {
+            "else": {
+              "else": {
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "if": {
+                "type": "object"
+              },
+              "then": {
+                "$ref": "#/$defs/TestDataOutputAssertions"
+              }
+            },
+            "if": {
+              "properties": {
+                "class": {
+                  "const": "Collection"
+                }
+              },
+              "required": [
+                "class"
+              ],
+              "type": "object"
+            },
+            "then": {
+              "$ref": "#/$defs/TestCollectionOutputAssertions"
+            }
+          },
+          "description": "Defines assertions about outputs (datasets, collections or parameters). Each key corresponds to a labeled output; values are dictionaries describing the expected output.",
+          "title": "Outputs",
+          "type": "object"
+        }
+      },
+      "required": [
+        "job",
+        "outputs"
+      ],
+      "title": "TestJob",
+      "type": "object"
+    },
+    "assertion_dict": {
+      "additionalProperties": false,
+      "properties": {
+        "attribute_is": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_attribute_is_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Attribute Is"
+        },
+        "attribute_matches": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_attribute_matches_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Attribute Matches"
+        },
+        "element_text": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_element_text_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Element Text"
+        },
+        "element_text_is": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_element_text_is_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Element Text Is"
+        },
+        "element_text_matches": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_element_text_matches_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Element Text Matches"
+        },
+        "has_archive_member": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_archive_member_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Archive Member"
+        },
+        "has_element_with_path": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_element_with_path_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Element With Path"
+        },
+        "has_h5_attribute": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_h5_attribute_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has H5 Attribute"
+        },
+        "has_h5_keys": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_h5_keys_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has H5 Keys"
+        },
+        "has_image_center_of_mass": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_image_center_of_mass_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Image Center Of Mass"
+        },
+        "has_image_channels": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_image_channels_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Image Channels"
+        },
+        "has_image_depth": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_image_depth_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Image Depth"
+        },
+        "has_image_frames": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_image_frames_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Image Frames"
+        },
+        "has_image_height": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_image_height_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Image Height"
+        },
+        "has_image_mean_intensity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_image_mean_intensity_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Image Mean Intensity"
+        },
+        "has_image_mean_object_size": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_image_mean_object_size_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Image Mean Object Size"
+        },
+        "has_image_n_labels": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_image_n_labels_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Image N Labels"
+        },
+        "has_image_width": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_image_width_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Image Width"
+        },
+        "has_json_property_with_text": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_json_property_with_text_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Json Property With Text"
+        },
+        "has_json_property_with_value": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_json_property_with_value_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Json Property With Value"
+        },
+        "has_line": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_line_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Line"
+        },
+        "has_line_matching": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_line_matching_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Line Matching"
+        },
+        "has_n_columns": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_n_columns_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has N Columns"
+        },
+        "has_n_elements_with_path": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_n_elements_with_path_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has N Elements With Path"
+        },
+        "has_n_lines": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_n_lines_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has N Lines"
+        },
+        "has_size": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_size_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Size"
+        },
+        "has_text": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_text_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Text"
+        },
+        "has_text_matching": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_has_text_matching_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Has Text Matching"
+        },
+        "is_valid_xml": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_is_valid_xml_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Is Valid Xml"
+        },
+        "not_has_text": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_not_has_text_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Not Has Text"
+        },
+        "xml_element": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/base_xml_element_model"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assert Xml Element"
+        }
+      },
+      "title": "assertion_dict",
+      "type": "object"
+    },
+    "assertion_list": {
+      "items": {
+        "anyOf": [
+          {
+            "discriminator": {
+              "mapping": {
+                "attribute_is": "#/$defs/attribute_is_model",
+                "attribute_matches": "#/$defs/attribute_matches_model",
+                "element_text": "#/$defs/element_text_model",
+                "element_text_is": "#/$defs/element_text_is_model",
+                "element_text_matches": "#/$defs/element_text_matches_model",
+                "has_archive_member": "#/$defs/has_archive_member_model",
+                "has_element_with_path": "#/$defs/has_element_with_path_model",
+                "has_h5_attribute": "#/$defs/has_h5_attribute_model",
+                "has_h5_keys": "#/$defs/has_h5_keys_model",
+                "has_image_center_of_mass": "#/$defs/has_image_center_of_mass_model",
+                "has_image_channels": "#/$defs/has_image_channels_model",
+                "has_image_depth": "#/$defs/has_image_depth_model",
+                "has_image_frames": "#/$defs/has_image_frames_model",
+                "has_image_height": "#/$defs/has_image_height_model",
+                "has_image_mean_intensity": "#/$defs/has_image_mean_intensity_model",
+                "has_image_mean_object_size": "#/$defs/has_image_mean_object_size_model",
+                "has_image_n_labels": "#/$defs/has_image_n_labels_model",
+                "has_image_width": "#/$defs/has_image_width_model",
+                "has_json_property_with_text": "#/$defs/has_json_property_with_text_model",
+                "has_json_property_with_value": "#/$defs/has_json_property_with_value_model",
+                "has_line": "#/$defs/has_line_model",
+                "has_line_matching": "#/$defs/has_line_matching_model",
+                "has_n_columns": "#/$defs/has_n_columns_model",
+                "has_n_elements_with_path": "#/$defs/has_n_elements_with_path_model",
+                "has_n_lines": "#/$defs/has_n_lines_model",
+                "has_size": "#/$defs/has_size_model",
+                "has_text": "#/$defs/has_text_model",
+                "has_text_matching": "#/$defs/has_text_matching_model",
+                "is_valid_xml": "#/$defs/is_valid_xml_model",
+                "not_has_text": "#/$defs/not_has_text_model",
+                "xml_element": "#/$defs/xml_element_model"
+              },
+              "propertyName": "that"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/has_line_model"
+              },
+              {
+                "$ref": "#/$defs/has_line_matching_model"
+              },
+              {
+                "$ref": "#/$defs/has_n_lines_model"
+              },
+              {
+                "$ref": "#/$defs/has_text_model"
+              },
+              {
+                "$ref": "#/$defs/has_text_matching_model"
+              },
+              {
+                "$ref": "#/$defs/not_has_text_model"
+              },
+              {
+                "$ref": "#/$defs/has_n_columns_model"
+              },
+              {
+                "$ref": "#/$defs/attribute_is_model"
+              },
+              {
+                "$ref": "#/$defs/attribute_matches_model"
+              },
+              {
+                "$ref": "#/$defs/element_text_model"
+              },
+              {
+                "$ref": "#/$defs/element_text_is_model"
+              },
+              {
+                "$ref": "#/$defs/element_text_matches_model"
+              },
+              {
+                "$ref": "#/$defs/has_element_with_path_model"
+              },
+              {
+                "$ref": "#/$defs/has_n_elements_with_path_model"
+              },
+              {
+                "$ref": "#/$defs/is_valid_xml_model"
+              },
+              {
+                "$ref": "#/$defs/xml_element_model"
+              },
+              {
+                "$ref": "#/$defs/has_json_property_with_text_model"
+              },
+              {
+                "$ref": "#/$defs/has_json_property_with_value_model"
+              },
+              {
+                "$ref": "#/$defs/has_h5_attribute_model"
+              },
+              {
+                "$ref": "#/$defs/has_h5_keys_model"
+              },
+              {
+                "$ref": "#/$defs/has_archive_member_model"
+              },
+              {
+                "$ref": "#/$defs/has_size_model"
+              },
+              {
+                "$ref": "#/$defs/has_image_center_of_mass_model"
+              },
+              {
+                "$ref": "#/$defs/has_image_channels_model"
+              },
+              {
+                "$ref": "#/$defs/has_image_depth_model"
+              },
+              {
+                "$ref": "#/$defs/has_image_frames_model"
+              },
+              {
+                "$ref": "#/$defs/has_image_height_model"
+              },
+              {
+                "$ref": "#/$defs/has_image_mean_intensity_model"
+              },
+              {
+                "$ref": "#/$defs/has_image_mean_object_size_model"
+              },
+              {
+                "$ref": "#/$defs/has_image_n_labels_model"
+              },
+              {
+                "$ref": "#/$defs/has_image_width_model"
+              }
+            ]
+          },
+          {
+            "$ref": "#/$defs/has_line_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_line_matching_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_n_lines_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_text_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_text_matching_model_nested"
+          },
+          {
+            "$ref": "#/$defs/not_has_text_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_n_columns_model_nested"
+          },
+          {
+            "$ref": "#/$defs/attribute_is_model_nested"
+          },
+          {
+            "$ref": "#/$defs/attribute_matches_model_nested"
+          },
+          {
+            "$ref": "#/$defs/element_text_model_nested"
+          },
+          {
+            "$ref": "#/$defs/element_text_is_model_nested"
+          },
+          {
+            "$ref": "#/$defs/element_text_matches_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_element_with_path_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_n_elements_with_path_model_nested"
+          },
+          {
+            "$ref": "#/$defs/is_valid_xml_model_nested"
+          },
+          {
+            "$ref": "#/$defs/xml_element_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_json_property_with_text_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_json_property_with_value_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_h5_attribute_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_h5_keys_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_archive_member_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_size_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_image_center_of_mass_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_image_channels_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_image_depth_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_image_frames_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_image_height_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_image_mean_intensity_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_image_mean_object_size_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_image_n_labels_model_nested"
+          },
+          {
+            "$ref": "#/$defs/has_image_width_model_nested"
+          }
+        ]
+      },
+      "title": "assertion_list",
+      "type": "array"
+    },
+    "attribute_is_model": {
+      "additionalProperties": false,
+      "description": "Asserts the XML ``attribute`` for the element (or tag) with the specified\nXPath-like ``path`` is the specified ``text``.\n\nFor example:\n\n```xml\n<attribute_is path=\"outerElement/innerElement1\" attribute=\"foo\" text=\"bar\" />\n```\n\nThe assertion implicitly also asserts that an element matching ``path`` exists.\nWith ``negate`` the result of the assertion (on the equality) can be inverted (the\nimplicit assertion on the existence of the path is not affected).",
+      "properties": {
+        "attribute": {
+          "description": "The XML attribute name to test against from the target XML element.",
+          "title": "Attribute",
+          "type": "string"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        },
+        "text": {
+          "description": "The expected attribute value to test against on the target XML element",
+          "title": "Text",
+          "type": "string"
+        },
+        "that": {
+          "const": "attribute_is",
+          "default": "attribute_is",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "attribute",
+        "text"
+      ],
+      "title": "Assert Attribute Is",
+      "type": "object"
+    },
+    "attribute_is_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "attribute_is": {
+          "$ref": "#/$defs/base_attribute_is_model",
+          "title": "Assert Attribute Is"
+        }
+      },
+      "required": [
+        "attribute_is"
+      ],
+      "title": "Assert Attribute Is (Nested)",
+      "type": "object"
+    },
+    "attribute_matches_model": {
+      "additionalProperties": false,
+      "description": "Asserts the XML ``attribute`` for the element (or tag) with the specified\nXPath-like ``path`` matches the regular expression specified by ``expression``.\n\nFor example:\n\n```xml\n<attribute_matches path=\"outerElement/innerElement2\" attribute=\"foo2\" expression=\"bar\\d+\" />\n```\n\nThe assertion implicitly also asserts that an element matching ``path`` exists.\nWith ``negate`` the result of the assertion (on the matching) can be inverted (the\nimplicit assertion on the existence of the path is not affected).",
+      "properties": {
+        "attribute": {
+          "description": "The XML attribute name to test against from the target XML element.",
+          "title": "Attribute",
+          "type": "string"
+        },
+        "expression": {
+          "description": "The regular expressions to apply against the named attribute on the target XML element.",
+          "title": "Expression",
+          "type": "string"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        },
+        "that": {
+          "const": "attribute_matches",
+          "default": "attribute_matches",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "attribute",
+        "expression"
+      ],
+      "title": "Assert Attribute Matches",
+      "type": "object"
+    },
+    "attribute_matches_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "attribute_matches": {
+          "$ref": "#/$defs/base_attribute_matches_model",
+          "title": "Assert Attribute Matches"
+        }
+      },
+      "required": [
+        "attribute_matches"
+      ],
+      "title": "Assert Attribute Matches (Nested)",
+      "type": "object"
+    },
+    "base_attribute_is_model": {
+      "additionalProperties": false,
+      "description": "base model for attribute_is describing attributes.",
+      "properties": {
+        "attribute": {
+          "description": "The XML attribute name to test against from the target XML element.",
+          "title": "Attribute",
+          "type": "string"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        },
+        "text": {
+          "description": "The expected attribute value to test against on the target XML element",
+          "title": "Text",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "attribute",
+        "text"
+      ],
+      "title": "base_attribute_is_model",
+      "type": "object"
+    },
+    "base_attribute_matches_model": {
+      "additionalProperties": false,
+      "description": "base model for attribute_matches describing attributes.",
+      "properties": {
+        "attribute": {
+          "description": "The XML attribute name to test against from the target XML element.",
+          "title": "Attribute",
+          "type": "string"
+        },
+        "expression": {
+          "description": "The regular expressions to apply against the named attribute on the target XML element.",
+          "title": "Expression",
+          "type": "string"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "attribute",
+        "expression"
+      ],
+      "title": "base_attribute_matches_model",
+      "type": "object"
+    },
+    "base_element_text_is_model": {
+      "additionalProperties": false,
+      "description": "base model for element_text_is describing attributes.",
+      "properties": {
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        },
+        "text": {
+          "description": "The expected element text (body of the XML tag) to test against on the target XML element",
+          "title": "Text",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "text"
+      ],
+      "title": "base_element_text_is_model",
+      "type": "object"
+    },
+    "base_element_text_matches_model": {
+      "additionalProperties": false,
+      "description": "base model for element_text_matches describing attributes.",
+      "properties": {
+        "expression": {
+          "description": "The regular expressions to apply against the target element.",
+          "title": "Expression",
+          "type": "string"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "expression"
+      ],
+      "title": "base_element_text_matches_model",
+      "type": "object"
+    },
+    "base_element_text_model": {
+      "additionalProperties": false,
+      "description": "base model for element_text describing attributes.",
+      "properties": {
+        "asserts": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Asserts"
+        },
+        "children": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Children"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "base_element_text_model",
+      "type": "object"
+    },
+    "base_has_archive_member_model": {
+      "additionalProperties": false,
+      "description": "base model for has_archive_member describing attributes.",
+      "properties": {
+        "all": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "Check the sub-assertions for all paths matching the path. Default: false, i.e. only the first",
+          "title": "All"
+        },
+        "asserts": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Asserts"
+        },
+        "children": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Children"
+        },
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The regular expression specifying the archive member.",
+          "title": "Path",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "base_has_archive_member_model",
+      "type": "object"
+    },
+    "base_has_element_with_path_model": {
+      "additionalProperties": false,
+      "description": "base model for has_element_with_path describing attributes.",
+      "properties": {
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "base_has_element_with_path_model",
+      "type": "object"
+    },
+    "base_has_h5_attribute_model": {
+      "additionalProperties": false,
+      "description": "base model for has_h5_attribute describing attributes.",
+      "properties": {
+        "key": {
+          "description": "HDF5 attribute to check value of.",
+          "title": "Key",
+          "type": "string"
+        },
+        "value": {
+          "description": "Expected value of HDF5 attribute to check.",
+          "title": "Value",
+          "type": "string"
+        }
+      },
+      "required": [
+        "key",
+        "value"
+      ],
+      "title": "base_has_h5_attribute_model",
+      "type": "object"
+    },
+    "base_has_h5_keys_model": {
+      "additionalProperties": false,
+      "description": "base model for has_h5_keys describing attributes.",
+      "properties": {
+        "keys": {
+          "description": "HDF5 attributes to check value of as a comma-separated string.",
+          "title": "Keys",
+          "type": "string"
+        }
+      },
+      "required": [
+        "keys"
+      ],
+      "title": "base_has_h5_keys_model",
+      "type": "object"
+    },
+    "base_has_image_center_of_mass_model": {
+      "additionalProperties": false,
+      "description": "base model for has_image_center_of_mass describing attributes.",
+      "properties": {
+        "center_of_mass": {
+          "description": "The required center of mass of the image intensities (horizontal and vertical coordinate, separated by a comma).",
+          "title": "Center Of Mass",
+          "type": "string"
+        },
+        "channel": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific channel of the image (where ``0`` corresponds to the first image channel).",
+          "title": "Channel"
+        },
+        "eps": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.01,
+          "description": "The maximum allowed Euclidean distance to the required center of mass (defaults to ``0.01``).",
+          "title": "Eps"
+        },
+        "frame": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific frame of the image sequence (where ``0`` corresponds to the first image frame).",
+          "title": "Frame"
+        },
+        "slice": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific slice of the image (where ``0`` corresponds to the first image slice).",
+          "title": "Slice"
+        }
+      },
+      "required": [
+        "center_of_mass"
+      ],
+      "title": "base_has_image_center_of_mass_model",
+      "type": "object"
+    },
+    "base_has_image_channels_model": {
+      "additionalProperties": false,
+      "description": "base model for has_image_channels describing attributes.",
+      "properties": {
+        "channels": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected number of channels of the image.",
+          "title": "Channels"
+        },
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the number of channels (default is 0). The observed number of channels has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed number of channels.",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed number of channels.",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        }
+      },
+      "title": "base_has_image_channels_model",
+      "type": "object"
+    },
+    "base_has_image_depth_model": {
+      "additionalProperties": false,
+      "description": "base model for has_image_depth describing attributes.",
+      "properties": {
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the image depth (number of slices, default is 0). The observed depth has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "depth": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected depth of the image (number of slices).",
+          "title": "Depth"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed depth of the image (number of slices).",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed depth of the image (number of slices).",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        }
+      },
+      "title": "base_has_image_depth_model",
+      "type": "object"
+    },
+    "base_has_image_frames_model": {
+      "additionalProperties": false,
+      "description": "base model for has_image_frames describing attributes.",
+      "properties": {
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the number of frames in the image sequence (number of time steps, default is 0). The observed number of frames has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "frames": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected number of frames in the image sequence (number of time steps).",
+          "title": "Frames"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed number of frames in the image sequence (number of time steps).",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed number of frames in the image sequence (number of time steps).",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        }
+      },
+      "title": "base_has_image_frames_model",
+      "type": "object"
+    },
+    "base_has_image_height_model": {
+      "additionalProperties": false,
+      "description": "base model for has_image_height describing attributes.",
+      "properties": {
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the image height (in pixels, default is 0). The observed height has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "height": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected height of the image (in pixels).",
+          "title": "Height"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed height of the image (in pixels).",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed height of the image (in pixels).",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        }
+      },
+      "title": "base_has_image_height_model",
+      "type": "object"
+    },
+    "base_has_image_mean_intensity_model": {
+      "additionalProperties": false,
+      "description": "base model for has_image_mean_intensity describing attributes.",
+      "properties": {
+        "channel": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific channel of the image (where ``0`` corresponds to the first image channel).",
+          "title": "Channel"
+        },
+        "eps": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.01,
+          "description": "The absolute tolerance to be used for ``value`` (defaults to ``0.01``). The observed mean value of the image intensities has to be in the range ``value +- eps``.",
+          "title": "Eps"
+        },
+        "frame": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific frame of the image sequence (where ``0`` corresponds to the first image frame).",
+          "title": "Frame"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "An upper bound of the required mean value of the image intensities.",
+          "title": "Max"
+        },
+        "mean_intensity": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The required mean value of the image intensities.",
+          "title": "Mean Intensity"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A lower bound of the required mean value of the image intensities.",
+          "title": "Min"
+        },
+        "slice": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific slice of the image (where ``0`` corresponds to the first image slice).",
+          "title": "Slice"
+        }
+      },
+      "title": "base_has_image_mean_intensity_model",
+      "type": "object"
+    },
+    "base_has_image_mean_object_size_model": {
+      "additionalProperties": false,
+      "description": "base model for has_image_mean_object_size describing attributes.",
+      "properties": {
+        "channel": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific channel of the image (where ``0`` corresponds to the first image channel).",
+          "title": "Channel"
+        },
+        "eps": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.01,
+          "description": "The absolute tolerance to be used for ``value`` (defaults to ``0.01``). The observed mean size of the uniquely labeled objects has to be in the range ``value +- eps``.",
+          "title": "Eps"
+        },
+        "exclude_labels": {
+          "anyOf": [
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "List of labels to be excluded from consideration, separated by a comma. The primary usage of this attribute is to exclude the background of a label image. Cannot be used in combination with ``labels``.",
+          "title": "Exclude Labels"
+        },
+        "frame": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific frame of the image sequence (where ``0`` corresponds to the first image frame).",
+          "title": "Frame"
+        },
+        "labels": {
+          "anyOf": [
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "List of labels, separated by a comma. Labels *not* on this list will be excluded from consideration. Cannot be used in combination with ``exclude_labels``.",
+          "title": "Labels"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "An upper bound of the required mean size of the uniquely labeled objects.",
+          "title": "Max"
+        },
+        "mean_object_size": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The required mean size of the uniquely labeled objects.",
+          "title": "Mean Object Size"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A lower bound of the required mean size of the uniquely labeled objects.",
+          "title": "Min"
+        },
+        "slice": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific slice of the image (where ``0`` corresponds to the first image slice).",
+          "title": "Slice"
+        }
+      },
+      "title": "base_has_image_mean_object_size_model",
+      "type": "object"
+    },
+    "base_has_image_n_labels_model": {
+      "additionalProperties": false,
+      "description": "base model for has_image_n_labels describing attributes.",
+      "properties": {
+        "channel": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific channel of the image (where ``0`` corresponds to the first image channel).",
+          "title": "Channel"
+        },
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the number of labels (default is 0). The observed number of labels has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "exclude_labels": {
+          "anyOf": [
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "List of labels to be excluded from consideration, separated by a comma. The primary usage of this attribute is to exclude the background of a label image. Cannot be used in combination with ``labels``.",
+          "title": "Exclude Labels"
+        },
+        "frame": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific frame of the image sequence (where ``0`` corresponds to the first image frame).",
+          "title": "Frame"
+        },
+        "labels": {
+          "anyOf": [
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "List of labels, separated by a comma. Labels *not* on this list will be excluded from consideration. Cannot be used in combination with ``exclude_labels``.",
+          "title": "Labels"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed number of labels.",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed number of labels.",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected number of labels.",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "slice": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific slice of the image (where ``0`` corresponds to the first image slice).",
+          "title": "Slice"
+        }
+      },
+      "title": "base_has_image_n_labels_model",
+      "type": "object"
+    },
+    "base_has_image_width_model": {
+      "additionalProperties": false,
+      "description": "base model for has_image_width describing attributes.",
+      "properties": {
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the image width (in pixels, default is 0). The observed width has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed width of the image (in pixels).",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed width of the image (in pixels).",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "width": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected width of the image (in pixels).",
+          "title": "Width"
+        }
+      },
+      "title": "base_has_image_width_model",
+      "type": "object"
+    },
+    "base_has_json_property_with_text_model": {
+      "additionalProperties": false,
+      "description": "base model for has_json_property_with_text describing attributes.",
+      "properties": {
+        "property": {
+          "description": "The property name to search the JSON document for.",
+          "title": "Property",
+          "type": "string"
+        },
+        "text": {
+          "description": "The expected text value of the target JSON attribute.",
+          "title": "Text",
+          "type": "string"
+        }
+      },
+      "required": [
+        "property",
+        "text"
+      ],
+      "title": "base_has_json_property_with_text_model",
+      "type": "object"
+    },
+    "base_has_json_property_with_value_model": {
+      "additionalProperties": false,
+      "description": "base model for has_json_property_with_value describing attributes.",
+      "properties": {
+        "property": {
+          "description": "The property name to search the JSON document for.",
+          "title": "Property",
+          "type": "string"
+        },
+        "value": {
+          "description": "The expected JSON value of the target JSON attribute (as a JSON encoded string).",
+          "title": "Value",
+          "type": "string"
+        }
+      },
+      "required": [
+        "property",
+        "value"
+      ],
+      "title": "base_has_json_property_with_value_model",
+      "type": "object"
+    },
+    "base_has_line_matching_model": {
+      "additionalProperties": false,
+      "description": "base model for has_line_matching describing attributes.",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "expression": {
+          "description": "The regular expressions to attempt match in the output.",
+          "title": "Expression",
+          "type": "string"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        }
+      },
+      "required": [
+        "expression"
+      ],
+      "title": "base_has_line_matching_model",
+      "type": "object"
+    },
+    "base_has_line_model": {
+      "additionalProperties": false,
+      "description": "base model for has_line describing attributes.",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "line": {
+          "description": "The full line of text to search for in the output.",
+          "title": "Line",
+          "type": "string"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        }
+      },
+      "required": [
+        "line"
+      ],
+      "title": "base_has_line_model",
+      "type": "object"
+    },
+    "base_has_n_columns_model": {
+      "additionalProperties": false,
+      "description": "base model for has_n_columns describing attributes.",
+      "properties": {
+        "comment": {
+          "default": "",
+          "description": "Comment character(s) used to skip comment lines (which should not be used for counting columns)",
+          "title": "Comment",
+          "type": "string"
+        },
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "sep": {
+          "default": "\t",
+          "description": "Separator defining columns, default: tab",
+          "title": "Sep",
+          "type": "string"
+        }
+      },
+      "title": "base_has_n_columns_model",
+      "type": "object"
+    },
+    "base_has_n_elements_with_path_model": {
+      "additionalProperties": false,
+      "description": "base model for has_n_elements_with_path describing attributes.",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "base_has_n_elements_with_path_model",
+      "type": "object"
+    },
+    "base_has_n_lines_model": {
+      "additionalProperties": false,
+      "description": "base model for has_n_lines describing attributes.",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        }
+      },
+      "title": "base_has_n_lines_model",
+      "type": "object"
+    },
+    "base_has_size_model": {
+      "additionalProperties": false,
+      "description": "base model for has_size describing attributes.",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "size": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired size of the output (in bytes), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Size"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Deprecated alias for `size`",
+          "title": "Value"
+        }
+      },
+      "title": "base_has_size_model",
+      "type": "object"
+    },
+    "base_has_text_matching_model": {
+      "additionalProperties": false,
+      "description": "base model for has_text_matching describing attributes.",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "expression": {
+          "description": "The regular expressions to attempt match in the output.",
+          "title": "Expression",
+          "type": "string"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        }
+      },
+      "required": [
+        "expression"
+      ],
+      "title": "base_has_text_matching_model",
+      "type": "object"
+    },
+    "base_has_text_model": {
+      "additionalProperties": false,
+      "description": "base model for has_text describing attributes.",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "text": {
+          "description": "The text to search for in the output.",
+          "title": "Text",
+          "type": "string"
+        }
+      },
+      "required": [
+        "text"
+      ],
+      "title": "base_has_text_model",
+      "type": "object"
+    },
+    "base_is_valid_xml_model": {
+      "additionalProperties": false,
+      "description": "base model for is_valid_xml describing attributes.",
+      "properties": {},
+      "title": "base_is_valid_xml_model",
+      "type": "object"
+    },
+    "base_not_has_text_model": {
+      "additionalProperties": false,
+      "description": "base model for not_has_text describing attributes.",
+      "properties": {
+        "text": {
+          "description": "The text to search for in the output.",
+          "title": "Text",
+          "type": "string"
+        }
+      },
+      "required": [
+        "text"
+      ],
+      "title": "base_not_has_text_model",
+      "type": "object"
+    },
+    "base_xml_element_model": {
+      "additionalProperties": false,
+      "description": "base model for xml_element describing attributes.",
+      "properties": {
+        "all": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "Check the sub-assertions for all paths matching the path. Default: false, i.e. only the first ",
+          "title": "All"
+        },
+        "asserts": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Asserts"
+        },
+        "attribute": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The XML attribute name to test against from the target XML element.",
+          "title": "Attribute"
+        },
+        "children": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Children"
+        },
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "base_xml_element_model",
+      "type": "object"
+    },
+    "element_text_is_model": {
+      "additionalProperties": false,
+      "description": "Asserts the text of the XML element with the specified XPath-like ``path`` is\nthe specified ``text``.\n\nFor example:\n\n```xml\n<element_text_is path=\"BlastOutput_program\" text=\"blastp\" />\n```\n\nThe assertion implicitly also asserts that an element matching ``path`` exists.\nWith ``negate`` the result of the assertion (on the equality) can be inverted (the\nimplicit assertion on the existence of the path is not affected).",
+      "properties": {
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        },
+        "text": {
+          "description": "The expected element text (body of the XML tag) to test against on the target XML element",
+          "title": "Text",
+          "type": "string"
+        },
+        "that": {
+          "const": "element_text_is",
+          "default": "element_text_is",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "text"
+      ],
+      "title": "Assert Element Text Is",
+      "type": "object"
+    },
+    "element_text_is_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "element_text_is": {
+          "$ref": "#/$defs/base_element_text_is_model",
+          "title": "Assert Element Text Is"
+        }
+      },
+      "required": [
+        "element_text_is"
+      ],
+      "title": "Assert Element Text Is (Nested)",
+      "type": "object"
+    },
+    "element_text_matches_model": {
+      "additionalProperties": false,
+      "description": "Asserts the text of the XML element with the specified XPath-like ``path``\nmatches the regular expression defined by ``expression``.\n\nFor example:\n\n```xml\n<element_text_matches path=\"BlastOutput_version\" expression=\"BLASTP\\s+2\\.2.*\"/>\n```\n\nThe assertion implicitly also asserts that an element matching ``path`` exists.\nWith ``negate`` the result of the assertion (on the matching) can be inverted (the\nimplicit assertion on the existence of the path is not affected).",
+      "properties": {
+        "expression": {
+          "description": "The regular expressions to apply against the target element.",
+          "title": "Expression",
+          "type": "string"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        },
+        "that": {
+          "const": "element_text_matches",
+          "default": "element_text_matches",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "expression"
+      ],
+      "title": "Assert Element Text Matches",
+      "type": "object"
+    },
+    "element_text_matches_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "element_text_matches": {
+          "$ref": "#/$defs/base_element_text_matches_model",
+          "title": "Assert Element Text Matches"
+        }
+      },
+      "required": [
+        "element_text_matches"
+      ],
+      "title": "Assert Element Text Matches (Nested)",
+      "type": "object"
+    },
+    "element_text_model": {
+      "additionalProperties": false,
+      "description": "This tag allows the developer to recurisively specify additional assertions as\nchild elements about just the text contained in the element specified by the\nXPath-like ``path``, e.g.\n\n```xml\n<element_text path=\"BlastOutput_iterations/Iteration/Iteration_hits/Hit/Hit_def\">\n  <not_has_text text=\"EDK72998.1\" />\n</element_text>\n```\n\nThe assertion implicitly also asserts that an element matching ``path`` exists.\nWith ``negate`` the result of the implicit assertions can be inverted.\nThe sub-assertions, which have their own ``negate`` attribute, are not affected\nby ``negate``.",
+      "properties": {
+        "asserts": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Asserts"
+        },
+        "children": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Children"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        },
+        "that": {
+          "const": "element_text",
+          "default": "element_text",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "Assert Element Text",
+      "type": "object"
+    },
+    "element_text_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "element_text": {
+          "$ref": "#/$defs/base_element_text_model",
+          "title": "Assert Element Text"
+        }
+      },
+      "required": [
+        "element_text"
+      ],
+      "title": "Assert Element Text (Nested)",
+      "type": "object"
+    },
+    "has_archive_member_model": {
+      "additionalProperties": false,
+      "description": "This tag allows to check if ``path`` is contained in a compressed file.\n\nThe path is a regular expression that is matched against the full paths of the objects in\nthe compressed file (remember that \"matching\" means it is checked if a prefix of\nthe full path of an archive member is described by the regular expression).\nValid archive formats include ``.zip``, ``.tar``, and ``.tar.gz``. Note that\ndepending on the archive creation method:\n\n- full paths of the members may be prefixed with ``./``\n- directories may be treated as empty files\n\n```xml\n<has_archive_member path=\"./path/to/my-file.txt\"/>\n```\n\nWith ``n`` and ``delta`` (or ``min`` and ``max``) assertions on the number of\narchive members matching ``path`` can be expressed. The following could be used,\ne.g., to assert an archive containing n&plusmn;1 elements out of which at least\n4 need to have a ``txt`` extension.\n\n```xml\n<has_archive_member path=\".*\" n=\"10\" delta=\"1\"/>\n<has_archive_member path=\".*\\.txt\" min=\"4\"/>\n```\n\nIn addition the tag can contain additional assertions as child elements about\nthe first member in the archive matching the regular expression ``path``. For\ninstance\n\n```xml\n<has_archive_member path=\".*/my-file.txt\">\n  <not_has_text text=\"EDK72998.1\"/>\n</has_archive_member>\n```\n\nIf the ``all`` attribute is set to ``true`` then all archive members are subject\nto the assertions. Note that, archive members matching the ``path`` are sorted\nalphabetically.\n\nThe ``negate`` attribute of the ``has_archive_member`` assertion only affects\nthe asserts on the presence and number of matching archive members, but not any\nsub-assertions (which can offer the ``negate`` attribute on their own).  The\ncheck if the file is an archive at all, which is also done by the function, is\nnot affected.",
+      "properties": {
+        "all": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "Check the sub-assertions for all paths matching the path. Default: false, i.e. only the first",
+          "title": "All"
+        },
+        "asserts": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Asserts"
+        },
+        "children": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Children"
+        },
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The regular expression specifying the archive member.",
+          "title": "Path",
+          "type": "string"
+        },
+        "that": {
+          "const": "has_archive_member",
+          "default": "has_archive_member",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "Assert Has Archive Member",
+      "type": "object"
+    },
+    "has_archive_member_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_archive_member": {
+          "$ref": "#/$defs/base_has_archive_member_model",
+          "title": "Assert Has Archive Member"
+        }
+      },
+      "required": [
+        "has_archive_member"
+      ],
+      "title": "Assert Has Archive Member (Nested)",
+      "type": "object"
+    },
+    "has_element_with_path_model": {
+      "additionalProperties": false,
+      "description": "Asserts the XML output contains at least one element (or tag) with the specified\nXPath-like ``path``, e.g.\n\n```xml\n<has_element_with_path path=\"BlastOutput_param/Parameters/Parameters_matrix\" />\n```\n\nWith ``negate`` the result of the assertion can be inverted.",
+      "properties": {
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        },
+        "that": {
+          "const": "has_element_with_path",
+          "default": "has_element_with_path",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "Assert Has Element With Path",
+      "type": "object"
+    },
+    "has_element_with_path_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_element_with_path": {
+          "$ref": "#/$defs/base_has_element_with_path_model",
+          "title": "Assert Has Element With Path"
+        }
+      },
+      "required": [
+        "has_element_with_path"
+      ],
+      "title": "Assert Has Element With Path (Nested)",
+      "type": "object"
+    },
+    "has_h5_attribute_model": {
+      "additionalProperties": false,
+      "description": "Asserts HDF5 output contains the specified ``value`` for an attribute (``key``), e.g.\n\n```xml\n<has_h5_attribute key=\"nchroms\" value=\"15\" />\n```",
+      "properties": {
+        "key": {
+          "description": "HDF5 attribute to check value of.",
+          "title": "Key",
+          "type": "string"
+        },
+        "that": {
+          "const": "has_h5_attribute",
+          "default": "has_h5_attribute",
+          "title": "That",
+          "type": "string"
+        },
+        "value": {
+          "description": "Expected value of HDF5 attribute to check.",
+          "title": "Value",
+          "type": "string"
+        }
+      },
+      "required": [
+        "key",
+        "value"
+      ],
+      "title": "Assert Has H5 Attribute",
+      "type": "object"
+    },
+    "has_h5_attribute_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_h5_attribute": {
+          "$ref": "#/$defs/base_has_h5_attribute_model",
+          "title": "Assert Has H5 Attribute"
+        }
+      },
+      "required": [
+        "has_h5_attribute"
+      ],
+      "title": "Assert Has H5 Attribute (Nested)",
+      "type": "object"
+    },
+    "has_h5_keys_model": {
+      "additionalProperties": false,
+      "description": "Asserts the specified HDF5 output has the given keys.",
+      "properties": {
+        "keys": {
+          "description": "HDF5 attributes to check value of as a comma-separated string.",
+          "title": "Keys",
+          "type": "string"
+        },
+        "that": {
+          "const": "has_h5_keys",
+          "default": "has_h5_keys",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "keys"
+      ],
+      "title": "Assert Has H5 Keys",
+      "type": "object"
+    },
+    "has_h5_keys_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_h5_keys": {
+          "$ref": "#/$defs/base_has_h5_keys_model",
+          "title": "Assert Has H5 Keys"
+        }
+      },
+      "required": [
+        "has_h5_keys"
+      ],
+      "title": "Assert Has H5 Keys (Nested)",
+      "type": "object"
+    },
+    "has_image_center_of_mass_model": {
+      "additionalProperties": false,
+      "description": "Asserts the specified output is an image and has the specified center of mass.\n\nAsserts the output is an image and has a specific center of mass,\nor has an Euclidean distance of ``eps`` or less to that point (e.g.,\n``<has_image_center_of_mass center_of_mass=\"511.07, 223.34\" />``).",
+      "properties": {
+        "center_of_mass": {
+          "description": "The required center of mass of the image intensities (horizontal and vertical coordinate, separated by a comma).",
+          "title": "Center Of Mass",
+          "type": "string"
+        },
+        "channel": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific channel of the image (where ``0`` corresponds to the first image channel).",
+          "title": "Channel"
+        },
+        "eps": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.01,
+          "description": "The maximum allowed Euclidean distance to the required center of mass (defaults to ``0.01``).",
+          "title": "Eps"
+        },
+        "frame": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific frame of the image sequence (where ``0`` corresponds to the first image frame).",
+          "title": "Frame"
+        },
+        "slice": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific slice of the image (where ``0`` corresponds to the first image slice).",
+          "title": "Slice"
+        },
+        "that": {
+          "const": "has_image_center_of_mass",
+          "default": "has_image_center_of_mass",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "center_of_mass"
+      ],
+      "title": "Assert Has Image Center Of Mass",
+      "type": "object"
+    },
+    "has_image_center_of_mass_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_image_center_of_mass": {
+          "$ref": "#/$defs/base_has_image_center_of_mass_model",
+          "title": "Assert Has Image Center Of Mass"
+        }
+      },
+      "required": [
+        "has_image_center_of_mass"
+      ],
+      "title": "Assert Has Image Center Of Mass (Nested)",
+      "type": "object"
+    },
+    "has_image_channels_model": {
+      "additionalProperties": false,
+      "description": "Asserts the output is an image and has a specific number of channels.\n\nThe number of channels is plus/minus ``delta`` (e.g., ``<has_image_channels channels=\"3\" />``).\n\nAlternatively the range of the expected number of channels can be specified by ``min`` and/or ``max``.",
+      "properties": {
+        "channels": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected number of channels of the image.",
+          "title": "Channels"
+        },
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the number of channels (default is 0). The observed number of channels has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed number of channels.",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed number of channels.",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "that": {
+          "const": "has_image_channels",
+          "default": "has_image_channels",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "title": "Assert Has Image Channels",
+      "type": "object"
+    },
+    "has_image_channels_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_image_channels": {
+          "$ref": "#/$defs/base_has_image_channels_model",
+          "title": "Assert Has Image Channels"
+        }
+      },
+      "required": [
+        "has_image_channels"
+      ],
+      "title": "Assert Has Image Channels (Nested)",
+      "type": "object"
+    },
+    "has_image_depth_model": {
+      "additionalProperties": false,
+      "description": "Asserts the output is an image and has a specific depth (number of slices).\n\nThe depth is plus/minus ``delta`` (e.g., ``<has_image_depth depth=\"512\" delta=\"2\" />``).\nAlternatively the range of the expected depth can be specified by ``min`` and/or ``max``.",
+      "properties": {
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the image depth (number of slices, default is 0). The observed depth has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "depth": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected depth of the image (number of slices).",
+          "title": "Depth"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed depth of the image (number of slices).",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed depth of the image (number of slices).",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "that": {
+          "const": "has_image_depth",
+          "default": "has_image_depth",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "title": "Assert Has Image Depth",
+      "type": "object"
+    },
+    "has_image_depth_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_image_depth": {
+          "$ref": "#/$defs/base_has_image_depth_model",
+          "title": "Assert Has Image Depth"
+        }
+      },
+      "required": [
+        "has_image_depth"
+      ],
+      "title": "Assert Has Image Depth (Nested)",
+      "type": "object"
+    },
+    "has_image_frames_model": {
+      "additionalProperties": false,
+      "description": "Asserts the output is an image and has a specific number of frames (number of time steps).\n\nThe number of frames is plus/minus ``delta`` (e.g., ``<has_image_frames depth=\"512\" delta=\"2\" />``).\nAlternatively the range of the expected number of frames can be specified by ``min`` and/or ``max``.",
+      "properties": {
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the number of frames in the image sequence (number of time steps, default is 0). The observed number of frames has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "frames": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected number of frames in the image sequence (number of time steps).",
+          "title": "Frames"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed number of frames in the image sequence (number of time steps).",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed number of frames in the image sequence (number of time steps).",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "that": {
+          "const": "has_image_frames",
+          "default": "has_image_frames",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "title": "Assert Has Image Frames",
+      "type": "object"
+    },
+    "has_image_frames_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_image_frames": {
+          "$ref": "#/$defs/base_has_image_frames_model",
+          "title": "Assert Has Image Frames"
+        }
+      },
+      "required": [
+        "has_image_frames"
+      ],
+      "title": "Assert Has Image Frames (Nested)",
+      "type": "object"
+    },
+    "has_image_height_model": {
+      "additionalProperties": false,
+      "description": "Asserts the output is an image and has a specific height (in pixels).\n\nThe height is plus/minus ``delta`` (e.g., ``<has_image_height height=\"512\" delta=\"2\" />``).\nAlternatively the range of the expected height can be specified by ``min`` and/or ``max``.",
+      "properties": {
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the image height (in pixels, default is 0). The observed height has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "height": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected height of the image (in pixels).",
+          "title": "Height"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed height of the image (in pixels).",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed height of the image (in pixels).",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "that": {
+          "const": "has_image_height",
+          "default": "has_image_height",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "title": "Assert Has Image Height",
+      "type": "object"
+    },
+    "has_image_height_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_image_height": {
+          "$ref": "#/$defs/base_has_image_height_model",
+          "title": "Assert Has Image Height"
+        }
+      },
+      "required": [
+        "has_image_height"
+      ],
+      "title": "Assert Has Image Height (Nested)",
+      "type": "object"
+    },
+    "has_image_mean_intensity_model": {
+      "additionalProperties": false,
+      "description": "Asserts the output is an image and has a specific mean intensity value.\n\nThe mean intensity value is plus/minus ``eps`` (e.g., ``<has_image_mean_intensity mean_intensity=\"0.83\" />``).\nAlternatively the range of the expected mean intensity value can be specified by ``min`` and/or ``max``.",
+      "properties": {
+        "channel": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific channel of the image (where ``0`` corresponds to the first image channel).",
+          "title": "Channel"
+        },
+        "eps": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.01,
+          "description": "The absolute tolerance to be used for ``value`` (defaults to ``0.01``). The observed mean value of the image intensities has to be in the range ``value +- eps``.",
+          "title": "Eps"
+        },
+        "frame": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific frame of the image sequence (where ``0`` corresponds to the first image frame).",
+          "title": "Frame"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "An upper bound of the required mean value of the image intensities.",
+          "title": "Max"
+        },
+        "mean_intensity": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The required mean value of the image intensities.",
+          "title": "Mean Intensity"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A lower bound of the required mean value of the image intensities.",
+          "title": "Min"
+        },
+        "slice": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific slice of the image (where ``0`` corresponds to the first image slice).",
+          "title": "Slice"
+        },
+        "that": {
+          "const": "has_image_mean_intensity",
+          "default": "has_image_mean_intensity",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "title": "Assert Has Image Mean Intensity",
+      "type": "object"
+    },
+    "has_image_mean_intensity_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_image_mean_intensity": {
+          "$ref": "#/$defs/base_has_image_mean_intensity_model",
+          "title": "Assert Has Image Mean Intensity"
+        }
+      },
+      "required": [
+        "has_image_mean_intensity"
+      ],
+      "title": "Assert Has Image Mean Intensity (Nested)",
+      "type": "object"
+    },
+    "has_image_mean_object_size_model": {
+      "additionalProperties": false,
+      "description": "Asserts the output is an image with labeled objects which have the specified mean size (number of pixels),\n\nThe mean size is plus/minus ``eps`` (e.g., ``<has_image_mean_object_size mean_object_size=\"111.87\" exclude_labels=\"0\" />``).\n\nThe labels must be unique.",
+      "properties": {
+        "channel": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific channel of the image (where ``0`` corresponds to the first image channel).",
+          "title": "Channel"
+        },
+        "eps": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.01,
+          "description": "The absolute tolerance to be used for ``value`` (defaults to ``0.01``). The observed mean size of the uniquely labeled objects has to be in the range ``value +- eps``.",
+          "title": "Eps"
+        },
+        "exclude_labels": {
+          "anyOf": [
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "List of labels to be excluded from consideration, separated by a comma. The primary usage of this attribute is to exclude the background of a label image. Cannot be used in combination with ``labels``.",
+          "title": "Exclude Labels"
+        },
+        "frame": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific frame of the image sequence (where ``0`` corresponds to the first image frame).",
+          "title": "Frame"
+        },
+        "labels": {
+          "anyOf": [
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "List of labels, separated by a comma. Labels *not* on this list will be excluded from consideration. Cannot be used in combination with ``exclude_labels``.",
+          "title": "Labels"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "An upper bound of the required mean size of the uniquely labeled objects.",
+          "title": "Max"
+        },
+        "mean_object_size": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The required mean size of the uniquely labeled objects.",
+          "title": "Mean Object Size"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A lower bound of the required mean size of the uniquely labeled objects.",
+          "title": "Min"
+        },
+        "slice": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific slice of the image (where ``0`` corresponds to the first image slice).",
+          "title": "Slice"
+        },
+        "that": {
+          "const": "has_image_mean_object_size",
+          "default": "has_image_mean_object_size",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "title": "Assert Has Image Mean Object Size",
+      "type": "object"
+    },
+    "has_image_mean_object_size_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_image_mean_object_size": {
+          "$ref": "#/$defs/base_has_image_mean_object_size_model",
+          "title": "Assert Has Image Mean Object Size"
+        }
+      },
+      "required": [
+        "has_image_mean_object_size"
+      ],
+      "title": "Assert Has Image Mean Object Size (Nested)",
+      "type": "object"
+    },
+    "has_image_n_labels_model": {
+      "additionalProperties": false,
+      "description": "Asserts the output is an image and has the specified labels.\n\nLabels can be a number of labels or unique values (e.g.,\n``<has_image_n_labels n=\"187\" exclude_labels=\"0\" />``).\n\nThe primary usage of this assertion is to verify the number of objects in images with uniquely labeled objects.",
+      "properties": {
+        "channel": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific channel of the image (where ``0`` corresponds to the first image channel).",
+          "title": "Channel"
+        },
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the number of labels (default is 0). The observed number of labels has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "exclude_labels": {
+          "anyOf": [
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "List of labels to be excluded from consideration, separated by a comma. The primary usage of this attribute is to exclude the background of a label image. Cannot be used in combination with ``labels``.",
+          "title": "Exclude Labels"
+        },
+        "frame": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific frame of the image sequence (where ``0`` corresponds to the first image frame).",
+          "title": "Frame"
+        },
+        "labels": {
+          "anyOf": [
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "List of labels, separated by a comma. Labels *not* on this list will be excluded from consideration. Cannot be used in combination with ``exclude_labels``.",
+          "title": "Labels"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed number of labels.",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed number of labels.",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected number of labels.",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "slice": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Restricts the assertion to a specific slice of the image (where ``0`` corresponds to the first image slice).",
+          "title": "Slice"
+        },
+        "that": {
+          "const": "has_image_n_labels",
+          "default": "has_image_n_labels",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "title": "Assert Has Image N Labels",
+      "type": "object"
+    },
+    "has_image_n_labels_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_image_n_labels": {
+          "$ref": "#/$defs/base_has_image_n_labels_model",
+          "title": "Assert Has Image N Labels"
+        }
+      },
+      "required": [
+        "has_image_n_labels"
+      ],
+      "title": "Assert Has Image N Labels (Nested)",
+      "type": "object"
+    },
+    "has_image_width_model": {
+      "additionalProperties": false,
+      "description": "Asserts the output is an image and has a specific width (in pixels).\n\nThe width is plus/minus ``delta`` (e.g., ``<has_image_width width=\"512\" delta=\"2\" />``).\nAlternatively the range of the expected width can be specified by ``min`` and/or ``max``.",
+      "properties": {
+        "delta": {
+          "default": 0,
+          "description": "Maximum allowed difference of the image width (in pixels, default is 0). The observed width has to be in the range ``value +- delta``.",
+          "title": "Delta",
+          "type": "integer"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum allowed width of the image (in pixels).",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum allowed width of the image (in pixels).",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "that": {
+          "const": "has_image_width",
+          "default": "has_image_width",
+          "title": "That",
+          "type": "string"
+        },
+        "width": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected width of the image (in pixels).",
+          "title": "Width"
+        }
+      },
+      "title": "Assert Has Image Width",
+      "type": "object"
+    },
+    "has_image_width_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_image_width": {
+          "$ref": "#/$defs/base_has_image_width_model",
+          "title": "Assert Has Image Width"
+        }
+      },
+      "required": [
+        "has_image_width"
+      ],
+      "title": "Assert Has Image Width (Nested)",
+      "type": "object"
+    },
+    "has_json_property_with_text_model": {
+      "additionalProperties": false,
+      "description": "Asserts the JSON document contains a property or key with the specified text (i.e. string) value.\n\n```xml\n<has_json_property_with_text property=\"color\" text=\"red\" />\n```",
+      "properties": {
+        "property": {
+          "description": "The property name to search the JSON document for.",
+          "title": "Property",
+          "type": "string"
+        },
+        "text": {
+          "description": "The expected text value of the target JSON attribute.",
+          "title": "Text",
+          "type": "string"
+        },
+        "that": {
+          "const": "has_json_property_with_text",
+          "default": "has_json_property_with_text",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "property",
+        "text"
+      ],
+      "title": "Assert Has Json Property With Text",
+      "type": "object"
+    },
+    "has_json_property_with_text_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_json_property_with_text": {
+          "$ref": "#/$defs/base_has_json_property_with_text_model",
+          "title": "Assert Has Json Property With Text"
+        }
+      },
+      "required": [
+        "has_json_property_with_text"
+      ],
+      "title": "Assert Has Json Property With Text (Nested)",
+      "type": "object"
+    },
+    "has_json_property_with_value_model": {
+      "additionalProperties": false,
+      "description": "Asserts the JSON document contains a property or key with the specified JSON value.\n\n```xml\n<has_json_property_with_value property=\"skipped_columns\" value=\"[1, 3, 5]\" />\n```",
+      "properties": {
+        "property": {
+          "description": "The property name to search the JSON document for.",
+          "title": "Property",
+          "type": "string"
+        },
+        "that": {
+          "const": "has_json_property_with_value",
+          "default": "has_json_property_with_value",
+          "title": "That",
+          "type": "string"
+        },
+        "value": {
+          "description": "The expected JSON value of the target JSON attribute (as a JSON encoded string).",
+          "title": "Value",
+          "type": "string"
+        }
+      },
+      "required": [
+        "property",
+        "value"
+      ],
+      "title": "Assert Has Json Property With Value",
+      "type": "object"
+    },
+    "has_json_property_with_value_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_json_property_with_value": {
+          "$ref": "#/$defs/base_has_json_property_with_value_model",
+          "title": "Assert Has Json Property With Value"
+        }
+      },
+      "required": [
+        "has_json_property_with_value"
+      ],
+      "title": "Assert Has Json Property With Value (Nested)",
+      "type": "object"
+    },
+    "has_line_matching_model": {
+      "additionalProperties": false,
+      "description": "Asserts the specified output contains a line matching the\nregular expression specified by the argument expression. If n is given\nthe assertion checks for exactly n occurrences.",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "expression": {
+          "description": "The regular expressions to attempt match in the output.",
+          "title": "Expression",
+          "type": "string"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "that": {
+          "const": "has_line_matching",
+          "default": "has_line_matching",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "expression"
+      ],
+      "title": "Assert Has Line Matching",
+      "type": "object"
+    },
+    "has_line_matching_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_line_matching": {
+          "$ref": "#/$defs/base_has_line_matching_model",
+          "title": "Assert Has Line Matching"
+        }
+      },
+      "required": [
+        "has_line_matching"
+      ],
+      "title": "Assert Has Line Matching (Nested)",
+      "type": "object"
+    },
+    "has_line_model": {
+      "additionalProperties": false,
+      "description": "Asserts the specified output contains the line specified by the\nargument line. The exact number of occurrences can be optionally\nspecified by the argument n",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "line": {
+          "description": "The full line of text to search for in the output.",
+          "title": "Line",
+          "type": "string"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "that": {
+          "const": "has_line",
+          "default": "has_line",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "line"
+      ],
+      "title": "Assert Has Line",
+      "type": "object"
+    },
+    "has_line_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_line": {
+          "$ref": "#/$defs/base_has_line_model",
+          "title": "Assert Has Line"
+        }
+      },
+      "required": [
+        "has_line"
+      ],
+      "title": "Assert Has Line (Nested)",
+      "type": "object"
+    },
+    "has_n_columns_model": {
+      "additionalProperties": false,
+      "description": "Asserts tabular output  contains the specified\nnumber (``n``) of columns.\n\nFor instance, ``<has_n_columns n=\"3\"/>``. The assertion tests only the first line.\nNumber of columns can optionally also be specified with ``delta``. Alternatively the\nrange of expected occurrences can be specified by ``min`` and/or ``max``.\n\nOptionally a column separator (``sep``, default is ``       ``) `and comment character(s)\ncan be specified (``comment``, default is empty string). The first non-comment\nline is used for determining the number of columns.",
+      "properties": {
+        "comment": {
+          "default": "",
+          "description": "Comment character(s) used to skip comment lines (which should not be used for counting columns)",
+          "title": "Comment",
+          "type": "string"
+        },
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "sep": {
+          "default": "\t",
+          "description": "Separator defining columns, default: tab",
+          "title": "Sep",
+          "type": "string"
+        },
+        "that": {
+          "const": "has_n_columns",
+          "default": "has_n_columns",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "title": "Assert Has N Columns",
+      "type": "object"
+    },
+    "has_n_columns_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_n_columns": {
+          "$ref": "#/$defs/base_has_n_columns_model",
+          "title": "Assert Has N Columns"
+        }
+      },
+      "required": [
+        "has_n_columns"
+      ],
+      "title": "Assert Has N Columns (Nested)",
+      "type": "object"
+    },
+    "has_n_elements_with_path_model": {
+      "additionalProperties": false,
+      "description": "Asserts the XML output contains the specified number (``n``, optionally with ``delta``) of elements (or\ntags) with the specified XPath-like ``path``.\n\nFor example:\n\n```xml\n<has_n_elements_with_path n=\"9\" path=\"BlastOutput_iterations/Iteration/Iteration_hits/Hit/Hit_num\" />\n```\n\nAlternatively to ``n`` and ``delta`` also the ``min`` and ``max`` attributes\ncan be used to specify the range of the expected number of occurrences.\nWith ``negate`` the result of the assertion can be inverted.",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        },
+        "that": {
+          "const": "has_n_elements_with_path",
+          "default": "has_n_elements_with_path",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "Assert Has N Elements With Path",
+      "type": "object"
+    },
+    "has_n_elements_with_path_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_n_elements_with_path": {
+          "$ref": "#/$defs/base_has_n_elements_with_path_model",
+          "title": "Assert Has N Elements With Path"
+        }
+      },
+      "required": [
+        "has_n_elements_with_path"
+      ],
+      "title": "Assert Has N Elements With Path (Nested)",
+      "type": "object"
+    },
+    "has_n_lines_model": {
+      "additionalProperties": false,
+      "description": "Asserts the specified output contains ``n`` lines allowing\nfor a difference in the number of lines (delta)\nor relative differebce in the number of lines",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "that": {
+          "const": "has_n_lines",
+          "default": "has_n_lines",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "title": "Assert Has N Lines",
+      "type": "object"
+    },
+    "has_n_lines_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_n_lines": {
+          "$ref": "#/$defs/base_has_n_lines_model",
+          "title": "Assert Has N Lines"
+        }
+      },
+      "required": [
+        "has_n_lines"
+      ],
+      "title": "Assert Has N Lines (Nested)",
+      "type": "object"
+    },
+    "has_size_model": {
+      "additionalProperties": false,
+      "description": "Asserts the specified output has a size of the specified value\n\nAttributes size and value or synonyms though value is considered deprecated.\nThe size optionally allows for absolute (``delta``) difference.",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "size": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired size of the output (in bytes), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Size"
+        },
+        "that": {
+          "const": "has_size",
+          "default": "has_size",
+          "title": "That",
+          "type": "string"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Deprecated alias for `size`",
+          "title": "Value"
+        }
+      },
+      "title": "Assert Has Size",
+      "type": "object"
+    },
+    "has_size_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_size": {
+          "$ref": "#/$defs/base_has_size_model",
+          "title": "Assert Has Size"
+        }
+      },
+      "required": [
+        "has_size"
+      ],
+      "title": "Assert Has Size (Nested)",
+      "type": "object"
+    },
+    "has_text_matching_model": {
+      "additionalProperties": false,
+      "description": "Asserts the specified output contains text matching the\nregular expression specified by the argument expression.\nIf n is given the assertion checks for exactly n (nonoverlapping)\noccurrences.",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "expression": {
+          "description": "The regular expressions to attempt match in the output.",
+          "title": "Expression",
+          "type": "string"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "that": {
+          "const": "has_text_matching",
+          "default": "has_text_matching",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "expression"
+      ],
+      "title": "Assert Has Text Matching",
+      "type": "object"
+    },
+    "has_text_matching_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_text_matching": {
+          "$ref": "#/$defs/base_has_text_matching_model",
+          "title": "Assert Has Text Matching"
+        }
+      },
+      "required": [
+        "has_text_matching"
+      ],
+      "title": "Assert Has Text Matching (Nested)",
+      "type": "object"
+    },
+    "has_text_model": {
+      "additionalProperties": false,
+      "description": "Asserts specified output contains the substring specified by\nthe argument text. The exact number of occurrences can be\noptionally specified by the argument n",
+      "properties": {
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "text": {
+          "description": "The text to search for in the output.",
+          "title": "Text",
+          "type": "string"
+        },
+        "that": {
+          "const": "has_text",
+          "default": "has_text",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "text"
+      ],
+      "title": "Assert Has Text",
+      "type": "object"
+    },
+    "has_text_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "has_text": {
+          "$ref": "#/$defs/base_has_text_model",
+          "title": "Assert Has Text"
+        }
+      },
+      "required": [
+        "has_text"
+      ],
+      "title": "Assert Has Text (Nested)",
+      "type": "object"
+    },
+    "is_valid_xml_model": {
+      "additionalProperties": false,
+      "description": "Asserts the output is a valid XML file (e.g. ``<is_valid_xml />``).",
+      "properties": {
+        "that": {
+          "const": "is_valid_xml",
+          "default": "is_valid_xml",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "title": "Assert Is Valid Xml",
+      "type": "object"
+    },
+    "is_valid_xml_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "is_valid_xml": {
+          "$ref": "#/$defs/base_is_valid_xml_model",
+          "title": "Assert Is Valid Xml"
+        }
+      },
+      "required": [
+        "is_valid_xml"
+      ],
+      "title": "Assert Is Valid Xml (Nested)",
+      "type": "object"
+    },
+    "not_has_text_model": {
+      "additionalProperties": false,
+      "description": "Asserts specified output does not contain the substring\nspecified by the argument text",
+      "properties": {
+        "text": {
+          "description": "The text to search for in the output.",
+          "title": "Text",
+          "type": "string"
+        },
+        "that": {
+          "const": "not_has_text",
+          "default": "not_has_text",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "text"
+      ],
+      "title": "Assert Not Has Text",
+      "type": "object"
+    },
+    "not_has_text_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "not_has_text": {
+          "$ref": "#/$defs/base_not_has_text_model",
+          "title": "Assert Not Has Text"
+        }
+      },
+      "required": [
+        "not_has_text"
+      ],
+      "title": "Assert Not Has Text (Nested)",
+      "type": "object"
+    },
+    "xml_element_model": {
+      "additionalProperties": false,
+      "description": "Assert if the XML file contains element(s) or tag(s) with the specified\n[XPath-like ``path``](https://lxml.de/xpathxslt.html).  If ``n`` and ``delta``\nor ``min`` and ``max`` are given also the number of occurrences is checked.\n\n```xml\n<assert_contents>\n  <xml_element path=\"./elem\"/>\n  <xml_element path=\"./elem/more[2]\"/>\n  <xml_element path=\".//more\" n=\"3\" delta=\"1\"/>\n</assert_contents>\n```\n\nWith ``negate=\"true\"`` the outcome of the assertions wrt the presence and number\nof ``path`` can be negated. If there are any sub assertions then check them against\n\n- the content of the attribute ``attribute``\n- the element's text if no attribute is given\n\n```xml\n<assert_contents>\n  <xml_element path=\"./elem/more[2]\" attribute=\"name\">\n    <has_text_matching expression=\"foo$\"/>\n  </xml_element>\n</assert_contents>\n```\n\nSub-assertions are not subject to the ``negate`` attribute of ``xml_element``.\nIf ``all`` is ``true`` then the sub assertions are checked for all occurrences.\n\nNote that all other XML assertions can be expressed by this assertion (Galaxy\nalso implements the other assertions by calling this one).",
+      "properties": {
+        "all": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "Check the sub-assertions for all paths matching the path. Default: false, i.e. only the first ",
+          "title": "All"
+        },
+        "asserts": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Asserts"
+        },
+        "attribute": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The XML attribute name to test against from the target XML element.",
+          "title": "Attribute"
+        },
+        "children": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/assertion_list"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Children"
+        },
+        "delta": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 0,
+          "description": "Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Delta"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number (default: infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Max"
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum number (default: -infinity), can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "Min"
+        },
+        "n": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``",
+          "title": "N"
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "A boolean that can be set to true to negate the outcome of the assertion.",
+          "title": "Negate"
+        },
+        "path": {
+          "description": "The Python xpath-like expression to find the target element.",
+          "title": "Path",
+          "type": "string"
+        },
+        "that": {
+          "const": "xml_element",
+          "default": "xml_element",
+          "title": "That",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "Assert Xml Element",
+      "type": "object"
+    },
+    "xml_element_model_nested": {
+      "additionalProperties": false,
+      "description": "Nested version of this assertion model.",
+      "properties": {
+        "xml_element": {
+          "$ref": "#/$defs/base_xml_element_model",
+          "title": "Assert Xml Element"
+        }
+      },
+      "required": [
+        "xml_element"
+      ],
+      "title": "Assert Xml Element (Nested)",
+      "type": "object"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Galaxy workflow tests file — a YAML list of test entries asserting the expected inputs and outputs of a workflow run.",
+  "items": {
+    "$ref": "#/$defs/TestJob"
+  },
+  "title": "GalaxyWorkflowTests",
+  "type": "array"
+}

--- a/casts/claude/skills/debug-cwl-workflow-output/SKILL.md
+++ b/casts/claude/skills/debug-cwl-workflow-output/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: debug-cwl-workflow-output
+description: "Triage failing CWL run outputs; classify failure modes; propose fixes."
+---
+
+# debug-cwl-workflow-output
+
+Follow the procedure below and use the artifact/reference sections as the runtime contract.
+
+## When To Use
+
+- Triage failing CWL run outputs; classify failure modes; propose fixes.
+
+## Inputs
+
+- No upstream artifact inputs declared. See the procedure for user-supplied runtime inputs.
+
+## Outputs
+
+- None declared.
+
+## Required Tools
+
+- None declared. Procedure should not assume external CLIs are present.
+
+## Load Upfront
+
+- None declared.
+
+## Load On Demand
+
+- None declared.
+
+## Validation
+
+- None declared.
+
+## Procedure
+
+Triage a failing CWL run: classify the failure mode from logs and outputs and propose a fix routed to the authoring step responsible for it.
+
+## Runtime Notes
+
+- Do not read Foundry source files at runtime; use only files packaged in this skill bundle and user-supplied artifacts.
+- Preserve declared artifact filenames unless the user or harness supplies explicit paths.
+- Carry unresolved assumptions into the output artifact instead of silently inventing missing source evidence.

--- a/casts/claude/skills/debug-cwl-workflow-output/_provenance.json
+++ b/casts/claude/skills/debug-cwl-workflow-output/_provenance.json
@@ -1,0 +1,13 @@
+{
+  "provenance_schema_version": 3,
+  "cast_target": "claude",
+  "mold": {
+    "name": "debug-cwl-workflow-output",
+    "path": "content/molds/debug-cwl-workflow-output/index.md",
+    "revision": 2,
+    "content_hash": "dd86078aac141070bbd438dd5eaab775c880515996d2e336131d4b80522dbc83",
+    "commit": "e487fe785f468afdf25f2b6bd140c3a115a12021"
+  },
+  "cast_at": "2026-07-24T13:51:12.321Z",
+  "refs": []
+}

--- a/casts/claude/skills/debug-cwl-workflow-output/_verify.json
+++ b/casts/claude/skills/debug-cwl-workflow-output/_verify.json
@@ -1,0 +1,4 @@
+{
+  "verify_schema_version": 1,
+  "entries": []
+}

--- a/casts/claude/skills/freeform-summary-to-cwl-design/SKILL.md
+++ b/casts/claude/skills/freeform-summary-to-cwl-design/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: freeform-summary-to-cwl-design
+description: "Translate a free-form source summary into a CWL workflow design brief."
+---
+
+# freeform-summary-to-cwl-design
+
+Follow the procedure below and use the artifact/reference sections as the runtime contract.
+
+## When To Use
+
+- Translate a free-form source summary into a CWL workflow design brief.
+
+## Inputs
+
+- Read artifact `freeform-summary`. Produced by `interview-to-freeform-summary`, `summarize-paper`. Free-form source summary emitted by summarize-paper or interview-to-freeform-summary; methods, tools, sample data, references, and workflow intent.
+
+## Outputs
+
+- Write artifact `freeform-cwl-design` as `freeform-cwl-design.md`. Format: `markdown`. Combined CWL interface + data-flow design brief; a single reviewable handoff for free-form sources until examples justify a split.
+
+## Required Tools
+
+- None declared. Procedure should not assume external CLIs are present.
+
+## Load Upfront
+
+- None declared.
+
+## Load On Demand
+
+- None declared.
+
+## Validation
+
+- None declared.
+
+## Procedure
+
+Read a free-form source summary and emit a reviewable Markdown CWL workflow design brief. Combine interface choices and abstract data-flow choices until free-form source examples justify a cleaner split.
+
+The output is not a concrete CWL Workflow. summary-to-cwl-template turns this brief and the free-form summary into a skeleton.
+
+## Runtime Notes
+
+- Do not read Foundry source files at runtime; use only files packaged in this skill bundle and user-supplied artifacts.
+- Preserve declared artifact filenames unless the user or harness supplies explicit paths.
+- Carry unresolved assumptions into the output artifact instead of silently inventing missing source evidence.

--- a/casts/claude/skills/freeform-summary-to-cwl-design/_provenance.json
+++ b/casts/claude/skills/freeform-summary-to-cwl-design/_provenance.json
@@ -1,0 +1,33 @@
+{
+  "provenance_schema_version": 3,
+  "cast_target": "claude",
+  "mold": {
+    "name": "freeform-summary-to-cwl-design",
+    "path": "content/molds/freeform-summary-to-cwl-design/index.md",
+    "revision": 1,
+    "content_hash": "35bde6960d0abfd147377bf0a7b33addb30b295faf47c6257403957d5f0ddad3",
+    "commit": "e487fe785f468afdf25f2b6bd140c3a115a12021"
+  },
+  "cast_at": "2026-07-24T13:51:12.886Z",
+  "refs": [],
+  "artifacts": {
+    "produces": [
+      {
+        "id": "freeform-cwl-design",
+        "kind": "markdown",
+        "default_filename": "freeform-cwl-design.md",
+        "description": "Combined CWL interface + data-flow design brief; a single reviewable handoff for free-form sources until examples justify a split."
+      }
+    ],
+    "consumes": [
+      {
+        "id": "freeform-summary",
+        "description": "Free-form source summary emitted by [[summarize-paper]] or [[interview-to-freeform-summary]]; methods, tools, sample data, references, and workflow intent.",
+        "producers": [
+          "interview-to-freeform-summary",
+          "summarize-paper"
+        ]
+      }
+    ]
+  }
+}

--- a/casts/claude/skills/freeform-summary-to-cwl-design/_verify.json
+++ b/casts/claude/skills/freeform-summary-to-cwl-design/_verify.json
@@ -1,0 +1,4 @@
+{
+  "verify_schema_version": 1,
+  "entries": []
+}

--- a/casts/claude/skills/implement-cwl-tool-step/SKILL.md
+++ b/casts/claude/skills/implement-cwl-tool-step/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: implement-cwl-tool-step
+description: "Convert an abstract step into a concrete CWL CommandLineTool + step."
+---
+
+# implement-cwl-tool-step
+
+Follow the procedure below and use the artifact/reference sections as the runtime contract.
+
+## When To Use
+
+- Convert an abstract step into a concrete CWL CommandLineTool + step.
+
+## Inputs
+
+- Read artifact `cwl-tool-summary`. Produced by `summarize-cwl-tool`. Compact CWL tool summary from summarize-cwl-tool; binds the abstract step to a concrete CommandLineTool.
+- Read artifact `cwl-workflow-draft`. Produced by `implement-cwl-tool-step`, `summary-to-cwl-template`. CWL Workflow skeleton being filled in step by step; the step replaces a placeholder in this draft.
+
+## Outputs
+
+- Write artifact `cwl-workflow-draft` as `cwl-workflow-draft.cwl`. Format: `yaml`. CWL Workflow skeleton with one more abstract step replaced by a concrete CommandLineTool step (loop iteration output).
+
+## Required Tools
+
+- None declared. Procedure should not assume external CLIs are present.
+
+## Load Upfront
+
+- None declared.
+
+## Load On Demand
+
+- None declared.
+
+## Validation
+
+- None declared.
+
+## Procedure
+
+Bind one abstract step to a concrete CWL CommandLineTool using its summarize-cwl-tool summary, replacing a single placeholder in the CWL workflow draft per loop iteration.
+
+## Runtime Notes
+
+- Do not read Foundry source files at runtime; use only files packaged in this skill bundle and user-supplied artifacts.
+- Preserve declared artifact filenames unless the user or harness supplies explicit paths.
+- Carry unresolved assumptions into the output artifact instead of silently inventing missing source evidence.

--- a/casts/claude/skills/implement-cwl-tool-step/_provenance.json
+++ b/casts/claude/skills/implement-cwl-tool-step/_provenance.json
@@ -1,0 +1,40 @@
+{
+  "provenance_schema_version": 3,
+  "cast_target": "claude",
+  "mold": {
+    "name": "implement-cwl-tool-step",
+    "path": "content/molds/implement-cwl-tool-step/index.md",
+    "revision": 2,
+    "content_hash": "44c99d56127b03301120403a8244fca7486e900c79bcd26617a873da7be1ac17",
+    "commit": "e487fe785f468afdf25f2b6bd140c3a115a12021"
+  },
+  "cast_at": "2026-07-24T13:51:13.428Z",
+  "refs": [],
+  "artifacts": {
+    "produces": [
+      {
+        "id": "cwl-workflow-draft",
+        "kind": "yaml",
+        "default_filename": "cwl-workflow-draft.cwl",
+        "description": "CWL Workflow skeleton with one more abstract step replaced by a concrete CommandLineTool step (loop iteration output)."
+      }
+    ],
+    "consumes": [
+      {
+        "id": "cwl-tool-summary",
+        "description": "Compact CWL tool summary from [[summarize-cwl-tool]]; binds the abstract step to a concrete CommandLineTool.",
+        "producers": [
+          "summarize-cwl-tool"
+        ]
+      },
+      {
+        "id": "cwl-workflow-draft",
+        "description": "CWL Workflow skeleton being filled in step by step; the step replaces a placeholder in this draft.",
+        "producers": [
+          "implement-cwl-tool-step",
+          "summary-to-cwl-template"
+        ]
+      }
+    ]
+  }
+}

--- a/casts/claude/skills/implement-cwl-tool-step/_verify.json
+++ b/casts/claude/skills/implement-cwl-tool-step/_verify.json
@@ -1,0 +1,4 @@
+{
+  "verify_schema_version": 1,
+  "entries": []
+}

--- a/casts/claude/skills/implement-cwl-workflow-test/SKILL.md
+++ b/casts/claude/skills/implement-cwl-workflow-test/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: implement-cwl-workflow-test
+description: "Assemble CWL job file(s) and expected-output assertions."
+---
+
+# implement-cwl-workflow-test
+
+Follow the procedure below and use the artifact/reference sections as the runtime contract.
+
+## When To Use
+
+- Assemble CWL job file(s) and expected-output assertions.
+
+## Inputs
+
+- Read artifact `cwl-test-plan`. Produced by `nextflow-test-to-cwl-test-plan`. Reviewable CWL test plan from nextflow-test-to-cwl-test-plan (or future CWL test-plan producers); job, fixture, assertion provenance.
+- Read artifact `cwl-workflow-draft`. Produced by `implement-cwl-tool-step`, `summary-to-cwl-template`. CWL Workflow being tested; provides input/output ports and shapes the job + assertions must match.
+
+## Outputs
+
+- Write artifact `cwl-workflow-test` as `cwl-job.yml`. Format: `yaml`. CWL job file(s) with inputs and expected-output assertions for the implemented workflow.
+
+## Required Tools
+
+- None declared. Procedure should not assume external CLIs are present.
+
+## Load Upfront
+
+- None declared.
+
+## Load On Demand
+
+- None declared.
+
+## Validation
+
+- None declared.
+
+## Procedure
+
+Assemble the CWL job file(s) and expected-output assertions for the drafted workflow from its reviewed nextflow-test-to-cwl-test-plan test plan and the workflow's input/output ports.
+
+## Runtime Notes
+
+- Do not read Foundry source files at runtime; use only files packaged in this skill bundle and user-supplied artifacts.
+- Preserve declared artifact filenames unless the user or harness supplies explicit paths.
+- Carry unresolved assumptions into the output artifact instead of silently inventing missing source evidence.

--- a/casts/claude/skills/implement-cwl-workflow-test/_provenance.json
+++ b/casts/claude/skills/implement-cwl-workflow-test/_provenance.json
@@ -1,0 +1,40 @@
+{
+  "provenance_schema_version": 3,
+  "cast_target": "claude",
+  "mold": {
+    "name": "implement-cwl-workflow-test",
+    "path": "content/molds/implement-cwl-workflow-test/index.md",
+    "revision": 2,
+    "content_hash": "030e46e888bcb9edc55041bd7fb99739676b2ae985581ca0f2e119d7795d323e",
+    "commit": "e487fe785f468afdf25f2b6bd140c3a115a12021"
+  },
+  "cast_at": "2026-07-24T13:51:13.993Z",
+  "refs": [],
+  "artifacts": {
+    "produces": [
+      {
+        "id": "cwl-workflow-test",
+        "kind": "yaml",
+        "default_filename": "cwl-job.yml",
+        "description": "CWL job file(s) with inputs and expected-output assertions for the implemented workflow."
+      }
+    ],
+    "consumes": [
+      {
+        "id": "cwl-test-plan",
+        "description": "Reviewable CWL test plan from [[nextflow-test-to-cwl-test-plan]] (or future CWL test-plan producers); job, fixture, assertion provenance.",
+        "producers": [
+          "nextflow-test-to-cwl-test-plan"
+        ]
+      },
+      {
+        "id": "cwl-workflow-draft",
+        "description": "CWL Workflow being tested; provides input/output ports and shapes the job + assertions must match.",
+        "producers": [
+          "implement-cwl-tool-step",
+          "summary-to-cwl-template"
+        ]
+      }
+    ]
+  }
+}

--- a/casts/claude/skills/implement-cwl-workflow-test/_verify.json
+++ b/casts/claude/skills/implement-cwl-workflow-test/_verify.json
@@ -1,0 +1,4 @@
+{
+  "verify_schema_version": 1,
+  "entries": []
+}

--- a/casts/claude/skills/nextflow-summary-to-cwl-data-flow/SKILL.md
+++ b/casts/claude/skills/nextflow-summary-to-cwl-data-flow/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: nextflow-summary-to-cwl-data-flow
+description: "Translate a Nextflow summary into a CWL data-flow design brief."
+---
+
+# nextflow-summary-to-cwl-data-flow
+
+Follow the procedure below and use the artifact/reference sections as the runtime contract.
+
+## When To Use
+
+- Translate a Nextflow summary into a CWL data-flow design brief.
+
+## Inputs
+
+- Read artifact `summary-nextflow`. Schema: summary-nextflow. Produced by `summarize-nextflow`. Structured Nextflow pipeline summary emitted by summarize-nextflow; consumed alongside the CWL interface brief.
+- Read artifact `nextflow-cwl-interface`. Produced by `nextflow-summary-to-cwl-interface`. Preceding CWL interface brief from nextflow-summary-to-cwl-interface that pins inputs, outputs, and labels.
+
+## Outputs
+
+- Write artifact `nextflow-cwl-data-flow` as `nextflow-cwl-data-flow.md`. Format: `markdown`. Reviewable Markdown brief: abstract topology, scatter/gather choices, value transformations, unresolved CommandLineTool needs, confidence.
+
+## Required Tools
+
+- None declared. Procedure should not assume external CLIs are present.
+
+## Load Upfront
+
+- `references/schemas/summary-nextflow.schema.json`: Schema file copied verbatim into the bundle. Read process, channel, operator, and fixture structure while drafting CWL-facing abstract data flow.
+
+## Load On Demand
+
+- None declared.
+
+## Validation
+
+- None declared.
+
+## Procedure
+
+Read a Nextflow summary plus the preceding CWL interface brief and emit a reviewable Markdown data-flow brief. Capture abstract operations, CWL scatter/gather choices, value transformations, unresolved CommandLineTool needs, confidence, and open questions.
+
+The output is not a concrete CWL Workflow. summary-to-cwl-template turns this handoff and the interface brief into a skeleton.
+
+## Runtime Notes
+
+- Do not read Foundry source files at runtime; use only files packaged in this skill bundle and user-supplied artifacts.
+- Preserve declared artifact filenames unless the user or harness supplies explicit paths.
+- Carry unresolved assumptions into the output artifact instead of silently inventing missing source evidence.

--- a/casts/claude/skills/nextflow-summary-to-cwl-data-flow/_provenance.json
+++ b/casts/claude/skills/nextflow-summary-to-cwl-data-flow/_provenance.json
@@ -1,0 +1,56 @@
+{
+  "provenance_schema_version": 3,
+  "cast_target": "claude",
+  "mold": {
+    "name": "nextflow-summary-to-cwl-data-flow",
+    "path": "content/molds/nextflow-summary-to-cwl-data-flow/index.md",
+    "revision": 1,
+    "content_hash": "9f1b25edc84a70670780e41f582cbc157390699c0f04856b1a5e0f55d8964013",
+    "commit": "e487fe785f468afdf25f2b6bd140c3a115a12021"
+  },
+  "cast_at": "2026-07-24T13:51:14.581Z",
+  "refs": [
+    {
+      "kind": "schema",
+      "mode": "verbatim",
+      "ref": "[[summary-nextflow]]",
+      "src": "package://@galaxy-foundry/summarize-nextflow#summaryNextflowSchema",
+      "dst": "references/schemas/summary-nextflow.schema.json",
+      "used_at": "runtime",
+      "load": "upfront",
+      "evidence": "corpus-observed",
+      "purpose": "Read process, channel, operator, and fixture structure while drafting CWL-facing abstract data flow.",
+      "license": "MIT",
+      "src_hash": "06430103b6111c40c030990459d41fe599faba0015865bba54d0e8bd0cf9fd1c",
+      "dst_hash": "06430103b6111c40c030990459d41fe599faba0015865bba54d0e8bd0cf9fd1c",
+      "source": "deterministic"
+    }
+  ],
+  "artifacts": {
+    "produces": [
+      {
+        "id": "nextflow-cwl-data-flow",
+        "kind": "markdown",
+        "default_filename": "nextflow-cwl-data-flow.md",
+        "description": "Reviewable Markdown brief: abstract topology, scatter/gather choices, value transformations, unresolved CommandLineTool needs, confidence."
+      }
+    ],
+    "consumes": [
+      {
+        "id": "summary-nextflow",
+        "description": "Structured Nextflow pipeline summary emitted by [[summarize-nextflow]]; consumed alongside the CWL interface brief.",
+        "inherited_schema": "[[summary-nextflow]]",
+        "producers": [
+          "summarize-nextflow"
+        ]
+      },
+      {
+        "id": "nextflow-cwl-interface",
+        "description": "Preceding CWL interface brief from [[nextflow-summary-to-cwl-interface]] that pins inputs, outputs, and labels.",
+        "producers": [
+          "nextflow-summary-to-cwl-interface"
+        ]
+      }
+    ]
+  }
+}

--- a/casts/claude/skills/nextflow-summary-to-cwl-data-flow/_verify.json
+++ b/casts/claude/skills/nextflow-summary-to-cwl-data-flow/_verify.json
@@ -1,0 +1,17 @@
+{
+  "verify_schema_version": 1,
+  "entries": [
+    {
+      "artifact_id": "summary-nextflow",
+      "direction": "input",
+      "kind": "json",
+      "default_filename": "summary-nextflow.json",
+      "schema": "[[summary-nextflow]]",
+      "validator_bin": "foundry",
+      "args": [
+        "validate-summary-nextflow",
+        "{artifact_path}"
+      ]
+    }
+  ]
+}

--- a/casts/claude/skills/nextflow-summary-to-cwl-data-flow/references/schemas/summary-nextflow.schema.json
+++ b/casts/claude/skills/nextflow-summary-to-cwl-data-flow/references/schemas/summary-nextflow.schema.json
@@ -1,0 +1,1514 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://galaxyproject.org/foundry/schemas/summary-nextflow.schema.json",
+  "$comment": "Canonical source: packages/summarize-nextflow/src/schema/summary-nextflow.schema.json in galaxyproject/foundry. Mold frontmatter cites this schema via [[summary-nextflow]] wiki-links; the cast pipeline imports the `summaryNextflowSchema` runtime export and serializes it into cast bundles.",
+  "title": "Nextflow Pipeline Summary",
+  "description": "Structured per-source summary emitted by the summarize-nextflow Mold.\n\nPer-source schema by design — paper, Nextflow, and CWL each have their own summary shape; downstream Molds (data flow, templates, tool wrappers) consume any source's summary and handle the polymorphism.\n\nField names mirror gxy-sketches' SketchSource / ToolSpec / TestDataRef / ExpectedOutputRef where parity exists; see content/research/gxy-sketches-alignment.md.",
+  "$ref": "#/$defs/Summary",
+  "$defs": {
+    "Summary": {
+      "title": "Summary",
+      "description": "Top-level shape. Every Nextflow summary is exactly this object.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source",
+        "params",
+        "sample_sheets",
+        "profiles",
+        "tools",
+        "processes",
+        "subworkflows",
+        "workflow",
+        "reference_assets",
+        "reference_rebuilds",
+        "test_fixtures",
+        "nf_tests"
+      ],
+      "properties": {
+        "source": {
+          "$ref": "#/$defs/SourceRecord"
+        },
+        "params": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Param"
+          }
+        },
+        "sample_sheets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SampleSheet"
+          },
+          "description": "Structured sample-sheet inputs. Each entry binds one `params[]` parameter to a row schema (column names, types, path-vs-meta classification, required flags, enums, patterns). Promoted from prose inside `params[].description` so downstream target translations (Galaxy `sample_sheet*` collections, CWL records-of-arrays) can choose collection variants without re-parsing the source pipeline. Empty array when no sample-sheet idiom is detected. Discovery sources: nf-schema `schema:` references, `samplesheetToList()` calls, and `splitCsv(header: true)` materializations."
+        },
+        "profiles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Tool"
+          }
+        },
+        "processes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Process"
+          }
+        },
+        "subworkflows": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Subworkflow"
+          }
+        },
+        "workflow": {
+          "$ref": "#/$defs/Workflow"
+        },
+        "reference_assets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ReferenceAsset"
+          },
+          "description": "Curated, target-agnostic view of reference-data inputs the source pipeline consumes (FASTAs, indexes, dictionaries, annotation tables, …). Each entry is a foreign-key projection onto `params[]` plus source-side metadata (asset kind, format hint, source expression, schema group, callers). Empty array when no reference assets are detected. Downstream Molds (e.g. nextflow-summary-to-galaxy-reference-data) classify these against Galaxy translation rungs; classification decisions are not encoded here."
+        },
+        "reference_rebuilds": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ReferenceRebuildRule"
+          },
+          "description": "Compute-if-missing rebuild branches detected in workflow/subworkflow bodies. Each entry binds an asset param to the guard and builder process that recomputes it when absent. Empty when no rebuild idioms are found. Source evidence only — Galaxy in-tool-rebuild decisions live downstream."
+        },
+        "test_fixtures": {
+          "$ref": "#/$defs/TestFixtures",
+          "description": "Test-input data shape for the *selected* profile (the cast's `profile` argument, default `test`). For pipelines with multiple test profiles, see `nf_tests[]` for the full enumeration."
+        },
+        "nf_tests": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/NfTest"
+          },
+          "description": "All `tests/*.nf.test` files in the pipeline. Each entry captures one test-program — its profile, params overrides, and structured assertions. Empty array when the pipeline has no nf-test fixtures."
+        },
+        "warnings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Cast-skill-emitted advisory messages (e.g. DSL1 detected, meta.yml/script disagreement, lossy assertion summarization). Empty array on a clean run."
+        }
+      }
+    },
+    "SourceRecord": {
+      "title": "SourceRecord",
+      "description": "Provenance block. Mirrors gxy-sketches SketchSource field names so a Foundry summary is structurally consumable by anyone using that shape.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "ecosystem",
+        "workflow",
+        "url",
+        "version",
+        "slug"
+      ],
+      "properties": {
+        "ecosystem": {
+          "type": "string",
+          "enum": [
+            "nf-core",
+            "nextflow"
+          ],
+          "description": "Pipeline flavor. `nf-core` when `manifest.name` is `nf-core/<slug>` and the canonical layout is present; `nextflow` for ad-hoc DSL2 pipelines. Superset of gxy-sketches' enum (which adds `iwc`, `snakemake-workflows`, `wdl` for its other ingestors)."
+        },
+        "workflow": {
+          "type": "string",
+          "description": "Pipeline name (typically the part after `nf-core/`)."
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Git remote URL of the pipeline repository."
+        },
+        "version": {
+          "type": "string",
+          "description": "Tag, branch, or commit SHA the summary was derived from."
+        },
+        "license": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "SPDX license identifier when detectable from a LICENSE file."
+        },
+        "slug": {
+          "type": "string",
+          "description": "Kebab-case identifier; `<owner>-<repo>` for nf-core, repo basename otherwise."
+        }
+      }
+    },
+    "Param": {
+      "title": "Param",
+      "description": "One pipeline parameter. Sourced from `nextflow.config`'s `params { ... }` block, augmented from `nextflow_schema.json` when present (nf-core).",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "type",
+        "required"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "description": "JSON Schema-style type when nextflow_schema.json supplies it (string, integer, number, boolean, path); free-form when inferred from a default value."
+        },
+        "default": {
+          "description": "Default value verbatim from the source. May be null."
+        },
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "enum": {
+          "type": "array",
+          "items": {},
+          "description": "Allowed values when nextflow_schema.json declares them."
+        },
+        "format": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "JSON Schema `format` keyword from nextflow_schema.json. nf-schema vocabulary: `file-path`, `directory-path`, `path`, `file-path-pattern`. Distinguishes path-typed params (datasets/collections) from plain strings without re-reading the source schema. Null when undeclared."
+        },
+        "hidden": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "nf-schema `hidden` keyword. True for CLI-plumbing params (e.g. `validate_params`, `pipelines_testdata_base_path`, `version`) that shouldn't surface in user-facing target interfaces. Null when undeclared."
+        },
+        "mimetype": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "nf-schema `mimetype` keyword (e.g. `text/csv`, `text/plain`, `application/gzip`). Useful for seeding Galaxy `format` on path-typed params. Null when undeclared."
+        },
+        "schema_group": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Human-readable group label from the parent nextflow_schema.json `$defs` section's `title` (e.g. `Input/output options`, `Reference genome options`). Preserves nf-schema sectioning so target interfaces can group inputs without re-parsing the source. Null when the param is not under a titled section."
+        },
+        "fa_icon": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Font Awesome icon class from the parent `$defs` section's `fa_icon` (e.g. `fas fa-terminal`). Optional UI hint; null when undeclared."
+        },
+        "source_kind": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "nextflow_schema",
+            "params_block",
+            "getGenomeAttribute",
+            "computed",
+            null
+          ],
+          "description": "How this param entry was derived. `nextflow_schema`: declared in `nextflow_schema.json`. `params_block`: declared (or defaulted) in `nextflow.config`'s `params { ... }` block. `getGenomeAttribute`: synthesized from `params.X = getGenomeAttribute('X')` assignments in `nextflow.config` (nf-core key-expanded bundle pattern). `computed`: derived from another non-getGenomeAttribute expression. Null when provenance was not classified."
+        },
+        "source_expression": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Verbatim right-hand-side expression when the param was assigned in Groovy (e.g. `getGenomeAttribute('fasta_fai')`). Null when the param comes from a JSON Schema entry only."
+        },
+        "source_path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Repo-relative path of the source file where the assignment lives (e.g. `nextflow.config`, `conf/igenomes.config`). Null when undefined or when the param comes only from `nextflow_schema.json`."
+        }
+      }
+    },
+    "SampleSheet": {
+      "title": "SampleSheet",
+      "description": "One sample-sheet-shaped pipeline input. Captures the row schema, path-vs-meta column classification, and discovery provenance so downstream Molds can map onto Galaxy `sample_sheet[:variant]` collections, CWL records-of-arrays, or other target shapes without re-reading the source.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "param",
+        "discovered_via",
+        "columns"
+      ],
+      "properties": {
+        "param": {
+          "type": "string",
+          "description": "Foreign key into `params[].name` — the parameter whose value points at the sample-sheet file."
+        },
+        "schema_path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Repo-relative path of the JSON Schema file describing rows (e.g. `assets/schema_input.json`), resolved from the param's nf-schema entry's `schema:` keyword. Null when discovered via `samplesheetToList` without a schema reference, or via `splitCsv(header: true)` ad-hoc parsing."
+        },
+        "discovered_via": {
+          "type": "string",
+          "enum": [
+            "nf-schema",
+            "samplesheetToList",
+            "splitCsv",
+            "ad-hoc"
+          ],
+          "description": "How the sample-sheet shape was detected. `nf-schema`: nextflow_schema.json entry has `schema:` keyword. `samplesheetToList`: workflow imports nf-schema's helper and calls it on the param. `splitCsv`: workflow uses `splitCsv(header: true)` on the param's path. `ad-hoc`: pipeline-specific CSV/TSV parsing inferred from script bodies."
+        },
+        "format": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "csv",
+            "tsv",
+            "csv-or-tsv",
+            null
+          ],
+          "description": "Tabular format declared by the param's `mimetype` or inferred from `samplesheetToList` / `splitCsv` semantics. Null when undeclared."
+        },
+        "header": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Whether the file is expected to have a header row. Null when the discovery source doesn't pin it."
+        },
+        "columns": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SampleSheetColumn"
+          },
+          "description": "Row schema in declaration order. nf-schema's `samplesheetToList` emits columns in property order, not source-column order — preserve property order here so downstream translations match runtime channel item layout."
+        }
+      }
+    },
+    "SampleSheetColumn": {
+      "title": "SampleSheetColumn",
+      "description": "One column in a sample-sheet row schema. Type vocabulary is JSON Schema-style scalar; `kind` separates dataset-reference columns from per-row metadata. Validation hints (`pattern`, `enum`, `exists`, `mimetype`) are preserved verbatim — target Molds decide which of them survive translation (e.g. Galaxy's `sample_sheet` validator allowlist is regex/in_range/length).",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "type",
+        "kind",
+        "required"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "integer",
+            "number",
+            "boolean"
+          ],
+          "description": "JSON Schema-style scalar type. Path columns are typed `string` with a `format: file-path|directory-path|path` qualifier — see `format` and `kind`."
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "data",
+            "meta"
+          ],
+          "description": "`data`: path-typed column whose values are dataset references (becomes element/inner-collection slot in Galaxy `sample_sheet`). `meta`: scalar metadata column (becomes a `column_definitions` entry, populated per row in `columns[]`). Includes the nf-schema `meta:` annotation when present; in its absence inferred from `format` (`file-path`/`directory-path`/`path` → `data`, anything else → `meta`)."
+        },
+        "format": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "JSON Schema `format` keyword. nf-schema vocabulary: `file-path`, `directory-path`, `path`, `file-path-pattern`. Null for scalar metadata columns without a format hint."
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "default": {
+          "description": "Default value verbatim from the sample-sheet schema. May be null."
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "enum": {
+          "type": "array",
+          "items": {},
+          "description": "Allowed values when the column schema declares an `enum`. Empty array when absent."
+        },
+        "pattern": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "JSON Schema regex `pattern` when present."
+        },
+        "exists": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "nf-schema `exists` flag for path columns. True when the parser must verify the file exists."
+        },
+        "mimetype": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "nf-schema `mimetype` keyword (e.g. `text/csv`, `application/gzip`). Useful for target datatypes."
+        }
+      }
+    },
+    "Tool": {
+      "title": "Tool",
+      "description": "One tool/dependency the pipeline runs. Mirrors gxy-sketches ToolSpec (name + version) and augments it with the resolved container/conda strings the bridge to author-galaxy-tool-wrapper needs.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "version"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Canonical tool name (e.g. `fastp`, `samtools`). Used as the foreign key from `processes[].tool`."
+        },
+        "version": {
+          "type": "string",
+          "description": "Exact version when the conda spec pins one (`name=1.0`, `name==1.0`, or the space-separated `name 1.0`; a trailing `=<build>` is a conda build string and is not part of the version). The literal `unknown` when no exact pin was declared — either because the spec names no version at all (a legitimate authoring choice, e.g. `conda-forge::r-base`) or because it declares an inexact constraint, in which case `version_constraint` carries it. A spec the parser cannot read at all is reported in `warnings[]` rather than landing here as `unknown`."
+        },
+        "version_constraint": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Verbatim version constraint when the conda spec declares an inexact one (e.g. `>=1.17`, `>=1.0,<2.0`). Null when the spec pins exactly or names no version. Present so a range is preserved rather than flattened into the `unknown` sentinel; a consumer that needs an exact version should read a non-null constraint as \"the pipeline constrains this tool, but not to a single version\"."
+        },
+        "biocontainer": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "BioContainers image reference when one was found. Includes both `quay.io/biocontainers/<name>:<version>--<build>` and the docker.io alias `biocontainers/<name>:<version>--<build>` (modern nf-core modules typically use the docker.io form in the docker branch and the depot.galaxyproject.org form in the singularity branch)."
+        },
+        "bioconda": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "`bioconda::<name>=<version>` spec when a `conda` directive provides one — directly or by reference to a `${moduleDir}/environment.yml` whose `dependencies:` list contains a single bioconda entry. The latter is the modern nf-core convention."
+        },
+        "docker": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Non-biocontainer Docker registry image string when present."
+        },
+        "singularity": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Singularity image reference when present (e.g. `https://depot.galaxyproject.org/singularity/...`)."
+        },
+        "wave": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Seqera Wave / community-cr registry reference (e.g. `community.wave.seqera.io/library/<name>:<version>--<digest>` or `https://community-cr-prod.seqera.io/.../sha256/<digest>/data`). Wave-built containers are increasingly common in nf-core; kept distinct from `docker` because the resolution rules and provenance differ."
+        },
+        "mulled_components": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ToolSpec"
+          },
+          "description": "Constituent Bioconda packages for an opaque `mulled-v2-*` multi-package container when resolved from a cached BioContainers multi-package-containers TSV. Omitted when no matching cached row is available."
+        },
+        "versions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Every distinct version of this tool declared anywhere in the pipeline, sorted, when processes disagree. nf-core modules pin independently, so one pipeline routinely runs several versions of a shared dependency (e.g. `samtools` at 1.17, 1.18, 1.19.2, 1.20). The sibling `version`, `biocontainer`, `docker`, `singularity`, and `wave` fields all come from whichever declaration was read last, so on a divergent tool they describe one arbitrary process rather than the pipeline as a whole — treat this array as the authoritative version set and read `processes[].conda` / `processes[].container` for what a given process actually runs. Declarations that name no version contribute nothing here, so a tool pinned by some processes and left unpinned by others lists only its real versions. Omitted when fewer than two distinct versions were declared."
+        }
+      }
+    },
+    "ToolSpec": {
+      "title": "ToolSpec",
+      "description": "One constituent package in a decomposed multi-package container.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "version",
+        "bioconda"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "bioconda": {
+          "type": "string",
+          "description": "Exact Bioconda requirement spec, e.g. `bioconda::samtools=1.20`."
+        }
+      }
+    },
+    "ChannelIO": {
+      "title": "ChannelIO",
+      "description": "One declared input or output channel of a process. Channel shape is a string, not a structured type — `tuple(meta, [path,path])` is enough for downstream Molds and avoids a research project on NF channel typing.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "shape"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "shape": {
+          "type": "string",
+          "description": "String-encoded channel shape, e.g. `tuple(meta, [path,path])`, `path`, `val(integer)`."
+        },
+        "description": {
+          "type": "string"
+        },
+        "topic": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Nextflow channel-topic name when this output is bound to a topic (e.g. `versions` for the standard nf-core version-aggregation topic). Topics are a Nextflow 24+ feature; the module-level `topic: <name>` annotation on a process output emits to a global named channel that any consumer can `channel.topic('<name>')` to read. Null for non-topic outputs and for all inputs."
+        }
+      }
+    },
+    "Process": {
+      "title": "Process",
+      "description": "One Nextflow `process { ... }` block.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "module_path",
+        "meta",
+        "module_tests",
+        "inputs",
+        "outputs"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Canonical process name (uppercase NF convention) as declared by the `process <NAME>` line in `module_path`."
+        },
+        "aliases": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Alias names this process is imported as in workflow scopes via `include { <NAME> as <ALIAS> }`. Real nf-core pipelines re-import a single module multiple times under different aliases to invoke it with distinct runtime args (e.g. `MINIMAP2_ALIGN as MINIMAP2_CONSENSUS`, `MINIMAP2_ALIGN as MINIMAP2_POLISH`). Each alias appears in `workflow.edges[].from`/`.to` exactly as written; the canonical `name` does not appear in edges unless an unaliased import exists. Default `[]` when the process is only imported under its canonical name."
+        },
+        "in_subworkflows": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Denormalized FK: names of `subworkflows[]` whose `calls[]` invoke this process (canonical name or any alias). Empty `[]` when the process is only invoked from the primary `workflow` body. Useful for grouping the flat process-tier DAG into a subworkflow-tier view client-side. Multi-entry when the same module is invoked from several subworkflows (typically via aliases)."
+        },
+        "module_path": {
+          "type": "string",
+          "description": "Relative path from the pipeline root to the file declaring the process."
+        },
+        "meta": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ModuleMeta"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Normalized `meta.yml` from the module directory when present. Null for local/ad-hoc processes without module metadata."
+        },
+        "module_tests": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/NfTest"
+          },
+          "description": "Module-scoped nf-test files under the module's `tests/` directory. Empty for local/ad-hoc modules without unit tests."
+        },
+        "tool": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Foreign key into `tools[].name` when the process runs a single recognizable tool; null for multi-tool or pure-Groovy processes."
+        },
+        "container": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Verbatim text of the process's `container` directive (or null). Modern nf-core modules use a ternary expression `\"${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ? '<singularity-uri>' : '<docker-uri>' }\"` — keep that text intact here. The two resolved branches are split out into `tools[].docker` / `tools[].singularity` (and `tools[].wave` / `tools[].biocontainer` as appropriate)."
+        },
+        "conda": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Verbatim text of the process's `conda` directive (or null). Two common shapes: a literal `bioconda::<name>=<version>` (legacy) or a file reference `${moduleDir}/environment.yml` (modern nf-core convention). Either way the resolved bioconda spec lands in `tools[].bioconda`."
+        },
+        "inputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ChannelIO"
+          }
+        },
+        "outputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ChannelIO"
+          }
+        },
+        "when": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Verbatim `when:` guard expression, or null if absent."
+        },
+        "script_summary": {
+          "type": "string",
+          "description": "One-line LLM-derived summary of what the `script:` body does. Free text."
+        },
+        "publish_dir": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "`publishDir` value when the process publishes outputs (or null)."
+        }
+      }
+    },
+    "ModuleMeta": {
+      "title": "ModuleMeta",
+      "description": "Normalized subset of nf-core module `meta.yml`, captured next to a process so module-scoped downstream Molds can consume `processes[i]` without reading the full pipeline summary.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "keywords",
+        "authors",
+        "maintainers",
+        "tools",
+        "input",
+        "output"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "keywords": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "authors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "maintainers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ModuleMetaEntry"
+          }
+        },
+        "input": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ModuleMetaEntry"
+          }
+        },
+        "output": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ModuleMetaEntry"
+          }
+        }
+      }
+    },
+    "ModuleMetaEntry": {
+      "title": "ModuleMetaEntry",
+      "description": "One named entry from a module `meta.yml` section, normalized from nf-core's single-key YAML maps into `{ name, ...fields }` objects.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "homepage": {
+          "type": "string"
+        },
+        "documentation": {
+          "type": "string"
+        },
+        "tool_dev_url": {
+          "type": "string"
+        },
+        "doi": {
+          "type": "string"
+        },
+        "licence": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "identifier": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "pattern": {
+          "type": "string"
+        }
+      }
+    },
+    "Subworkflow": {
+      "title": "Subworkflow",
+      "description": "One named `workflow <NAME> { ... }` block other than the primary workflow. Includes nf-core utility wrappers (PIPELINE_INITIALISATION, PIPELINE_COMPLETION, UTILS_NFCORE_PIPELINE) which exist to compose helper-function calls rather than to invoke processes.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "path",
+        "kind",
+        "calls",
+        "tests"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string",
+          "description": "Relative path from the pipeline root."
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "pipeline",
+            "utility"
+          ],
+          "description": "`pipeline` when the subworkflow invokes pipeline processes (data-flow contributor). `utility` when it composes helper functions only — common nf-core template subworkflows like PIPELINE_INITIALISATION (which calls `paramsHelp`, `samplesheetToList`, `UTILS_NFSCHEMA_PLUGIN`) and PIPELINE_COMPLETION (`completionEmail`, `completionSummary`). Utility subworkflows have empty `calls[]` for processes but may still expose channel outputs the primary workflow consumes."
+        },
+        "calls": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Names of processes and nested subworkflows this subworkflow invokes. Free-function calls (e.g. `paramsHelp`, `completionEmail`) are NOT recorded here; they're implied by `kind = utility`."
+        },
+        "inputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ChannelIO"
+          },
+          "description": "Parsed entries of the subworkflow's `take:` block. `name` is the take name, `description` carries any adjacent `// ...` comment, `shape` carries the verbatim source line."
+        },
+        "outputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ChannelIO"
+          }
+        },
+        "invocations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SubworkflowInvocation"
+          },
+          "description": "Call-sites where this subworkflow was invoked. Each entry records the calling workflow/subworkflow, the verbatim positional arguments, and a per-argument binding onto this subworkflow's `inputs[].name` (take names). Drives reference-asset attribution (`reference_assets[].used_by`) without re-parsing call sites. Empty when uncalled or when the call could not be positionally aligned."
+        },
+        "tests": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/NfTest"
+          },
+          "description": "Subworkflow-scoped nf-test files under the subworkflow's `tests/` directory. Empty when absent."
+        }
+      }
+    },
+    "SubworkflowInvocation": {
+      "title": "SubworkflowInvocation",
+      "description": "One call-site of a subworkflow, with positional arguments bound to its `take:` names.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "caller",
+        "arguments",
+        "bindings"
+      ],
+      "properties": {
+        "caller": {
+          "type": "string",
+          "description": "Name of the calling workflow or subworkflow."
+        },
+        "caller_path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Repo-relative path of the file the caller is defined in. Null when not resolvable."
+        },
+        "arguments": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Verbatim positional argument expressions in source order (e.g. `params.fasta`, `PREPARE_GENOME.out.fai`)."
+        },
+        "bindings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/InvocationBinding"
+          },
+          "description": "Per-argument binding onto the callee's `inputs[].name` (take names), in source order. Length matches `arguments[]` when the call positionally aligns to the callee's take block; shorter when only a prefix aligns."
+        }
+      }
+    },
+    "InvocationBinding": {
+      "title": "InvocationBinding",
+      "description": "Binding of one positional argument to a callee `take:` name.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "take",
+        "argument"
+      ],
+      "properties": {
+        "take": {
+          "type": "string",
+          "description": "Callee `take:` name (FK into the callee subworkflow's `inputs[].name`)."
+        },
+        "argument": {
+          "type": "string",
+          "description": "Verbatim caller-side argument expression."
+        }
+      }
+    },
+    "Channel": {
+      "title": "Channel",
+      "description": "One top-level channel constructed in the workflow. Sources include `Channel.fromPath`, `Channel.fromFilePairs`, `samplesheetToList`-driven `Channel.fromList`, `splitCsv`, `file`/`files`, and plain `params.*` references.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "source",
+        "shape",
+        "construct",
+        "from_param",
+        "required_runtime"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string",
+          "description": "Verbatim channel-construction expression."
+        },
+        "shape": {
+          "type": "string",
+          "description": "String-encoded channel shape; same convention as ChannelIO."
+        },
+        "construct": {
+          "type": "string",
+          "enum": [
+            "fromPath",
+            "fromFilePairs",
+            "fromList",
+            "samplesheetToList",
+            "splitCsv",
+            "file",
+            "files",
+            "of",
+            "value",
+            "empty",
+            "topic",
+            "other"
+          ],
+          "description": "Classifies the channel's primary materialization factory or shape-determining operator. Selection precedence: (1) `samplesheetToList` when the chain contains `samplesheetToList(...)` (typically wrapped in `Channel.fromList`); (2) `splitCsv` when the chain ends in `.splitCsv(header: true)` over a path; (3) otherwise the outermost factory (`Channel.fromPath` → `fromPath`, `Channel.fromFilePairs` → `fromFilePairs`, `file(...)` → `file`, etc.); (4) `other` for unrecognized constructions. The verbatim `source` retains the full chain — `construct` is the typed lookup the converter would otherwise re-parse."
+        },
+        "from_param": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Foreign key into `params[].name` when the construction expression directly references `params.X` (e.g. `Channel.fromPath(params.reads)`, `samplesheetToList(params.input, ...)`, `file(params.fasta)`). Null for literal-glob construction, expressions that compose multiple params, and channels derived from other channels. v1 resolution is direct-only; one-hop Groovy bindings (`def reads = params.reads; Channel.fromPath(reads)`) are not chased — see galaxyproject/foundry#211."
+        },
+        "required_runtime": {
+          "type": "boolean",
+          "description": "True when the construction chain ends in `.ifEmpty { error ... }` (or an equivalent imperative emptiness-throw guard). Captures runtime requiredness even when the param's nf-schema entry does not mark it required. Combine with `params[].required` and any imperative pre-construction `error` checks for the full requiredness picture."
+        }
+      }
+    },
+    "Edge": {
+      "title": "Edge",
+      "description": "One edge in the workflow's call graph. The deterministic parser records the literal operator chain in `via`; reconciliation of the source and target shapes is the LLM step.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "from",
+        "to"
+      ],
+      "properties": {
+        "from": {
+          "type": "string",
+          "description": "Channel name or `<PROCESS>.out.<chan>` reference."
+        },
+        "to": {
+          "type": "string",
+          "description": "Process or subworkflow name receiving this channel."
+        },
+        "via": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Operators on the path between source and target, in order (e.g. `[\"map\", \"join\", \"groupTuple\"]`). Empty for a direct edge."
+        },
+        "notes": {
+          "type": "string",
+          "description": "LLM-emitted note when the reconciliation is low-confidence (e.g. deeply nested closures)."
+        }
+      }
+    },
+    "Conditional": {
+      "title": "Conditional",
+      "description": "One workflow-level conditional that gates a subgraph.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "guard",
+        "branch",
+        "affects"
+      ],
+      "properties": {
+        "guard": {
+          "type": "string",
+          "description": "Verbatim guard expression, e.g. `params.skip_alignment`."
+        },
+        "branch": {
+          "type": "string",
+          "enum": [
+            "default",
+            "alternate"
+          ],
+          "description": "Which side of the conditional this entry describes. `default` is the truthy branch; `alternate` is the else branch."
+        },
+        "affects": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Process or subworkflow names whose execution is gated by this conditional."
+        }
+      }
+    },
+    "Workflow": {
+      "title": "Workflow",
+      "description": "Primary workflow: channel construction plus the call-graph DAG. Real nf-core pipelines have multiple named `workflow` blocks (an anonymous entrypoint `workflow {}` in main.nf that wires PIPELINE_INITIALISATION → NFCORE_<NAME> → PIPELINE_COMPLETION; a named NFCORE_<NAME> wrapper; a substantive named workflow under workflows/<name>.nf). The summary collapses this into one primary `workflow` plus `subworkflows[]`. Selection rule: pick the workflow that invokes the most pipeline processes — typically the one under `workflows/<name>.nf`. The anonymous `workflow {}` glue and the NFCORE_<NAME> wrapper land in `subworkflows[]`.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "channels",
+        "edges"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the selected primary workflow (uppercase NF convention). The anonymous `workflow {}` entrypoint is never the primary; if it is the only workflow block, the pipeline is too small to summarize and the cast skill should emit a warning."
+        },
+        "channels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Channel"
+          }
+        },
+        "edges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Edge"
+          }
+        },
+        "conditionals": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Conditional"
+          }
+        }
+      }
+    },
+    "TestDataRef": {
+      "title": "TestDataRef",
+      "description": "One test-fixture input. Field names mirror gxy-sketches' TestDataRef verbatim. The sketch-bundle constraint that `path` must live under `test_data/` is intentionally dropped; the Foundry summary describes fixtures as data, it does not bundle them.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "role"
+      ],
+      "properties": {
+        "role": {
+          "type": "string",
+          "description": "Logical role of the input (e.g. `samplesheet`, `reference_fasta`)."
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Repo-relative path when the fixture lives in-tree, or local filesystem path when the CLI fetched the remote fixture into a caller-provided test-data directory."
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uri"
+        },
+        "sha1": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "SHA-1 integrity hash when published alongside the fixture."
+        },
+        "filetype": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "File format, e.g. `fastq.gz`, `csv`."
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "path"
+          ]
+        },
+        {
+          "required": [
+            "url"
+          ]
+        }
+      ]
+    },
+    "ExpectedOutputRef": {
+      "title": "ExpectedOutputRef",
+      "description": "One expected output. Field names mirror gxy-sketches' ExpectedOutputRef verbatim. At least one of path / url / assertions is required.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "role"
+      ],
+      "properties": {
+        "role": {
+          "type": "string"
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uri"
+        },
+        "kind": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Coarse output kind: `report`, `tabular`, `image`, `archive`, `sequence`, `other`."
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "assertions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Assertion strings. Simple equality / regex / contains-string checks are preserved verbatim; complex Groovy assertions are summarized to prose with a `warnings[]` flag in the parent Summary."
+        }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "path"
+          ]
+        },
+        {
+          "required": [
+            "url"
+          ]
+        },
+        {
+          "required": [
+            "assertions"
+          ]
+        }
+      ]
+    },
+    "TestFixtures": {
+      "title": "TestFixtures",
+      "description": "Test fixtures derived from a `conf/<profile>.config` for the cast's selected profile. Pipelines with multiple test profiles (bacass has 11) record only the selected profile here; the full nf-test enumeration lives in `nf_tests[]`.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "profile",
+        "inputs",
+        "outputs"
+      ],
+      "properties": {
+        "profile": {
+          "type": "string",
+          "description": "Which `conf/<profile>.config` produced these fixtures (typically `test`)."
+        },
+        "inputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TestDataRef"
+          }
+        },
+        "outputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ExpectedOutputRef"
+          }
+        }
+      }
+    },
+    "NfTest": {
+      "title": "NfTest",
+      "description": "One `tests/*.nf.test` file. nf-core templates use a near-uniform shape: a `nextflow_pipeline { test(\"<desc>\") { when { params { ... } } then { assertAll(...) } } }` block, with one test() per profile, asserting `workflow.success` plus a snapshot match. This shape captures the data so downstream test-conversion molds (e.g. nextflow-test-to-target-tests) don't have to re-parse Groovy.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "path",
+        "profiles",
+        "assert_workflow_success",
+        "prose_assertions"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Description string passed to `test(\"...\")`. Often duplicates the profile name."
+        },
+        "path": {
+          "type": "string",
+          "description": "Repo-relative path of the .nf.test file (e.g. `tests/dfast.nf.test`)."
+        },
+        "profiles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Profile name(s) the test runs under, from the file-level `profile \"<name>\"` declaration and/or per-test config overrides. Usually a single profile."
+        },
+        "params_overrides": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "The `when { params { ... } }` block as a key→value map. Most templates set only `outdir`; pipeline-specific overrides land here."
+        },
+        "assert_workflow_success": {
+          "type": "boolean",
+          "description": "Whether the test asserts `workflow.success`. Almost always true for nf-core templates."
+        },
+        "snapshot": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SnapshotFixture"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Structured representation of the `assert snapshot(...).match()` clause when present; null when the test uses no snapshot."
+        },
+        "prose_assertions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Other assertions (regex matches, count checks, content equality on specific files) summarized to prose strings. Empty for snapshot-only tests, which is the common nf-core case."
+        }
+      }
+    },
+    "SnapshotFixture": {
+      "title": "SnapshotFixture",
+      "description": "Structured shape of an nf-test `snapshot(...).match()` assertion. nf-core templates pass a small set of values into snapshot() — succeeded-task count, version YAML (with Nextflow version stripped), stable file-name list, stable file-content list — and prune the comparison via `getAllFilesFromDir(..., ignoreFile: ..., ignore: [...])` helpers. This breakdown lets downstream consumers reconstruct equivalent assertions in target test frameworks without re-parsing Groovy.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "captures",
+        "helpers",
+        "ignore_files",
+        "ignore_globs"
+      ],
+      "properties": {
+        "captures": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Logical names of values passed to snapshot(), in order. Common set: `succeeded_task_count`, `versions_yml`, `stable_names`, `stable_paths`. Free-form strings rather than an enum because pipelines can pass other values."
+        },
+        "helpers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "nf-test helper functions invoked in the snapshot expression (e.g. `getAllFilesFromDir`, `removeNextflowVersion`). Used to detect whether a target framework can replicate the comparison."
+        },
+        "ignore_files": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Repo-relative paths passed as `ignoreFile:` to helpers (e.g. `tests/.nftignore`, `tests/.nftignore_files_entirely`). The files themselves are line-delimited globs."
+        },
+        "ignore_globs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Inline `ignore: [...]` glob list passed to helpers (e.g. `['Prokka/**', '**/multiqc_busco.yaml']`). Distinct from ignore_files which references on-disk lists."
+        },
+        "snap_path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Repo-relative path of the corresponding `.nf.test.snap` file when present."
+        },
+        "parsed_content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SnapshotContent"
+          },
+          "description": "Parsed entries from the `.nf.test.snap` JSON sidecar. Empty when the sidecar is absent, too large for compact summary output, or not valid JSON. Each entry preserves the snapshot name plus channel-keyed file md5 assertions and non-file scalar values."
+        }
+      }
+    },
+    "SnapshotContent": {
+      "title": "SnapshotContent",
+      "description": "One top-level snapshot entry from an nf-test `.snap` JSON sidecar.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "channels"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Top-level key in the `.snap` file, usually the `test(\"...\")` name."
+        },
+        "channels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SnapshotChannel"
+          },
+          "description": "Channel-keyed snapshot values. Pipeline-template flat file lists use `key: null`."
+        }
+      }
+    },
+    "SnapshotChannel": {
+      "title": "SnapshotChannel",
+      "description": "One output channel or flat snapshot list inside a `.snap` entry.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "key",
+        "files",
+        "values"
+      ],
+      "properties": {
+        "key": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Channel key from the snapshot object, e.g. `0`, `1`, or `genome_gtf`; null for flat file-list snapshots."
+        },
+        "files": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SnapshotFile"
+          },
+          "description": "File md5 assertions parsed from `<path>:md5,<hex>` strings."
+        },
+        "values": {
+          "type": "array",
+          "items": {},
+          "description": "Non-file snapshot values preserved verbatim for consumers that need versions, counts, or scalar tuple emissions."
+        }
+      }
+    },
+    "Evidence": {
+      "title": "Evidence",
+      "description": "Shared provenance block for source-detected facts. `source_path` localizes the finding; `confidence` is a coarse self-assessment; `evidence[]` carries free-form snippets (matched lines, normalized expressions, detector notes). Reused by ReferenceAsset and ReferenceRebuildRule.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_path",
+        "confidence",
+        "evidence"
+      ],
+      "properties": {
+        "source_path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Repo-relative path of the source file where the finding was detected (e.g. `subworkflows/local/prepare_genome/main.nf`, `nextflow.config`). Null when the finding spans files or cannot be localized."
+        },
+        "confidence": {
+          "type": "string",
+          "enum": [
+            "high",
+            "medium",
+            "low"
+          ],
+          "description": "Detector self-assessment. `high`: all signals match the expected idiom; `medium`: some signals match but the guard or builder is partial / mixes non-param locals; `low`: heuristic match, downstream should treat as a hint."
+        },
+        "evidence": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Free-form evidence snippets (matched source lines, normalized expressions, detector notes). Empty when none."
+        }
+      }
+    },
+    "ReferenceAsset": {
+      "title": "ReferenceAsset",
+      "description": "Curated source-side view of one reference-data input the pipeline consumes. A foreign-key projection onto `params[].name` plus the metadata downstream classification Molds need. Target-agnostic: no Galaxy translation decisions are encoded here.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "param",
+        "asset_kind",
+        "required",
+        "used_by",
+        "evidence"
+      ],
+      "properties": {
+        "param": {
+          "type": "string",
+          "description": "FK into `params[].name`."
+        },
+        "asset_kind": {
+          "type": "string",
+          "description": "Coarse asset classification (e.g. `fasta`, `fasta_index`, `sequence_dictionary`, `bwa_index`, `bwamem2_index`, `tabix_index`, `gtf`, `gff`, `bed`, `vcf`, `database`, `reference_sheet`, `other`). Free-form string; downstream Molds choose how to map onto target datatypes."
+        },
+        "format_hint": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Format hint, often the nf-schema `format` keyword (`file-path`, `directory-path`, `path`, `file-path-pattern`) or a domain hint like `fai`, `dict`. Null when undetermined."
+        },
+        "required": {
+          "type": "boolean",
+          "description": "True when the source pipeline treats this asset as required (no compute-if-missing branch, no optional guard). When false, see `reference_rebuilds[]` for any rebuild branch covering this param."
+        },
+        "source_kind": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "nextflow_schema",
+            "params_block",
+            "getGenomeAttribute",
+            "computed",
+            null
+          ],
+          "description": "Mirrors `params[<this>].source_kind`. Duplicated here so reference-data consumers don't have to dereference."
+        },
+        "source_expression": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Mirrors `params[<this>].source_expression`. Duplicated for the same reason."
+        },
+        "schema_group": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Mirrors `params[<this>].schema_group`. Useful for grouping (`Reference genome options`)."
+        },
+        "used_by": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Names of processes / subworkflows that receive this param as an argument (via direct invocation binding or channel construction). Empty when no caller could be attributed."
+        },
+        "evidence": {
+          "$ref": "#/$defs/Evidence"
+        }
+      }
+    },
+    "ReferenceRebuildRule": {
+      "title": "ReferenceRebuildRule",
+      "description": "One compute-if-missing rebuild branch detected in a workflow or subworkflow body. Binds an asset param to the guard expression and builder process that produces it when absent. Source evidence only; in-tool-rebuild decisions live downstream.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "asset_param",
+        "guard",
+        "builder",
+        "builder_outputs",
+        "evidence"
+      ],
+      "properties": {
+        "asset_param": {
+          "type": "string",
+          "description": "FK into `params[].name` — the asset this branch reconstitutes when missing."
+        },
+        "guard": {
+          "type": "string",
+          "description": "Verbatim guard expression, e.g. `!fasta_fai_in && step != \"annotate\"`."
+        },
+        "guard_params": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Param names referenced by the guard. Empty when the guard binds only non-param locals."
+        },
+        "builder": {
+          "type": "string",
+          "description": "Builder process or subworkflow name invoked inside the branch (e.g. `SAMTOOLS_FAIDX`, `BWA_INDEX`)."
+        },
+        "builder_outputs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Output channel names from the builder that are assigned to the asset (e.g. `fai`, `dict`)."
+        },
+        "fallback_for": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Name of the `<asset>_in`-style param that, when present, supplies the asset directly and skips the rebuild. Null when no such pairing was detected."
+        },
+        "evidence": {
+          "$ref": "#/$defs/Evidence"
+        }
+      }
+    },
+    "SnapshotFile": {
+      "title": "SnapshotFile",
+      "description": "One file digest assertion from a `.snap` sidecar.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "basename",
+        "md5",
+        "stub"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Path portion before `:md5,` exactly as stored in the sidecar."
+        },
+        "basename": {
+          "type": "string",
+          "description": "Final path segment, suitable for Galaxy test `file:` assertions when the snapshot stores only basenames."
+        },
+        "md5": {
+          "type": "string",
+          "pattern": "^[a-fA-F0-9]{32}$",
+          "description": "MD5 digest from the sidecar."
+        },
+        "stub": {
+          "type": "boolean",
+          "description": "True when the digest is the empty-file md5 emitted by many `-stub` tests."
+        }
+      }
+    }
+  }
+}

--- a/casts/claude/skills/nextflow-summary-to-cwl-interface/SKILL.md
+++ b/casts/claude/skills/nextflow-summary-to-cwl-interface/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: nextflow-summary-to-cwl-interface
+description: "Map a Nextflow summary into a CWL Workflow interface design brief."
+---
+
+# nextflow-summary-to-cwl-interface
+
+Follow the procedure below and use the artifact/reference sections as the runtime contract.
+
+## When To Use
+
+- Map a Nextflow summary into a CWL Workflow interface design brief.
+
+## Inputs
+
+- Read artifact `summary-nextflow`. Schema: summary-nextflow. Produced by `summarize-nextflow`. Structured Nextflow pipeline summary emitted by summarize-nextflow; the source-of-truth JSON for CWL interface choices.
+
+## Outputs
+
+- Write artifact `nextflow-cwl-interface` as `nextflow-cwl-interface.md`. Format: `markdown`. Reviewable Markdown brief: CWL Workflow inputs, outputs, labels, array/record/File shapes, checkpoint outputs, source provenance.
+
+## Required Tools
+
+- None declared. Procedure should not assume external CLIs are present.
+
+## Load Upfront
+
+- `references/schemas/summary-nextflow.schema.json`: Schema file copied verbatim into the bundle. Read source-level channel, parameter, process, and test-fixture evidence before choosing CWL Workflow inputs and outputs.
+
+## Load On Demand
+
+- None declared.
+
+## Validation
+
+- None declared.
+
+## Procedure
+
+Read a Nextflow summary and emit a reviewable Markdown interface brief for a CWL Workflow. Capture workflow inputs, workflow outputs, labels, array/record/File shapes, checkpoint outputs worth exposing for tests, source-summary provenance, confidence, and open questions.
+
+The output is a design handoff consumed by nextflow-summary-to-cwl-data-flow, summary-to-cwl-template, and later test-plan work.
+
+## Runtime Notes
+
+- Do not read Foundry source files at runtime; use only files packaged in this skill bundle and user-supplied artifacts.
+- Preserve declared artifact filenames unless the user or harness supplies explicit paths.
+- Carry unresolved assumptions into the output artifact instead of silently inventing missing source evidence.

--- a/casts/claude/skills/nextflow-summary-to-cwl-interface/_provenance.json
+++ b/casts/claude/skills/nextflow-summary-to-cwl-interface/_provenance.json
@@ -1,0 +1,49 @@
+{
+  "provenance_schema_version": 3,
+  "cast_target": "claude",
+  "mold": {
+    "name": "nextflow-summary-to-cwl-interface",
+    "path": "content/molds/nextflow-summary-to-cwl-interface/index.md",
+    "revision": 1,
+    "content_hash": "dafc465608018eb5b0dc68f168632465aa5062f3e64b9d4bb3754a6024d92ef7",
+    "commit": "e487fe785f468afdf25f2b6bd140c3a115a12021"
+  },
+  "cast_at": "2026-07-24T13:51:15.200Z",
+  "refs": [
+    {
+      "kind": "schema",
+      "mode": "verbatim",
+      "ref": "[[summary-nextflow]]",
+      "src": "package://@galaxy-foundry/summarize-nextflow#summaryNextflowSchema",
+      "dst": "references/schemas/summary-nextflow.schema.json",
+      "used_at": "runtime",
+      "load": "upfront",
+      "evidence": "corpus-observed",
+      "purpose": "Read source-level channel, parameter, process, and test-fixture evidence before choosing CWL Workflow inputs and outputs.",
+      "license": "MIT",
+      "src_hash": "06430103b6111c40c030990459d41fe599faba0015865bba54d0e8bd0cf9fd1c",
+      "dst_hash": "06430103b6111c40c030990459d41fe599faba0015865bba54d0e8bd0cf9fd1c",
+      "source": "deterministic"
+    }
+  ],
+  "artifacts": {
+    "produces": [
+      {
+        "id": "nextflow-cwl-interface",
+        "kind": "markdown",
+        "default_filename": "nextflow-cwl-interface.md",
+        "description": "Reviewable Markdown brief: CWL Workflow inputs, outputs, labels, array/record/File shapes, checkpoint outputs, source provenance."
+      }
+    ],
+    "consumes": [
+      {
+        "id": "summary-nextflow",
+        "description": "Structured Nextflow pipeline summary emitted by [[summarize-nextflow]]; the source-of-truth JSON for CWL interface choices.",
+        "inherited_schema": "[[summary-nextflow]]",
+        "producers": [
+          "summarize-nextflow"
+        ]
+      }
+    ]
+  }
+}

--- a/casts/claude/skills/nextflow-summary-to-cwl-interface/_verify.json
+++ b/casts/claude/skills/nextflow-summary-to-cwl-interface/_verify.json
@@ -1,0 +1,17 @@
+{
+  "verify_schema_version": 1,
+  "entries": [
+    {
+      "artifact_id": "summary-nextflow",
+      "direction": "input",
+      "kind": "json",
+      "default_filename": "summary-nextflow.json",
+      "schema": "[[summary-nextflow]]",
+      "validator_bin": "foundry",
+      "args": [
+        "validate-summary-nextflow",
+        "{artifact_path}"
+      ]
+    }
+  ]
+}

--- a/casts/claude/skills/nextflow-summary-to-cwl-interface/references/schemas/summary-nextflow.schema.json
+++ b/casts/claude/skills/nextflow-summary-to-cwl-interface/references/schemas/summary-nextflow.schema.json
@@ -1,0 +1,1514 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://galaxyproject.org/foundry/schemas/summary-nextflow.schema.json",
+  "$comment": "Canonical source: packages/summarize-nextflow/src/schema/summary-nextflow.schema.json in galaxyproject/foundry. Mold frontmatter cites this schema via [[summary-nextflow]] wiki-links; the cast pipeline imports the `summaryNextflowSchema` runtime export and serializes it into cast bundles.",
+  "title": "Nextflow Pipeline Summary",
+  "description": "Structured per-source summary emitted by the summarize-nextflow Mold.\n\nPer-source schema by design — paper, Nextflow, and CWL each have their own summary shape; downstream Molds (data flow, templates, tool wrappers) consume any source's summary and handle the polymorphism.\n\nField names mirror gxy-sketches' SketchSource / ToolSpec / TestDataRef / ExpectedOutputRef where parity exists; see content/research/gxy-sketches-alignment.md.",
+  "$ref": "#/$defs/Summary",
+  "$defs": {
+    "Summary": {
+      "title": "Summary",
+      "description": "Top-level shape. Every Nextflow summary is exactly this object.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source",
+        "params",
+        "sample_sheets",
+        "profiles",
+        "tools",
+        "processes",
+        "subworkflows",
+        "workflow",
+        "reference_assets",
+        "reference_rebuilds",
+        "test_fixtures",
+        "nf_tests"
+      ],
+      "properties": {
+        "source": {
+          "$ref": "#/$defs/SourceRecord"
+        },
+        "params": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Param"
+          }
+        },
+        "sample_sheets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SampleSheet"
+          },
+          "description": "Structured sample-sheet inputs. Each entry binds one `params[]` parameter to a row schema (column names, types, path-vs-meta classification, required flags, enums, patterns). Promoted from prose inside `params[].description` so downstream target translations (Galaxy `sample_sheet*` collections, CWL records-of-arrays) can choose collection variants without re-parsing the source pipeline. Empty array when no sample-sheet idiom is detected. Discovery sources: nf-schema `schema:` references, `samplesheetToList()` calls, and `splitCsv(header: true)` materializations."
+        },
+        "profiles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Tool"
+          }
+        },
+        "processes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Process"
+          }
+        },
+        "subworkflows": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Subworkflow"
+          }
+        },
+        "workflow": {
+          "$ref": "#/$defs/Workflow"
+        },
+        "reference_assets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ReferenceAsset"
+          },
+          "description": "Curated, target-agnostic view of reference-data inputs the source pipeline consumes (FASTAs, indexes, dictionaries, annotation tables, …). Each entry is a foreign-key projection onto `params[]` plus source-side metadata (asset kind, format hint, source expression, schema group, callers). Empty array when no reference assets are detected. Downstream Molds (e.g. nextflow-summary-to-galaxy-reference-data) classify these against Galaxy translation rungs; classification decisions are not encoded here."
+        },
+        "reference_rebuilds": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ReferenceRebuildRule"
+          },
+          "description": "Compute-if-missing rebuild branches detected in workflow/subworkflow bodies. Each entry binds an asset param to the guard and builder process that recomputes it when absent. Empty when no rebuild idioms are found. Source evidence only — Galaxy in-tool-rebuild decisions live downstream."
+        },
+        "test_fixtures": {
+          "$ref": "#/$defs/TestFixtures",
+          "description": "Test-input data shape for the *selected* profile (the cast's `profile` argument, default `test`). For pipelines with multiple test profiles, see `nf_tests[]` for the full enumeration."
+        },
+        "nf_tests": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/NfTest"
+          },
+          "description": "All `tests/*.nf.test` files in the pipeline. Each entry captures one test-program — its profile, params overrides, and structured assertions. Empty array when the pipeline has no nf-test fixtures."
+        },
+        "warnings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Cast-skill-emitted advisory messages (e.g. DSL1 detected, meta.yml/script disagreement, lossy assertion summarization). Empty array on a clean run."
+        }
+      }
+    },
+    "SourceRecord": {
+      "title": "SourceRecord",
+      "description": "Provenance block. Mirrors gxy-sketches SketchSource field names so a Foundry summary is structurally consumable by anyone using that shape.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "ecosystem",
+        "workflow",
+        "url",
+        "version",
+        "slug"
+      ],
+      "properties": {
+        "ecosystem": {
+          "type": "string",
+          "enum": [
+            "nf-core",
+            "nextflow"
+          ],
+          "description": "Pipeline flavor. `nf-core` when `manifest.name` is `nf-core/<slug>` and the canonical layout is present; `nextflow` for ad-hoc DSL2 pipelines. Superset of gxy-sketches' enum (which adds `iwc`, `snakemake-workflows`, `wdl` for its other ingestors)."
+        },
+        "workflow": {
+          "type": "string",
+          "description": "Pipeline name (typically the part after `nf-core/`)."
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Git remote URL of the pipeline repository."
+        },
+        "version": {
+          "type": "string",
+          "description": "Tag, branch, or commit SHA the summary was derived from."
+        },
+        "license": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "SPDX license identifier when detectable from a LICENSE file."
+        },
+        "slug": {
+          "type": "string",
+          "description": "Kebab-case identifier; `<owner>-<repo>` for nf-core, repo basename otherwise."
+        }
+      }
+    },
+    "Param": {
+      "title": "Param",
+      "description": "One pipeline parameter. Sourced from `nextflow.config`'s `params { ... }` block, augmented from `nextflow_schema.json` when present (nf-core).",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "type",
+        "required"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "description": "JSON Schema-style type when nextflow_schema.json supplies it (string, integer, number, boolean, path); free-form when inferred from a default value."
+        },
+        "default": {
+          "description": "Default value verbatim from the source. May be null."
+        },
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "enum": {
+          "type": "array",
+          "items": {},
+          "description": "Allowed values when nextflow_schema.json declares them."
+        },
+        "format": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "JSON Schema `format` keyword from nextflow_schema.json. nf-schema vocabulary: `file-path`, `directory-path`, `path`, `file-path-pattern`. Distinguishes path-typed params (datasets/collections) from plain strings without re-reading the source schema. Null when undeclared."
+        },
+        "hidden": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "nf-schema `hidden` keyword. True for CLI-plumbing params (e.g. `validate_params`, `pipelines_testdata_base_path`, `version`) that shouldn't surface in user-facing target interfaces. Null when undeclared."
+        },
+        "mimetype": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "nf-schema `mimetype` keyword (e.g. `text/csv`, `text/plain`, `application/gzip`). Useful for seeding Galaxy `format` on path-typed params. Null when undeclared."
+        },
+        "schema_group": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Human-readable group label from the parent nextflow_schema.json `$defs` section's `title` (e.g. `Input/output options`, `Reference genome options`). Preserves nf-schema sectioning so target interfaces can group inputs without re-parsing the source. Null when the param is not under a titled section."
+        },
+        "fa_icon": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Font Awesome icon class from the parent `$defs` section's `fa_icon` (e.g. `fas fa-terminal`). Optional UI hint; null when undeclared."
+        },
+        "source_kind": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "nextflow_schema",
+            "params_block",
+            "getGenomeAttribute",
+            "computed",
+            null
+          ],
+          "description": "How this param entry was derived. `nextflow_schema`: declared in `nextflow_schema.json`. `params_block`: declared (or defaulted) in `nextflow.config`'s `params { ... }` block. `getGenomeAttribute`: synthesized from `params.X = getGenomeAttribute('X')` assignments in `nextflow.config` (nf-core key-expanded bundle pattern). `computed`: derived from another non-getGenomeAttribute expression. Null when provenance was not classified."
+        },
+        "source_expression": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Verbatim right-hand-side expression when the param was assigned in Groovy (e.g. `getGenomeAttribute('fasta_fai')`). Null when the param comes from a JSON Schema entry only."
+        },
+        "source_path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Repo-relative path of the source file where the assignment lives (e.g. `nextflow.config`, `conf/igenomes.config`). Null when undefined or when the param comes only from `nextflow_schema.json`."
+        }
+      }
+    },
+    "SampleSheet": {
+      "title": "SampleSheet",
+      "description": "One sample-sheet-shaped pipeline input. Captures the row schema, path-vs-meta column classification, and discovery provenance so downstream Molds can map onto Galaxy `sample_sheet[:variant]` collections, CWL records-of-arrays, or other target shapes without re-reading the source.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "param",
+        "discovered_via",
+        "columns"
+      ],
+      "properties": {
+        "param": {
+          "type": "string",
+          "description": "Foreign key into `params[].name` — the parameter whose value points at the sample-sheet file."
+        },
+        "schema_path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Repo-relative path of the JSON Schema file describing rows (e.g. `assets/schema_input.json`), resolved from the param's nf-schema entry's `schema:` keyword. Null when discovered via `samplesheetToList` without a schema reference, or via `splitCsv(header: true)` ad-hoc parsing."
+        },
+        "discovered_via": {
+          "type": "string",
+          "enum": [
+            "nf-schema",
+            "samplesheetToList",
+            "splitCsv",
+            "ad-hoc"
+          ],
+          "description": "How the sample-sheet shape was detected. `nf-schema`: nextflow_schema.json entry has `schema:` keyword. `samplesheetToList`: workflow imports nf-schema's helper and calls it on the param. `splitCsv`: workflow uses `splitCsv(header: true)` on the param's path. `ad-hoc`: pipeline-specific CSV/TSV parsing inferred from script bodies."
+        },
+        "format": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "csv",
+            "tsv",
+            "csv-or-tsv",
+            null
+          ],
+          "description": "Tabular format declared by the param's `mimetype` or inferred from `samplesheetToList` / `splitCsv` semantics. Null when undeclared."
+        },
+        "header": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Whether the file is expected to have a header row. Null when the discovery source doesn't pin it."
+        },
+        "columns": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SampleSheetColumn"
+          },
+          "description": "Row schema in declaration order. nf-schema's `samplesheetToList` emits columns in property order, not source-column order — preserve property order here so downstream translations match runtime channel item layout."
+        }
+      }
+    },
+    "SampleSheetColumn": {
+      "title": "SampleSheetColumn",
+      "description": "One column in a sample-sheet row schema. Type vocabulary is JSON Schema-style scalar; `kind` separates dataset-reference columns from per-row metadata. Validation hints (`pattern`, `enum`, `exists`, `mimetype`) are preserved verbatim — target Molds decide which of them survive translation (e.g. Galaxy's `sample_sheet` validator allowlist is regex/in_range/length).",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "type",
+        "kind",
+        "required"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "integer",
+            "number",
+            "boolean"
+          ],
+          "description": "JSON Schema-style scalar type. Path columns are typed `string` with a `format: file-path|directory-path|path` qualifier — see `format` and `kind`."
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "data",
+            "meta"
+          ],
+          "description": "`data`: path-typed column whose values are dataset references (becomes element/inner-collection slot in Galaxy `sample_sheet`). `meta`: scalar metadata column (becomes a `column_definitions` entry, populated per row in `columns[]`). Includes the nf-schema `meta:` annotation when present; in its absence inferred from `format` (`file-path`/`directory-path`/`path` → `data`, anything else → `meta`)."
+        },
+        "format": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "JSON Schema `format` keyword. nf-schema vocabulary: `file-path`, `directory-path`, `path`, `file-path-pattern`. Null for scalar metadata columns without a format hint."
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "default": {
+          "description": "Default value verbatim from the sample-sheet schema. May be null."
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "enum": {
+          "type": "array",
+          "items": {},
+          "description": "Allowed values when the column schema declares an `enum`. Empty array when absent."
+        },
+        "pattern": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "JSON Schema regex `pattern` when present."
+        },
+        "exists": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "nf-schema `exists` flag for path columns. True when the parser must verify the file exists."
+        },
+        "mimetype": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "nf-schema `mimetype` keyword (e.g. `text/csv`, `application/gzip`). Useful for target datatypes."
+        }
+      }
+    },
+    "Tool": {
+      "title": "Tool",
+      "description": "One tool/dependency the pipeline runs. Mirrors gxy-sketches ToolSpec (name + version) and augments it with the resolved container/conda strings the bridge to author-galaxy-tool-wrapper needs.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "version"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Canonical tool name (e.g. `fastp`, `samtools`). Used as the foreign key from `processes[].tool`."
+        },
+        "version": {
+          "type": "string",
+          "description": "Exact version when the conda spec pins one (`name=1.0`, `name==1.0`, or the space-separated `name 1.0`; a trailing `=<build>` is a conda build string and is not part of the version). The literal `unknown` when no exact pin was declared — either because the spec names no version at all (a legitimate authoring choice, e.g. `conda-forge::r-base`) or because it declares an inexact constraint, in which case `version_constraint` carries it. A spec the parser cannot read at all is reported in `warnings[]` rather than landing here as `unknown`."
+        },
+        "version_constraint": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Verbatim version constraint when the conda spec declares an inexact one (e.g. `>=1.17`, `>=1.0,<2.0`). Null when the spec pins exactly or names no version. Present so a range is preserved rather than flattened into the `unknown` sentinel; a consumer that needs an exact version should read a non-null constraint as \"the pipeline constrains this tool, but not to a single version\"."
+        },
+        "biocontainer": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "BioContainers image reference when one was found. Includes both `quay.io/biocontainers/<name>:<version>--<build>` and the docker.io alias `biocontainers/<name>:<version>--<build>` (modern nf-core modules typically use the docker.io form in the docker branch and the depot.galaxyproject.org form in the singularity branch)."
+        },
+        "bioconda": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "`bioconda::<name>=<version>` spec when a `conda` directive provides one — directly or by reference to a `${moduleDir}/environment.yml` whose `dependencies:` list contains a single bioconda entry. The latter is the modern nf-core convention."
+        },
+        "docker": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Non-biocontainer Docker registry image string when present."
+        },
+        "singularity": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Singularity image reference when present (e.g. `https://depot.galaxyproject.org/singularity/...`)."
+        },
+        "wave": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Seqera Wave / community-cr registry reference (e.g. `community.wave.seqera.io/library/<name>:<version>--<digest>` or `https://community-cr-prod.seqera.io/.../sha256/<digest>/data`). Wave-built containers are increasingly common in nf-core; kept distinct from `docker` because the resolution rules and provenance differ."
+        },
+        "mulled_components": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ToolSpec"
+          },
+          "description": "Constituent Bioconda packages for an opaque `mulled-v2-*` multi-package container when resolved from a cached BioContainers multi-package-containers TSV. Omitted when no matching cached row is available."
+        },
+        "versions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Every distinct version of this tool declared anywhere in the pipeline, sorted, when processes disagree. nf-core modules pin independently, so one pipeline routinely runs several versions of a shared dependency (e.g. `samtools` at 1.17, 1.18, 1.19.2, 1.20). The sibling `version`, `biocontainer`, `docker`, `singularity`, and `wave` fields all come from whichever declaration was read last, so on a divergent tool they describe one arbitrary process rather than the pipeline as a whole — treat this array as the authoritative version set and read `processes[].conda` / `processes[].container` for what a given process actually runs. Declarations that name no version contribute nothing here, so a tool pinned by some processes and left unpinned by others lists only its real versions. Omitted when fewer than two distinct versions were declared."
+        }
+      }
+    },
+    "ToolSpec": {
+      "title": "ToolSpec",
+      "description": "One constituent package in a decomposed multi-package container.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "version",
+        "bioconda"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "bioconda": {
+          "type": "string",
+          "description": "Exact Bioconda requirement spec, e.g. `bioconda::samtools=1.20`."
+        }
+      }
+    },
+    "ChannelIO": {
+      "title": "ChannelIO",
+      "description": "One declared input or output channel of a process. Channel shape is a string, not a structured type — `tuple(meta, [path,path])` is enough for downstream Molds and avoids a research project on NF channel typing.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "shape"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "shape": {
+          "type": "string",
+          "description": "String-encoded channel shape, e.g. `tuple(meta, [path,path])`, `path`, `val(integer)`."
+        },
+        "description": {
+          "type": "string"
+        },
+        "topic": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Nextflow channel-topic name when this output is bound to a topic (e.g. `versions` for the standard nf-core version-aggregation topic). Topics are a Nextflow 24+ feature; the module-level `topic: <name>` annotation on a process output emits to a global named channel that any consumer can `channel.topic('<name>')` to read. Null for non-topic outputs and for all inputs."
+        }
+      }
+    },
+    "Process": {
+      "title": "Process",
+      "description": "One Nextflow `process { ... }` block.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "module_path",
+        "meta",
+        "module_tests",
+        "inputs",
+        "outputs"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Canonical process name (uppercase NF convention) as declared by the `process <NAME>` line in `module_path`."
+        },
+        "aliases": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Alias names this process is imported as in workflow scopes via `include { <NAME> as <ALIAS> }`. Real nf-core pipelines re-import a single module multiple times under different aliases to invoke it with distinct runtime args (e.g. `MINIMAP2_ALIGN as MINIMAP2_CONSENSUS`, `MINIMAP2_ALIGN as MINIMAP2_POLISH`). Each alias appears in `workflow.edges[].from`/`.to` exactly as written; the canonical `name` does not appear in edges unless an unaliased import exists. Default `[]` when the process is only imported under its canonical name."
+        },
+        "in_subworkflows": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Denormalized FK: names of `subworkflows[]` whose `calls[]` invoke this process (canonical name or any alias). Empty `[]` when the process is only invoked from the primary `workflow` body. Useful for grouping the flat process-tier DAG into a subworkflow-tier view client-side. Multi-entry when the same module is invoked from several subworkflows (typically via aliases)."
+        },
+        "module_path": {
+          "type": "string",
+          "description": "Relative path from the pipeline root to the file declaring the process."
+        },
+        "meta": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ModuleMeta"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Normalized `meta.yml` from the module directory when present. Null for local/ad-hoc processes without module metadata."
+        },
+        "module_tests": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/NfTest"
+          },
+          "description": "Module-scoped nf-test files under the module's `tests/` directory. Empty for local/ad-hoc modules without unit tests."
+        },
+        "tool": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Foreign key into `tools[].name` when the process runs a single recognizable tool; null for multi-tool or pure-Groovy processes."
+        },
+        "container": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Verbatim text of the process's `container` directive (or null). Modern nf-core modules use a ternary expression `\"${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ? '<singularity-uri>' : '<docker-uri>' }\"` — keep that text intact here. The two resolved branches are split out into `tools[].docker` / `tools[].singularity` (and `tools[].wave` / `tools[].biocontainer` as appropriate)."
+        },
+        "conda": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Verbatim text of the process's `conda` directive (or null). Two common shapes: a literal `bioconda::<name>=<version>` (legacy) or a file reference `${moduleDir}/environment.yml` (modern nf-core convention). Either way the resolved bioconda spec lands in `tools[].bioconda`."
+        },
+        "inputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ChannelIO"
+          }
+        },
+        "outputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ChannelIO"
+          }
+        },
+        "when": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Verbatim `when:` guard expression, or null if absent."
+        },
+        "script_summary": {
+          "type": "string",
+          "description": "One-line LLM-derived summary of what the `script:` body does. Free text."
+        },
+        "publish_dir": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "`publishDir` value when the process publishes outputs (or null)."
+        }
+      }
+    },
+    "ModuleMeta": {
+      "title": "ModuleMeta",
+      "description": "Normalized subset of nf-core module `meta.yml`, captured next to a process so module-scoped downstream Molds can consume `processes[i]` without reading the full pipeline summary.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "keywords",
+        "authors",
+        "maintainers",
+        "tools",
+        "input",
+        "output"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "keywords": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "authors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "maintainers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ModuleMetaEntry"
+          }
+        },
+        "input": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ModuleMetaEntry"
+          }
+        },
+        "output": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ModuleMetaEntry"
+          }
+        }
+      }
+    },
+    "ModuleMetaEntry": {
+      "title": "ModuleMetaEntry",
+      "description": "One named entry from a module `meta.yml` section, normalized from nf-core's single-key YAML maps into `{ name, ...fields }` objects.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "homepage": {
+          "type": "string"
+        },
+        "documentation": {
+          "type": "string"
+        },
+        "tool_dev_url": {
+          "type": "string"
+        },
+        "doi": {
+          "type": "string"
+        },
+        "licence": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "identifier": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "pattern": {
+          "type": "string"
+        }
+      }
+    },
+    "Subworkflow": {
+      "title": "Subworkflow",
+      "description": "One named `workflow <NAME> { ... }` block other than the primary workflow. Includes nf-core utility wrappers (PIPELINE_INITIALISATION, PIPELINE_COMPLETION, UTILS_NFCORE_PIPELINE) which exist to compose helper-function calls rather than to invoke processes.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "path",
+        "kind",
+        "calls",
+        "tests"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string",
+          "description": "Relative path from the pipeline root."
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "pipeline",
+            "utility"
+          ],
+          "description": "`pipeline` when the subworkflow invokes pipeline processes (data-flow contributor). `utility` when it composes helper functions only — common nf-core template subworkflows like PIPELINE_INITIALISATION (which calls `paramsHelp`, `samplesheetToList`, `UTILS_NFSCHEMA_PLUGIN`) and PIPELINE_COMPLETION (`completionEmail`, `completionSummary`). Utility subworkflows have empty `calls[]` for processes but may still expose channel outputs the primary workflow consumes."
+        },
+        "calls": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Names of processes and nested subworkflows this subworkflow invokes. Free-function calls (e.g. `paramsHelp`, `completionEmail`) are NOT recorded here; they're implied by `kind = utility`."
+        },
+        "inputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ChannelIO"
+          },
+          "description": "Parsed entries of the subworkflow's `take:` block. `name` is the take name, `description` carries any adjacent `// ...` comment, `shape` carries the verbatim source line."
+        },
+        "outputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ChannelIO"
+          }
+        },
+        "invocations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SubworkflowInvocation"
+          },
+          "description": "Call-sites where this subworkflow was invoked. Each entry records the calling workflow/subworkflow, the verbatim positional arguments, and a per-argument binding onto this subworkflow's `inputs[].name` (take names). Drives reference-asset attribution (`reference_assets[].used_by`) without re-parsing call sites. Empty when uncalled or when the call could not be positionally aligned."
+        },
+        "tests": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/NfTest"
+          },
+          "description": "Subworkflow-scoped nf-test files under the subworkflow's `tests/` directory. Empty when absent."
+        }
+      }
+    },
+    "SubworkflowInvocation": {
+      "title": "SubworkflowInvocation",
+      "description": "One call-site of a subworkflow, with positional arguments bound to its `take:` names.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "caller",
+        "arguments",
+        "bindings"
+      ],
+      "properties": {
+        "caller": {
+          "type": "string",
+          "description": "Name of the calling workflow or subworkflow."
+        },
+        "caller_path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Repo-relative path of the file the caller is defined in. Null when not resolvable."
+        },
+        "arguments": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Verbatim positional argument expressions in source order (e.g. `params.fasta`, `PREPARE_GENOME.out.fai`)."
+        },
+        "bindings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/InvocationBinding"
+          },
+          "description": "Per-argument binding onto the callee's `inputs[].name` (take names), in source order. Length matches `arguments[]` when the call positionally aligns to the callee's take block; shorter when only a prefix aligns."
+        }
+      }
+    },
+    "InvocationBinding": {
+      "title": "InvocationBinding",
+      "description": "Binding of one positional argument to a callee `take:` name.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "take",
+        "argument"
+      ],
+      "properties": {
+        "take": {
+          "type": "string",
+          "description": "Callee `take:` name (FK into the callee subworkflow's `inputs[].name`)."
+        },
+        "argument": {
+          "type": "string",
+          "description": "Verbatim caller-side argument expression."
+        }
+      }
+    },
+    "Channel": {
+      "title": "Channel",
+      "description": "One top-level channel constructed in the workflow. Sources include `Channel.fromPath`, `Channel.fromFilePairs`, `samplesheetToList`-driven `Channel.fromList`, `splitCsv`, `file`/`files`, and plain `params.*` references.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "source",
+        "shape",
+        "construct",
+        "from_param",
+        "required_runtime"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string",
+          "description": "Verbatim channel-construction expression."
+        },
+        "shape": {
+          "type": "string",
+          "description": "String-encoded channel shape; same convention as ChannelIO."
+        },
+        "construct": {
+          "type": "string",
+          "enum": [
+            "fromPath",
+            "fromFilePairs",
+            "fromList",
+            "samplesheetToList",
+            "splitCsv",
+            "file",
+            "files",
+            "of",
+            "value",
+            "empty",
+            "topic",
+            "other"
+          ],
+          "description": "Classifies the channel's primary materialization factory or shape-determining operator. Selection precedence: (1) `samplesheetToList` when the chain contains `samplesheetToList(...)` (typically wrapped in `Channel.fromList`); (2) `splitCsv` when the chain ends in `.splitCsv(header: true)` over a path; (3) otherwise the outermost factory (`Channel.fromPath` → `fromPath`, `Channel.fromFilePairs` → `fromFilePairs`, `file(...)` → `file`, etc.); (4) `other` for unrecognized constructions. The verbatim `source` retains the full chain — `construct` is the typed lookup the converter would otherwise re-parse."
+        },
+        "from_param": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Foreign key into `params[].name` when the construction expression directly references `params.X` (e.g. `Channel.fromPath(params.reads)`, `samplesheetToList(params.input, ...)`, `file(params.fasta)`). Null for literal-glob construction, expressions that compose multiple params, and channels derived from other channels. v1 resolution is direct-only; one-hop Groovy bindings (`def reads = params.reads; Channel.fromPath(reads)`) are not chased — see galaxyproject/foundry#211."
+        },
+        "required_runtime": {
+          "type": "boolean",
+          "description": "True when the construction chain ends in `.ifEmpty { error ... }` (or an equivalent imperative emptiness-throw guard). Captures runtime requiredness even when the param's nf-schema entry does not mark it required. Combine with `params[].required` and any imperative pre-construction `error` checks for the full requiredness picture."
+        }
+      }
+    },
+    "Edge": {
+      "title": "Edge",
+      "description": "One edge in the workflow's call graph. The deterministic parser records the literal operator chain in `via`; reconciliation of the source and target shapes is the LLM step.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "from",
+        "to"
+      ],
+      "properties": {
+        "from": {
+          "type": "string",
+          "description": "Channel name or `<PROCESS>.out.<chan>` reference."
+        },
+        "to": {
+          "type": "string",
+          "description": "Process or subworkflow name receiving this channel."
+        },
+        "via": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Operators on the path between source and target, in order (e.g. `[\"map\", \"join\", \"groupTuple\"]`). Empty for a direct edge."
+        },
+        "notes": {
+          "type": "string",
+          "description": "LLM-emitted note when the reconciliation is low-confidence (e.g. deeply nested closures)."
+        }
+      }
+    },
+    "Conditional": {
+      "title": "Conditional",
+      "description": "One workflow-level conditional that gates a subgraph.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "guard",
+        "branch",
+        "affects"
+      ],
+      "properties": {
+        "guard": {
+          "type": "string",
+          "description": "Verbatim guard expression, e.g. `params.skip_alignment`."
+        },
+        "branch": {
+          "type": "string",
+          "enum": [
+            "default",
+            "alternate"
+          ],
+          "description": "Which side of the conditional this entry describes. `default` is the truthy branch; `alternate` is the else branch."
+        },
+        "affects": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Process or subworkflow names whose execution is gated by this conditional."
+        }
+      }
+    },
+    "Workflow": {
+      "title": "Workflow",
+      "description": "Primary workflow: channel construction plus the call-graph DAG. Real nf-core pipelines have multiple named `workflow` blocks (an anonymous entrypoint `workflow {}` in main.nf that wires PIPELINE_INITIALISATION → NFCORE_<NAME> → PIPELINE_COMPLETION; a named NFCORE_<NAME> wrapper; a substantive named workflow under workflows/<name>.nf). The summary collapses this into one primary `workflow` plus `subworkflows[]`. Selection rule: pick the workflow that invokes the most pipeline processes — typically the one under `workflows/<name>.nf`. The anonymous `workflow {}` glue and the NFCORE_<NAME> wrapper land in `subworkflows[]`.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "channels",
+        "edges"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the selected primary workflow (uppercase NF convention). The anonymous `workflow {}` entrypoint is never the primary; if it is the only workflow block, the pipeline is too small to summarize and the cast skill should emit a warning."
+        },
+        "channels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Channel"
+          }
+        },
+        "edges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Edge"
+          }
+        },
+        "conditionals": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Conditional"
+          }
+        }
+      }
+    },
+    "TestDataRef": {
+      "title": "TestDataRef",
+      "description": "One test-fixture input. Field names mirror gxy-sketches' TestDataRef verbatim. The sketch-bundle constraint that `path` must live under `test_data/` is intentionally dropped; the Foundry summary describes fixtures as data, it does not bundle them.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "role"
+      ],
+      "properties": {
+        "role": {
+          "type": "string",
+          "description": "Logical role of the input (e.g. `samplesheet`, `reference_fasta`)."
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Repo-relative path when the fixture lives in-tree, or local filesystem path when the CLI fetched the remote fixture into a caller-provided test-data directory."
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uri"
+        },
+        "sha1": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "SHA-1 integrity hash when published alongside the fixture."
+        },
+        "filetype": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "File format, e.g. `fastq.gz`, `csv`."
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "path"
+          ]
+        },
+        {
+          "required": [
+            "url"
+          ]
+        }
+      ]
+    },
+    "ExpectedOutputRef": {
+      "title": "ExpectedOutputRef",
+      "description": "One expected output. Field names mirror gxy-sketches' ExpectedOutputRef verbatim. At least one of path / url / assertions is required.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "role"
+      ],
+      "properties": {
+        "role": {
+          "type": "string"
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uri"
+        },
+        "kind": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Coarse output kind: `report`, `tabular`, `image`, `archive`, `sequence`, `other`."
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "assertions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Assertion strings. Simple equality / regex / contains-string checks are preserved verbatim; complex Groovy assertions are summarized to prose with a `warnings[]` flag in the parent Summary."
+        }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "path"
+          ]
+        },
+        {
+          "required": [
+            "url"
+          ]
+        },
+        {
+          "required": [
+            "assertions"
+          ]
+        }
+      ]
+    },
+    "TestFixtures": {
+      "title": "TestFixtures",
+      "description": "Test fixtures derived from a `conf/<profile>.config` for the cast's selected profile. Pipelines with multiple test profiles (bacass has 11) record only the selected profile here; the full nf-test enumeration lives in `nf_tests[]`.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "profile",
+        "inputs",
+        "outputs"
+      ],
+      "properties": {
+        "profile": {
+          "type": "string",
+          "description": "Which `conf/<profile>.config` produced these fixtures (typically `test`)."
+        },
+        "inputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TestDataRef"
+          }
+        },
+        "outputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ExpectedOutputRef"
+          }
+        }
+      }
+    },
+    "NfTest": {
+      "title": "NfTest",
+      "description": "One `tests/*.nf.test` file. nf-core templates use a near-uniform shape: a `nextflow_pipeline { test(\"<desc>\") { when { params { ... } } then { assertAll(...) } } }` block, with one test() per profile, asserting `workflow.success` plus a snapshot match. This shape captures the data so downstream test-conversion molds (e.g. nextflow-test-to-target-tests) don't have to re-parse Groovy.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "path",
+        "profiles",
+        "assert_workflow_success",
+        "prose_assertions"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Description string passed to `test(\"...\")`. Often duplicates the profile name."
+        },
+        "path": {
+          "type": "string",
+          "description": "Repo-relative path of the .nf.test file (e.g. `tests/dfast.nf.test`)."
+        },
+        "profiles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Profile name(s) the test runs under, from the file-level `profile \"<name>\"` declaration and/or per-test config overrides. Usually a single profile."
+        },
+        "params_overrides": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "The `when { params { ... } }` block as a key→value map. Most templates set only `outdir`; pipeline-specific overrides land here."
+        },
+        "assert_workflow_success": {
+          "type": "boolean",
+          "description": "Whether the test asserts `workflow.success`. Almost always true for nf-core templates."
+        },
+        "snapshot": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SnapshotFixture"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Structured representation of the `assert snapshot(...).match()` clause when present; null when the test uses no snapshot."
+        },
+        "prose_assertions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Other assertions (regex matches, count checks, content equality on specific files) summarized to prose strings. Empty for snapshot-only tests, which is the common nf-core case."
+        }
+      }
+    },
+    "SnapshotFixture": {
+      "title": "SnapshotFixture",
+      "description": "Structured shape of an nf-test `snapshot(...).match()` assertion. nf-core templates pass a small set of values into snapshot() — succeeded-task count, version YAML (with Nextflow version stripped), stable file-name list, stable file-content list — and prune the comparison via `getAllFilesFromDir(..., ignoreFile: ..., ignore: [...])` helpers. This breakdown lets downstream consumers reconstruct equivalent assertions in target test frameworks without re-parsing Groovy.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "captures",
+        "helpers",
+        "ignore_files",
+        "ignore_globs"
+      ],
+      "properties": {
+        "captures": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Logical names of values passed to snapshot(), in order. Common set: `succeeded_task_count`, `versions_yml`, `stable_names`, `stable_paths`. Free-form strings rather than an enum because pipelines can pass other values."
+        },
+        "helpers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "nf-test helper functions invoked in the snapshot expression (e.g. `getAllFilesFromDir`, `removeNextflowVersion`). Used to detect whether a target framework can replicate the comparison."
+        },
+        "ignore_files": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Repo-relative paths passed as `ignoreFile:` to helpers (e.g. `tests/.nftignore`, `tests/.nftignore_files_entirely`). The files themselves are line-delimited globs."
+        },
+        "ignore_globs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Inline `ignore: [...]` glob list passed to helpers (e.g. `['Prokka/**', '**/multiqc_busco.yaml']`). Distinct from ignore_files which references on-disk lists."
+        },
+        "snap_path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Repo-relative path of the corresponding `.nf.test.snap` file when present."
+        },
+        "parsed_content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SnapshotContent"
+          },
+          "description": "Parsed entries from the `.nf.test.snap` JSON sidecar. Empty when the sidecar is absent, too large for compact summary output, or not valid JSON. Each entry preserves the snapshot name plus channel-keyed file md5 assertions and non-file scalar values."
+        }
+      }
+    },
+    "SnapshotContent": {
+      "title": "SnapshotContent",
+      "description": "One top-level snapshot entry from an nf-test `.snap` JSON sidecar.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "channels"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Top-level key in the `.snap` file, usually the `test(\"...\")` name."
+        },
+        "channels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SnapshotChannel"
+          },
+          "description": "Channel-keyed snapshot values. Pipeline-template flat file lists use `key: null`."
+        }
+      }
+    },
+    "SnapshotChannel": {
+      "title": "SnapshotChannel",
+      "description": "One output channel or flat snapshot list inside a `.snap` entry.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "key",
+        "files",
+        "values"
+      ],
+      "properties": {
+        "key": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Channel key from the snapshot object, e.g. `0`, `1`, or `genome_gtf`; null for flat file-list snapshots."
+        },
+        "files": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SnapshotFile"
+          },
+          "description": "File md5 assertions parsed from `<path>:md5,<hex>` strings."
+        },
+        "values": {
+          "type": "array",
+          "items": {},
+          "description": "Non-file snapshot values preserved verbatim for consumers that need versions, counts, or scalar tuple emissions."
+        }
+      }
+    },
+    "Evidence": {
+      "title": "Evidence",
+      "description": "Shared provenance block for source-detected facts. `source_path` localizes the finding; `confidence` is a coarse self-assessment; `evidence[]` carries free-form snippets (matched lines, normalized expressions, detector notes). Reused by ReferenceAsset and ReferenceRebuildRule.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_path",
+        "confidence",
+        "evidence"
+      ],
+      "properties": {
+        "source_path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Repo-relative path of the source file where the finding was detected (e.g. `subworkflows/local/prepare_genome/main.nf`, `nextflow.config`). Null when the finding spans files or cannot be localized."
+        },
+        "confidence": {
+          "type": "string",
+          "enum": [
+            "high",
+            "medium",
+            "low"
+          ],
+          "description": "Detector self-assessment. `high`: all signals match the expected idiom; `medium`: some signals match but the guard or builder is partial / mixes non-param locals; `low`: heuristic match, downstream should treat as a hint."
+        },
+        "evidence": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Free-form evidence snippets (matched source lines, normalized expressions, detector notes). Empty when none."
+        }
+      }
+    },
+    "ReferenceAsset": {
+      "title": "ReferenceAsset",
+      "description": "Curated source-side view of one reference-data input the pipeline consumes. A foreign-key projection onto `params[].name` plus the metadata downstream classification Molds need. Target-agnostic: no Galaxy translation decisions are encoded here.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "param",
+        "asset_kind",
+        "required",
+        "used_by",
+        "evidence"
+      ],
+      "properties": {
+        "param": {
+          "type": "string",
+          "description": "FK into `params[].name`."
+        },
+        "asset_kind": {
+          "type": "string",
+          "description": "Coarse asset classification (e.g. `fasta`, `fasta_index`, `sequence_dictionary`, `bwa_index`, `bwamem2_index`, `tabix_index`, `gtf`, `gff`, `bed`, `vcf`, `database`, `reference_sheet`, `other`). Free-form string; downstream Molds choose how to map onto target datatypes."
+        },
+        "format_hint": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Format hint, often the nf-schema `format` keyword (`file-path`, `directory-path`, `path`, `file-path-pattern`) or a domain hint like `fai`, `dict`. Null when undetermined."
+        },
+        "required": {
+          "type": "boolean",
+          "description": "True when the source pipeline treats this asset as required (no compute-if-missing branch, no optional guard). When false, see `reference_rebuilds[]` for any rebuild branch covering this param."
+        },
+        "source_kind": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "nextflow_schema",
+            "params_block",
+            "getGenomeAttribute",
+            "computed",
+            null
+          ],
+          "description": "Mirrors `params[<this>].source_kind`. Duplicated here so reference-data consumers don't have to dereference."
+        },
+        "source_expression": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Mirrors `params[<this>].source_expression`. Duplicated for the same reason."
+        },
+        "schema_group": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Mirrors `params[<this>].schema_group`. Useful for grouping (`Reference genome options`)."
+        },
+        "used_by": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Names of processes / subworkflows that receive this param as an argument (via direct invocation binding or channel construction). Empty when no caller could be attributed."
+        },
+        "evidence": {
+          "$ref": "#/$defs/Evidence"
+        }
+      }
+    },
+    "ReferenceRebuildRule": {
+      "title": "ReferenceRebuildRule",
+      "description": "One compute-if-missing rebuild branch detected in a workflow or subworkflow body. Binds an asset param to the guard expression and builder process that produces it when absent. Source evidence only; in-tool-rebuild decisions live downstream.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "asset_param",
+        "guard",
+        "builder",
+        "builder_outputs",
+        "evidence"
+      ],
+      "properties": {
+        "asset_param": {
+          "type": "string",
+          "description": "FK into `params[].name` — the asset this branch reconstitutes when missing."
+        },
+        "guard": {
+          "type": "string",
+          "description": "Verbatim guard expression, e.g. `!fasta_fai_in && step != \"annotate\"`."
+        },
+        "guard_params": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Param names referenced by the guard. Empty when the guard binds only non-param locals."
+        },
+        "builder": {
+          "type": "string",
+          "description": "Builder process or subworkflow name invoked inside the branch (e.g. `SAMTOOLS_FAIDX`, `BWA_INDEX`)."
+        },
+        "builder_outputs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Output channel names from the builder that are assigned to the asset (e.g. `fai`, `dict`)."
+        },
+        "fallback_for": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Name of the `<asset>_in`-style param that, when present, supplies the asset directly and skips the rebuild. Null when no such pairing was detected."
+        },
+        "evidence": {
+          "$ref": "#/$defs/Evidence"
+        }
+      }
+    },
+    "SnapshotFile": {
+      "title": "SnapshotFile",
+      "description": "One file digest assertion from a `.snap` sidecar.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "basename",
+        "md5",
+        "stub"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Path portion before `:md5,` exactly as stored in the sidecar."
+        },
+        "basename": {
+          "type": "string",
+          "description": "Final path segment, suitable for Galaxy test `file:` assertions when the snapshot stores only basenames."
+        },
+        "md5": {
+          "type": "string",
+          "pattern": "^[a-fA-F0-9]{32}$",
+          "description": "MD5 digest from the sidecar."
+        },
+        "stub": {
+          "type": "boolean",
+          "description": "True when the digest is the empty-file md5 emitted by many `-stub` tests."
+        }
+      }
+    }
+  }
+}

--- a/casts/claude/skills/nextflow-test-to-cwl-test-plan/SKILL.md
+++ b/casts/claude/skills/nextflow-test-to-cwl-test-plan/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: nextflow-test-to-cwl-test-plan
+description: "Translate Nextflow test evidence into a CWL workflow test plan."
+---
+
+# nextflow-test-to-cwl-test-plan
+
+Follow the procedure below and use the artifact/reference sections as the runtime contract.
+
+## When To Use
+
+- Translate Nextflow test evidence into a CWL workflow test plan.
+
+## Inputs
+
+- Read artifact `summary-nextflow`. Schema: summary-nextflow. Produced by `summarize-nextflow`. Structured Nextflow summary from summarize-nextflow; carries test_fixtures, nf_tests, snapshot evidence.
+
+## Outputs
+
+- Write artifact `cwl-test-plan` as `cwl-test-plan.md`. Format: `markdown`. Reviewable CWL workflow test plan: job inputs, expected outputs, assertions, fixtures, rationale provenance.
+
+## Required Tools
+
+- None declared. Procedure should not assume external CLIs are present.
+
+## Load Upfront
+
+- `references/schemas/summary-nextflow.schema.json`: Schema file copied verbatim into the bundle. Read summarized nf-test profiles, snapshot fixtures, selected test data, params, and expected outputs.
+
+## Load On Demand
+
+- None declared.
+
+## Validation
+
+- None declared.
+
+## Procedure
+
+Translate Nextflow test evidence into a CWL workflow test plan. This preserves the `NEXTFLOW → CWL` pipeline after the Galaxy-specific test-plan split; concrete CWL test artifact assembly remains owned by implement-cwl-workflow-test.
+
+## Runtime Notes
+
+- Do not read Foundry source files at runtime; use only files packaged in this skill bundle and user-supplied artifacts.
+- Preserve declared artifact filenames unless the user or harness supplies explicit paths.
+- Carry unresolved assumptions into the output artifact instead of silently inventing missing source evidence.

--- a/casts/claude/skills/nextflow-test-to-cwl-test-plan/_provenance.json
+++ b/casts/claude/skills/nextflow-test-to-cwl-test-plan/_provenance.json
@@ -1,0 +1,49 @@
+{
+  "provenance_schema_version": 3,
+  "cast_target": "claude",
+  "mold": {
+    "name": "nextflow-test-to-cwl-test-plan",
+    "path": "content/molds/nextflow-test-to-cwl-test-plan/index.md",
+    "revision": 1,
+    "content_hash": "c71fe933917ad6429721aa69a4fc4f5f470d4a945251855cc1034fbb80637754",
+    "commit": "e487fe785f468afdf25f2b6bd140c3a115a12021"
+  },
+  "cast_at": "2026-07-24T13:51:15.802Z",
+  "refs": [
+    {
+      "kind": "schema",
+      "mode": "verbatim",
+      "ref": "[[summary-nextflow]]",
+      "src": "package://@galaxy-foundry/summarize-nextflow#summaryNextflowSchema",
+      "dst": "references/schemas/summary-nextflow.schema.json",
+      "used_at": "runtime",
+      "load": "upfront",
+      "evidence": "corpus-observed",
+      "purpose": "Read summarized nf-test profiles, snapshot fixtures, selected test data, params, and expected outputs.",
+      "license": "MIT",
+      "src_hash": "06430103b6111c40c030990459d41fe599faba0015865bba54d0e8bd0cf9fd1c",
+      "dst_hash": "06430103b6111c40c030990459d41fe599faba0015865bba54d0e8bd0cf9fd1c",
+      "source": "deterministic"
+    }
+  ],
+  "artifacts": {
+    "produces": [
+      {
+        "id": "cwl-test-plan",
+        "kind": "markdown",
+        "default_filename": "cwl-test-plan.md",
+        "description": "Reviewable CWL workflow test plan: job inputs, expected outputs, assertions, fixtures, rationale provenance."
+      }
+    ],
+    "consumes": [
+      {
+        "id": "summary-nextflow",
+        "description": "Structured Nextflow summary from [[summarize-nextflow]]; carries test_fixtures, nf_tests, snapshot evidence.",
+        "inherited_schema": "[[summary-nextflow]]",
+        "producers": [
+          "summarize-nextflow"
+        ]
+      }
+    ]
+  }
+}

--- a/casts/claude/skills/nextflow-test-to-cwl-test-plan/_verify.json
+++ b/casts/claude/skills/nextflow-test-to-cwl-test-plan/_verify.json
@@ -1,0 +1,17 @@
+{
+  "verify_schema_version": 1,
+  "entries": [
+    {
+      "artifact_id": "summary-nextflow",
+      "direction": "input",
+      "kind": "json",
+      "default_filename": "summary-nextflow.json",
+      "schema": "[[summary-nextflow]]",
+      "validator_bin": "foundry",
+      "args": [
+        "validate-summary-nextflow",
+        "{artifact_path}"
+      ]
+    }
+  ]
+}

--- a/casts/claude/skills/nextflow-test-to-cwl-test-plan/references/schemas/summary-nextflow.schema.json
+++ b/casts/claude/skills/nextflow-test-to-cwl-test-plan/references/schemas/summary-nextflow.schema.json
@@ -1,0 +1,1514 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://galaxyproject.org/foundry/schemas/summary-nextflow.schema.json",
+  "$comment": "Canonical source: packages/summarize-nextflow/src/schema/summary-nextflow.schema.json in galaxyproject/foundry. Mold frontmatter cites this schema via [[summary-nextflow]] wiki-links; the cast pipeline imports the `summaryNextflowSchema` runtime export and serializes it into cast bundles.",
+  "title": "Nextflow Pipeline Summary",
+  "description": "Structured per-source summary emitted by the summarize-nextflow Mold.\n\nPer-source schema by design — paper, Nextflow, and CWL each have their own summary shape; downstream Molds (data flow, templates, tool wrappers) consume any source's summary and handle the polymorphism.\n\nField names mirror gxy-sketches' SketchSource / ToolSpec / TestDataRef / ExpectedOutputRef where parity exists; see content/research/gxy-sketches-alignment.md.",
+  "$ref": "#/$defs/Summary",
+  "$defs": {
+    "Summary": {
+      "title": "Summary",
+      "description": "Top-level shape. Every Nextflow summary is exactly this object.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source",
+        "params",
+        "sample_sheets",
+        "profiles",
+        "tools",
+        "processes",
+        "subworkflows",
+        "workflow",
+        "reference_assets",
+        "reference_rebuilds",
+        "test_fixtures",
+        "nf_tests"
+      ],
+      "properties": {
+        "source": {
+          "$ref": "#/$defs/SourceRecord"
+        },
+        "params": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Param"
+          }
+        },
+        "sample_sheets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SampleSheet"
+          },
+          "description": "Structured sample-sheet inputs. Each entry binds one `params[]` parameter to a row schema (column names, types, path-vs-meta classification, required flags, enums, patterns). Promoted from prose inside `params[].description` so downstream target translations (Galaxy `sample_sheet*` collections, CWL records-of-arrays) can choose collection variants without re-parsing the source pipeline. Empty array when no sample-sheet idiom is detected. Discovery sources: nf-schema `schema:` references, `samplesheetToList()` calls, and `splitCsv(header: true)` materializations."
+        },
+        "profiles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Tool"
+          }
+        },
+        "processes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Process"
+          }
+        },
+        "subworkflows": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Subworkflow"
+          }
+        },
+        "workflow": {
+          "$ref": "#/$defs/Workflow"
+        },
+        "reference_assets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ReferenceAsset"
+          },
+          "description": "Curated, target-agnostic view of reference-data inputs the source pipeline consumes (FASTAs, indexes, dictionaries, annotation tables, …). Each entry is a foreign-key projection onto `params[]` plus source-side metadata (asset kind, format hint, source expression, schema group, callers). Empty array when no reference assets are detected. Downstream Molds (e.g. nextflow-summary-to-galaxy-reference-data) classify these against Galaxy translation rungs; classification decisions are not encoded here."
+        },
+        "reference_rebuilds": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ReferenceRebuildRule"
+          },
+          "description": "Compute-if-missing rebuild branches detected in workflow/subworkflow bodies. Each entry binds an asset param to the guard and builder process that recomputes it when absent. Empty when no rebuild idioms are found. Source evidence only — Galaxy in-tool-rebuild decisions live downstream."
+        },
+        "test_fixtures": {
+          "$ref": "#/$defs/TestFixtures",
+          "description": "Test-input data shape for the *selected* profile (the cast's `profile` argument, default `test`). For pipelines with multiple test profiles, see `nf_tests[]` for the full enumeration."
+        },
+        "nf_tests": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/NfTest"
+          },
+          "description": "All `tests/*.nf.test` files in the pipeline. Each entry captures one test-program — its profile, params overrides, and structured assertions. Empty array when the pipeline has no nf-test fixtures."
+        },
+        "warnings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Cast-skill-emitted advisory messages (e.g. DSL1 detected, meta.yml/script disagreement, lossy assertion summarization). Empty array on a clean run."
+        }
+      }
+    },
+    "SourceRecord": {
+      "title": "SourceRecord",
+      "description": "Provenance block. Mirrors gxy-sketches SketchSource field names so a Foundry summary is structurally consumable by anyone using that shape.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "ecosystem",
+        "workflow",
+        "url",
+        "version",
+        "slug"
+      ],
+      "properties": {
+        "ecosystem": {
+          "type": "string",
+          "enum": [
+            "nf-core",
+            "nextflow"
+          ],
+          "description": "Pipeline flavor. `nf-core` when `manifest.name` is `nf-core/<slug>` and the canonical layout is present; `nextflow` for ad-hoc DSL2 pipelines. Superset of gxy-sketches' enum (which adds `iwc`, `snakemake-workflows`, `wdl` for its other ingestors)."
+        },
+        "workflow": {
+          "type": "string",
+          "description": "Pipeline name (typically the part after `nf-core/`)."
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Git remote URL of the pipeline repository."
+        },
+        "version": {
+          "type": "string",
+          "description": "Tag, branch, or commit SHA the summary was derived from."
+        },
+        "license": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "SPDX license identifier when detectable from a LICENSE file."
+        },
+        "slug": {
+          "type": "string",
+          "description": "Kebab-case identifier; `<owner>-<repo>` for nf-core, repo basename otherwise."
+        }
+      }
+    },
+    "Param": {
+      "title": "Param",
+      "description": "One pipeline parameter. Sourced from `nextflow.config`'s `params { ... }` block, augmented from `nextflow_schema.json` when present (nf-core).",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "type",
+        "required"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "description": "JSON Schema-style type when nextflow_schema.json supplies it (string, integer, number, boolean, path); free-form when inferred from a default value."
+        },
+        "default": {
+          "description": "Default value verbatim from the source. May be null."
+        },
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "enum": {
+          "type": "array",
+          "items": {},
+          "description": "Allowed values when nextflow_schema.json declares them."
+        },
+        "format": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "JSON Schema `format` keyword from nextflow_schema.json. nf-schema vocabulary: `file-path`, `directory-path`, `path`, `file-path-pattern`. Distinguishes path-typed params (datasets/collections) from plain strings without re-reading the source schema. Null when undeclared."
+        },
+        "hidden": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "nf-schema `hidden` keyword. True for CLI-plumbing params (e.g. `validate_params`, `pipelines_testdata_base_path`, `version`) that shouldn't surface in user-facing target interfaces. Null when undeclared."
+        },
+        "mimetype": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "nf-schema `mimetype` keyword (e.g. `text/csv`, `text/plain`, `application/gzip`). Useful for seeding Galaxy `format` on path-typed params. Null when undeclared."
+        },
+        "schema_group": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Human-readable group label from the parent nextflow_schema.json `$defs` section's `title` (e.g. `Input/output options`, `Reference genome options`). Preserves nf-schema sectioning so target interfaces can group inputs without re-parsing the source. Null when the param is not under a titled section."
+        },
+        "fa_icon": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Font Awesome icon class from the parent `$defs` section's `fa_icon` (e.g. `fas fa-terminal`). Optional UI hint; null when undeclared."
+        },
+        "source_kind": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "nextflow_schema",
+            "params_block",
+            "getGenomeAttribute",
+            "computed",
+            null
+          ],
+          "description": "How this param entry was derived. `nextflow_schema`: declared in `nextflow_schema.json`. `params_block`: declared (or defaulted) in `nextflow.config`'s `params { ... }` block. `getGenomeAttribute`: synthesized from `params.X = getGenomeAttribute('X')` assignments in `nextflow.config` (nf-core key-expanded bundle pattern). `computed`: derived from another non-getGenomeAttribute expression. Null when provenance was not classified."
+        },
+        "source_expression": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Verbatim right-hand-side expression when the param was assigned in Groovy (e.g. `getGenomeAttribute('fasta_fai')`). Null when the param comes from a JSON Schema entry only."
+        },
+        "source_path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Repo-relative path of the source file where the assignment lives (e.g. `nextflow.config`, `conf/igenomes.config`). Null when undefined or when the param comes only from `nextflow_schema.json`."
+        }
+      }
+    },
+    "SampleSheet": {
+      "title": "SampleSheet",
+      "description": "One sample-sheet-shaped pipeline input. Captures the row schema, path-vs-meta column classification, and discovery provenance so downstream Molds can map onto Galaxy `sample_sheet[:variant]` collections, CWL records-of-arrays, or other target shapes without re-reading the source.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "param",
+        "discovered_via",
+        "columns"
+      ],
+      "properties": {
+        "param": {
+          "type": "string",
+          "description": "Foreign key into `params[].name` — the parameter whose value points at the sample-sheet file."
+        },
+        "schema_path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Repo-relative path of the JSON Schema file describing rows (e.g. `assets/schema_input.json`), resolved from the param's nf-schema entry's `schema:` keyword. Null when discovered via `samplesheetToList` without a schema reference, or via `splitCsv(header: true)` ad-hoc parsing."
+        },
+        "discovered_via": {
+          "type": "string",
+          "enum": [
+            "nf-schema",
+            "samplesheetToList",
+            "splitCsv",
+            "ad-hoc"
+          ],
+          "description": "How the sample-sheet shape was detected. `nf-schema`: nextflow_schema.json entry has `schema:` keyword. `samplesheetToList`: workflow imports nf-schema's helper and calls it on the param. `splitCsv`: workflow uses `splitCsv(header: true)` on the param's path. `ad-hoc`: pipeline-specific CSV/TSV parsing inferred from script bodies."
+        },
+        "format": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "csv",
+            "tsv",
+            "csv-or-tsv",
+            null
+          ],
+          "description": "Tabular format declared by the param's `mimetype` or inferred from `samplesheetToList` / `splitCsv` semantics. Null when undeclared."
+        },
+        "header": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Whether the file is expected to have a header row. Null when the discovery source doesn't pin it."
+        },
+        "columns": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SampleSheetColumn"
+          },
+          "description": "Row schema in declaration order. nf-schema's `samplesheetToList` emits columns in property order, not source-column order — preserve property order here so downstream translations match runtime channel item layout."
+        }
+      }
+    },
+    "SampleSheetColumn": {
+      "title": "SampleSheetColumn",
+      "description": "One column in a sample-sheet row schema. Type vocabulary is JSON Schema-style scalar; `kind` separates dataset-reference columns from per-row metadata. Validation hints (`pattern`, `enum`, `exists`, `mimetype`) are preserved verbatim — target Molds decide which of them survive translation (e.g. Galaxy's `sample_sheet` validator allowlist is regex/in_range/length).",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "type",
+        "kind",
+        "required"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "integer",
+            "number",
+            "boolean"
+          ],
+          "description": "JSON Schema-style scalar type. Path columns are typed `string` with a `format: file-path|directory-path|path` qualifier — see `format` and `kind`."
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "data",
+            "meta"
+          ],
+          "description": "`data`: path-typed column whose values are dataset references (becomes element/inner-collection slot in Galaxy `sample_sheet`). `meta`: scalar metadata column (becomes a `column_definitions` entry, populated per row in `columns[]`). Includes the nf-schema `meta:` annotation when present; in its absence inferred from `format` (`file-path`/`directory-path`/`path` → `data`, anything else → `meta`)."
+        },
+        "format": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "JSON Schema `format` keyword. nf-schema vocabulary: `file-path`, `directory-path`, `path`, `file-path-pattern`. Null for scalar metadata columns without a format hint."
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "default": {
+          "description": "Default value verbatim from the sample-sheet schema. May be null."
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "enum": {
+          "type": "array",
+          "items": {},
+          "description": "Allowed values when the column schema declares an `enum`. Empty array when absent."
+        },
+        "pattern": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "JSON Schema regex `pattern` when present."
+        },
+        "exists": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "nf-schema `exists` flag for path columns. True when the parser must verify the file exists."
+        },
+        "mimetype": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "nf-schema `mimetype` keyword (e.g. `text/csv`, `application/gzip`). Useful for target datatypes."
+        }
+      }
+    },
+    "Tool": {
+      "title": "Tool",
+      "description": "One tool/dependency the pipeline runs. Mirrors gxy-sketches ToolSpec (name + version) and augments it with the resolved container/conda strings the bridge to author-galaxy-tool-wrapper needs.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "version"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Canonical tool name (e.g. `fastp`, `samtools`). Used as the foreign key from `processes[].tool`."
+        },
+        "version": {
+          "type": "string",
+          "description": "Exact version when the conda spec pins one (`name=1.0`, `name==1.0`, or the space-separated `name 1.0`; a trailing `=<build>` is a conda build string and is not part of the version). The literal `unknown` when no exact pin was declared — either because the spec names no version at all (a legitimate authoring choice, e.g. `conda-forge::r-base`) or because it declares an inexact constraint, in which case `version_constraint` carries it. A spec the parser cannot read at all is reported in `warnings[]` rather than landing here as `unknown`."
+        },
+        "version_constraint": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Verbatim version constraint when the conda spec declares an inexact one (e.g. `>=1.17`, `>=1.0,<2.0`). Null when the spec pins exactly or names no version. Present so a range is preserved rather than flattened into the `unknown` sentinel; a consumer that needs an exact version should read a non-null constraint as \"the pipeline constrains this tool, but not to a single version\"."
+        },
+        "biocontainer": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "BioContainers image reference when one was found. Includes both `quay.io/biocontainers/<name>:<version>--<build>` and the docker.io alias `biocontainers/<name>:<version>--<build>` (modern nf-core modules typically use the docker.io form in the docker branch and the depot.galaxyproject.org form in the singularity branch)."
+        },
+        "bioconda": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "`bioconda::<name>=<version>` spec when a `conda` directive provides one — directly or by reference to a `${moduleDir}/environment.yml` whose `dependencies:` list contains a single bioconda entry. The latter is the modern nf-core convention."
+        },
+        "docker": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Non-biocontainer Docker registry image string when present."
+        },
+        "singularity": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Singularity image reference when present (e.g. `https://depot.galaxyproject.org/singularity/...`)."
+        },
+        "wave": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Seqera Wave / community-cr registry reference (e.g. `community.wave.seqera.io/library/<name>:<version>--<digest>` or `https://community-cr-prod.seqera.io/.../sha256/<digest>/data`). Wave-built containers are increasingly common in nf-core; kept distinct from `docker` because the resolution rules and provenance differ."
+        },
+        "mulled_components": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ToolSpec"
+          },
+          "description": "Constituent Bioconda packages for an opaque `mulled-v2-*` multi-package container when resolved from a cached BioContainers multi-package-containers TSV. Omitted when no matching cached row is available."
+        },
+        "versions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Every distinct version of this tool declared anywhere in the pipeline, sorted, when processes disagree. nf-core modules pin independently, so one pipeline routinely runs several versions of a shared dependency (e.g. `samtools` at 1.17, 1.18, 1.19.2, 1.20). The sibling `version`, `biocontainer`, `docker`, `singularity`, and `wave` fields all come from whichever declaration was read last, so on a divergent tool they describe one arbitrary process rather than the pipeline as a whole — treat this array as the authoritative version set and read `processes[].conda` / `processes[].container` for what a given process actually runs. Declarations that name no version contribute nothing here, so a tool pinned by some processes and left unpinned by others lists only its real versions. Omitted when fewer than two distinct versions were declared."
+        }
+      }
+    },
+    "ToolSpec": {
+      "title": "ToolSpec",
+      "description": "One constituent package in a decomposed multi-package container.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "version",
+        "bioconda"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "bioconda": {
+          "type": "string",
+          "description": "Exact Bioconda requirement spec, e.g. `bioconda::samtools=1.20`."
+        }
+      }
+    },
+    "ChannelIO": {
+      "title": "ChannelIO",
+      "description": "One declared input or output channel of a process. Channel shape is a string, not a structured type — `tuple(meta, [path,path])` is enough for downstream Molds and avoids a research project on NF channel typing.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "shape"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "shape": {
+          "type": "string",
+          "description": "String-encoded channel shape, e.g. `tuple(meta, [path,path])`, `path`, `val(integer)`."
+        },
+        "description": {
+          "type": "string"
+        },
+        "topic": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Nextflow channel-topic name when this output is bound to a topic (e.g. `versions` for the standard nf-core version-aggregation topic). Topics are a Nextflow 24+ feature; the module-level `topic: <name>` annotation on a process output emits to a global named channel that any consumer can `channel.topic('<name>')` to read. Null for non-topic outputs and for all inputs."
+        }
+      }
+    },
+    "Process": {
+      "title": "Process",
+      "description": "One Nextflow `process { ... }` block.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "module_path",
+        "meta",
+        "module_tests",
+        "inputs",
+        "outputs"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Canonical process name (uppercase NF convention) as declared by the `process <NAME>` line in `module_path`."
+        },
+        "aliases": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Alias names this process is imported as in workflow scopes via `include { <NAME> as <ALIAS> }`. Real nf-core pipelines re-import a single module multiple times under different aliases to invoke it with distinct runtime args (e.g. `MINIMAP2_ALIGN as MINIMAP2_CONSENSUS`, `MINIMAP2_ALIGN as MINIMAP2_POLISH`). Each alias appears in `workflow.edges[].from`/`.to` exactly as written; the canonical `name` does not appear in edges unless an unaliased import exists. Default `[]` when the process is only imported under its canonical name."
+        },
+        "in_subworkflows": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Denormalized FK: names of `subworkflows[]` whose `calls[]` invoke this process (canonical name or any alias). Empty `[]` when the process is only invoked from the primary `workflow` body. Useful for grouping the flat process-tier DAG into a subworkflow-tier view client-side. Multi-entry when the same module is invoked from several subworkflows (typically via aliases)."
+        },
+        "module_path": {
+          "type": "string",
+          "description": "Relative path from the pipeline root to the file declaring the process."
+        },
+        "meta": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ModuleMeta"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Normalized `meta.yml` from the module directory when present. Null for local/ad-hoc processes without module metadata."
+        },
+        "module_tests": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/NfTest"
+          },
+          "description": "Module-scoped nf-test files under the module's `tests/` directory. Empty for local/ad-hoc modules without unit tests."
+        },
+        "tool": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Foreign key into `tools[].name` when the process runs a single recognizable tool; null for multi-tool or pure-Groovy processes."
+        },
+        "container": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Verbatim text of the process's `container` directive (or null). Modern nf-core modules use a ternary expression `\"${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ? '<singularity-uri>' : '<docker-uri>' }\"` — keep that text intact here. The two resolved branches are split out into `tools[].docker` / `tools[].singularity` (and `tools[].wave` / `tools[].biocontainer` as appropriate)."
+        },
+        "conda": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Verbatim text of the process's `conda` directive (or null). Two common shapes: a literal `bioconda::<name>=<version>` (legacy) or a file reference `${moduleDir}/environment.yml` (modern nf-core convention). Either way the resolved bioconda spec lands in `tools[].bioconda`."
+        },
+        "inputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ChannelIO"
+          }
+        },
+        "outputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ChannelIO"
+          }
+        },
+        "when": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Verbatim `when:` guard expression, or null if absent."
+        },
+        "script_summary": {
+          "type": "string",
+          "description": "One-line LLM-derived summary of what the `script:` body does. Free text."
+        },
+        "publish_dir": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "`publishDir` value when the process publishes outputs (or null)."
+        }
+      }
+    },
+    "ModuleMeta": {
+      "title": "ModuleMeta",
+      "description": "Normalized subset of nf-core module `meta.yml`, captured next to a process so module-scoped downstream Molds can consume `processes[i]` without reading the full pipeline summary.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "keywords",
+        "authors",
+        "maintainers",
+        "tools",
+        "input",
+        "output"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "keywords": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "authors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "maintainers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ModuleMetaEntry"
+          }
+        },
+        "input": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ModuleMetaEntry"
+          }
+        },
+        "output": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ModuleMetaEntry"
+          }
+        }
+      }
+    },
+    "ModuleMetaEntry": {
+      "title": "ModuleMetaEntry",
+      "description": "One named entry from a module `meta.yml` section, normalized from nf-core's single-key YAML maps into `{ name, ...fields }` objects.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "homepage": {
+          "type": "string"
+        },
+        "documentation": {
+          "type": "string"
+        },
+        "tool_dev_url": {
+          "type": "string"
+        },
+        "doi": {
+          "type": "string"
+        },
+        "licence": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "identifier": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "pattern": {
+          "type": "string"
+        }
+      }
+    },
+    "Subworkflow": {
+      "title": "Subworkflow",
+      "description": "One named `workflow <NAME> { ... }` block other than the primary workflow. Includes nf-core utility wrappers (PIPELINE_INITIALISATION, PIPELINE_COMPLETION, UTILS_NFCORE_PIPELINE) which exist to compose helper-function calls rather than to invoke processes.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "path",
+        "kind",
+        "calls",
+        "tests"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string",
+          "description": "Relative path from the pipeline root."
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "pipeline",
+            "utility"
+          ],
+          "description": "`pipeline` when the subworkflow invokes pipeline processes (data-flow contributor). `utility` when it composes helper functions only — common nf-core template subworkflows like PIPELINE_INITIALISATION (which calls `paramsHelp`, `samplesheetToList`, `UTILS_NFSCHEMA_PLUGIN`) and PIPELINE_COMPLETION (`completionEmail`, `completionSummary`). Utility subworkflows have empty `calls[]` for processes but may still expose channel outputs the primary workflow consumes."
+        },
+        "calls": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Names of processes and nested subworkflows this subworkflow invokes. Free-function calls (e.g. `paramsHelp`, `completionEmail`) are NOT recorded here; they're implied by `kind = utility`."
+        },
+        "inputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ChannelIO"
+          },
+          "description": "Parsed entries of the subworkflow's `take:` block. `name` is the take name, `description` carries any adjacent `// ...` comment, `shape` carries the verbatim source line."
+        },
+        "outputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ChannelIO"
+          }
+        },
+        "invocations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SubworkflowInvocation"
+          },
+          "description": "Call-sites where this subworkflow was invoked. Each entry records the calling workflow/subworkflow, the verbatim positional arguments, and a per-argument binding onto this subworkflow's `inputs[].name` (take names). Drives reference-asset attribution (`reference_assets[].used_by`) without re-parsing call sites. Empty when uncalled or when the call could not be positionally aligned."
+        },
+        "tests": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/NfTest"
+          },
+          "description": "Subworkflow-scoped nf-test files under the subworkflow's `tests/` directory. Empty when absent."
+        }
+      }
+    },
+    "SubworkflowInvocation": {
+      "title": "SubworkflowInvocation",
+      "description": "One call-site of a subworkflow, with positional arguments bound to its `take:` names.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "caller",
+        "arguments",
+        "bindings"
+      ],
+      "properties": {
+        "caller": {
+          "type": "string",
+          "description": "Name of the calling workflow or subworkflow."
+        },
+        "caller_path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Repo-relative path of the file the caller is defined in. Null when not resolvable."
+        },
+        "arguments": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Verbatim positional argument expressions in source order (e.g. `params.fasta`, `PREPARE_GENOME.out.fai`)."
+        },
+        "bindings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/InvocationBinding"
+          },
+          "description": "Per-argument binding onto the callee's `inputs[].name` (take names), in source order. Length matches `arguments[]` when the call positionally aligns to the callee's take block; shorter when only a prefix aligns."
+        }
+      }
+    },
+    "InvocationBinding": {
+      "title": "InvocationBinding",
+      "description": "Binding of one positional argument to a callee `take:` name.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "take",
+        "argument"
+      ],
+      "properties": {
+        "take": {
+          "type": "string",
+          "description": "Callee `take:` name (FK into the callee subworkflow's `inputs[].name`)."
+        },
+        "argument": {
+          "type": "string",
+          "description": "Verbatim caller-side argument expression."
+        }
+      }
+    },
+    "Channel": {
+      "title": "Channel",
+      "description": "One top-level channel constructed in the workflow. Sources include `Channel.fromPath`, `Channel.fromFilePairs`, `samplesheetToList`-driven `Channel.fromList`, `splitCsv`, `file`/`files`, and plain `params.*` references.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "source",
+        "shape",
+        "construct",
+        "from_param",
+        "required_runtime"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string",
+          "description": "Verbatim channel-construction expression."
+        },
+        "shape": {
+          "type": "string",
+          "description": "String-encoded channel shape; same convention as ChannelIO."
+        },
+        "construct": {
+          "type": "string",
+          "enum": [
+            "fromPath",
+            "fromFilePairs",
+            "fromList",
+            "samplesheetToList",
+            "splitCsv",
+            "file",
+            "files",
+            "of",
+            "value",
+            "empty",
+            "topic",
+            "other"
+          ],
+          "description": "Classifies the channel's primary materialization factory or shape-determining operator. Selection precedence: (1) `samplesheetToList` when the chain contains `samplesheetToList(...)` (typically wrapped in `Channel.fromList`); (2) `splitCsv` when the chain ends in `.splitCsv(header: true)` over a path; (3) otherwise the outermost factory (`Channel.fromPath` → `fromPath`, `Channel.fromFilePairs` → `fromFilePairs`, `file(...)` → `file`, etc.); (4) `other` for unrecognized constructions. The verbatim `source` retains the full chain — `construct` is the typed lookup the converter would otherwise re-parse."
+        },
+        "from_param": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Foreign key into `params[].name` when the construction expression directly references `params.X` (e.g. `Channel.fromPath(params.reads)`, `samplesheetToList(params.input, ...)`, `file(params.fasta)`). Null for literal-glob construction, expressions that compose multiple params, and channels derived from other channels. v1 resolution is direct-only; one-hop Groovy bindings (`def reads = params.reads; Channel.fromPath(reads)`) are not chased — see galaxyproject/foundry#211."
+        },
+        "required_runtime": {
+          "type": "boolean",
+          "description": "True when the construction chain ends in `.ifEmpty { error ... }` (or an equivalent imperative emptiness-throw guard). Captures runtime requiredness even when the param's nf-schema entry does not mark it required. Combine with `params[].required` and any imperative pre-construction `error` checks for the full requiredness picture."
+        }
+      }
+    },
+    "Edge": {
+      "title": "Edge",
+      "description": "One edge in the workflow's call graph. The deterministic parser records the literal operator chain in `via`; reconciliation of the source and target shapes is the LLM step.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "from",
+        "to"
+      ],
+      "properties": {
+        "from": {
+          "type": "string",
+          "description": "Channel name or `<PROCESS>.out.<chan>` reference."
+        },
+        "to": {
+          "type": "string",
+          "description": "Process or subworkflow name receiving this channel."
+        },
+        "via": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Operators on the path between source and target, in order (e.g. `[\"map\", \"join\", \"groupTuple\"]`). Empty for a direct edge."
+        },
+        "notes": {
+          "type": "string",
+          "description": "LLM-emitted note when the reconciliation is low-confidence (e.g. deeply nested closures)."
+        }
+      }
+    },
+    "Conditional": {
+      "title": "Conditional",
+      "description": "One workflow-level conditional that gates a subgraph.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "guard",
+        "branch",
+        "affects"
+      ],
+      "properties": {
+        "guard": {
+          "type": "string",
+          "description": "Verbatim guard expression, e.g. `params.skip_alignment`."
+        },
+        "branch": {
+          "type": "string",
+          "enum": [
+            "default",
+            "alternate"
+          ],
+          "description": "Which side of the conditional this entry describes. `default` is the truthy branch; `alternate` is the else branch."
+        },
+        "affects": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Process or subworkflow names whose execution is gated by this conditional."
+        }
+      }
+    },
+    "Workflow": {
+      "title": "Workflow",
+      "description": "Primary workflow: channel construction plus the call-graph DAG. Real nf-core pipelines have multiple named `workflow` blocks (an anonymous entrypoint `workflow {}` in main.nf that wires PIPELINE_INITIALISATION → NFCORE_<NAME> → PIPELINE_COMPLETION; a named NFCORE_<NAME> wrapper; a substantive named workflow under workflows/<name>.nf). The summary collapses this into one primary `workflow` plus `subworkflows[]`. Selection rule: pick the workflow that invokes the most pipeline processes — typically the one under `workflows/<name>.nf`. The anonymous `workflow {}` glue and the NFCORE_<NAME> wrapper land in `subworkflows[]`.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "channels",
+        "edges"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the selected primary workflow (uppercase NF convention). The anonymous `workflow {}` entrypoint is never the primary; if it is the only workflow block, the pipeline is too small to summarize and the cast skill should emit a warning."
+        },
+        "channels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Channel"
+          }
+        },
+        "edges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Edge"
+          }
+        },
+        "conditionals": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Conditional"
+          }
+        }
+      }
+    },
+    "TestDataRef": {
+      "title": "TestDataRef",
+      "description": "One test-fixture input. Field names mirror gxy-sketches' TestDataRef verbatim. The sketch-bundle constraint that `path` must live under `test_data/` is intentionally dropped; the Foundry summary describes fixtures as data, it does not bundle them.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "role"
+      ],
+      "properties": {
+        "role": {
+          "type": "string",
+          "description": "Logical role of the input (e.g. `samplesheet`, `reference_fasta`)."
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Repo-relative path when the fixture lives in-tree, or local filesystem path when the CLI fetched the remote fixture into a caller-provided test-data directory."
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uri"
+        },
+        "sha1": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "SHA-1 integrity hash when published alongside the fixture."
+        },
+        "filetype": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "File format, e.g. `fastq.gz`, `csv`."
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "path"
+          ]
+        },
+        {
+          "required": [
+            "url"
+          ]
+        }
+      ]
+    },
+    "ExpectedOutputRef": {
+      "title": "ExpectedOutputRef",
+      "description": "One expected output. Field names mirror gxy-sketches' ExpectedOutputRef verbatim. At least one of path / url / assertions is required.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "role"
+      ],
+      "properties": {
+        "role": {
+          "type": "string"
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uri"
+        },
+        "kind": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Coarse output kind: `report`, `tabular`, `image`, `archive`, `sequence`, `other`."
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "assertions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Assertion strings. Simple equality / regex / contains-string checks are preserved verbatim; complex Groovy assertions are summarized to prose with a `warnings[]` flag in the parent Summary."
+        }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "path"
+          ]
+        },
+        {
+          "required": [
+            "url"
+          ]
+        },
+        {
+          "required": [
+            "assertions"
+          ]
+        }
+      ]
+    },
+    "TestFixtures": {
+      "title": "TestFixtures",
+      "description": "Test fixtures derived from a `conf/<profile>.config` for the cast's selected profile. Pipelines with multiple test profiles (bacass has 11) record only the selected profile here; the full nf-test enumeration lives in `nf_tests[]`.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "profile",
+        "inputs",
+        "outputs"
+      ],
+      "properties": {
+        "profile": {
+          "type": "string",
+          "description": "Which `conf/<profile>.config` produced these fixtures (typically `test`)."
+        },
+        "inputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TestDataRef"
+          }
+        },
+        "outputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ExpectedOutputRef"
+          }
+        }
+      }
+    },
+    "NfTest": {
+      "title": "NfTest",
+      "description": "One `tests/*.nf.test` file. nf-core templates use a near-uniform shape: a `nextflow_pipeline { test(\"<desc>\") { when { params { ... } } then { assertAll(...) } } }` block, with one test() per profile, asserting `workflow.success` plus a snapshot match. This shape captures the data so downstream test-conversion molds (e.g. nextflow-test-to-target-tests) don't have to re-parse Groovy.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "path",
+        "profiles",
+        "assert_workflow_success",
+        "prose_assertions"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Description string passed to `test(\"...\")`. Often duplicates the profile name."
+        },
+        "path": {
+          "type": "string",
+          "description": "Repo-relative path of the .nf.test file (e.g. `tests/dfast.nf.test`)."
+        },
+        "profiles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Profile name(s) the test runs under, from the file-level `profile \"<name>\"` declaration and/or per-test config overrides. Usually a single profile."
+        },
+        "params_overrides": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "The `when { params { ... } }` block as a key→value map. Most templates set only `outdir`; pipeline-specific overrides land here."
+        },
+        "assert_workflow_success": {
+          "type": "boolean",
+          "description": "Whether the test asserts `workflow.success`. Almost always true for nf-core templates."
+        },
+        "snapshot": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SnapshotFixture"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Structured representation of the `assert snapshot(...).match()` clause when present; null when the test uses no snapshot."
+        },
+        "prose_assertions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Other assertions (regex matches, count checks, content equality on specific files) summarized to prose strings. Empty for snapshot-only tests, which is the common nf-core case."
+        }
+      }
+    },
+    "SnapshotFixture": {
+      "title": "SnapshotFixture",
+      "description": "Structured shape of an nf-test `snapshot(...).match()` assertion. nf-core templates pass a small set of values into snapshot() — succeeded-task count, version YAML (with Nextflow version stripped), stable file-name list, stable file-content list — and prune the comparison via `getAllFilesFromDir(..., ignoreFile: ..., ignore: [...])` helpers. This breakdown lets downstream consumers reconstruct equivalent assertions in target test frameworks without re-parsing Groovy.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "captures",
+        "helpers",
+        "ignore_files",
+        "ignore_globs"
+      ],
+      "properties": {
+        "captures": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Logical names of values passed to snapshot(), in order. Common set: `succeeded_task_count`, `versions_yml`, `stable_names`, `stable_paths`. Free-form strings rather than an enum because pipelines can pass other values."
+        },
+        "helpers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "nf-test helper functions invoked in the snapshot expression (e.g. `getAllFilesFromDir`, `removeNextflowVersion`). Used to detect whether a target framework can replicate the comparison."
+        },
+        "ignore_files": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Repo-relative paths passed as `ignoreFile:` to helpers (e.g. `tests/.nftignore`, `tests/.nftignore_files_entirely`). The files themselves are line-delimited globs."
+        },
+        "ignore_globs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Inline `ignore: [...]` glob list passed to helpers (e.g. `['Prokka/**', '**/multiqc_busco.yaml']`). Distinct from ignore_files which references on-disk lists."
+        },
+        "snap_path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Repo-relative path of the corresponding `.nf.test.snap` file when present."
+        },
+        "parsed_content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SnapshotContent"
+          },
+          "description": "Parsed entries from the `.nf.test.snap` JSON sidecar. Empty when the sidecar is absent, too large for compact summary output, or not valid JSON. Each entry preserves the snapshot name plus channel-keyed file md5 assertions and non-file scalar values."
+        }
+      }
+    },
+    "SnapshotContent": {
+      "title": "SnapshotContent",
+      "description": "One top-level snapshot entry from an nf-test `.snap` JSON sidecar.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "channels"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Top-level key in the `.snap` file, usually the `test(\"...\")` name."
+        },
+        "channels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SnapshotChannel"
+          },
+          "description": "Channel-keyed snapshot values. Pipeline-template flat file lists use `key: null`."
+        }
+      }
+    },
+    "SnapshotChannel": {
+      "title": "SnapshotChannel",
+      "description": "One output channel or flat snapshot list inside a `.snap` entry.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "key",
+        "files",
+        "values"
+      ],
+      "properties": {
+        "key": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Channel key from the snapshot object, e.g. `0`, `1`, or `genome_gtf`; null for flat file-list snapshots."
+        },
+        "files": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SnapshotFile"
+          },
+          "description": "File md5 assertions parsed from `<path>:md5,<hex>` strings."
+        },
+        "values": {
+          "type": "array",
+          "items": {},
+          "description": "Non-file snapshot values preserved verbatim for consumers that need versions, counts, or scalar tuple emissions."
+        }
+      }
+    },
+    "Evidence": {
+      "title": "Evidence",
+      "description": "Shared provenance block for source-detected facts. `source_path` localizes the finding; `confidence` is a coarse self-assessment; `evidence[]` carries free-form snippets (matched lines, normalized expressions, detector notes). Reused by ReferenceAsset and ReferenceRebuildRule.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_path",
+        "confidence",
+        "evidence"
+      ],
+      "properties": {
+        "source_path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Repo-relative path of the source file where the finding was detected (e.g. `subworkflows/local/prepare_genome/main.nf`, `nextflow.config`). Null when the finding spans files or cannot be localized."
+        },
+        "confidence": {
+          "type": "string",
+          "enum": [
+            "high",
+            "medium",
+            "low"
+          ],
+          "description": "Detector self-assessment. `high`: all signals match the expected idiom; `medium`: some signals match but the guard or builder is partial / mixes non-param locals; `low`: heuristic match, downstream should treat as a hint."
+        },
+        "evidence": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Free-form evidence snippets (matched source lines, normalized expressions, detector notes). Empty when none."
+        }
+      }
+    },
+    "ReferenceAsset": {
+      "title": "ReferenceAsset",
+      "description": "Curated source-side view of one reference-data input the pipeline consumes. A foreign-key projection onto `params[].name` plus the metadata downstream classification Molds need. Target-agnostic: no Galaxy translation decisions are encoded here.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "param",
+        "asset_kind",
+        "required",
+        "used_by",
+        "evidence"
+      ],
+      "properties": {
+        "param": {
+          "type": "string",
+          "description": "FK into `params[].name`."
+        },
+        "asset_kind": {
+          "type": "string",
+          "description": "Coarse asset classification (e.g. `fasta`, `fasta_index`, `sequence_dictionary`, `bwa_index`, `bwamem2_index`, `tabix_index`, `gtf`, `gff`, `bed`, `vcf`, `database`, `reference_sheet`, `other`). Free-form string; downstream Molds choose how to map onto target datatypes."
+        },
+        "format_hint": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Format hint, often the nf-schema `format` keyword (`file-path`, `directory-path`, `path`, `file-path-pattern`) or a domain hint like `fai`, `dict`. Null when undetermined."
+        },
+        "required": {
+          "type": "boolean",
+          "description": "True when the source pipeline treats this asset as required (no compute-if-missing branch, no optional guard). When false, see `reference_rebuilds[]` for any rebuild branch covering this param."
+        },
+        "source_kind": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "nextflow_schema",
+            "params_block",
+            "getGenomeAttribute",
+            "computed",
+            null
+          ],
+          "description": "Mirrors `params[<this>].source_kind`. Duplicated here so reference-data consumers don't have to dereference."
+        },
+        "source_expression": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Mirrors `params[<this>].source_expression`. Duplicated for the same reason."
+        },
+        "schema_group": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Mirrors `params[<this>].schema_group`. Useful for grouping (`Reference genome options`)."
+        },
+        "used_by": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Names of processes / subworkflows that receive this param as an argument (via direct invocation binding or channel construction). Empty when no caller could be attributed."
+        },
+        "evidence": {
+          "$ref": "#/$defs/Evidence"
+        }
+      }
+    },
+    "ReferenceRebuildRule": {
+      "title": "ReferenceRebuildRule",
+      "description": "One compute-if-missing rebuild branch detected in a workflow or subworkflow body. Binds an asset param to the guard expression and builder process that produces it when absent. Source evidence only; in-tool-rebuild decisions live downstream.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "asset_param",
+        "guard",
+        "builder",
+        "builder_outputs",
+        "evidence"
+      ],
+      "properties": {
+        "asset_param": {
+          "type": "string",
+          "description": "FK into `params[].name` — the asset this branch reconstitutes when missing."
+        },
+        "guard": {
+          "type": "string",
+          "description": "Verbatim guard expression, e.g. `!fasta_fai_in && step != \"annotate\"`."
+        },
+        "guard_params": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Param names referenced by the guard. Empty when the guard binds only non-param locals."
+        },
+        "builder": {
+          "type": "string",
+          "description": "Builder process or subworkflow name invoked inside the branch (e.g. `SAMTOOLS_FAIDX`, `BWA_INDEX`)."
+        },
+        "builder_outputs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Output channel names from the builder that are assigned to the asset (e.g. `fai`, `dict`)."
+        },
+        "fallback_for": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Name of the `<asset>_in`-style param that, when present, supplies the asset directly and skips the rebuild. Null when no such pairing was detected."
+        },
+        "evidence": {
+          "$ref": "#/$defs/Evidence"
+        }
+      }
+    },
+    "SnapshotFile": {
+      "title": "SnapshotFile",
+      "description": "One file digest assertion from a `.snap` sidecar.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "basename",
+        "md5",
+        "stub"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Path portion before `:md5,` exactly as stored in the sidecar."
+        },
+        "basename": {
+          "type": "string",
+          "description": "Final path segment, suitable for Galaxy test `file:` assertions when the snapshot stores only basenames."
+        },
+        "md5": {
+          "type": "string",
+          "pattern": "^[a-fA-F0-9]{32}$",
+          "description": "MD5 digest from the sidecar."
+        },
+        "stub": {
+          "type": "boolean",
+          "description": "True when the digest is the empty-file md5 emitted by many `-stub` tests."
+        }
+      }
+    }
+  }
+}

--- a/casts/claude/skills/paper-to-test-data/SKILL.md
+++ b/casts/claude/skills/paper-to-test-data/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: paper-to-test-data
+description: "Derive workflow test inputs and expected outputs from a paper."
+---
+
+# paper-to-test-data
+
+Follow the procedure below and use the artifact/reference sections as the runtime contract.
+
+## When To Use
+
+- Derive workflow test inputs and expected outputs from a paper.
+
+## Inputs
+
+- Read artifact `freeform-summary`. Produced by `interview-to-freeform-summary`, `summarize-paper`. Free-form summary from summarize-paper; sample data and reference evidence the test fixtures derive from.
+
+## Outputs
+
+- Write artifact `test-data-refs` as `test-data-refs.json`. Format: `json`. Resolved workflow test inputs and expected outputs derived from paper evidence (URLs, file shapes, expected hashes).
+
+## Required Tools
+
+- None declared. Procedure should not assume external CLIs are present.
+
+## Load Upfront
+
+- None declared.
+
+## Load On Demand
+
+- None declared.
+
+## Validation
+
+- None declared.
+
+## Procedure
+
+Read the paper free-form summary from summarize-paper and derive concrete workflow test inputs and expected outputs — resolvable URLs, file shapes, and expected hashes — emitted as `test-data-refs`.
+
+## Runtime Notes
+
+- Do not read Foundry source files at runtime; use only files packaged in this skill bundle and user-supplied artifacts.
+- Preserve declared artifact filenames unless the user or harness supplies explicit paths.
+- Carry unresolved assumptions into the output artifact instead of silently inventing missing source evidence.

--- a/casts/claude/skills/paper-to-test-data/_provenance.json
+++ b/casts/claude/skills/paper-to-test-data/_provenance.json
@@ -1,0 +1,33 @@
+{
+  "provenance_schema_version": 3,
+  "cast_target": "claude",
+  "mold": {
+    "name": "paper-to-test-data",
+    "path": "content/molds/paper-to-test-data/index.md",
+    "revision": 2,
+    "content_hash": "39fbe4c3e624f0b2ef1242d8bc25a453210b8623097ed24044d2407792738ed3",
+    "commit": "e487fe785f468afdf25f2b6bd140c3a115a12021"
+  },
+  "cast_at": "2026-07-24T13:51:16.344Z",
+  "refs": [],
+  "artifacts": {
+    "produces": [
+      {
+        "id": "test-data-refs",
+        "kind": "json",
+        "default_filename": "test-data-refs.json",
+        "description": "Resolved workflow test inputs and expected outputs derived from paper evidence (URLs, file shapes, expected hashes)."
+      }
+    ],
+    "consumes": [
+      {
+        "id": "freeform-summary",
+        "description": "Free-form summary from [[summarize-paper]]; sample data and reference evidence the test fixtures derive from.",
+        "producers": [
+          "interview-to-freeform-summary",
+          "summarize-paper"
+        ]
+      }
+    ]
+  }
+}

--- a/casts/claude/skills/paper-to-test-data/_verify.json
+++ b/casts/claude/skills/paper-to-test-data/_verify.json
@@ -1,0 +1,4 @@
+{
+  "verify_schema_version": 1,
+  "entries": []
+}

--- a/casts/claude/skills/pipeline-cwl-to-galaxy/SKILL.md
+++ b/casts/claude/skills/pipeline-cwl-to-galaxy/SKILL.md
@@ -67,7 +67,7 @@ Run these phases in order. After each, confirm the expected artifact exists in t
    - Try `cwl-to-test-data` — Resolve a CWL workflow's own declared test cases into Galaxy workflow test-data refs.
    - Otherwise try `find-test-data` — Search IWC fixtures and public sources for test data matching a data-flow shape.
    - **user-supplied** — if nothing above yields acceptable output, ask the user to supply it directly.
-8. **cwl-test-to-galaxy-test-plan** — MANUAL — `cwl-test-to-galaxy-test-plan` is not yet cast. Translate CWL test fixtures into a Galaxy workflow test plan. Do this by hand and confirm before continuing.
+8. **cwl-test-to-galaxy-test-plan** — invoke the `cwl-test-to-galaxy-test-plan` skill. Translate CWL test fixtures into a Galaxy workflow test plan.
 9. **implement-galaxy-workflow-test** — invoke the `implement-galaxy-workflow-test` skill. Assemble Galaxy workflow test fixtures and assertions.
 10. **validate-galaxy-workflow** — invoke the `validate-galaxy-workflow` skill. Run terminal gxwf validation on an assembled Galaxy workflow and classify workflow-level failures.
 11. **run-workflow-test** — invoke the `run-workflow-test` skill. Execute a workflow's tests via Planemo; emit structured pass/fail and outputs.

--- a/casts/claude/skills/pipeline-cwl-to-galaxy/_assembly.json
+++ b/casts/claude/skills/pipeline-cwl-to-galaxy/_assembly.json
@@ -18,7 +18,7 @@
     { "phase": 5, "kind": "mold", "skill": "cwl-summary-to-galaxy-template", "cast_present": true, "loop": false },
     { "phase": 6, "kind": "mold", "skill": "advance-galaxy-draft-step", "cast_present": true, "loop": true },
     { "phase": 7, "kind": "branch", "pattern": "test-data-resolution", "chain": ["cwl-to-test-data", "find-test-data", "user-supplied"], "cast_present": [true, true, null] },
-    { "phase": 8, "kind": "mold", "skill": "cwl-test-to-galaxy-test-plan", "cast_present": false, "loop": false },
+    { "phase": 8, "kind": "mold", "skill": "cwl-test-to-galaxy-test-plan", "cast_present": true, "loop": false },
     { "phase": 9, "kind": "mold", "skill": "implement-galaxy-workflow-test", "cast_present": true, "loop": false },
     { "phase": 10, "kind": "mold", "skill": "validate-galaxy-workflow", "cast_present": true, "loop": false },
     { "phase": 11, "kind": "mold", "skill": "run-workflow-test", "cast_present": true, "loop": false },

--- a/casts/claude/skills/pipeline-nextflow-to-cwl/SKILL.md
+++ b/casts/claude/skills/pipeline-nextflow-to-cwl/SKILL.md
@@ -7,8 +7,6 @@ description: "Direct path from a Nextflow pipeline to a CWL Workflow + CommandLi
 
 Harness for the **NEXTFLOW → CWL** Foundry pipeline. Runs the constituent skills in order inside a single per-run working directory. Assembled from `content/pipelines/nextflow-to-cwl/index.md` (revision 2) — regenerate with `foundry-build assemble-pipeline nextflow-to-cwl` if the pipeline changes; do not hand-edit.
 
-Most of this pipeline's Molds are not yet cast, so this harness is mostly manual checkpoints today; it still fixes the phase order, the per-run working directory, and the few real casts. It strengthens as the remaining Molds are cast.
-
 ## When To Use
 
 - Direct path from a Nextflow pipeline to a CWL Workflow + CommandLineTool set.
@@ -52,21 +50,21 @@ Announce the chosen directory before starting.
 Run these phases in order. After each, confirm the expected artifact exists in the run directory before advancing.
 
 1. **summarize-nextflow** — invoke the `summarize-nextflow` skill. Read a Nextflow pipeline source tree (nf-core or ad-hoc DSL2) and emit a structured JSON summary for downstream translation Molds.
-2. **nextflow-summary-to-cwl-interface** — MANUAL — `nextflow-summary-to-cwl-interface` is not yet cast. Map a Nextflow summary into a CWL Workflow interface design brief. Do this by hand and confirm before continuing.
-3. **nextflow-summary-to-cwl-data-flow** — MANUAL — `nextflow-summary-to-cwl-data-flow` is not yet cast. Translate a Nextflow summary into a CWL data-flow design brief. Do this by hand and confirm before continuing.
-4. **summary-to-cwl-template** — MANUAL — `summary-to-cwl-template` is not yet cast. CWL Workflow skeleton with per-step TODOs from source and design handoffs. Do this by hand and confirm before continuing.
-5. **summarize-cwl-tool** (loop) — MANUAL — `summarize-cwl-tool` is not yet cast. Derive a CommandLineTool description (container, baseCommand, IO) for a CWL target. No shared endstate oracle yet; iterate over the tools enumerated in the CWL template, doing each by hand.
-6. **implement-cwl-tool-step** (loop) — MANUAL — `implement-cwl-tool-step` is not yet cast. Convert an abstract step into a concrete CWL CommandLineTool + step. No shared endstate oracle yet; iterate over the tools enumerated in the CWL template, doing each by hand.
-7. **validate-cwl** (loop) — MANUAL — `validate-cwl` is not yet cast. Run cwltool --validate / schema lint, classify failures, recommend fixes. No shared endstate oracle yet; iterate over the tools enumerated in the CWL template, doing each by hand.
-8. **nextflow-test-to-cwl-test-plan** — MANUAL — `nextflow-test-to-cwl-test-plan` is not yet cast. Translate Nextflow test evidence into a CWL workflow test plan. Do this by hand and confirm before continuing.
-9. **implement-cwl-workflow-test** — MANUAL — `implement-cwl-workflow-test` is not yet cast. Assemble CWL job file(s) and expected-output assertions. Do this by hand and confirm before continuing.
-10. **validate-cwl** — MANUAL — `validate-cwl` is not yet cast. Run cwltool --validate / schema lint, classify failures, recommend fixes. Do this by hand and confirm before continuing.
+2. **nextflow-summary-to-cwl-interface** — invoke the `nextflow-summary-to-cwl-interface` skill. Map a Nextflow summary into a CWL Workflow interface design brief.
+3. **nextflow-summary-to-cwl-data-flow** — invoke the `nextflow-summary-to-cwl-data-flow` skill. Translate a Nextflow summary into a CWL data-flow design brief.
+4. **summary-to-cwl-template** — invoke the `summary-to-cwl-template` skill. CWL Workflow skeleton with per-step TODOs from source and design handoffs.
+5. **summarize-cwl-tool** (loop) — invoke the `summarize-cwl-tool` skill, once per step. No shared endstate oracle yet; iterate over the tools enumerated in the CWL template, doing each by hand.
+6. **implement-cwl-tool-step** (loop) — invoke the `implement-cwl-tool-step` skill, once per step. No shared endstate oracle yet; iterate over the tools enumerated in the CWL template, doing each by hand.
+7. **validate-cwl** (loop) — invoke the `validate-cwl` skill, once per step. No shared endstate oracle yet; iterate over the tools enumerated in the CWL template, doing each by hand.
+8. **nextflow-test-to-cwl-test-plan** — invoke the `nextflow-test-to-cwl-test-plan` skill. Translate Nextflow test evidence into a CWL workflow test plan.
+9. **implement-cwl-workflow-test** — invoke the `implement-cwl-workflow-test` skill. Assemble CWL job file(s) and expected-output assertions.
+10. **validate-cwl** — invoke the `validate-cwl` skill. Run cwltool --validate / schema lint, classify failures, recommend fixes.
 11. **run-workflow-test** — invoke the `run-workflow-test` skill. Execute a workflow's tests via Planemo; emit structured pass/fail and outputs.
-12. **debug-cwl-workflow-output** — MANUAL — `debug-cwl-workflow-output` is not yet cast. Triage failing CWL run outputs; classify failure modes; propose fixes. Do this by hand and confirm before continuing.
+12. **debug-cwl-workflow-output** — invoke the `debug-cwl-workflow-output` skill. Triage failing CWL run outputs; classify failure modes; propose fixes.
 
 ## Done
 
-Report the final artifacts in `./<run-slug>/` and any phases handled manually (marked MANUAL above).
+Report the final artifacts in `./<run-slug>/`.
 
 ## Notes
 

--- a/casts/claude/skills/pipeline-nextflow-to-cwl/_assembly.json
+++ b/casts/claude/skills/pipeline-nextflow-to-cwl/_assembly.json
@@ -10,16 +10,16 @@
   ],
   "phases": [
     { "phase": 1, "kind": "mold", "skill": "summarize-nextflow", "cast_present": true, "loop": false },
-    { "phase": 2, "kind": "mold", "skill": "nextflow-summary-to-cwl-interface", "cast_present": false, "loop": false },
-    { "phase": 3, "kind": "mold", "skill": "nextflow-summary-to-cwl-data-flow", "cast_present": false, "loop": false },
-    { "phase": 4, "kind": "mold", "skill": "summary-to-cwl-template", "cast_present": false, "loop": false },
-    { "phase": 5, "kind": "mold", "skill": "summarize-cwl-tool", "cast_present": false, "loop": true },
-    { "phase": 6, "kind": "mold", "skill": "implement-cwl-tool-step", "cast_present": false, "loop": true },
-    { "phase": 7, "kind": "mold", "skill": "validate-cwl", "cast_present": false, "loop": true },
-    { "phase": 8, "kind": "mold", "skill": "nextflow-test-to-cwl-test-plan", "cast_present": false, "loop": false },
-    { "phase": 9, "kind": "mold", "skill": "implement-cwl-workflow-test", "cast_present": false, "loop": false },
-    { "phase": 10, "kind": "mold", "skill": "validate-cwl", "cast_present": false, "loop": false },
+    { "phase": 2, "kind": "mold", "skill": "nextflow-summary-to-cwl-interface", "cast_present": true, "loop": false },
+    { "phase": 3, "kind": "mold", "skill": "nextflow-summary-to-cwl-data-flow", "cast_present": true, "loop": false },
+    { "phase": 4, "kind": "mold", "skill": "summary-to-cwl-template", "cast_present": true, "loop": false },
+    { "phase": 5, "kind": "mold", "skill": "summarize-cwl-tool", "cast_present": true, "loop": true },
+    { "phase": 6, "kind": "mold", "skill": "implement-cwl-tool-step", "cast_present": true, "loop": true },
+    { "phase": 7, "kind": "mold", "skill": "validate-cwl", "cast_present": true, "loop": true },
+    { "phase": 8, "kind": "mold", "skill": "nextflow-test-to-cwl-test-plan", "cast_present": true, "loop": false },
+    { "phase": 9, "kind": "mold", "skill": "implement-cwl-workflow-test", "cast_present": true, "loop": false },
+    { "phase": 10, "kind": "mold", "skill": "validate-cwl", "cast_present": true, "loop": false },
     { "phase": 11, "kind": "mold", "skill": "run-workflow-test", "cast_present": true, "loop": false },
-    { "phase": 12, "kind": "mold", "skill": "debug-cwl-workflow-output", "cast_present": false, "loop": false }
+    { "phase": 12, "kind": "mold", "skill": "debug-cwl-workflow-output", "cast_present": true, "loop": false }
   ]
 }

--- a/casts/claude/skills/pipeline-paper-to-cwl/SKILL.md
+++ b/casts/claude/skills/pipeline-paper-to-cwl/SKILL.md
@@ -7,8 +7,6 @@ description: "Direct path from a paper to a CWL Workflow + CommandLineTool set �
 
 Harness for the **PAPER → CWL** Foundry pipeline. Runs the constituent skills in order inside a single per-run working directory. Assembled from `content/pipelines/paper-to-cwl/index.md` (revision 2) — regenerate with `foundry-build assemble-pipeline paper-to-cwl` if the pipeline changes; do not hand-edit.
 
-Most of this pipeline's Molds are not yet cast, so this harness is mostly manual checkpoints today; it still fixes the phase order, the per-run working directory, and the few real casts. It strengthens as the remaining Molds are cast.
-
 ## When To Use
 
 - Direct path from a paper to a CWL Workflow + CommandLineTool set.
@@ -47,20 +45,20 @@ Announce the chosen directory before starting.
 
 Run these phases in order. After each, confirm the expected artifact exists in the run directory before advancing.
 
-1. **summarize-paper** — MANUAL — `summarize-paper` is not yet cast. Extract methods, tools, sample data, and references from a paper. Do this by hand and confirm before continuing.
-2. **freeform-summary-to-cwl-design** — MANUAL — `freeform-summary-to-cwl-design` is not yet cast. Translate a free-form source summary into a CWL workflow design brief. Do this by hand and confirm before continuing.
-3. **summary-to-cwl-template** — MANUAL — `summary-to-cwl-template` is not yet cast. CWL Workflow skeleton with per-step TODOs from source and design handoffs. Do this by hand and confirm before continuing.
-4. **summarize-cwl-tool** (loop) — MANUAL — `summarize-cwl-tool` is not yet cast. Derive a CommandLineTool description (container, baseCommand, IO) for a CWL target. No shared endstate oracle yet; iterate over the tools enumerated in the CWL template, doing each by hand.
-5. **implement-cwl-tool-step** (loop) — MANUAL — `implement-cwl-tool-step` is not yet cast. Convert an abstract step into a concrete CWL CommandLineTool + step. No shared endstate oracle yet; iterate over the tools enumerated in the CWL template, doing each by hand.
-6. **validate-cwl** (loop) — MANUAL — `validate-cwl` is not yet cast. Run cwltool --validate / schema lint, classify failures, recommend fixes. No shared endstate oracle yet; iterate over the tools enumerated in the CWL template, doing each by hand.
+1. **summarize-paper** — invoke the `summarize-paper` skill. Extract methods, tools, sample data, and references from a paper.
+2. **freeform-summary-to-cwl-design** — invoke the `freeform-summary-to-cwl-design` skill. Translate a free-form source summary into a CWL workflow design brief.
+3. **summary-to-cwl-template** — invoke the `summary-to-cwl-template` skill. CWL Workflow skeleton with per-step TODOs from source and design handoffs.
+4. **summarize-cwl-tool** (loop) — invoke the `summarize-cwl-tool` skill, once per step. No shared endstate oracle yet; iterate over the tools enumerated in the CWL template, doing each by hand.
+5. **implement-cwl-tool-step** (loop) — invoke the `implement-cwl-tool-step` skill, once per step. No shared endstate oracle yet; iterate over the tools enumerated in the CWL template, doing each by hand.
+6. **validate-cwl** (loop) — invoke the `validate-cwl` skill, once per step. No shared endstate oracle yet; iterate over the tools enumerated in the CWL template, doing each by hand.
 7. **test-data-resolution** (branch) — resolve in order; stop at the first that yields acceptable output:
-   - Try `paper-to-test-data` (MANUAL — not yet cast). Derive workflow test inputs and expected outputs from a paper. Do this by hand.
+   - Try `paper-to-test-data` — Derive workflow test inputs and expected outputs from a paper.
    - Otherwise try `find-test-data` — Search IWC fixtures and public sources for test data matching a data-flow shape.
    - **user-supplied** — if nothing above yields acceptable output, ask the user to supply it directly.
-8. **implement-cwl-workflow-test** — MANUAL — `implement-cwl-workflow-test` is not yet cast. Assemble CWL job file(s) and expected-output assertions. Do this by hand and confirm before continuing.
-9. **validate-cwl** — MANUAL — `validate-cwl` is not yet cast. Run cwltool --validate / schema lint, classify failures, recommend fixes. Do this by hand and confirm before continuing.
+8. **implement-cwl-workflow-test** — invoke the `implement-cwl-workflow-test` skill. Assemble CWL job file(s) and expected-output assertions.
+9. **validate-cwl** — invoke the `validate-cwl` skill. Run cwltool --validate / schema lint, classify failures, recommend fixes.
 10. **run-workflow-test** — invoke the `run-workflow-test` skill. Execute a workflow's tests via Planemo; emit structured pass/fail and outputs.
-11. **debug-cwl-workflow-output** — MANUAL — `debug-cwl-workflow-output` is not yet cast. Triage failing CWL run outputs; classify failure modes; propose fixes. Do this by hand and confirm before continuing.
+11. **debug-cwl-workflow-output** — invoke the `debug-cwl-workflow-output` skill. Triage failing CWL run outputs; classify failure modes; propose fixes.
 
 ## Done
 

--- a/casts/claude/skills/pipeline-paper-to-cwl/_assembly.json
+++ b/casts/claude/skills/pipeline-paper-to-cwl/_assembly.json
@@ -8,16 +8,16 @@
     { "tool": "planemo", "origin": "pypi", "package": "planemo", "package_version": "0.75.45", "invoke": "planemo", "invoke_fallback": "uvx --from planemo==0.75.45 planemo", "availability_check": "planemo --version", "docs_url": "https://planemo.readthedocs.io/", "source": "referenced" }
   ],
   "phases": [
-    { "phase": 1, "kind": "mold", "skill": "summarize-paper", "cast_present": false, "loop": false },
-    { "phase": 2, "kind": "mold", "skill": "freeform-summary-to-cwl-design", "cast_present": false, "loop": false },
-    { "phase": 3, "kind": "mold", "skill": "summary-to-cwl-template", "cast_present": false, "loop": false },
-    { "phase": 4, "kind": "mold", "skill": "summarize-cwl-tool", "cast_present": false, "loop": true },
-    { "phase": 5, "kind": "mold", "skill": "implement-cwl-tool-step", "cast_present": false, "loop": true },
-    { "phase": 6, "kind": "mold", "skill": "validate-cwl", "cast_present": false, "loop": true },
-    { "phase": 7, "kind": "branch", "pattern": "test-data-resolution", "chain": ["paper-to-test-data", "find-test-data", "user-supplied"], "cast_present": [false, true, null] },
-    { "phase": 8, "kind": "mold", "skill": "implement-cwl-workflow-test", "cast_present": false, "loop": false },
-    { "phase": 9, "kind": "mold", "skill": "validate-cwl", "cast_present": false, "loop": false },
+    { "phase": 1, "kind": "mold", "skill": "summarize-paper", "cast_present": true, "loop": false },
+    { "phase": 2, "kind": "mold", "skill": "freeform-summary-to-cwl-design", "cast_present": true, "loop": false },
+    { "phase": 3, "kind": "mold", "skill": "summary-to-cwl-template", "cast_present": true, "loop": false },
+    { "phase": 4, "kind": "mold", "skill": "summarize-cwl-tool", "cast_present": true, "loop": true },
+    { "phase": 5, "kind": "mold", "skill": "implement-cwl-tool-step", "cast_present": true, "loop": true },
+    { "phase": 6, "kind": "mold", "skill": "validate-cwl", "cast_present": true, "loop": true },
+    { "phase": 7, "kind": "branch", "pattern": "test-data-resolution", "chain": ["paper-to-test-data", "find-test-data", "user-supplied"], "cast_present": [true, true, null] },
+    { "phase": 8, "kind": "mold", "skill": "implement-cwl-workflow-test", "cast_present": true, "loop": false },
+    { "phase": 9, "kind": "mold", "skill": "validate-cwl", "cast_present": true, "loop": false },
     { "phase": 10, "kind": "mold", "skill": "run-workflow-test", "cast_present": true, "loop": false },
-    { "phase": 11, "kind": "mold", "skill": "debug-cwl-workflow-output", "cast_present": false, "loop": false }
+    { "phase": 11, "kind": "mold", "skill": "debug-cwl-workflow-output", "cast_present": true, "loop": false }
   ]
 }

--- a/casts/claude/skills/pipeline-paper-to-galaxy/SKILL.md
+++ b/casts/claude/skills/pipeline-paper-to-galaxy/SKILL.md
@@ -45,14 +45,14 @@ Announce the chosen directory before starting.
 
 Run these phases in order. After each, confirm the expected artifact exists in the run directory before advancing.
 
-1. **summarize-paper** — MANUAL — `summarize-paper` is not yet cast. Extract methods, tools, sample data, and references from a paper. Do this by hand and confirm before continuing.
+1. **summarize-paper** — invoke the `summarize-paper` skill. Extract methods, tools, sample data, and references from a paper.
 2. **freeform-summary-to-galaxy-interface** — invoke the `freeform-summary-to-galaxy-interface` skill. Map a free-form source summary into a Galaxy workflow interface design brief.
 3. **freeform-summary-to-galaxy-data-flow** — invoke the `freeform-summary-to-galaxy-data-flow` skill. Translate a free-form source summary into a Galaxy data-flow design brief.
 4. **compare-against-iwc-exemplar** — invoke the `compare-against-iwc-exemplar` skill. Find nearest IWC exemplar(s) and surface a structural diff against the upstream Galaxy design briefs to guide template authoring.
 5. **freeform-summary-to-galaxy-template** — invoke the `freeform-summary-to-galaxy-template` skill. gxformat2 skeleton with per-step TODOs from a free-form summary and Galaxy design brief.
 6. **advance-galaxy-draft-step** (loop) — invoke the `advance-galaxy-draft-step` skill, once per step. It owns its own endstate oracle (`gxwf draft-next-step`) and concretizes one drafty step per call; re-invoke until it reports `draft: false`, then it extracts the concrete `galaxy-workflow.gxwf.yml` (via `gxwf draft-extract`) and continues.
 7. **test-data-resolution** (branch) — resolve in order; stop at the first that yields acceptable output:
-   - Try `paper-to-test-data` (MANUAL — not yet cast). Derive workflow test inputs and expected outputs from a paper. Do this by hand.
+   - Try `paper-to-test-data` — Derive workflow test inputs and expected outputs from a paper.
    - Otherwise try `find-test-data` — Search IWC fixtures and public sources for test data matching a data-flow shape.
    - **user-supplied** — if nothing above yields acceptable output, ask the user to supply it directly.
 8. **freeform-summary-to-galaxy-test-plan** — invoke the `freeform-summary-to-galaxy-test-plan` skill. Synthesize a Galaxy workflow test plan from a free-form summary and the Galaxy design briefs.

--- a/casts/claude/skills/pipeline-paper-to-galaxy/_assembly.json
+++ b/casts/claude/skills/pipeline-paper-to-galaxy/_assembly.json
@@ -8,13 +8,13 @@
     { "tool": "planemo", "origin": "pypi", "package": "planemo", "package_version": "0.75.45", "invoke": "planemo", "invoke_fallback": "uvx --from planemo==0.75.45 planemo", "availability_check": "planemo --version", "docs_url": "https://planemo.readthedocs.io/", "source": "referenced" }
   ],
   "phases": [
-    { "phase": 1, "kind": "mold", "skill": "summarize-paper", "cast_present": false, "loop": false },
+    { "phase": 1, "kind": "mold", "skill": "summarize-paper", "cast_present": true, "loop": false },
     { "phase": 2, "kind": "mold", "skill": "freeform-summary-to-galaxy-interface", "cast_present": true, "loop": false },
     { "phase": 3, "kind": "mold", "skill": "freeform-summary-to-galaxy-data-flow", "cast_present": true, "loop": false },
     { "phase": 4, "kind": "mold", "skill": "compare-against-iwc-exemplar", "cast_present": true, "loop": false },
     { "phase": 5, "kind": "mold", "skill": "freeform-summary-to-galaxy-template", "cast_present": true, "loop": false },
     { "phase": 6, "kind": "mold", "skill": "advance-galaxy-draft-step", "cast_present": true, "loop": true },
-    { "phase": 7, "kind": "branch", "pattern": "test-data-resolution", "chain": ["paper-to-test-data", "find-test-data", "user-supplied"], "cast_present": [false, true, null] },
+    { "phase": 7, "kind": "branch", "pattern": "test-data-resolution", "chain": ["paper-to-test-data", "find-test-data", "user-supplied"], "cast_present": [true, true, null] },
     { "phase": 8, "kind": "mold", "skill": "freeform-summary-to-galaxy-test-plan", "cast_present": true, "loop": false },
     { "phase": 9, "kind": "mold", "skill": "implement-galaxy-workflow-test", "cast_present": true, "loop": false },
     { "phase": 10, "kind": "mold", "skill": "validate-galaxy-workflow", "cast_present": true, "loop": false },

--- a/casts/claude/skills/repair-galaxy-draft-topology/SKILL.md
+++ b/casts/claude/skills/repair-galaxy-draft-topology/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: repair-galaxy-draft-topology
+description: "Re-wire a Galaxy draft region when a step's declared output can't be computed from its wired inputs."
+---
+
+# repair-galaxy-draft-topology
+
+Follow the procedure below and use the artifact/reference sections as the runtime contract.
+
+## When To Use
+
+- Re-wire a Galaxy draft region when a step's declared output can't be computed from its wired inputs.
+
+## Inputs
+
+- Read artifact `galaxy-workflow-draft`. Schema: galaxy-workflow-draft. Produced by `advance-galaxy-draft-step`, `apply-galaxy-workflow-changeset`, `cwl-summary-to-galaxy-template`, `freeform-summary-to-galaxy-template`, `implement-galaxy-tool-step`, `nextflow-summary-to-galaxy-template`, `repair-galaxy-draft-topology`. Partially-realized gxformat2 draft (see galaxy-workflow-draft-format) whose topology can't support a declared step — the region to repair.
+- Read artifact `open-requirements-ledger`. Produced by `advance-galaxy-draft-step`, `apply-galaxy-workflow-changeset`, `compare-against-iwc-exemplar`, `cwl-summary-to-galaxy-data-flow`, `cwl-summary-to-galaxy-interface`, `cwl-summary-to-galaxy-template`, `freeform-summary-to-galaxy-data-flow`, `freeform-summary-to-galaxy-interface`, `freeform-summary-to-galaxy-template`, `implement-galaxy-tool-step`, `interview-to-galaxy-workflow-changeset`, `nextflow-summary-to-galaxy-data-flow`, `nextflow-summary-to-galaxy-interface`, `nextflow-summary-to-galaxy-reference-data`, `nextflow-summary-to-galaxy-template`, `repair-galaxy-draft-topology`. Carried obligations from open-requirements-ledger; the open blocking entries name which step output is uncomputable and what evidence is missing.
+
+## Outputs
+
+- Write artifact `galaxy-workflow-draft` as `galaxy-workflow-draft.gxwf.yml`. Format: `yaml`. Schema: galaxy-workflow-draft. Re-wired gxformat2 draft: a producer step (or small sub-path) inserted so the previously-blocked step's declared output is computable; new steps land at draft (TODO) tier.
+- Write artifact `open-requirements-ledger` as `open-requirements.ledger.yml`. Format: `yaml`. Ledger with the addressed blocking entries marked resolved, or surrendered with a note when no producer can be found within the escalation budget.
+
+## Required Tools
+
+- None declared. Procedure should not assume external CLIs are present.
+
+## Load Upfront
+
+- `references/notes/galaxy-data-flow-draft-contract.md`: Research note copied verbatim into the bundle. Re-wire the affected region consistently with the data-flow design that settled the surrounding topology.
+- `references/notes/galaxy-workflow-draft-format.md`: Research note copied verbatim into the bundle. Emit re-wired steps in the draft superset (TODO tool_id, _plan_* fields) so existing per-step machinery realizes them; respect the settle-vs-repair boundary.
+- `references/notes/open-requirements-ledger.md`: Research note copied verbatim into the bundle. Read open blocking entries to scope the repair; mark each resolved or surrender it, feeding the loop's decreasing-blocker convergence gate.
+- `references/schemas/galaxy-workflow-draft.schema.json`: Schema file copied verbatim into the bundle. In/out contract: the draft this Mold reads and re-wires conforms to galaxy-workflow-draft; cast bundles the JSON Schema so the re-wired draft stays inside the superset the per-step loop expects.
+
+## Load On Demand
+
+- `references/patterns/galaxy-collection-patterns.md`: Pattern note copied verbatim into the bundle. Choose a corpus-attested collection recipe when the missing producer is a collection construction, reshape, or bridge. Use when: the repair sub-path needs collection cleanup, reshaping, relabeling, identifier synchronization, or a collection-tabular bridge.
+- `references/patterns/galaxy-tabular-patterns.md`: Pattern note copied verbatim into the bundle. Choose a corpus-attested tabular recipe when the missing evidence is a column, key, or aggregate a tabular step can produce. Use when: the repair sub-path needs a computed column, join key, filter criterion, or aggregate the blocked step depends on.
+- `references/notes/galaxy-collection-semantics.md`: Research note copied verbatim into the bundle. Preserve collection typing and map-over/reduction semantics when an inserted producer step joins or reshapes collection inputs. Use when: the repair inserts or rewires steps touching collection inputs, outputs, or mapped/reduced connections.
+- `references/notes/galaxy-collection-semantics.upstream.myst`: Companion file copied verbatim into the bundle. Sibling of `references/notes/galaxy-collection-semantics.md`; read it where that note directs.
+- `references/notes/galaxy-collection-semantics.yml`: Companion file copied verbatim into the bundle. Sibling of `references/notes/galaxy-collection-semantics.md`; read it where that note directs.
+
+## Validation
+
+- Validate `galaxy-workflow-draft.gxwf.yml` for artifact `galaxy-workflow-draft` against the galaxy-workflow-draft schema when a validator is available.
+
+## Procedure
+
+Topology is settled upstream by the `*-summary-to-galaxy-template` skill, and the per-step loop is wrapper-tier — it does not edit topology. This skill is the **escalation target** the loop reaches when implementation proves the settled topology cannot support a declared step: a step output that needs evidence no wired input carries (the connection graph validates fine, but nothing produces what the output requires). Wrapper-tier gaps — no Tool Shed wrapper picked yet — are not this case; those route through the discover-or-author branch.
+
+You are invoked with the partially-realized draft and the open-requirements-ledger. Read the open blocking entries: each names a step, the uncomputable output, and the missing evidence. Your job is **bounded topology repair** — not re-settling the workflow. Repair the named region and nothing else; the surrounding topology, already-realized steps, and workflow interface stay put.
+
+Decide the *shape* of the fix from the missing evidence, the surrounding data-flow design (galaxy-data-flow-draft-contract), IWC structure, and the pattern pages. It may be one producer step, or a small sub-path of a few tools, or — when the declared output is genuinely uncomputable and no producer exists — narrowing the step to what its inputs can support. Insert the new step(s) in the draft superset (galaxy-workflow-draft-format): concrete topology and edges, wrapper-tier `TODO` for `tool_id` and ports, `_plan_*` fields carrying intent. The existing discover-or-author → `summarize-galaxy-tool` → `implement-galaxy-tool-step` machinery realizes them on later loop iterations; do not resolve wrappers here.
+
+Then update the ledger. For each blocking entry your repair addresses, mark it `resolved` with a note on how (producer added, sub-path added, output narrowed). The loop's convergence gate counts open blocking entries and requires each escalation to strictly reduce that count, under a hard cap on escalations. If you cannot close an entry — no producer is discoverable and the output cannot be honestly narrowed — **surrender it**: leave it open with a note, so the terminal path writes it into the final draft as a labelled gap rather than spinning or fabricating. Never insert a producer whose own output is uncomputable from what feeds it; that grows the DAG without reducing the open count and the loop will not converge.
+
+## Runtime Notes
+
+- Do not read Foundry source files at runtime; use only files packaged in this skill bundle and user-supplied artifacts.
+- Preserve declared artifact filenames unless the user or harness supplies explicit paths.
+- Carry unresolved assumptions into the output artifact instead of silently inventing missing source evidence.

--- a/casts/claude/skills/repair-galaxy-draft-topology/_provenance.json
+++ b/casts/claude/skills/repair-galaxy-draft-topology/_provenance.json
@@ -1,0 +1,217 @@
+{
+  "provenance_schema_version": 3,
+  "cast_target": "claude",
+  "mold": {
+    "name": "repair-galaxy-draft-topology",
+    "path": "content/molds/repair-galaxy-draft-topology/index.md",
+    "revision": 1,
+    "content_hash": "d31030715b0bec833af6fc568afa88ca90972f189caf33c58c3a7677fba8caf4",
+    "commit": "e487fe785f468afdf25f2b6bd140c3a115a12021"
+  },
+  "cast_at": "2026-07-24T13:51:17.496Z",
+  "refs": [
+    {
+      "kind": "pattern",
+      "mode": "verbatim",
+      "ref": "[[galaxy-collection-patterns]]",
+      "src": "content/patterns/galaxy-collection-patterns.md",
+      "dst": "references/patterns/galaxy-collection-patterns.md",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Choose a corpus-attested collection recipe when the missing producer is a collection construction, reshape, or bridge.",
+      "trigger": "When the repair sub-path needs collection cleanup, reshaping, relabeling, identifier synchronization, or a collection-tabular bridge.",
+      "src_hash": "8da85411065e8c384bfdd18d96893137c6863c483640f1c8ad9ce97aed1441e8",
+      "dst_hash": "8da85411065e8c384bfdd18d96893137c6863c483640f1c8ad9ce97aed1441e8",
+      "source": "deterministic"
+    },
+    {
+      "kind": "pattern",
+      "mode": "verbatim",
+      "ref": "[[galaxy-tabular-patterns]]",
+      "src": "content/patterns/galaxy-tabular-patterns.md",
+      "dst": "references/patterns/galaxy-tabular-patterns.md",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Choose a corpus-attested tabular recipe when the missing evidence is a column, key, or aggregate a tabular step can produce.",
+      "trigger": "When the repair sub-path needs a computed column, join key, filter criterion, or aggregate the blocked step depends on.",
+      "src_hash": "a458296e7636fb87cff2a5ff038f1cd1ccb5f426d37d5d6aa9676644f4131dfa",
+      "dst_hash": "a458296e7636fb87cff2a5ff038f1cd1ccb5f426d37d5d6aa9676644f4131dfa",
+      "source": "deterministic"
+    },
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[galaxy-collection-semantics]]",
+      "src": "content/research/galaxy-collection-semantics.md",
+      "dst": "references/notes/galaxy-collection-semantics.md",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Preserve collection typing and map-over/reduction semantics when an inserted producer step joins or reshapes collection inputs.",
+      "trigger": "When the repair inserts or rewires steps touching collection inputs, outputs, or mapped/reduced connections.",
+      "license": "MIT",
+      "license_file": "LICENSES/galaxy.LICENSE",
+      "src_hash": "75d22f549355dff8aec171cef13a59a8416f70adf4ef414ddc54fb68c9928325",
+      "dst_hash": "75d22f549355dff8aec171cef13a59a8416f70adf4ef414ddc54fb68c9928325",
+      "source": "deterministic",
+      "license_file_hash": "3fdd32b75cfad3266871456423f4d91529953629fe4bc803c3df2f445fd8a858"
+    },
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[galaxy-collection-semantics]]",
+      "src": "content/research/galaxy-collection-semantics.upstream.myst",
+      "dst": "references/notes/galaxy-collection-semantics.upstream.myst",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Preserve collection typing and map-over/reduction semantics when an inserted producer step joins or reshapes collection inputs.",
+      "trigger": "When the repair inserts or rewires steps touching collection inputs, outputs, or mapped/reduced connections.",
+      "companion_of": "references/notes/galaxy-collection-semantics.md",
+      "license": "MIT",
+      "license_file": "LICENSES/galaxy.LICENSE",
+      "src_hash": "bbc8215b0a6ae8e735042af8353c73fc0d740f4ff8a32d85aba83eae63a2b3a1",
+      "dst_hash": "bbc8215b0a6ae8e735042af8353c73fc0d740f4ff8a32d85aba83eae63a2b3a1",
+      "source": "deterministic",
+      "license_file_hash": "3fdd32b75cfad3266871456423f4d91529953629fe4bc803c3df2f445fd8a858"
+    },
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[galaxy-collection-semantics]]",
+      "src": "content/research/galaxy-collection-semantics.yml",
+      "dst": "references/notes/galaxy-collection-semantics.yml",
+      "used_at": "runtime",
+      "load": "on-demand",
+      "evidence": "corpus-observed",
+      "purpose": "Preserve collection typing and map-over/reduction semantics when an inserted producer step joins or reshapes collection inputs.",
+      "trigger": "When the repair inserts or rewires steps touching collection inputs, outputs, or mapped/reduced connections.",
+      "companion_of": "references/notes/galaxy-collection-semantics.md",
+      "license": "MIT",
+      "license_file": "LICENSES/galaxy.LICENSE",
+      "src_hash": "f4e9d0a55459b6080b826e2ae41a920c9404f95fda0e518be8f86bc3d2e73e6e",
+      "dst_hash": "f4e9d0a55459b6080b826e2ae41a920c9404f95fda0e518be8f86bc3d2e73e6e",
+      "source": "deterministic",
+      "license_file_hash": "3fdd32b75cfad3266871456423f4d91529953629fe4bc803c3df2f445fd8a858"
+    },
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[galaxy-data-flow-draft-contract]]",
+      "src": "content/research/galaxy-data-flow-draft-contract.md",
+      "dst": "references/notes/galaxy-data-flow-draft-contract.md",
+      "used_at": "runtime",
+      "load": "upfront",
+      "evidence": "hypothesis",
+      "purpose": "Re-wire the affected region consistently with the data-flow design that settled the surrounding topology.",
+      "verification": "Promote after two repairs preserve the surrounding data-flow design without re-deriving it from the source.",
+      "src_hash": "af68cbd0a4460d2ce5c9768a6437f909f533f4f7cbe0473ad6b5e75db9d81681",
+      "dst_hash": "af68cbd0a4460d2ce5c9768a6437f909f533f4f7cbe0473ad6b5e75db9d81681",
+      "source": "deterministic"
+    },
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[galaxy-workflow-draft-format]]",
+      "src": "content/research/galaxy-workflow-draft-format.md",
+      "dst": "references/notes/galaxy-workflow-draft-format.md",
+      "used_at": "runtime",
+      "load": "upfront",
+      "evidence": "hypothesis",
+      "purpose": "Emit re-wired steps in the draft superset (TODO tool_id, _plan_* fields) so existing per-step machinery realizes them; respect the settle-vs-repair boundary.",
+      "verification": "Promote after a repair run inserts a producer the per-step loop then realizes without re-running the template Mold over the whole draft.",
+      "src_hash": "e17baee79b786a2003c66baed9ce6e9c581f79b29b423e83c93c871b3e61bdda",
+      "dst_hash": "e17baee79b786a2003c66baed9ce6e9c581f79b29b423e83c93c871b3e61bdda",
+      "source": "deterministic"
+    },
+    {
+      "kind": "research",
+      "mode": "verbatim",
+      "ref": "[[open-requirements-ledger]]",
+      "src": "content/research/open-requirements-ledger.md",
+      "dst": "references/notes/open-requirements-ledger.md",
+      "used_at": "runtime",
+      "load": "upfront",
+      "evidence": "hypothesis",
+      "purpose": "Read open blocking entries to scope the repair; mark each resolved or surrender it, feeding the loop's decreasing-blocker convergence gate.",
+      "verification": "Promote after a run closes a blocking entry and the loop terminates on the reduced open count.",
+      "src_hash": "04d5c952cf0e952ae6153b3962334066f0a440a64da4237cf61264a59920be4f",
+      "dst_hash": "04d5c952cf0e952ae6153b3962334066f0a440a64da4237cf61264a59920be4f",
+      "source": "deterministic"
+    },
+    {
+      "kind": "schema",
+      "mode": "verbatim",
+      "ref": "[[galaxy-workflow-draft]]",
+      "src": "package://@galaxy-tool-util/schema#galaxyWorkflowDraftJsonSchema",
+      "dst": "references/schemas/galaxy-workflow-draft.schema.json",
+      "used_at": "runtime",
+      "load": "upfront",
+      "evidence": "cast-validated",
+      "purpose": "In/out contract: the draft this Mold reads and re-wires conforms to [[galaxy-workflow-draft]]; cast bundles the JSON Schema so the re-wired draft stays inside the superset the per-step loop expects.",
+      "license": "MIT",
+      "license_file": "LICENSES/galaxy-tool-util-ts.LICENSE",
+      "src_hash": "86822b6bf4c11ba1d9eaa12d9e442db7f7d28b2734a2daddf62b5cdd2f1f75aa",
+      "dst_hash": "86822b6bf4c11ba1d9eaa12d9e442db7f7d28b2734a2daddf62b5cdd2f1f75aa",
+      "source": "deterministic",
+      "license_file_hash": "383450c494c01c466bcf22df102540a39ac89da50563fd7be686ba06772f96b3"
+    }
+  ],
+  "artifacts": {
+    "produces": [
+      {
+        "id": "galaxy-workflow-draft",
+        "kind": "yaml",
+        "default_filename": "galaxy-workflow-draft.gxwf.yml",
+        "schema": "[[galaxy-workflow-draft]]",
+        "description": "Re-wired gxformat2 draft: a producer step (or small sub-path) inserted so the previously-blocked step's declared output is computable; new steps land at draft (TODO) tier."
+      },
+      {
+        "id": "open-requirements-ledger",
+        "kind": "yaml",
+        "default_filename": "open-requirements.ledger.yml",
+        "description": "Ledger with the addressed blocking entries marked resolved, or surrendered with a note when no producer can be found within the escalation budget."
+      }
+    ],
+    "consumes": [
+      {
+        "id": "galaxy-workflow-draft",
+        "description": "Partially-realized gxformat2 draft (see [[galaxy-workflow-draft-format]]) whose topology can't support a declared step — the region to repair.",
+        "inherited_schema": "[[galaxy-workflow-draft]]",
+        "producers": [
+          "advance-galaxy-draft-step",
+          "apply-galaxy-workflow-changeset",
+          "cwl-summary-to-galaxy-template",
+          "freeform-summary-to-galaxy-template",
+          "implement-galaxy-tool-step",
+          "nextflow-summary-to-galaxy-template",
+          "repair-galaxy-draft-topology"
+        ]
+      },
+      {
+        "id": "open-requirements-ledger",
+        "description": "Carried obligations from [[open-requirements-ledger]]; the open blocking entries name which step output is uncomputable and what evidence is missing.",
+        "producers": [
+          "advance-galaxy-draft-step",
+          "apply-galaxy-workflow-changeset",
+          "compare-against-iwc-exemplar",
+          "cwl-summary-to-galaxy-data-flow",
+          "cwl-summary-to-galaxy-interface",
+          "cwl-summary-to-galaxy-template",
+          "freeform-summary-to-galaxy-data-flow",
+          "freeform-summary-to-galaxy-interface",
+          "freeform-summary-to-galaxy-template",
+          "implement-galaxy-tool-step",
+          "interview-to-galaxy-workflow-changeset",
+          "nextflow-summary-to-galaxy-data-flow",
+          "nextflow-summary-to-galaxy-interface",
+          "nextflow-summary-to-galaxy-reference-data",
+          "nextflow-summary-to-galaxy-template",
+          "repair-galaxy-draft-topology"
+        ]
+      }
+    ]
+  }
+}

--- a/casts/claude/skills/repair-galaxy-draft-topology/_verify.json
+++ b/casts/claude/skills/repair-galaxy-draft-topology/_verify.json
@@ -1,0 +1,4 @@
+{
+  "verify_schema_version": 1,
+  "entries": []
+}

--- a/casts/claude/skills/repair-galaxy-draft-topology/references/notes/galaxy-collection-semantics.md
+++ b/casts/claude/skills/repair-galaxy-draft-topology/references/notes/galaxy-collection-semantics.md
@@ -1,0 +1,44 @@
+---
+type: research
+subtype: component
+title: "Galaxy collection semantics"
+tags:
+  - research/component
+  - target/galaxy
+status: draft
+created: 2026-04-30
+revised: 2026-05-05
+revision: 3
+ai_generated: false
+license: MIT
+license_file: LICENSES/galaxy.LICENSE
+related_notes:
+  - "[[galaxy-xsd]]"
+  - "[[galaxy-collection-tools]]"
+  - "[[galaxy-apply-rules-dsl]]"
+  - "[[nextflow-to-galaxy-channel-shape-mapping]]"
+  - "[[nextflow-operators-to-galaxy-collection-recipes]]"
+  - "[[galaxy-tool-job-failure-reference]]"
+  - "[[galaxy-workflow-invocation-failure-reference]]"
+  - "[[iwc-transformations-survey]]"
+  - "[[galaxy-discover-datasets]]"
+sources:
+  - "https://github.com/galaxyproject/galaxy/blob/7765fae934fbfdee77e3be5f5b235e43735273ae/lib/galaxy/model/dataset_collections/types/collection_semantics.yml"
+companions:
+  - "galaxy-collection-semantics.yml"
+  - "galaxy-collection-semantics.upstream.myst"
+summary: "Vendored formal spec of Galaxy dataset-collection mapping/reduction semantics, with labeled examples and pinned test references."
+---
+
+> **Vendored from upstream**, pinned at SHA `7765fae`. Two files live next to this note:
+>
+> - `galaxy-collection-semantics.yml` — the structured source. **Agents and casting should consume this.** It carries the `tests:` blocks that pin concrete Galaxy test names; the rendered upstream view drops them.
+> - `galaxy-collection-semantics.upstream.myst` — Galaxy's auto-generated MyST/LaTeX rendering of the YAML, vendored only so the human view below has something to render. Sync is manual.
+>
+> **When to consult:** authoring or reasoning about Molds and patterns that touch `data_collection` inputs, map-over / reduction shape changes, sub-collection mapping, `paired_or_unpaired`, or `sample_sheet`.
+
+```vendored-myst
+file: galaxy-collection-semantics.upstream.myst
+source: https://github.com/galaxyproject/galaxy/blob/7765fae934fbfdee77e3be5f5b235e43735273ae/doc/source/dev/collection_semantics.md
+sha: 7765fae
+```

--- a/casts/claude/skills/repair-galaxy-draft-topology/references/notes/galaxy-collection-semantics.upstream.myst
+++ b/casts/claude/skills/repair-galaxy-draft-topology/references/notes/galaxy-collection-semantics.upstream.myst
@@ -1,0 +1,1120 @@
+# Collection Semantics
+
+This document describes the semantics around working with Galaxy dataset collections.
+In particular it describes how they operate within Galaxy tools and workflows.
+
+:::{admonition} You Probably Don't Need to Read This
+:class: caution
+
+Any significantly sophisticated workflow language will have ways to collect data
+into arrays or vectors or dictionaries and apply operations across this data (mapping)
+or reduce the dimensionality of this data (reductions). Typically, this is explicitly
+annotated with map functions or for loops. Galaxy however is designed to be a point
+and click interface for connecting steps and running tools. It is important that steps
+just connect and just do the most natural thing - and this is what Galaxy does.
+This document just provides a mathematical formalism to that "what should just
+intuitively work" that can be used to document test cases and help with implementation.
+This is reference documentation not user documentation, Galaxy should just work.
+:::
+
+## Mapping
+
+If a tool consumes a simple dataset parameter and produces a simple dataset parameter,
+then any collection type may be "mapped over" the data input to that tool. The result of
+that is the tool being applied to each element of the collection and "implicit collections"
+being created from the outputs that are produced from those operations. Those implicit
+collections have the same element identifiers in the same order as the input collection that is
+mapped over. Each element of the implicit collections correspond to their own job and
+Galaxy very naturally and intuitively parallelizes jobs without extra work from the user
+and without any knowledge of the tool.
+
+
+(BASIC_MAPPING_PAIRED)=
+(BASIC_MAPPING_PAIRED_OR_UNPAIRED_PAIRED)=
+(BASIC_MAPPING_PAIRED_OR_UNPAIRED_UNPAIRED)=
+(BASIC_MAPPING_LIST)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `BASIC_MAPPING_PAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ dataset }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{paired},\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C)) \mapsto \left\{o: \text{collection}<\text{paired},\left\{\text{forward}=tool(i=d_f)[o], \text{reverse}=tool(i=d_r)[o]\right\}>\right\}$$
+
+:::
+
+
+
+:::{admonition} Example: `BASIC_MAPPING_PAIRED_OR_UNPAIRED_PAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ dataset }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{paired\_or\_unpaired},\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C)) \mapsto \left\{o: \text{collection}<\text{paired\_or\_unpaired},\left\{\text{forward}=tool(i=d_f)[o], \text{reverse}=tool(i=d_r)[o]\right\}>\right\}$$
+
+:::
+
+
+
+:::{admonition} Example: `BASIC_MAPPING_PAIRED_OR_UNPAIRED_UNPAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_u $ is a dataset
+* $ tool \text{ is } (i: \text{ dataset }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{paired\_or\_unpaired},\left\{ \text{ unpaired }=d_u \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C)) \mapsto \left\{o: \text{collection}<\text{paired\_or\_unpaired},\left\{\text{unpaired}=tool(i=d_u)[o]\right\}>\right\}$$
+
+:::
+
+
+
+:::{admonition} Example: `BASIC_MAPPING_LIST` 
+:class: note
+
+Assuming,
+
+* $ d_1,...,d_n $ are datasets
+* $ tool \text{ is } (i: \text{ dataset }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list},\left\{ \text{ i1 }=d_1, ..., \text{ in }=d_n \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C)) \mapsto \left\{o: \text{collection}<\text{list},\left\{\text{i1}=tool(i=d_1)[o],...,\text{in}=tool(i=d_n)[o]\right\}>\right\}$$
+
+:::
+
+
+
+</details><br>
+
+
+
+The above description of mapping over inputs works naturally and as expected for
+nested collections.
+
+
+(NESTED_LIST_MAPPING)=
+(BASIC_MAPPING_LIST_PAIRED_OR_UNPAIRED)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `NESTED_LIST_MAPPING` 
+:class: note
+
+Assuming,
+
+* $ d_1,...,d_n $ are datasets
+* $ tool \text{ is } (i: \text{ dataset }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list}:\text{list},\left\{ \text{ o1 }=\left\{ \text{ inner }=d_1 \right\}, ..., \text{ on }=\left\{ \text{ inner }=d_n \right\} \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C)) \mapsto \left\{o: \text{collection}<\text{list}:\text{list},\left\{\text{o1}=\left\{\text{inner}=tool(i=d_1)[o]\right\},...,\text{on}=\left\{\text{inner}=tool(i=d_n)[o]\right\}\right\}>\right\}$$
+
+:::
+
+
+
+:::{admonition} Example: `BASIC_MAPPING_LIST_PAIRED_OR_UNPAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ dataset }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list}:\text{paired\_or\_unpaired},\left\{ \text{ el1 }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C)) \mapsto \left\{o: \text{collection}<\text{list}:\text{paired\_or\_unpaired},\left\{\text{el1}=\left\{\text{forward}=tool(i=d_f)[o], \text{reverse}=tool(i=d_r)[o]\right\}\right\}>\right\}$$
+
+:::
+
+
+
+</details><br>
+
+
+
+
+For tools with multiple data inputs, the tool can be executed with individual
+datasets for the non-mapped over input and each tool execution will just be executed
+with that dataset. The dataset not mapped over serves as the input for each execution.
+
+
+(BASIC_MAPPING_INCLUDING_SINGLE_DATASET)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `BASIC_MAPPING_INCLUDING_SINGLE_DATASET` 
+:class: note
+
+Assuming,
+
+* $ d_1,...,d_n $, $ d_o $ are datasets
+* $ tool \text{ is } (i: \text{ dataset }, i2: \text{ dataset }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list},\left\{ \text{ i1 }=d_1, ..., \text{ in }=d_n \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C), i2=d_o) \mapsto \left\{o: \text{collection}<\text{list},\left\{\text{i1}=tool(i=d_1, i2=d_o)[o],...,\text{in}=tool(i=d_n, i2=d_o)[o]\right\}>\right\}$$
+
+:::
+
+
+
+</details><br>
+
+
+
+If a tool consumes two input datasets and produces one output dataset, you can map two
+collections with identical structure (same element identifiers in the same order) over
+the respective inputs and the result is an implicit collection with the same structure
+as the inputs and where each output in the implicit collection corresponds to the tool
+being executed with the two inputs corresponding to that position in the input
+collections.
+
+The default behavior here is the collections are linked and the act of mapping over
+inputs to the tool are sort of a flat map or a dot product. No extra dimensionality
+in the resulting collections.
+
+From a user perspective this means if you start with a collection and apply a bunch
+of map over operations on tools - the results will all continue to match and work together
+very naturally - again without extra work by the user and without extra knowledge
+by the tool author.
+
+
+(BASIC_MAPPING_TWO_INPUTS_WITH_IDENTICAL_STRUCTURE)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `BASIC_MAPPING_TWO_INPUTS_WITH_IDENTICAL_STRUCTURE` 
+:class: note
+
+Assuming,
+
+* $ d1_1,...,d1_n $, $ d2_1,...,d2_n $ are datasets
+* $ tool \text{ is } (i: \text{ dataset }, i2: \text{ dataset }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C1 $ is $ \text{CollectionInstance<}\text{list},\left\{ \text{ i1 }=d1_1, ..., \text{ in }=d1_n \right\}\text{>} $
+* $ C2 $ is $ \text{CollectionInstance<}\text{list},\left\{ \text{ i1 }=d2_1, ..., \text{ in }=d2_n \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C1), i2=\text{mapOver}(C2)) \mapsto \left\{o: \text{collection}<\text{list},\left\{\text{i1}=tool(i=d1_1, i2=d2_1)[o],...,\text{in}=tool(i=d1_n, i2=d2_n)[o]\right\}>\right\}$$
+
+:::
+
+
+
+</details><br>
+
+
+
+## Reduction
+
+Not all tool executions result in implicit collections and mapping
+over inputs. Tool inputs of ``type`` ``data_collection`` can consume
+collections directly and do not necessarily result in mapping over.
+
+Tools that consume collections and output datasets effectively
+reduce the dimension of the Galaxy data structure. When used at runtime
+this is often referred to as a "reduction" in the code.
+
+
+(COLLECTION_INPUT_PAIRED)=
+(COLLECTION_INPUT_LIST)=
+(COLLECTION_INPUT_PAIRED_OR_UNPAIRED)=
+(COLLECTION_INPUT_LIST_PAIRED_OR_UNPAIRED)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `COLLECTION_INPUT_PAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<paired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{paired},\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\}\text{>} $
+
+
+then
+
+$$tool(i=C) \rightarrow \left\{o: \text{dataset}\right\}$$
+
+:::
+
+
+
+:::{admonition} Example: `COLLECTION_INPUT_LIST` 
+:class: note
+
+Assuming,
+
+* $ d_1,...,d_n $ are datasets
+* $ tool \text{ is } (i: \text{ collection<list> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list},\left\{ \text{ el1 }=d_1, ..., \text{ eln }=d_n \right\}\text{>} $
+
+
+then
+
+$$tool(i=C) \rightarrow \left\{o: \text{dataset}\right\}$$
+
+:::
+
+
+
+:::{admonition} Example: `COLLECTION_INPUT_PAIRED_OR_UNPAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<paired\_or\_unpaired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{paired\_or\_unpaired},\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\}\text{>} $
+
+
+then
+
+$$tool(i=C) \rightarrow \left\{o: \text{dataset}\right\}$$
+
+:::
+
+
+
+:::{admonition} Example: `COLLECTION_INPUT_LIST_PAIRED_OR_UNPAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<list:paired\_or\_unpaired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list}:\text{paired\_or\_unpaired},\left\{ \text{ el1 }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\}\text{>} $
+
+
+then
+
+$$tool(i=C) \rightarrow \left\{o: \text{dataset}\right\}$$
+
+:::
+
+
+
+</details><br>
+
+
+
+For nested collections where each rank is a ``list`` or a ``paired`` collection,
+then collection inputs must match every part of the collection type input definition.
+
+
+(COLLECTION_INPUT_LIST_NOT_CONSUMES_PAIRS)=
+(COLLECTION_INPUT_PAIRED_NOT_CONSUMES_LIST)=
+(COLLECTION_INPUT_LIST_PAIRED_NOT_CONSUMES_PAIRED_PAIRED)=
+(COLLECTION_INPUT_LIST_PAIRED_OR_NOT_PAIRED_NOT_CONSUMES_PAIRED_PAIRED)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `COLLECTION_INPUT_LIST_NOT_CONSUMES_PAIRS` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<list> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{paired},\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\}\text{>} $
+
+
+then
+
+$$tool(i=C)\text{ is invalid}$$
+
+:::
+
+
+
+:::{admonition} Example: `COLLECTION_INPUT_PAIRED_NOT_CONSUMES_LIST` 
+:class: note
+
+Assuming,
+
+* $ d_1,...,d_n $ are datasets
+* $ tool \text{ is } (i: \text{ collection<paired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list},\left\{ \text{ i1 }=d_1, ..., \text{ in }=d_n \right\}\text{>} $
+
+
+then
+
+$$tool(i=C)\text{ is invalid}$$
+
+:::
+
+
+
+:::{admonition} Example: `COLLECTION_INPUT_LIST_PAIRED_NOT_CONSUMES_PAIRED_PAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<list:paired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{paired}:\text{paired},\left\{ \text{ forward }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\}, \text{ reverse }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\}\text{>} $
+
+
+then
+
+$$tool(i=C)\text{ is invalid}$$
+
+:::
+
+
+
+:::{admonition} Example: `COLLECTION_INPUT_LIST_PAIRED_OR_NOT_PAIRED_NOT_CONSUMES_PAIRED_PAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<list:paired\_or\_unpaired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{paired}:\text{paired},\left\{ \text{ forward }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\}, \text{ reverse }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\}\text{>} $
+
+
+then
+
+$$tool(i=C)\text{ is invalid}$$
+
+:::
+
+
+
+</details><br>
+
+
+
+In addition to explicit collection inputs, tool inputs of ``type`` ``data``
+where ``multiple="true"`` can consume lists directly. This is likewise a
+"reduction" and does not result in implicit collection creation.
+
+
+(LIST_REDUCTION)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `LIST_REDUCTION` 
+:class: note
+
+Assuming,
+
+* $ d_1,...,d_n $ are datasets
+* $ tool \text{ is } (i: \text{ dataset<multiple=true> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list},\left\{ \text{ i1 }=d_1, ..., \text{ in }=d_n \right\}\text{>} $
+
+
+then
+
+$$tool(i=C) == tool(i=[d_1,...,d_n])$$
+
+:::
+
+
+
+</details><br>
+
+
+
+Paired collections cannot be reduced this way. ``paired`` is not meant
+to represent a list/array/vector data structure - it is more like a tuple.
+
+
+(PAIRED_REDUCTION_INVALID)=
+(PAIRED_OR_UNPAIRED_REDUCTION_INVALID)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `PAIRED_REDUCTION_INVALID` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ dataset<multiple=true> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{paired},\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\}\text{>} $
+
+
+then
+
+$$tool(i=C)\text{ is invalid}$$
+
+:::
+
+
+
+:::{admonition} Example: `PAIRED_OR_UNPAIRED_REDUCTION_INVALID` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ dataset<multiple=true> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{paired\_or\_unpaired},\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\}\text{>} $
+
+
+then
+
+$$tool(i=C)\text{ is invalid}$$
+
+:::
+
+
+
+</details><br>
+
+
+
+## Sub-collection Mapping
+
+![](https://planemo.readthedocs.io/en/master/_images/subcollection_mapping_identifiers.svg)
+
+
+(MAPPING_LIST_PAIRED_OVER_PAIRED)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `MAPPING_LIST_PAIRED_OVER_PAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<paired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list}:\text{paired},\left\{ \text{ el1 }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\}\text{>} $
+* $ C\_PAIRED $ is $ \text{CollectionInstance<}\text{paired},\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C, '\text{paired}')) \mapsto \left\{o: \text{collection}<\text{list},\left\{\text{el1}=tool(i=C\_PAIRED)[o]\right\}>\right\}$$
+
+:::
+
+
+
+</details><br>
+
+
+
+The natural extension of multiple data input parameters consuming list collections as described
+above when discussing reductions is that nested lists of lists (``list:list``) can be mapped
+over a multiple data input parameter. Each nested list will be reduced by this operation but the
+results will be mapped over. The result will be a list with the same structure as the outer list
+of the input collection.
+
+
+(NESTED_LIST_REDUCTION)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `NESTED_LIST_REDUCTION` 
+:class: note
+
+Assuming,
+
+* $ d_1,...,d_n $ are datasets
+* $ tool \text{ is } (i: \text{ dataset<multiple=true> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list}:\text{list},\left\{ \text{ o1 }=\left\{ \text{ inner }=d_1 \right\}, ..., \text{ on }=\left\{ \text{ inner }=d_n \right\} \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C, '\text{list}')) \mapsto \left\{o: \text{collection}<\text{list},\left\{\text{o1}=tool(i=[d_1])[o],...,\text{on}=tool(i=[d_n])[o]\right\}>\right\}$$
+
+:::
+
+
+
+</details><br>
+
+
+
+Just as a paired collection won't be reduced by a multiple data input, any sort of nested
+collection ending in a paired collection cannot be mapped over such an input. So a multiple
+data input parameter cannot be mapped over by a list of pairs (``list:paired``) for instance.
+
+
+(LIST_PAIRED_REDUCTION_INVALID)=
+(LIST_PAIRED_OR_UNPAIRED_REDUCTION_INVALID)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `LIST_PAIRED_REDUCTION_INVALID` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ dataset<multiple=true> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list}:\text{paired},\left\{ \text{ el1 }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C, '\text{paired}'))\text{ is invalid}$$
+
+:::
+
+
+
+:::{admonition} Example: `LIST_PAIRED_OR_UNPAIRED_REDUCTION_INVALID` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ dataset<multiple=true> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list}:\text{paired\_or\_unpaired},\left\{ \text{ el1 }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C, '\text{paired\_or\_unpaired}'))\text{ is invalid}$$
+
+:::
+
+
+
+</details><br>
+
+
+
+## paired_or_unpaired Collections
+
+The collection type ``paired_or_unpaired`` is meant to serve as a stand-in for
+an entity that can be either a single dataset or what is effectively a ``paired``
+dataset collection. These collections either have one element with identifier
+``unpaired`` or two elements with identifiers ``forward`` and ``reverse``.
+
+Tools can declare a data_collection input with collection type ``paired_or_unpaired``
+and that input will consume either an explicit ``paired_or_unpaired`` collection
+normally or can consume a ``paired`` input.
+
+
+(PAIRED_OR_UNPAIRED_CONSUMES_PAIRED)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `PAIRED_OR_UNPAIRED_CONSUMES_PAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<paired\_or\_unpaired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{paired},\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\}\text{>} $
+* $ C_AS_MIXED = CollectionInstance<\text{paired\_or\_unpaired}, \left\{\text{forward}: d_f, \text{reverse}: d_r\right\}> $
+
+
+then
+
+$$tool(i=C) == tool(i=C_AS_MIXED)$$
+
+:::
+
+
+
+</details><br>
+
+
+
+
+The inverse of this doesn't work intentionally. In some ways a ``paired`` collection
+acts as a ``paired_or_unpaired`` collection but a ``paired_or_unpaired`` is not a paired
+collection. This makes a lot of sense in terms of tools - a tool consuming a ``paired``
+dataset expects to find both a ``forward`` and ``reverse`` element but these may not exist
+in ``paired_or_unpaired`` collection.
+
+
+(PAIRED_OR_UNPAIRED_NOT_CONSUMED_BY_PAIRED)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `PAIRED_OR_UNPAIRED_NOT_CONSUMED_BY_PAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<paired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{paired\_or\_unpaired},\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\}\text{>} $
+
+
+then
+
+$$tool(i=C)\text{ is invalid}$$
+
+:::
+
+
+
+</details><br>
+
+
+
+
+The same logic holds for mapping, lists of paired datasets (``list:paired``) can be mapped over these
+``paired_or_unpaired`` inputs and mixed lists of pairs (``list:paired_or_unpaired``) cannot
+be mapped over a ``paired`` input. Following the same logic, ``list:paired_or_unpaired`` cannot
+be mapped over a ``list`` input or multiple data input.
+
+
+(MAPPING_LIST_PAIRED_OVER_PAIRED_OR_UNPAIRED)=
+(PAIRED_OR_UNPAIRED_NOT_CONSUMED_BY_PAIRED_WHEN_MAPPING)=
+(PAIRED_OR_UNPAIRED_NOT_CONSUMED_BY_LIST_WHEN_MAPPING)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `MAPPING_LIST_PAIRED_OVER_PAIRED_OR_UNPAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<paired\_or\_unpaired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list}:\text{paired},\left\{ \text{ el }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\}\text{>} $
+* $ C_AS_MIXED $ is $ \text{CollectionInstance<}\text{list}:\text{paired\_or\_unpaired},\left\{ \text{ el }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C)) == tool(i=\text{mapOver}(C_AS_MIXED))$$
+
+:::
+
+
+
+:::{admonition} Example: `PAIRED_OR_UNPAIRED_NOT_CONSUMED_BY_PAIRED_WHEN_MAPPING` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<paired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list}:\text{paired\_or\_unpaired},\left\{ \text{ el }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C))\text{ is invalid}$$
+
+:::
+
+
+
+:::{admonition} Example: `PAIRED_OR_UNPAIRED_NOT_CONSUMED_BY_LIST_WHEN_MAPPING` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<list> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list}:\text{paired\_or\_unpaired},\left\{ \text{ el }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C))\text{ is invalid}$$
+
+:::
+
+
+
+</details><br>
+
+
+
+This logic extends naturally into higher dimensional collections. A ``list:list:paired``
+can be mapped over either a ``paired_or_unpaired`` input to produce a nested list (``list:list``)
+or a ``list:paired_or_unpaired`` input to produce a flat list (``list``).
+
+
+(MAPPING_LIST_LIST_PAIRED_OVER_PAIRED_OR_UNPAIRED)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `MAPPING_LIST_LIST_PAIRED_OVER_PAIRED_OR_UNPAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<paired\_or\_unpaired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list}:\text{list}:\text{paired},\left\{ \text{ o1 }=\left\{ \text{ el1 }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\} \right\}\text{>} $
+* $ C_AS_MIXED $ is $ \text{CollectionInstance<}\text{list}:\text{list}:\text{paired\_or\_unpaired},\left\{ \text{ o1 }=\left\{ \text{ el1 }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\} \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C)) == tool(i=\text{mapOver}(C_AS_MIXED))$$
+
+:::
+
+
+
+</details><br>
+
+
+
+
+In order for ``paired_or_unpaired`` collections to also act as a single dataset,
+a flat list can be mapped over a such an input with a special sub collection mapping
+type of 'single_datasets'.
+
+
+(MAPPING_LIST_OVER_PAIRED_OR_UNPAIRED)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `MAPPING_LIST_OVER_PAIRED_OR_UNPAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_1,...,d_n $ are datasets
+* $ tool \text{ is } (i: \text{ collection<paired\_or\_unpaired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list},\left\{ \text{ i1 }=d_1, ..., \text{ in }=d_n \right\}\text{>} $
+* $ C_AS_UNPAIRED_i = CollectionInstance<\text{paired\_or\_unpaired},\left\{\text{unpaired}=di\right\}> for i from 1...n $
+
+
+then
+
+$$tool(i=\text{mapOver}(C, '\text{single\_datasets}')) \mapsto \left\{o: \text{collection}<\text{list},\left\{\text{i1}=tool(i=C_AS_UNPAIRED_1)[o],...,\text{in}=tool(i=C_AS_UNPAIRED_n)[o]\right\}>\right\}$$
+
+:::
+
+
+
+</details><br>
+
+
+
+This treatment of lists without pairing extends to nested structures naturally.
+For instance, a list of list of datasets (``list:list``) can be mapped over a
+``paired_or_unpaired`` input to produce a nested list of lists (``list:list``)
+with a structure matching the input. Likewise, the nested list can be mapped over
+a ``list:paired_or_unpaired`` input to produce a flat list with the same structure
+as the outer list of the input.
+
+
+(MAPPING_LIST_LIST_OVER_PAIRED_OR_UNPAIRED)=
+(MAPPING_LIST_LIST_OVER_LIST_PAIRED_OR_UNPAIRED)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `MAPPING_LIST_LIST_OVER_PAIRED_OR_UNPAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_1,...,d_n $ are datasets
+* $ tool \text{ is } (i: \text{ collection<paired\_or\_unpaired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list}:\text{list},\left\{ \text{ o1 }=\left\{ \text{ inner }=d_1 \right\}, ..., \text{ on }=\left\{ \text{ inner }=d_n \right\} \right\}\text{>} $
+* $ C_AS_UNPAIRED_j = CollectionInstance<\text{paired\_or\_unpaired},\left\{\text{unpaired}=dj\right\}> for each \text{dataset} dj in C $
+
+
+then
+
+$$tool(i=\text{mapOver}(C, '\text{single\_datasets}')) \mapsto \left\{o: \text{collection}<\text{list}:\text{list},\left\{\text{o1}=\left\{\text{inner}=tool(i=C_AS_UNPAIRED_1)[o]\right\},...,\text{on}=\left\{\text{inner}=tool(i=C_AS_UNPAIRED_n)[o]\right\}\right\}>\right\}$$
+
+:::
+
+
+
+:::{admonition} Example: `MAPPING_LIST_LIST_OVER_LIST_PAIRED_OR_UNPAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_1,...,d_n $ are datasets
+* $ tool \text{ is } (i: \text{ collection<list:paired\_or\_unpaired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list}:\text{list},\left\{ \text{ o1 }=\left\{ \text{ inner }=d_1 \right\}, ..., \text{ on }=\left\{ \text{ inner }=d_n \right\} \right\}\text{>} $
+* $ C_AS_LPU_i = \text{inner} \text{list} of C at position i, treated as \text{list}:\text{paired\_or\_unpaired} via \text{single\_datasets} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C, '\text{list}:\text{paired\_or\_unpaired}')) \mapsto \left\{o: \text{collection}<\text{list},\left\{\text{o1}=tool(i=C_AS_LPU_1)[o],...,\text{on}=tool(i=C_AS_LPU_n)[o]\right\}>\right\}$$
+
+:::
+
+
+
+</details><br>
+
+
+
+Due only to implementation time, the special casing of allowing paired_or_unpaired
+act as both datasets and paired collections only works when it is the deepest
+collection type. So while list:paired can be consumed by a list:paired_or_unpaired
+input, a paired:list cannot be consumed by a paired_or_unpaired:list input though
+it should be able to for consistency. We have focused our time on data structures
+more likely to be used in actual Galaxy analyses given current and guessed future
+usage.
+
+
+## sample_sheet Collections
+
+The collection type ``sample_sheet`` attaches typed, columnar metadata to each
+element of a dataset collection. For mapping and type matching purposes,
+``sample_sheet`` behaves identically to ``list`` - it can be mapped over tool
+inputs, matched against ``list`` collection inputs, and composed with inner types
+(``sample_sheet:paired``, ``sample_sheet:paired_or_unpaired``). The key asymmetry
+is that while a ``sample_sheet`` output can satisfy a ``list`` input, a ``list``
+output cannot satisfy a ``sample_sheet`` input - sample sheets carry metadata
+that plain lists do not.
+
+
+(SAMPLE_SHEET_MAPPING)=
+(SAMPLE_SHEET_MATCHES_LIST)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `SAMPLE_SHEET_MAPPING` 
+:class: note
+
+Assuming,
+
+* $ d_1,...,d_n $ are datasets
+* $ tool \text{ is } (i: \text{ dataset }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{sample\_sheet},\left\{ \text{ i1 }=d_1, ..., \text{ in }=d_n \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C)) \mapsto \left\{o: \text{collection}<\text{sample\_sheet},\left\{\text{i1}=tool(i=d_1)[o],...,\text{in}=tool(i=d_n)[o]\right\}>\right\}$$
+
+:::
+
+
+
+:::{admonition} Example: `SAMPLE_SHEET_MATCHES_LIST` 
+:class: note
+
+Assuming,
+
+* $ d_1,...,d_n $ are datasets
+* $ tool \text{ is } (i: \text{ collection<list> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{sample\_sheet},\left\{ \text{ i1 }=d_1, ..., \text{ in }=d_n \right\}\text{>} $
+
+
+then
+
+$$tool(i=C) \rightarrow \left\{o: \text{dataset}\right\}$$
+
+:::
+
+
+
+</details><br>
+
+
+
+Sub-collection mapping works the same as for ``list`` composites. A
+``sample_sheet:paired`` can be mapped over a ``paired`` collection input,
+extracting each inner pair and producing a ``sample_sheet`` implicit output.
+
+
+(SAMPLE_SHEET_PAIRED_MAPPING_OVER_PAIRED)=
+(SAMPLE_SHEET_PAIRED_MATCHES_LIST_PAIRED)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `SAMPLE_SHEET_PAIRED_MAPPING_OVER_PAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<paired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{sample\_sheet}:\text{paired},\left\{ \text{ el1 }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\}\text{>} $
+* $ C\_PAIRED $ is $ \text{CollectionInstance<}\text{paired},\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C, '\text{paired}')) \mapsto \left\{o: \text{collection}<\text{sample\_sheet},\left\{\text{el1}=tool(i=C\_PAIRED)[o]\right\}>\right\}$$
+
+:::
+
+
+
+:::{admonition} Example: `SAMPLE_SHEET_PAIRED_MATCHES_LIST_PAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<list:paired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{sample\_sheet}:\text{paired},\left\{ \text{ el1 }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\}\text{>} $
+
+
+then
+
+$$tool(i=C) \rightarrow \left\{o: \text{dataset}\right\}$$
+
+:::
+
+
+
+</details><br>
+
+
+
+The ``paired_or_unpaired`` integration rules carry over from ``list`` to
+``sample_sheet``. A flat ``sample_sheet`` can be mapped over a
+``paired_or_unpaired`` input via ``single_datasets`` sub-collection mapping,
+and ``sample_sheet:paired`` can be mapped over ``paired_or_unpaired`` just as
+``list:paired`` can.
+
+
+(SAMPLE_SHEET_MAPPING_OVER_PAIRED_OR_UNPAIRED)=
+(SAMPLE_SHEET_PAIRED_MAPPING_OVER_PAIRED_OR_UNPAIRED)=
+(SAMPLE_SHEET_PAIRED_OR_UNPAIRED_MATCHES_LIST_PAIRED_OR_UNPAIRED)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `SAMPLE_SHEET_MAPPING_OVER_PAIRED_OR_UNPAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_1,...,d_n $ are datasets
+* $ tool \text{ is } (i: \text{ collection<paired\_or\_unpaired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{sample\_sheet},\left\{ \text{ i1 }=d_1, ..., \text{ in }=d_n \right\}\text{>} $
+* $ C_AS_UNPAIRED_i = CollectionInstance<\text{paired\_or\_unpaired},\left\{\text{unpaired}=di\right\}> for i from 1...n $
+
+
+then
+
+$$tool(i=\text{mapOver}(C, '\text{single\_datasets}')) \mapsto \left\{o: \text{collection}<\text{sample\_sheet},\left\{\text{i1}=tool(i=C_AS_UNPAIRED_1)[o],...,\text{in}=tool(i=C_AS_UNPAIRED_n)[o]\right\}>\right\}$$
+
+:::
+
+
+
+:::{admonition} Example: `SAMPLE_SHEET_PAIRED_MAPPING_OVER_PAIRED_OR_UNPAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<paired\_or\_unpaired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{sample\_sheet}:\text{paired},\left\{ \text{ el1 }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\}\text{>} $
+* $ C_AS_MIXED $ is $ \text{CollectionInstance<}\text{sample\_sheet}:\text{paired\_or\_unpaired},\left\{ \text{ el1 }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\}\text{>} $
+
+
+then
+
+$$tool(i=\text{mapOver}(C)) == tool(i=\text{mapOver}(C_AS_MIXED))$$
+
+:::
+
+
+
+:::{admonition} Example: `SAMPLE_SHEET_PAIRED_OR_UNPAIRED_MATCHES_LIST_PAIRED_OR_UNPAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<list:paired\_or\_unpaired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{sample\_sheet}:\text{paired\_or\_unpaired},\left\{ \text{ el1 }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\}\text{>} $
+
+
+then
+
+$$tool(i=C) \rightarrow \left\{o: \text{dataset}\right\}$$
+
+:::
+
+
+
+</details><br>
+
+
+
+The type matching is asymmetric: a ``sample_sheet`` output can satisfy a ``list``
+input because sample sheets carry all the structural information lists have (plus
+metadata). However, a ``list`` output cannot satisfy a ``sample_sheet`` input because
+lists lack the ``column_definitions`` and per-element ``columns`` metadata that
+sample sheet consumers expect.
+
+
+(LIST_NOT_MATCHES_SAMPLE_SHEET)=
+(LIST_PAIRED_NOT_MATCHES_SAMPLE_SHEET_PAIRED)=
+(SAMPLE_SHEET_MATCHES_SAMPLE_SHEET)=
+<details><summary>Examples</summary>
+
+:::{admonition} Example: `LIST_NOT_MATCHES_SAMPLE_SHEET` 
+:class: note
+
+Assuming,
+
+* $ d_1,...,d_n $ are datasets
+* $ tool \text{ is } (i: \text{ collection<sample\_sheet> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list},\left\{ \text{ i1 }=d_1, ..., \text{ in }=d_n \right\}\text{>} $
+
+
+then
+
+$$tool(i=C)\text{ is invalid}$$
+
+:::
+
+
+
+:::{admonition} Example: `LIST_PAIRED_NOT_MATCHES_SAMPLE_SHEET_PAIRED` 
+:class: note
+
+Assuming,
+
+* $ d_f $, $ d_r $ are datasets
+* $ tool \text{ is } (i: \text{ collection<sample\_sheet:paired> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{list}:\text{paired},\left\{ \text{ el1 }=\left\{ \text{ forward }=d_f, \text{ reverse }=d_r \right\} \right\}\text{>} $
+
+
+then
+
+$$tool(i=C)\text{ is invalid}$$
+
+:::
+
+
+
+:::{admonition} Example: `SAMPLE_SHEET_MATCHES_SAMPLE_SHEET` 
+:class: note
+
+Assuming,
+
+* $ d_1,...,d_n $ are datasets
+* $ tool \text{ is } (i: \text{ collection<sample\_sheet> }) \Rightarrow \{ o: \text{ dataset } \} $
+* $ C $ is $ \text{CollectionInstance<}\text{sample\_sheet},\left\{ \text{ i1 }=d_1, ..., \text{ in }=d_n \right\}\text{>} $
+
+
+then
+
+$$tool(i=C) \rightarrow \left\{o: \text{dataset}\right\}$$
+
+:::
+
+
+
+</details><br>
+
+
+

--- a/casts/claude/skills/repair-galaxy-draft-topology/references/notes/galaxy-collection-semantics.yml
+++ b/casts/claude/skills/repair-galaxy-draft-topology/references/notes/galaxy-collection-semantics.yml
@@ -1,0 +1,1250 @@
+- doc: |
+    # Collection Semantics
+
+    This document describes the semantics around working with Galaxy dataset collections.
+    In particular it describes how they operate within Galaxy tools and workflows.
+
+    :::{admonition} You Probably Don't Need to Read This
+    :class: caution
+
+    Any significantly sophisticated workflow language will have ways to collect data
+    into arrays or vectors or dictionaries and apply operations across this data (mapping)
+    or reduce the dimensionality of this data (reductions). Typically, this is explicitly
+    annotated with map functions or for loops. Galaxy however is designed to be a point
+    and click interface for connecting steps and running tools. It is important that steps
+    just connect and just do the most natural thing - and this is what Galaxy does.
+    This document just provides a mathematical formalism to that "what should just
+    intuitively work" that can be used to document test cases and help with implementation.
+    This is reference documentation not user documentation, Galaxy should just work.
+    :::
+
+    ## Mapping
+
+    If a tool consumes a simple dataset parameter and produces a simple dataset parameter,
+    then any collection type may be "mapped over" the data input to that tool. The result of
+    that is the tool being applied to each element of the collection and "implicit collections"
+    being created from the outputs that are produced from those operations. Those implicit
+    collections have the same element identifiers in the same order as the input collection that is
+    mapped over. Each element of the implicit collections correspond to their own job and
+    Galaxy very naturally and intuitively parallelizes jobs without extra work from the user
+    and without any knowledge of the tool.
+
+- example:
+    label: BASIC_MAPPING_PAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: dataset}
+        out: {o: dataset}
+    - collections:
+        C: [paired, {forward: d_f, reverse: d_r}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C}
+        produces:
+            o:
+                type: collection
+                collection_type: paired
+                elements:
+                    forward:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d_f}}}
+                        output: o
+                    reverse:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d_r}}}
+                        output: o
+    tests:
+        tool_runtime:
+            api_test: "test_tool_execute.py::test_map_over_collection"
+        workflow_runtime:
+            framework_test: "collection_semantics_cat_0"
+        workflow_editor: "accepts paired data -> data connection"
+
+- example:
+    label: BASIC_MAPPING_PAIRED_OR_UNPAIRED_PAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: dataset}
+        out: {o: dataset}
+    - collections:
+        C: [paired_or_unpaired, {forward: d_f, reverse: d_r}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C}
+        produces:
+            o:
+                type: collection
+                collection_type: paired_or_unpaired
+                elements:
+                    forward:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d_f}}}
+                        output: o
+                    reverse:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d_r}}}
+                        output: o
+    tests:
+        tool_runtime:
+            api_test: "test_tool_execute.py::test_map_over_data_with_paired_or_unpaired_paired"
+        workflow_runtime:
+            framework_test: "collection_semantics_cat_1"
+        workflow_editor: "accepts paired_or_unpaired data -> data connection"
+
+- example:
+    label: BASIC_MAPPING_PAIRED_OR_UNPAIRED_UNPAIRED
+    assumptions:
+    - datasets: [d_u]
+    - tool:
+        in: {i: dataset}
+        out: {o: dataset}
+    - collections:
+        C: [paired_or_unpaired, {unpaired: d_u}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C}
+        produces:
+            o:
+                type: collection
+                collection_type: paired_or_unpaired
+                elements:
+                    unpaired:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d_u}}}
+                        output: o
+    tests:
+        tool_runtime:
+            api_test: "test_tool_execute.py::test_map_over_data_with_paired_or_unpaired_unpaired"
+        workflow_runtime:
+            framework_test: "collection_semantics_cat_2"
+        workflow_editor: "accepts paired_or_unpaired data -> data connection"
+
+- example:
+    label: BASIC_MAPPING_LIST
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: dataset}
+        out: {o: dataset}
+    - collections:
+        C: [list, {i1: "d_1", ..., in: "d_n"}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C}
+        produces:
+            o:
+                type: collection
+                collection_type: list
+                elements:
+                    i1:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d_1}}}
+                        output: o
+                    "...": {type: ellipsis}
+                    in:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d_n}}}
+                        output: o
+    tests:
+        workflow_editor: "accepts collection data -> data connection"
+
+- doc: |
+    The above description of mapping over inputs works naturally and as expected for
+    nested collections.
+
+- example:
+    label: NESTED_LIST_MAPPING
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: dataset}
+        out: {o: dataset}
+    - collections:
+        C: ["list:list", {o1: {inner: d_1}, ..., "on": {inner: d_n}}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C}
+        produces:
+            o:
+                type: collection
+                collection_type: "list:list"
+                elements:
+                    o1:
+                        type: nested_elements
+                        elements:
+                            inner:
+                                type: tool_output_ref
+                                invocation: {inputs: {i: {type: dataset, ref: d_1}}}
+                                output: o
+                    "...": {type: ellipsis}
+                    "on":
+                        type: nested_elements
+                        elements:
+                            inner:
+                                type: tool_output_ref
+                                invocation: {inputs: {i: {type: dataset, ref: d_n}}}
+                                output: o
+    tests:
+        tool_runtime:
+            api_test: "test_tools.py::TestToolsApi::test_map_over_nested_collections"
+        workflow_editor: "accepts list:list data -> data connection"
+
+- example:
+    label: BASIC_MAPPING_LIST_PAIRED_OR_UNPAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: dataset}
+        out: {o: dataset}
+    - collections:
+        C: ["list:paired_or_unpaired", {el1: {forward: d_f, reverse: d_r}}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C}
+        produces:
+            o:
+                type: collection
+                collection_type: "list:paired_or_unpaired"
+                elements:
+                    el1:
+                        type: nested_elements
+                        elements:
+                            forward:
+                                type: tool_output_ref
+                                invocation: {inputs: {i: {type: dataset, ref: d_f}}}
+                                output: o
+                            reverse:
+                                type: tool_output_ref
+                                invocation: {inputs: {i: {type: dataset, ref: d_r}}}
+                                output: o
+    tests:
+        tool_runtime:
+            api_test: "test_tool_execute.py::test_map_over_data_with_list_paired_or_unpaired"
+        workflow_runtime:
+            framework_test: "collection_semantics_cat_3"
+        workflow_editor: "accepts list:paired_or_unpaired data -> data connection"
+
+- doc: |
+
+    For tools with multiple data inputs, the tool can be executed with individual
+    datasets for the non-mapped over input and each tool execution will just be executed
+    with that dataset. The dataset not mapped over serves as the input for each execution.
+
+- example:
+    label: BASIC_MAPPING_INCLUDING_SINGLE_DATASET
+    assumptions:
+    - datasets: ["d_1,...,d_n", "d_o"]
+    - tool:
+        in: {i: dataset, i2: dataset}
+        out: {o: dataset}
+    - collections:
+        C: ["list", {i1: d_1, ..., in: d_n}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C}
+                i2: {type: dataset, ref: d_o}
+        produces:
+            o:
+                type: collection
+                collection_type: list
+                elements:
+                    i1:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d_1}, i2: {type: dataset, ref: d_o}}}
+                        output: o
+                    "...": {type: ellipsis}
+                    in:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d_n}, i2: {type: dataset, ref: d_o}}}
+                        output: o
+    tests:
+        tool_runtime:
+            api_test: "test_tools.py::TestToolsApi::test_map_over_collected_and_individual_datasets"
+        workflow_runtime:
+            framework_test: "collection_semantics_cat_two_inputs_0"
+
+- doc: |
+    If a tool consumes two input datasets and produces one output dataset, you can map two
+    collections with identical structure (same element identifiers in the same order) over
+    the respective inputs and the result is an implicit collection with the same structure
+    as the inputs and where each output in the implicit collection corresponds to the tool
+    being executed with the two inputs corresponding to that position in the input
+    collections.
+
+    The default behavior here is the collections are linked and the act of mapping over
+    inputs to the tool are sort of a flat map or a dot product. No extra dimensionality
+    in the resulting collections.
+
+    From a user perspective this means if you start with a collection and apply a bunch
+    of map over operations on tools - the results will all continue to match and work together
+    very naturally - again without extra work by the user and without extra knowledge
+    by the tool author.
+
+- example:
+    label: BASIC_MAPPING_TWO_INPUTS_WITH_IDENTICAL_STRUCTURE
+    assumptions:
+    - datasets: ["d1_1,...,d1_n", "d2_1,...,d2_n"]
+    - tool:
+        in: {i: dataset, i2: dataset}
+        out: {o: dataset}
+    - collections:
+        C1: ["list", {i1: d1_1, ..., in: d1_n}]
+        C2: ["list", {i1: d2_1, ..., in: d2_n}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C1}
+                i2: {type: map_over, collection: C2}
+        produces:
+            o:
+                type: collection
+                collection_type: list
+                elements:
+                    i1:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d1_1}, i2: {type: dataset, ref: d2_1}}}
+                        output: o
+                    "...": {type: ellipsis}
+                    in:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d1_n}, i2: {type: dataset, ref: d2_n}}}
+                        output: o
+    tests:
+        tool_runtime:
+            api_test: test_tools.py::TestToolsApi::test_map_over_two_collections
+        workflow_runtime:
+            framework_test: "collection_semantics_cat_two_inputs_1"
+
+- doc: "## Reduction"
+- doc: |
+    Not all tool executions result in implicit collections and mapping
+    over inputs. Tool inputs of ``type`` ``data_collection`` can consume
+    collections directly and do not necessarily result in mapping over.
+
+    Tools that consume collections and output datasets effectively
+    reduce the dimension of the Galaxy data structure. When used at runtime
+    this is often referred to as a "reduction" in the code.
+
+- example:
+    label: COLLECTION_INPUT_PAIRED
+    assumptions:
+    - datasets: ["d_f", "d_r"]
+    - tool:
+        in: {i: "collection<paired>"}
+        out: {o: dataset}
+    - collections:
+        C: [paired, {forward: d_f, reverse: d_r}]
+    then:
+        type: reduction
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+        produces:
+            o: {type: dataset}
+    tests:
+        tool_runtime:
+            tool: collection_paired_test
+        workflow_editor: "accepts paired -> paired connection"
+
+- example:
+    label: COLLECTION_INPUT_LIST
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: "collection<list>"}
+        out: {o: dataset}
+    - collections:
+        C: [list, {el1: d_1, ..., eln: d_n}]
+    then:
+        type: reduction
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+        produces:
+            o: {type: dataset}
+    tests:
+        workflow_runtime:
+            framework_test: "collection_semantics_cat_collection_0"
+        workflow_editor: "accepts list -> list connection"
+
+- example:
+    label: COLLECTION_INPUT_PAIRED_OR_UNPAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: [paired_or_unpaired, {forward: d_f, reverse: d_r}]
+    then:
+        type: reduction
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+        produces:
+            o: {type: dataset}
+    tests:
+        tool_runtime:
+            tool: collection_paired_or_unpaired
+        workflow_runtime:
+            framework_test: "collection_semantics_paired_or_unpaired_0"
+        workflow_editor: "accepts paired_or_unpaired data -> paired_or_unpaired connection"
+
+- example:
+    label: COLLECTION_INPUT_LIST_PAIRED_OR_UNPAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<list:paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:paired_or_unpaired", {el1: {forward: d_f, reverse: d_r}}]
+    then:
+        type: reduction
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+        produces:
+            o: {type: dataset}
+    tests:
+        tool_runtime:
+            tool: collection_list_paired_or_unpaired
+        workflow_runtime:
+            framework_test: "collection_semantics_list_paired_or_unpaired_0"
+        workflow_editor: "accepts list:paired_or_unpaired data -> list:paired_or_unpaired connection"
+
+- doc: |
+    For nested collections where each rank is a ``list`` or a ``paired`` collection,
+    then collection inputs must match every part of the collection type input definition.
+
+- example:
+    label: COLLECTION_INPUT_LIST_NOT_CONSUMES_PAIRS
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<list>"}
+        out: {o: dataset}
+    - collections:
+        C: [paired, {forward: d_f, reverse: d_r}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects connecting paired -> list"
+
+- example:
+    label: COLLECTION_INPUT_PAIRED_NOT_CONSUMES_LIST
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: "collection<paired>"}
+        out: {o: dataset}
+    - collections:
+        C: [list, {i1: d_1, ..., in: d_n}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects connecting list -> paired"
+
+- example:
+    label: COLLECTION_INPUT_LIST_PAIRED_NOT_CONSUMES_PAIRED_PAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<list:paired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["paired:paired", {forward: {forward: d_f, reverse: d_r}, reverse: {forward: d_f, reverse: d_r}}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects paired:paired -> list:paired connection"
+
+- example:
+    label: COLLECTION_INPUT_LIST_PAIRED_OR_NOT_PAIRED_NOT_CONSUMES_PAIRED_PAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<list:paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["paired:paired", {forward: {forward: d_f, reverse: d_r}, reverse: {forward: d_f, reverse: d_r}}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects paired:paired -> list:paired_or_unpaired connection"
+
+- doc: |
+    In addition to explicit collection inputs, tool inputs of ``type`` ``data``
+    where ``multiple="true"`` can consume lists directly. This is likewise a
+    "reduction" and does not result in implicit collection creation.
+
+- example:
+    label: LIST_REDUCTION
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: "dataset<multiple=true>"}
+        out: {o: dataset}
+    - collections:
+        C: [list, {i1: d_1, ..., in: d_n}]
+    then:
+        type: equivalence
+        left:
+            inputs:
+                i: {type: collection, ref: C}
+        right:
+            inputs:
+                i: {type: dataset_list, refs: ["d_1", "...", "d_n"]}
+    tests:
+        tool_runtime:
+            api_test: "test_tools.py::TestToolsApi::test_reduce_collections"
+        workflow_runtime:
+            framework_test: "collection_semantics_multi_data_optional_0"
+        workflow_editor: "treats multi data input as list input"
+
+- doc: |
+    Paired collections cannot be reduced this way. ``paired`` is not meant
+    to represent a list/array/vector data structure - it is more like a tuple.
+
+- example:
+    label: PAIRED_REDUCTION_INVALID
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "dataset<multiple=true>"}
+        out: {o: dataset}
+    - collections:
+        C: [paired, {forward: d_f, reverse: d_r}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects paired input on multi-data input"
+
+- example:
+    label: PAIRED_OR_UNPAIRED_REDUCTION_INVALID
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "dataset<multiple=true>"}
+        out: {o: dataset}
+    - collections:
+        C: [paired_or_unpaired, {forward: d_f, reverse: d_r}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects paired_or_unpaired input on multi-data input"
+
+- doc: "## Sub-collection Mapping"
+- doc: |
+    ![](https://planemo.readthedocs.io/en/master/_images/subcollection_mapping_identifiers.svg)
+
+- example:
+    label: MAPPING_LIST_PAIRED_OVER_PAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<paired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:paired", {el1: {forward: d_f, reverse: d_r}}]
+        "C\\_PAIRED": [paired, {forward: d_f,reverse: d_r}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C, sub_collection_type: paired}
+        produces:
+            o:
+                type: collection
+                collection_type: list
+                elements:
+                    el1:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: collection, ref: "C\\_PAIRED"}}}
+                        output: o
+    tests:
+        tool_runtime:
+            api_test: "test_tool_execute.py::test_simple_subcollection_mapping"
+        workflow_editor: "accepts list:paired -> paired connection"
+
+- doc: |
+    The natural extension of multiple data input parameters consuming list collections as described
+    above when discussing reductions is that nested lists of lists (``list:list``) can be mapped
+    over a multiple data input parameter. Each nested list will be reduced by this operation but the
+    results will be mapped over. The result will be a list with the same structure as the outer list
+    of the input collection.
+
+- example:
+    label: NESTED_LIST_REDUCTION
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: "dataset<multiple=true>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:list", {o1: {inner: d_1}, ..., "on": {inner: d_n}}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C, sub_collection_type: list}
+        produces:
+            o:
+                type: collection
+                collection_type: list
+                elements:
+                    o1:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset_list, refs: ["d_1"]}}}
+                        output: o
+                    "...": {type: ellipsis}
+                    "on":
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset_list, refs: ["d_n"]}}}
+                        output: o
+    tests:
+        workflow_editor: "maps list:list over multi data input"
+
+- doc: |
+    Just as a paired collection won't be reduced by a multiple data input, any sort of nested
+    collection ending in a paired collection cannot be mapped over such an input. So a multiple
+    data input parameter cannot be mapped over by a list of pairs (``list:paired``) for instance.
+
+- example:
+    label: LIST_PAIRED_REDUCTION_INVALID
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "dataset<multiple=true>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:paired", {el1: {forward: d_f, reverse: d_r}}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C, sub_collection_type: paired}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects list:paired input on multi-data input"
+
+- example:
+    label: LIST_PAIRED_OR_UNPAIRED_REDUCTION_INVALID
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "dataset<multiple=true>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:paired_or_unpaired", {el1: {forward: d_f, reverse: d_r}}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C, sub_collection_type: paired_or_unpaired}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects list:paired_or_unpaired input on multi-data input"
+
+- doc: "## paired_or_unpaired Collections"
+- doc: |
+    The collection type ``paired_or_unpaired`` is meant to serve as a stand-in for
+    an entity that can be either a single dataset or what is effectively a ``paired``
+    dataset collection. These collections either have one element with identifier
+    ``unpaired`` or two elements with identifiers ``forward`` and ``reverse``.
+
+    Tools can declare a data_collection input with collection type ``paired_or_unpaired``
+    and that input will consume either an explicit ``paired_or_unpaired`` collection
+    normally or can consume a ``paired`` input.
+
+- example:
+    label: PAIRED_OR_UNPAIRED_CONSUMES_PAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: [paired, {forward: d_f, reverse: d_r}]
+    - "C_AS_MIXED = CollectionInstance<paired_or_unpaired, {forward: d_f, reverse: d_r}>"
+    then:
+        type: equivalence
+        left:
+            inputs:
+                i: {type: collection, ref: C}
+        right:
+            inputs:
+                i: {type: collection, ref: C_AS_MIXED}
+    tests:
+        tool_runtime:
+            tool: collection_paired_or_unpaired
+        workflow_runtime:
+            framework_test: "collection_semantics_paired_or_unpaired_1"
+        workflow_editor: "accepts paired -> paired_or_unpaired connection"
+
+- doc: |
+
+    The inverse of this doesn't work intentionally. In some ways a ``paired`` collection
+    acts as a ``paired_or_unpaired`` collection but a ``paired_or_unpaired`` is not a paired
+    collection. This makes a lot of sense in terms of tools - a tool consuming a ``paired``
+    dataset expects to find both a ``forward`` and ``reverse`` element but these may not exist
+    in ``paired_or_unpaired`` collection.
+
+- example:
+    label: PAIRED_OR_UNPAIRED_NOT_CONSUMED_BY_PAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<paired>"}
+        out: {o: dataset}
+    - collections:
+        C: [paired_or_unpaired, {forward: d_f, reverse: d_r}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects paired_or_unpaired -> paired connection"
+
+- doc: |
+
+    The same logic holds for mapping, lists of paired datasets (``list:paired``) can be mapped over these
+    ``paired_or_unpaired`` inputs and mixed lists of pairs (``list:paired_or_unpaired``) cannot
+    be mapped over a ``paired`` input. Following the same logic, ``list:paired_or_unpaired`` cannot
+    be mapped over a ``list`` input or multiple data input.
+
+- example:
+    label: MAPPING_LIST_PAIRED_OVER_PAIRED_OR_UNPAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:paired", {el: {forward: d_f, reverse: d_r}}]
+        C_AS_MIXED: ["list:paired_or_unpaired", {el: {forward: d_f, reverse: d_r}}]
+    then:
+        type: equivalence
+        left:
+            inputs:
+                i: {type: map_over, collection: C}
+        right:
+            inputs:
+                i: {type: map_over, collection: C_AS_MIXED}
+    tests:
+        workflow_runtime:
+            framework_test: "collection_semantics_paired_or_unpaired_2"
+        workflow_editor: "accepts list:paired -> paired_or_unpaired connection"
+
+- example:
+    label: PAIRED_OR_UNPAIRED_NOT_CONSUMED_BY_PAIRED_WHEN_MAPPING
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<paired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:paired_or_unpaired", {el: {forward: d_f, reverse: d_r}}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C}
+    is_valid: false
+    tests:
+        tool_runtime:
+            api_test: "test_tool_execute.py::test_paired_or_unpaired_not_consumed_by_paired_when_mapping"
+        workflow_editor: "rejects list:paired_or_unpaired -> paired connection"
+
+- example:
+    label: PAIRED_OR_UNPAIRED_NOT_CONSUMED_BY_LIST_WHEN_MAPPING
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<list>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:paired_or_unpaired", {el: {forward: d_f, reverse: d_r}}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects list:paired_or_unpaired -> list connection"
+
+- doc: |
+    This logic extends naturally into higher dimensional collections. A ``list:list:paired``
+    can be mapped over either a ``paired_or_unpaired`` input to produce a nested list (``list:list``)
+    or a ``list:paired_or_unpaired`` input to produce a flat list (``list``).
+
+- example:
+    label: MAPPING_LIST_LIST_PAIRED_OVER_PAIRED_OR_UNPAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:list:paired", {o1: {el1: {forward: d_f, reverse: d_r}}}]
+        C_AS_MIXED: ["list:list:paired_or_unpaired", {o1: {el1: {forward: d_f, reverse: d_r}}}]
+    then:
+        type: equivalence
+        left:
+            inputs:
+                i: {type: map_over, collection: C}
+        right:
+            inputs:
+                i: {type: map_over, collection: C_AS_MIXED}
+    tests:
+        workflow_runtime:
+            framework_test: "collection_semantics_paired_or_unpaired_3"
+        workflow_editor: "accepts list:list:paired -> paired_or_unpaired connection"
+
+- doc: |
+
+    In order for ``paired_or_unpaired`` collections to also act as a single dataset,
+    a flat list can be mapped over a such an input with a special sub collection mapping
+    type of 'single_datasets'.
+
+- example:
+    label: MAPPING_LIST_OVER_PAIRED_OR_UNPAIRED
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: "collection<paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: [list, {i1: d_1, ..., in: d_n}]
+    - "C_AS_UNPAIRED_i = CollectionInstance<paired_or_unpaired,{unpaired=di}> for i from 1...n"
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C, sub_collection_type: single_datasets}
+        produces:
+            o:
+                type: collection
+                collection_type: list
+                elements:
+                    i1:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: collection, ref: C_AS_UNPAIRED_1}}}
+                        output: o
+                    "...": {type: ellipsis}
+                    in:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: collection, ref: C_AS_UNPAIRED_n}}}
+                        output: o
+    tests:
+        tool_runtime:
+            api_test: "test_tool_execute.py::test_map_over_paired_or_unpaired_with_list"
+        workflow_runtime:
+            framework_test: "collection_semantics_paired_or_unpaired_7"
+        workflow_editor: "accepts list -> paired_or_unpaired connection"
+
+- doc: |
+    This treatment of lists without pairing extends to nested structures naturally.
+    For instance, a list of list of datasets (``list:list``) can be mapped over a
+    ``paired_or_unpaired`` input to produce a nested list of lists (``list:list``)
+    with a structure matching the input. Likewise, the nested list can be mapped over
+    a ``list:paired_or_unpaired`` input to produce a flat list with the same structure
+    as the outer list of the input.
+
+- example:
+    label: MAPPING_LIST_LIST_OVER_PAIRED_OR_UNPAIRED
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: "collection<paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:list", {o1: {inner: d_1}, ..., "on": {inner: d_n}}]
+    - "C_AS_UNPAIRED_j = CollectionInstance<paired_or_unpaired,{unpaired=dj}> for each dataset dj in C"
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C, sub_collection_type: single_datasets}
+        produces:
+            o:
+                type: collection
+                collection_type: "list:list"
+                elements:
+                    o1:
+                        type: nested_elements
+                        elements:
+                            inner:
+                                type: tool_output_ref
+                                invocation: {inputs: {i: {type: collection, ref: C_AS_UNPAIRED_1}}}
+                                output: o
+                    "...": {type: ellipsis}
+                    "on":
+                        type: nested_elements
+                        elements:
+                            inner:
+                                type: tool_output_ref
+                                invocation: {inputs: {i: {type: collection, ref: C_AS_UNPAIRED_n}}}
+                                output: o
+    tests:
+        workflow_editor: "accepts list:list -> paired_or_unpaired connection"
+
+- example:
+    label: MAPPING_LIST_LIST_OVER_LIST_PAIRED_OR_UNPAIRED
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: "collection<list:paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:list", {o1: {inner: d_1}, ..., "on": {inner: d_n}}]
+    - "C_AS_LPU_i = inner list of C at position i, treated as list:paired_or_unpaired via single_datasets"
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C, sub_collection_type: "list:paired_or_unpaired"}
+        produces:
+            o:
+                type: collection
+                collection_type: list
+                elements:
+                    o1:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: collection, ref: C_AS_LPU_1}}}
+                        output: o
+                    "...": {type: ellipsis}
+                    "on":
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: collection, ref: C_AS_LPU_n}}}
+                        output: o
+    tests:
+        tool_runtime:
+            api_test: "test_tool_execute.py::test_map_over_list_paired_or_unpaired_with_list_of_lists"
+        workflow_runtime:
+            framework_test: "collection_semantics_list_paired_or_unpaired_2"
+        workflow_editor: "accepts list:list -> list:paired_or_unpaired connection"
+
+- doc: |
+    Due only to implementation time, the special casing of allowing paired_or_unpaired
+    act as both datasets and paired collections only works when it is the deepest
+    collection type. So while list:paired can be consumed by a list:paired_or_unpaired
+    input, a paired:list cannot be consumed by a paired_or_unpaired:list input though
+    it should be able to for consistency. We have focused our time on data structures
+    more likely to be used in actual Galaxy analyses given current and guessed future
+    usage.
+
+- doc: "## sample_sheet Collections"
+- doc: |
+    The collection type ``sample_sheet`` attaches typed, columnar metadata to each
+    element of a dataset collection. For mapping and type matching purposes,
+    ``sample_sheet`` behaves identically to ``list`` - it can be mapped over tool
+    inputs, matched against ``list`` collection inputs, and composed with inner types
+    (``sample_sheet:paired``, ``sample_sheet:paired_or_unpaired``). The key asymmetry
+    is that while a ``sample_sheet`` output can satisfy a ``list`` input, a ``list``
+    output cannot satisfy a ``sample_sheet`` input - sample sheets carry metadata
+    that plain lists do not.
+
+- example:
+    label: SAMPLE_SHEET_MAPPING
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: dataset}
+        out: {o: dataset}
+    - collections:
+        C: [sample_sheet, {i1: "d_1", ..., in: "d_n"}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C}
+        produces:
+            o:
+                type: collection
+                collection_type: sample_sheet
+                elements:
+                    i1:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d_1}}}
+                        output: o
+                    "...": {type: ellipsis}
+                    in:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: dataset, ref: d_n}}}
+                        output: o
+    tests:
+        workflow_runtime:
+            framework_test: "collection_semantics_cat_4"
+        workflow_editor: "accepts sample_sheet data -> data connection (maps like list)"
+
+- example:
+    label: SAMPLE_SHEET_MATCHES_LIST
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: "collection<list>"}
+        out: {o: dataset}
+    - collections:
+        C: [sample_sheet, {i1: d_1, ..., in: d_n}]
+    then:
+        type: reduction
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+        produces:
+            o: {type: dataset}
+    tests:
+        workflow_runtime:
+            framework_test: "collection_semantics_cat_collection_1"
+        workflow_editor: "accepts sample_sheet -> list connection (canMatch)"
+
+- doc: |
+    Sub-collection mapping works the same as for ``list`` composites. A
+    ``sample_sheet:paired`` can be mapped over a ``paired`` collection input,
+    extracting each inner pair and producing a ``sample_sheet`` implicit output.
+
+- example:
+    label: SAMPLE_SHEET_PAIRED_MAPPING_OVER_PAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<paired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["sample_sheet:paired", {el1: {forward: d_f, reverse: d_r}}]
+        "C\\_PAIRED": [paired, {forward: d_f, reverse: d_r}]
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C, sub_collection_type: paired}
+        produces:
+            o:
+                type: collection
+                collection_type: sample_sheet
+                elements:
+                    el1:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: collection, ref: "C\\_PAIRED"}}}
+                        output: o
+    tests:
+        workflow_runtime:
+            framework_test: "collection_semantics_paired_or_unpaired_5"
+        workflow_editor: "accepts sample_sheet:paired -> paired connection (maps over like list:paired)"
+
+- example:
+    label: SAMPLE_SHEET_PAIRED_MATCHES_LIST_PAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<list:paired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["sample_sheet:paired", {el1: {forward: d_f, reverse: d_r}}]
+    then:
+        type: reduction
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+        produces:
+            o: {type: dataset}
+    tests:
+        workflow_runtime:
+            framework_test: "collection_semantics_list_paired_0"
+        workflow_editor: "accepts sample_sheet:paired -> list:paired connection (canMatch)"
+
+- doc: |
+    The ``paired_or_unpaired`` integration rules carry over from ``list`` to
+    ``sample_sheet``. A flat ``sample_sheet`` can be mapped over a
+    ``paired_or_unpaired`` input via ``single_datasets`` sub-collection mapping,
+    and ``sample_sheet:paired`` can be mapped over ``paired_or_unpaired`` just as
+    ``list:paired`` can.
+
+- example:
+    label: SAMPLE_SHEET_MAPPING_OVER_PAIRED_OR_UNPAIRED
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: "collection<paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: [sample_sheet, {i1: d_1, ..., in: d_n}]
+    - "C_AS_UNPAIRED_i = CollectionInstance<paired_or_unpaired,{unpaired=di}> for i from 1...n"
+    then:
+        type: map_over
+        invocation:
+            inputs:
+                i: {type: map_over, collection: C, sub_collection_type: single_datasets}
+        produces:
+            o:
+                type: collection
+                collection_type: sample_sheet
+                elements:
+                    i1:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: collection, ref: C_AS_UNPAIRED_1}}}
+                        output: o
+                    "...": {type: ellipsis}
+                    in:
+                        type: tool_output_ref
+                        invocation: {inputs: {i: {type: collection, ref: C_AS_UNPAIRED_n}}}
+                        output: o
+    tests:
+        tool_runtime:
+            api_test: "test_tool_execute.py::test_map_over_paired_or_unpaired_with_sample_sheet"
+        workflow_runtime:
+            framework_test: "collection_semantics_paired_or_unpaired_8"
+        workflow_editor: "accepts sample_sheet -> paired_or_unpaired connection"
+
+- example:
+    label: SAMPLE_SHEET_PAIRED_MAPPING_OVER_PAIRED_OR_UNPAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["sample_sheet:paired", {el1: {forward: d_f, reverse: d_r}}]
+        C_AS_MIXED: ["sample_sheet:paired_or_unpaired", {el1: {forward: d_f, reverse: d_r}}]
+    then:
+        type: equivalence
+        left:
+            inputs:
+                i: {type: map_over, collection: C}
+        right:
+            inputs:
+                i: {type: map_over, collection: C_AS_MIXED}
+    tests:
+        workflow_runtime:
+            framework_test: "collection_semantics_paired_or_unpaired_6"
+        workflow_editor: "accepts sample_sheet:paired -> paired_or_unpaired connection"
+
+- example:
+    label: SAMPLE_SHEET_PAIRED_OR_UNPAIRED_MATCHES_LIST_PAIRED_OR_UNPAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<list:paired_or_unpaired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["sample_sheet:paired_or_unpaired", {el1: {forward: d_f, reverse: d_r}}]
+    then:
+        type: reduction
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+        produces:
+            o: {type: dataset}
+    tests:
+        workflow_runtime:
+            framework_test: "collection_semantics_list_paired_or_unpaired_1"
+        workflow_editor: "accepts sample_sheet:paired_or_unpaired -> list:paired_or_unpaired connection (canMatch)"
+
+- doc: |
+    The type matching is asymmetric: a ``sample_sheet`` output can satisfy a ``list``
+    input because sample sheets carry all the structural information lists have (plus
+    metadata). However, a ``list`` output cannot satisfy a ``sample_sheet`` input because
+    lists lack the ``column_definitions`` and per-element ``columns`` metadata that
+    sample sheet consumers expect.
+
+- example:
+    label: LIST_NOT_MATCHES_SAMPLE_SHEET
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: "collection<sample_sheet>"}
+        out: {o: dataset}
+    - collections:
+        C: [list, {i1: d_1, ..., in: d_n}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects list -> sample_sheet connection (asymmetry)"
+
+- example:
+    label: LIST_PAIRED_NOT_MATCHES_SAMPLE_SHEET_PAIRED
+    assumptions:
+    - datasets: [d_f, d_r]
+    - tool:
+        in: {i: "collection<sample_sheet:paired>"}
+        out: {o: dataset}
+    - collections:
+        C: ["list:paired", {el1: {forward: d_f, reverse: d_r}}]
+    then:
+        type: invalid
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+    is_valid: false
+    tests:
+        workflow_editor: "rejects list:paired -> sample_sheet:paired connection (asymmetry)"
+
+- example:
+    label: SAMPLE_SHEET_MATCHES_SAMPLE_SHEET
+    assumptions:
+    - datasets: ["d_1,...,d_n"]
+    - tool:
+        in: {i: "collection<sample_sheet>"}
+        out: {o: dataset}
+    - collections:
+        C: [sample_sheet, {i1: d_1, ..., in: d_n}]
+    then:
+        type: reduction
+        invocation:
+            inputs:
+                i: {type: collection, ref: C}
+        produces:
+            o: {type: dataset}
+    tests:
+        workflow_runtime:
+            framework_test: "collection_semantics_cat_sample_sheet_0"
+        workflow_editor: "accepts sample_sheet -> sample_sheet connection"

--- a/casts/claude/skills/repair-galaxy-draft-topology/references/notes/galaxy-data-flow-draft-contract.md
+++ b/casts/claude/skills/repair-galaxy-draft-topology/references/notes/galaxy-data-flow-draft-contract.md
@@ -1,0 +1,132 @@
+---
+type: research
+subtype: design-spec
+title: "Galaxy data-flow draft contract"
+tags:
+  - research/design-spec
+  - target/galaxy
+status: draft
+created: 2026-05-02
+revised: 2026-05-03
+revision: 2
+ai_generated: true
+related_notes:
+  - "[[nextflow-to-galaxy-channel-shape-mapping]]"
+  - "[[nextflow-operators-to-galaxy-collection-recipes]]"
+  - "[[galaxy-workflow-draft]]"
+related_molds:
+  - "[[nextflow-summary-to-galaxy-data-flow]]"
+  - "[[cwl-summary-to-galaxy-data-flow]]"
+  - "[[freeform-summary-to-galaxy-data-flow]]"
+  - "[[nextflow-summary-to-galaxy-template]]"
+  - "[[cwl-summary-to-galaxy-template]]"
+  - "[[freeform-summary-to-galaxy-template]]"
+  - "[[compare-against-iwc-exemplar]]"
+  - "[[advance-galaxy-draft-step]]"
+sources:
+  - "https://github.com/galaxyproject/foundry/issues/54"
+summary: "Defines the proposed boundary between Galaxy data-flow drafts, gxformat2 templates, and concrete step implementation."
+---
+
+# Galaxy Data-Flow Draft Contract
+
+This is an architectural contract, not a schema. Evidence is strongest for Mold and Pipeline boundaries. Proposed fields are speculative until exercised by two or three worked translations.
+
+## Boundary
+
+The data-flow draft owns a target-shaped abstract DAG for Galaxy. It should not be valid `gxformat2` and should not resolve exact Tool Shed tools.
+
+Data-flow draft owns:
+
+- Galaxy-facing workflow inputs and outputs.
+- Abstract nodes, edges, branches, collection mapping, collection reduction, and placeholder transformations.
+- Input/output shape decisions such as `File`, `list`, `paired`, `list:paired`, or `list:list`.
+- Conceptual Galaxy idioms: map-over, reduction, Apply Rules, collection cleanup, identifier synchronization, tabular bridge, fan-in / combine (concatenate, merge, or union N sources into one — a distinct node, not a side-effect of a reshape).
+- Abstract unresolved tool needs with input and output shapes.
+- Confidence and rationale on inferred nodes, edges, transforms, and tool needs.
+
+The Galaxy template owns:
+
+- A `gxformat2` skeleton.
+- Ordered steps, labels, workflow inputs, workflow outputs, and the producer→consumer connection graph.
+- Per-step wrapper resolution to the tier its evidence supports — **evidence-gated, not source-gated** (tiers defined in [[galaxy-workflow-draft-format]]): a fully **Resolved** step (concrete `tool_id`, changeset, `tool_state`) when wrapper and parameters are pinned jointly; **Identity-pinned** (`tool_id` only, `_plan_state` kept) when the wrapper is named but not its settings; **Deferred** (`tool_id: TODO`, full `_plan_*`) otherwise.
+- Placeholder collection-operation or Apply Rules steps only when the data-flow draft says they are necessary.
+- `_plan_*` handoff units (intent, evidence, constraints) for every step left short of Resolved.
+
+Concrete step implementation owns:
+
+- For every step the template left short of **Resolved**: the changeset (`tool_version`, `tool_shed_repository` owner/repository metadata), bound `tool_state` parameters, and `input_connections` — resolving any `tool_id: TODO` and confirming or correcting any `tool_id` the template pinned. Steps the template already Resolved pass through — confirm, do not re-derive.
+- Concrete built-in collection-operation steps and parameters.
+- Validation with `gxwf` and repair after schema/lint failures.
+
+## Proposed Body-Level Contract
+
+Do not add these as frontmatter fields yet.
+
+| Concept | Status | Notes |
+|---|---|---|
+| `source_summary_ref` | Speculative | Reference to the source summary consumed by the Mold. |
+| `workflow_inputs` | Speculative | Abstract Galaxy-facing inputs and collection types. |
+| `workflow_outputs` | Speculative | Intended outputs and source-summary provenance. |
+| `nodes` | Speculative | Abstract operations, not concrete Galaxy tools. |
+| `edges` | Speculative | Data dependencies, shape before/after, and source evidence. |
+| `galaxy_idioms` | Speculative | Map-over, reduction, Apply Rules, collection filter, tabular bridge, etc. |
+| `unresolved_tool_needs` | Speculative | Per abstract step needs for `discover-shed-tool` or `author-galaxy-tool-wrapper`. |
+| `placeholder_transformations` | Speculative | Shape/text/table transforms needed for Galaxy semantics but not concretely implemented. |
+| `confidence` | Speculative | Prefer `high`, `medium`, `low` plus rationale. |
+| `handoff_notes` | Speculative | Instructions to template, exemplar comparison, and per-step Molds. |
+| `open_questions` | Speculative | Semantic/tooling issues carried forward. |
+
+## Handoff Examples
+
+Unresolved tool need:
+
+- [[nextflow-summary-to-galaxy-data-flow]] emits an abstract node such as `trim FASTQ reads`, input `list:paired fastq`, output `list:paired fastq`, tool need `read trimming`, confidence `medium`.
+- [[nextflow-summary-to-galaxy-template]] creates a placeholder step with TODOs and collection-shaped connections.
+- The harness routes through tool discovery or wrapper authoring.
+- [[implement-galaxy-tool-step]] fills exact Galaxy tool metadata, parameters, and connections.
+
+Collection cleanup after fan-out:
+
+- Data-flow records a conceptual cleanup transform after a mapped step.
+- Template materializes a placeholder collection-operation step.
+- Implementation chooses exact built-in tool and parameters.
+
+Identifier-derived reshaping:
+
+- Data-flow records desired input shape, output shape, and identifier transformation.
+- Template emits an Apply Rules placeholder only if needed.
+- Implementation fills concrete rule JSON after exemplar comparison confirms the shape.
+
+IWC exemplar comparison:
+
+- Data-flow and template should hand [[compare-against-iwc-exemplar]] the abstract topology, placeholder transformations, unresolved tool needs, and confidence notes.
+- Exemplar comparison should flag structural divergence, not resolve tools.
+
+## Confidence Guidance
+
+- Attach confidence to the smallest useful unit: node, edge, transformation, or tool need.
+- Use qualitative `high`, `medium`, `low` until examples justify a richer schema.
+- Require rationale for low confidence.
+- Do not reuse source-summary `warnings[]` as data-flow confidence.
+- Keep evidence quality distinct from translation confidence. A claim can be corpus-observed but still low-confidence for a specific workflow.
+
+## Risks
+
+If the data-flow draft is too broad, it duplicates the template Mold, makes premature tool decisions, and leaks harness routing into Mold output.
+
+If it is too narrow, the template Mold receives source-summary details without Galaxy-shaped semantics, exemplar comparison has only a surface skeleton to diff, and tool discovery loses input/output shape context.
+
+## Evidence
+
+- [[nextflow-to-galaxy-channel-shape-mapping]] and [[nextflow-operators-to-galaxy-collection-recipes]] show why a Galaxy-shaped abstraction is needed between source summary and `gxformat2` template.
+- `content/pipelines/nextflow-to-galaxy.md` places data-flow before template, exemplar comparison, and per-step implementation.
+- `content/molds/summarize-nextflow/index.md` says source summarization should not produce Galaxy data flow.
+- `content/molds/implement-galaxy-tool-step/index.md` owns concrete step implementation.
+
+## TODOs
+
+- Decide whether to author `galaxy-data-flow-draft.schema.json` now or wait for worked examples.
+- Decide whether confidence should be a single enum or per-axis vector.
+- Decide how much ordering guidance belongs in data-flow versus template.
+- Decide whether built-in collection operations should be abstract placeholders or concrete template steps.

--- a/casts/claude/skills/repair-galaxy-draft-topology/references/notes/galaxy-workflow-draft-format.md
+++ b/casts/claude/skills/repair-galaxy-draft-topology/references/notes/galaxy-workflow-draft-format.md
@@ -1,0 +1,137 @@
+---
+type: research
+subtype: design-spec
+title: "Galaxy workflow draft format"
+tags:
+  - research/design-spec
+  - target/galaxy
+status: draft
+created: 2026-05-06
+revised: 2026-05-10
+revision: 2
+ai_generated: true
+related_notes:
+  - "[[gxformat2-schema]]"
+  - "[[galaxy-data-flow-draft-contract]]"
+  - "[[discover-shed-tool]]"
+  - "[[galaxy-workflow-draft]]"
+  - "[[open-requirements-ledger]]"
+related_molds:
+  - "[[nextflow-summary-to-galaxy-template]]"
+  - "[[cwl-summary-to-galaxy-template]]"
+  - "[[freeform-summary-to-galaxy-template]]"
+  - "[[compare-against-iwc-exemplar]]"
+  - "[[implement-galaxy-tool-step]]"
+  - "[[advance-galaxy-draft-step]]"
+  - "[[repair-galaxy-draft-topology]]"
+summary: "gxformat2 draft superset: wrapper-tier TODOs (tool_id, tool_state, port names) plus _plan_state / _plan_context / _plan_in / _plan_out per tool step."
+---
+
+# Galaxy workflow draft format
+
+The output artifact `galaxy-workflow-draft` produced by the `*-summary-to-galaxy-template` Molds is **gxformat2 with wrapper-tier relaxations and free-text planning fields**, sized to the gap between data-flow design and tool-resolved implementation.
+
+Topology — workflow inputs and their collection shapes, workflow outputs, the step set, the producer→consumer edge graph, branches, and `when:` guards — is **settled by the template Mold itself**, drawing on the upstream interface and data-flow briefs (see [[galaxy-data-flow-draft-contract]]). The output is concrete gxformat2 with no topology TODOs. Wrapper-tier resolution — which Tool Shed wrapper, what parameters, the wrapper-determined port names that populate `in:` / `out:` / `outputSource` — is **evidence-gated per step** (see Resolution tiers below): a step resolves fully when the evidence pins wrapper and parameters together, pins identity alone when the wrapper is named but its settings are not, and defers entirely when the evidence is weak.
+
+A step's declared `in:` arity is a topology decision and must be realizable by one wrapper. Combining N sources into one — concatenate, merge, union — is its own node (`gops_concat_1`, `cat1` for two/N datasets; `collapse_dataset` for a collection), never folded into a downstream 1→1 reshape. A step that would declare ≥2 dataset inputs under a reshape intent (awk, text-reformatting, "reshape") is a missing-combine-node smell: split it into an explicit combine step plus single-input reshapes. The relevant concat/merge/union recipes are reachable through the tabular, interval, and collection pattern indices the template already consults.
+
+## Resolution tiers
+
+Each tool step is resolved to the tier its evidence supports — **evidence-gated, not source-gated**. The source kind (free-form, nf-core, CWL) shifts how often a step reaches each tier but never caps it; each `*-summary-to-galaxy-template` Mold records its own source tendency.
+
+- **Resolved** — concrete `tool_id`, `tool_shed_repository` / changeset (or a stable built-in id), and bound `tool_state`; no `_plan_*`. Use when the evidence pins wrapper *and* parameters jointly: a built-in Galaxy tool with brief-determined params (`Filter1`, `Cut1`, a collection operation), or a pattern page / IWC exemplar worked example that supplies `tool_id`, changeset, and parameter values together. `draft-validate` rejects `_plan_*` on a fully-resolved step.
+- **Identity-pinned** — concrete `tool_id` with `tool_version: TODO` (changeset deferred); `tool_state` and `tool_shed_repository` absent; `_plan_state` (and any other open `_plan_*`) kept. The `tool_version: TODO` sentinel is load-bearing: it keeps the step drafty for [[draft-next-step]] and not-fully-resolved for [[draft-validate]], so the retained `_plan_state` is legal rather than a `semanticError`. (A step is "fully-resolved" — and so forbidden from carrying `_plan_*` — exactly when it has *no* remaining TODO sentinel in `tool_id`, `tool_version`, or any `in:` / `out:` port; pinning identity without this sentinel would trip that gate.) Use when the evidence confidently names *which* wrapper but not its settings or exact changeset for this context: a portion of an IWC exemplar that [[compare-against-iwc-exemplar]] flags as a high-confidence match, a pattern page's worked example, or a source summary that names a specific `tool_id` with evidence.
+- **Deferred** — `tool_id: TODO`, full `_plan_*`. Use when the evidence is weak, multi-candidate, a domain-specific scientific tool with no covering pattern or exemplar, or a corpus gap.
+
+Pin identity only on strong evidence — a wrapper an exemplar actually uses for the same operation, a worked pattern example, or a tool the source names explicitly — never on plausibility: a wrong pinned `tool_id` lets [[discover-shed-tool]] resolve the wrong tool's changeset instead of searching afresh. Port names follow the wrapper: real on a Resolved step, `TODO_<hint>` sentinels until the step resolves.
+
+The per-step loop does not edit topology — but it may **escalate back to a template-tier Mold** when implementation proves the settled topology can't support a declared step (see "Topology repair escalation" below). Wiring authority stays in the template tier; the loop only gains a path back to it.
+
+## Relaxations vs. gxformat2
+
+For tool steps, when the wrapper has not been picked:
+
+- `tool_id` and `tool_version` MAY be the literal string `TODO`. Resolution belongs to [[discover-shed-tool]] and the per-step implementation Mold.
+- `tool_shed_repository` (the `{ changeset_revision, name, owner, tool_shed }` block) MAY be absent.
+- `tool_state` / `state` MAY be absent.
+- Step `out[].id` and `in[]` keys MAY be `TODO_<hint>` sentinels (e.g. `TODO_trimmed_paired`, `TODO_input`). Workflow `outputs[].outputSource` MAY reference such a sentinel via `step/TODO_<hint>` so the connection graph still resolves syntactically. The connection itself (which step's output feeds which step's input) is topology and MUST be present; only the wrapper-determined port names are deferred.
+
+Workflow inputs (types, collection shapes, formats, optionality), workflow outputs, step labels, and the producer→consumer edge set MUST be expressed in normal gxformat2 form with concrete values — never `TODO`. The template Mold is the locus where these decisions are made; if the upstream brief leaves a topology choice open, decide it here from source evidence, IWC exemplars, and pattern pages rather than punting downstream.
+
+## Additions: `_plan_*` planning fields
+
+Free-text fields per tool step capture the template Mold's intent for the downstream per-step implementation Mold. All optional, but expected on any Identity-pinned or Deferred step (`tool_id` is `TODO`, or `tool_id` is pinned but `tool_state` is absent); a Resolved step carries none.
+
+- `_plan_state` — parameter binding intent: which knobs matter, value or range, why. Read by the per-step Mold to bind real `tool_state` once a wrapper is selected.
+- `_plan_context` — extras the per-step Mold needs to pick a wrapper: source `command:` block, conda packages, Docker/Singularity images, environment variables, preconditions, postconditions, container entrypoints, scratch-disk needs.
+- `_plan_in` — wrapper input port mapping intent. The connection graph already says "this source feeds this step"; `_plan_in` records the semantic role of each port and likely wrapper-side names (`single_paired` vs `paired_input` vs `input`) so the per-step Mold can collapse `TODO_*` keys to the real ones.
+- `_plan_out` — wrapper output surface intent: which outputs downstream consumers depend on (with the existing edges as evidence) so the per-step Mold can pick a wrapper that exposes them, or insert a follow-up step if it does not.
+
+The `_plan_*` family is **wrapper-tier**: each entry exists because the wrapper is not yet fully resolved and disappears the moment the step is. Topology decisions do not belong here.
+
+`_plan_*` fields are **draft-only**. They MUST be removed before the workflow is treated as a runnable gxformat2 document. Any remaining `TODO` / `TODO_*` sentinels MUST also be resolved at the same time.
+
+## Example (sketch)
+
+```yaml
+class: GalaxyWorkflowDraft
+inputs:
+  reads:
+    type: collection
+    collection_type: list:paired
+    format: fastqsanger.gz
+outputs:
+  trimmed:
+    outputSource: fastp/TODO_trimmed_paired
+steps:
+  fastp:
+    tool_id: TODO
+    label: trim and QC paired reads
+    in:
+      TODO_input: reads
+    out:
+      - id: TODO_trimmed_paired
+      - id: TODO_html_report
+    _plan_state: |
+      adapter trimming on, quality cutoff ~Q20, min length ~50.
+      preserve paired-end pairing for downstream alignment.
+    _plan_context: |
+      upstream: nf-core FASTP module.
+      conda: bioconda::fastp=0.23.4
+      container: quay.io/biocontainers/fastp:0.23.4--h5f740d0_0
+      precondition: paired list collection with sane element identifiers
+    _plan_in: |
+      single semantic port `reads`: feeds workflow `reads` (list:paired).
+      wrapper input port name likely one of `single_paired` | `paired_input` |
+      `input` depending on which fastp wrapper is picked.
+    _plan_out: |
+      need a paired output that preserves list:paired shape (downstream
+      alignment step consumes it). also expose the HTML report as a
+      checkpoint output for QC.
+```
+
+## Why this shape
+
+- Keeps the artifact recognizably gxformat2 so static tooling (`gxwf validate --no-tool-state`, structural diff against IWC) still applies to topology and port wiring.
+- Carves a stable handoff between the template Mold and the per-step implementation Mold without sneaking tool resolution into either side.
+- Makes the boundary between topology (settled upstream) and wrapper-tier (deferred) explicit — the `_plan_*` family lives squarely on the deferred side.
+- Free-text `_plan_*` is intentional for v1: it lets the templating agent record intent without a contract pretending to be parameterizable yet. Structuring those fields is open work — see each template Mold's `refinement.md`.
+
+## Topology repair escalation
+
+The template Mold settles topology, but it can miss a **computability** gap: a step whose declared output needs evidence no wired input carries. The connection graph validates — ports connect — yet the step can't be implemented. The template's computability review pass catches most of these and either wires the producer or records the gap in the [[open-requirements-ledger]]; the rest surface in the per-step loop.
+
+When one surfaces, the per-step loop does not author topology to fix it. It **escalates**:
+
+- [[implement-galaxy-tool-step]] detects, while implementing, that the declared output can't be computed from the wired inputs. It appends a blocking entry to the [[open-requirements-ledger]] and falls through rather than fabricating the output.
+- [[repair-galaxy-draft-topology]] — a template-tier Mold sharing the template's reference set — reads the blocking entries and re-wires the affected region: one producer step, a small sub-path, or honest narrowing of the output. New steps land at draft (wrapper-tier `TODO`) tier, so the existing discover-or-author → implement machinery realizes them.
+
+This is **repair**, distinct from **settling**: it is narrow (one named region), reactive (only a detected computability gap triggers it), and bounded. The loop's convergence gate counts open blocking entries in the ledger; each escalation must strictly reduce that count, under a hard cap on escalations. When the cap is reached with entries still open, they are **surrendered** — written into the final draft as labelled gaps — the clean terminal that replaces spin-or-fabricate. So the boundary "topology decisions do not belong in the per-step loop" still holds: the loop never decides topology, it returns the decision to the template tier.
+
+## Open work
+
+- Decide whether `_plan_state` should grow structure (parameter-name hints, value ranges, references back to the source summary).
+- Decide whether `_plan_context` should be split into typed fields (`source_command`, `conda`, `containers`, `env`, `pre`, `post`).
+- Decide structure for `_plan_in` and `_plan_out` once two or three worked drafts exercise them. Candidate `_plan_out`: array of `{ semantic_name, downstream_consumers[], required_for }`. Candidate `_plan_in`: map keyed by the `TODO_*` placeholder key to `{ semantic_name, source_step_output, shape_constraint }`.
+- Pick a JSON Schema strategy: extend the gxformat2 schema with `_plan_*` and the relaxed wrapper / port-name rules, or validate the draft via a sibling schema that wraps gxformat2 with the relaxations.
+- Specify the strip step that converts a draft into a runnable gxformat2 workflow. It MUST drop all `_plan_*` fields and reject any remaining `TODO` or `TODO_<hint>` sentinel in `tool_id`, `tool_version`, `out[].id`, `in[]` keys, or `outputSource`.

--- a/casts/claude/skills/repair-galaxy-draft-topology/references/notes/open-requirements-ledger.md
+++ b/casts/claude/skills/repair-galaxy-draft-topology/references/notes/open-requirements-ledger.md
@@ -1,0 +1,91 @@
+---
+type: research
+subtype: design-spec
+title: "Open-requirements ledger"
+tags:
+  - research/design-spec
+  - target/galaxy
+status: draft
+created: 2026-06-16
+revised: 2026-06-16
+revision: 1
+ai_generated: true
+related_notes:
+  - "[[galaxy-workflow-draft-format]]"
+related_molds:
+  - "[[advance-galaxy-draft-step]]"
+  - "[[repair-galaxy-draft-topology]]"
+  - "[[implement-galaxy-tool-step]]"
+summary: "Carried unresolved-requirements artifact the source→Galaxy pipeline discharges or explicitly surrenders, autonomously."
+---
+
+# Open-requirements ledger
+
+The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact.
+
+## Framing: obligations the pipeline discharges, not questions a human answers
+
+This is deliberately *not* an "open questions for the user" list. The pipeline is autonomous — no human-in-the-loop gate is assumed. The ledger's consumers are **Molds and the loop's convergence gate**, with human readout a secondary affordance. An entry is closed by a downstream Mold doing work (wiring a producer, picking a wrapper, settling a value), or — when nothing can close it — surrendered: written into the final draft as a known, labelled gap rather than silently dropped or fabricated around.
+
+The distinction matters because a "questions for a human" framing leaks an operator's personal interaction style into a tool meant to run inside anyone's harness. The ledger must behave identically cast into a fresh harness with no ambient configuration; that holds only because every obligation is **materialized in the artifact**, never carried as operator habit.
+
+## Entry shape (v1, loose)
+
+Like the `_plan_*` family in [[galaxy-workflow-draft-format]], ledger entries are intentionally low-ceremony for v1 — enough structure to count and close, no contract pretending to be machine-parameterizable yet. A reasonable per-entry shape:
+
+```yaml
+- id: sccmec-evidence-missing
+  status: open                # open | resolved | surrendered
+  raised_by: implement-galaxy-tool-step   # Mold that appended it
+  step: classify_context       # draft step the obligation attaches to (if any)
+  unmet: "SCCmec-region candidate output category"
+  missing: "no wired input carries SCCmec cassette evidence"
+  resolved_by: null            # Mold that closed it, once closed
+  note: ""                     # how it was closed or why surrendered
+```
+
+Provenance (`raised_by`, `resolved_by`) is the audit trail for *when* each obligation entered and left — the traceability #281 asked for, and the evidence the convergence gate reads.
+
+## Role in topology repair
+
+In the Galaxy per-step loop, the ledger is the substrate the topology-repair escalation rides on (see [[galaxy-workflow-draft-format]] and [[repair-galaxy-draft-topology]]):
+
+- **[[implement-galaxy-tool-step]]** detects, mid-implementation, that a declared step output cannot be computed from its wired inputs — a defect invisible to `gxwf` structural validation, because the connection graph knows ports connect, not what they contain. Rather than fabricate, it appends a blocking entry and falls through to repair.
+- **[[repair-galaxy-draft-topology]]** reads the open blocking entries, re-wires the affected region (template-tier authoring — one step or a small sub-path), and marks each entry it closes `resolved`; the existing discover-or-author → implement machinery then realizes the new steps.
+- The loop's **decreasing-blocker invariant** counts open blocking entries: each repair escalation must strictly reduce that count, under a hard cap on escalations. When the cap is hit with entries still open, those entries are **surrendered** into the final draft — the clean terminal that replaces spin-or-fabricate.
+
+So the ledger is not a convenience here; it is the countable state the termination guard depends on.
+
+## Escalation budget (loop-level state)
+
+The decreasing-blocker invariant needs more than the entries themselves: "strictly reduce the open count, under a hard cap" is *loop-level* state — it spans iterations and belongs to no single entry. The ledger carries it in a small `topology_repair` header beside the `entries:` list:
+
+```yaml
+topology_repair:
+  escalations: 2           # repairs invoked this run
+  cap: 5                   # hard ceiling; at cap, still-open entries are surrendered
+  open_history: [4, 3, 2]  # open blocking-entry count after each escalation — must be strictly decreasing
+entries:
+  - id: sccmec-evidence-missing
+    status: open
+    # … per-entry shape above
+```
+
+- `escalations` — how many times [[advance-galaxy-draft-step]] has escalated to [[repair-galaxy-draft-topology]] this run. The orchestrator increments it on each escalation.
+- `cap` — the hard ceiling. When `escalations` reaches `cap`, the loop stops escalating and surrenders any still-`open` blocking entries into the final draft as labelled gaps rather than retrying forever.
+- `open_history` — the open blocking-entry count recorded after each escalation. The convergence gate requires it to be strictly decreasing: a repair that fails to lower the open count — or raises it by inserting a producer that is itself uncomputable — is non-convergent and trips the gate immediately, without waiting for the cap.
+
+This block lives in the ledger as a v1 expedient: the ledger is already the carried, cast-visible state the loop reads each iteration. Its better long-term home is the **draft itself** — a workflow-level annotation that travels with the artifact it bounds, so the budget survives even when the ledger is stripped at the terminal. Recorded here for now; migrate when the draft grows a home for it.
+
+## Threaded through the whole design tier
+
+The ledger is not loop-only. It is a single artifact every design-tier Mold in the source→Galaxy pipelines **consumes and re-emits** — the interface, reference-data, data-flow, IWC-comparison, and template Molds (`*-summary-to-galaxy-interface`, `*-summary-to-galaxy-data-flow`, `*-summary-to-galaxy-reference-data`, `compare-against-iwc-exemplar`, `*-summary-to-galaxy-template`). The first design Mold in a run creates it; each subsequent Mold reads the open entries, **appends** the unknowns it newly surfaces, and **marks resolved** the ones its own decisions close (the template settling a topology choice the data-flow left open, the interface pinning a parameter, …). This is the direct answer to #281: the chain stops re-deriving the same unknowns because each Mold inherits them.
+
+The template Mold's computability review pass is one notable appender — `*-summary-to-galaxy-template` re-reads each settled step and, where an output needs evidence no input carries, wires the producer or records the gap as a blocking entry. Source-summary Molds upstream of the design tier keep their own free-text open-questions; the design tier is where those formalize into the ledger.
+
+## Open work
+
+- Decide whether entry structure should harden (typed `unmet` / `missing`, links back to source-summary evidence, machine-checkable `status` transitions) once two or three worked runs exercise it.
+- Decide whether the source-summary Molds should also emit structured entries, or keep their free-text open-questions until the design tier formalizes them.
+- Specify how surrendered entries surface in the runnable gxformat2 (a workflow-level annotation, a report output, or a sidecar) when the draft is stripped of `_plan_*` and TODO sentinels.
+- Move the `topology_repair` escalation budget out of the ledger and into the draft (a workflow-level annotation) so it travels with the artifact it bounds; the ledger home is a v1 expedient.

--- a/casts/claude/skills/repair-galaxy-draft-topology/references/patterns/galaxy-collection-patterns.md
+++ b/casts/claude/skills/repair-galaxy-draft-topology/references/patterns/galaxy-collection-patterns.md
@@ -1,0 +1,92 @@
+---
+type: pattern
+pattern_kind: moc
+evidence: corpus-observed
+title: "Galaxy: collection patterns"
+aliases:
+  - "Galaxy collection pattern MOC"
+  - "collection transformation patterns"
+  - "IWC collection pattern map"
+tags:
+  - pattern
+  - target/galaxy
+  - topic/galaxy-transform
+  - topic/collection-transform
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+summary: "Use this MOC to choose corpus-grounded Galaxy collection transformation patterns."
+related_notes:
+  - "[[iwc-transformations-survey]]"
+  - "[[iwc-conditionals-survey]]"
+related_patterns:
+  - "[[manifest-to-mapped-collection-lifecycle]]"
+  - "[[cleanup-sync-and-publish-nonempty-results]]"
+  - "[[reshape-relabel-remap-by-collection-axis]]"
+  - "[[fan-in-bundle-consume-and-flatten]]"
+  - "[[collection-cleanup-after-mapover-failure]]"
+  - "[[sync-collections-by-identifier]]"
+  - "[[harmonize-by-sortlist-from-identifiers]]"
+  - "[[regex-relabel-via-tabular]]"
+  - "[[relabel-via-rules-and-find-replace]]"
+  - "[[collection-swap-nesting-with-apply-rules]]"
+  - "[[collection-split-identifier-via-rules]]"
+  - "[[collection-build-list-paired-with-apply-rules]]"
+  - "[[tabular-to-collection-by-row]]"
+  - "[[tabular-concatenate-collection-to-table]]"
+  - "[[tabular-pivot-collection-to-wide]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+  - "[[nextflow-summary-to-galaxy-data-flow]]"
+  - "[[cwl-summary-to-galaxy-data-flow]]"
+  - "[[nextflow-summary-to-galaxy-template]]"
+  - "[[cwl-summary-to-galaxy-template]]"
+  - "[[freeform-summary-to-galaxy-template]]"
+  - "[[compare-against-iwc-exemplar]]"
+---
+
+# Galaxy: collection patterns
+
+This is the runtime-facing map for Galaxy collection transformation choices. Use it before loading raw survey notes. The survey remains evidence backing; the operation and recipe pages are the actionable references.
+
+## Cleanup
+
+- [[collection-cleanup-after-mapover-failure]] — use `__FILTER_EMPTY_DATASETS__` or `__FILTER_FAILED_DATASETS__` after map-over when empty or errored elements would break downstream steps.
+- [[collection-unbox-singleton]] — use `__EXTRACT_DATASET__` with `which: first` when a known one-element collection must become a dataset.
+
+## Map-over Lifecycle Recipes
+
+- [[manifest-to-mapped-collection-lifecycle]] — build collection elements from manifest/table rows, map a tool over them, then relabel or reshape outputs.
+- [[cleanup-sync-and-publish-nonempty-results]] — clean sparse mapped outputs, sync siblings from surviving identifiers, then gate final reports.
+- [[reshape-relabel-remap-by-collection-axis]] — correct the mapped axis after domain fan-out using Apply Rules and deterministic relabeling.
+- [[fan-in-bundle-consume-and-flatten]] — bundle parallel outputs for a collection consumer, then flatten or aggregate results.
+
+## Identifiers
+
+- [[sync-collections-by-identifier]] — membership sync: extract identifiers from one collection and filter or relabel a sibling collection.
+- [[harmonize-by-sortlist-from-identifiers]] — order sync: sort one sibling collection by another collection's identifier order.
+- [[regex-relabel-via-tabular]] — label rewrite: derive new element identifiers in tabular form and apply them with `__RELABEL_FROM_FILE__`.
+- [[relabel-via-rules-and-find-replace]] — relabel inside a structural reshape, currently grounded in the influenza fan-out pattern.
+
+## Structural Reshape
+
+- [[collection-flatten-after-fanout]] — collapse nested collection output to a flat list when the outer axis no longer matters.
+- [[collection-build-named-bundle]] — assemble individual outputs into a named collection bundle for publishing or downstream fan-in.
+- [[collection-swap-nesting-with-apply-rules]] — use Apply Rules to swap `list:list` axes.
+- [[collection-split-identifier-via-rules]] — use Apply Rules regex columns to derive nested list identifiers from one identifier string.
+- [[collection-build-list-paired-with-apply-rules]] — use Apply Rules to promote identifier columns into `list:paired` structure.
+
+## Bridges
+
+- [[tabular-to-collection-by-row]] — split a tabular manifest/list into collection elements for map-over.
+- [[tabular-concatenate-collection-to-table]] — row-bind a collection of tabular outputs into one table.
+- [[tabular-pivot-collection-to-wide]] — outer-join a collection of id/value tabulars into one wide table.
+
+## See also
+
+- [[iwc-transformations-survey]] — collection-transform survey and evidence trail.
+- [[galaxy-tabular-patterns]] — companion MOC for tabular operations.
+- [[galaxy-interval-patterns]] — companion MOC for coordinate-feature operations.
+- [[galaxy-sequence-patterns]] — companion MOC for sequence-record operations.

--- a/casts/claude/skills/repair-galaxy-draft-topology/references/patterns/galaxy-tabular-patterns.md
+++ b/casts/claude/skills/repair-galaxy-draft-topology/references/patterns/galaxy-tabular-patterns.md
@@ -1,0 +1,83 @@
+---
+type: pattern
+pattern_kind: moc
+evidence: corpus-observed
+title: "Galaxy: tabular patterns"
+aliases:
+  - "Galaxy tabular pattern MOC"
+  - "tabular transformation patterns"
+  - "IWC tabular pattern map"
+tags:
+  - pattern
+  - target/galaxy
+  - topic/galaxy-transform
+  - topic/tabular-transform
+status: draft
+created: 2026-05-02
+revised: 2026-05-02
+revision: 1
+ai_generated: true
+summary: "Use this MOC to choose corpus-grounded Galaxy tabular transformation patterns."
+related_notes:
+  - "[[iwc-tabular-operations-survey]]"
+related_patterns:
+  - "[[tabular-filter-by-column-value]]"
+  - "[[tabular-filter-by-regex]]"
+  - "[[tabular-cut-and-reorder-columns]]"
+  - "[[tabular-compute-new-column]]"
+  - "[[tabular-join-on-key]]"
+  - "[[tabular-group-and-aggregate-with-datamash]]"
+  - "[[tabular-sql-query]]"
+  - "[[tabular-prepend-header]]"
+  - "[[tabular-synthesize-bed-from-3col]]"
+  - "[[tabular-split-taxonomy-string]]"
+  - "[[tabular-relabel-by-row-counter]]"
+  - "[[tabular-to-collection-by-row]]"
+  - "[[tabular-concatenate-collection-to-table]]"
+  - "[[tabular-pivot-collection-to-wide]]"
+related_molds:
+  - "[[implement-galaxy-tool-step]]"
+  - "[[nextflow-summary-to-galaxy-data-flow]]"
+  - "[[cwl-summary-to-galaxy-data-flow]]"
+  - "[[nextflow-summary-to-galaxy-template]]"
+  - "[[cwl-summary-to-galaxy-template]]"
+  - "[[freeform-summary-to-galaxy-template]]"
+  - "[[compare-against-iwc-exemplar]]"
+---
+
+# Galaxy: tabular patterns
+
+This is the runtime-facing map for Galaxy tabular transformation choices. Use it before loading raw survey notes. The survey remains evidence backing; the operation pages are the actionable references.
+
+## Row And Column Operations
+
+- [[tabular-filter-by-column-value]] — keep/drop rows by string column value with `Filter1`.
+- [[tabular-filter-by-regex]] — keep/drop rows by regex or pattern matching.
+- [[tabular-cut-and-reorder-columns]] — project and reorder columns with `Cut1`.
+- [[tabular-compute-new-column]] — compute row-wise values into a new column.
+
+## Joins And Aggregation
+
+- [[tabular-join-on-key]] — join two tabular datasets by key columns.
+- [[tabular-group-and-aggregate-with-datamash]] — group and aggregate rows with `datamash_ops`.
+- [[tabular-sql-query]] — use SQL when filtering, joining, and projection are clearer as one query.
+
+## Text-Processing Recipes
+
+- [[tabular-prepend-header]] — add a header row with an awk/text-processing step.
+- [[tabular-synthesize-bed-from-3col]] — build BED from three-column tabular inputs.
+- [[tabular-split-taxonomy-string]] — split taxonomy-like strings into useful columns.
+- [[tabular-relabel-by-row-counter]] — synthesize row labels from row order.
+
+## Bridges
+
+- [[tabular-to-collection-by-row]] — split a tabular manifest/list into collection elements for map-over.
+- [[tabular-concatenate-collection-to-table]] — row-bind a collection of tabular outputs into one table.
+- [[tabular-pivot-collection-to-wide]] — outer-join a collection of id/value tabulars into one wide table.
+
+## See also
+
+- [[iwc-tabular-operations-survey]] — tabular-operation survey and evidence trail.
+- [[galaxy-sequence-patterns]] — companion MOC for sequence-record operations; FASTA↔tabular is the dominant sequence seam.
+- [[galaxy-interval-patterns]] — companion MOC for coordinate-feature operations.
+- [[galaxy-collection-patterns]] — companion MOC for collection operations.

--- a/casts/claude/skills/repair-galaxy-draft-topology/references/schemas/galaxy-workflow-draft.schema.json
+++ b/casts/claude/skills/repair-galaxy-draft-topology/references/schemas/galaxy-workflow-draft.schema.json
@@ -1,0 +1,2727 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "WorkflowStepSchema": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "id": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "label": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "doc": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "position": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "object",
+              "required": [
+                "top",
+                "left"
+              ],
+              "properties": {
+                "top": {
+                  "type": "number"
+                },
+                "left": {
+                  "type": "number"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "tool_id": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "tool_shed_repository": {
+          "$ref": "#/$defs/Shared15"
+        },
+        "tool_version": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "errors": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "uuid": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "in": {
+          "$ref": "#/$defs/Shared16"
+        },
+        "out": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/Shared4"
+              }
+            },
+            {
+              "type": "object",
+              "required": [],
+              "properties": {},
+              "additionalProperties": {
+                "$ref": "#/$defs/Shared4"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "state": {
+          "anyOf": [
+            {
+              "type": "object",
+              "required": [],
+              "properties": {},
+              "additionalProperties": {
+                "title": "unknown"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tool_state": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "required": [],
+              "properties": {},
+              "additionalProperties": {
+                "title": "unknown"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "post_job_actions": {
+          "anyOf": [
+            {
+              "type": "object",
+              "required": [],
+              "properties": {},
+              "additionalProperties": {
+                "title": "unknown"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "type": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "enum": [
+                "tool",
+                "subworkflow",
+                "pause",
+                "pick_value"
+              ]
+            }
+          ]
+        },
+        "run": {
+          "$ref": "#/$defs/Shared0"
+        },
+        "runtime_inputs": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "when": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Shared0": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "class": {
+              "enum": [
+                "GalaxyWorkflow"
+              ],
+              "type": "string"
+            },
+            "comments": {
+              "anyOf": [
+                {
+                  "items": {
+                    "$ref": "#/$defs/Shared2"
+                  },
+                  "type": "array"
+                },
+                {
+                  "additionalProperties": {
+                    "$ref": "#/$defs/Shared2"
+                  },
+                  "properties": {},
+                  "required": [],
+                  "type": "object"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "creator": {
+              "$ref": "#/$defs/Shared6"
+            },
+            "doc": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              ]
+            },
+            "id": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "inputs": {
+              "$ref": "#/$defs/Shared1"
+            },
+            "label": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "license": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "outputs": {
+              "$ref": "#/$defs/Shared14"
+            },
+            "release": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "report": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "markdown": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "markdown"
+                  ],
+                  "type": "object"
+                }
+              ]
+            },
+            "steps": {
+              "anyOf": [
+                {
+                  "items": {
+                    "$ref": "#/$defs/WorkflowStepSchema"
+                  },
+                  "type": "array"
+                },
+                {
+                  "additionalProperties": {
+                    "$ref": "#/$defs/WorkflowStepSchema"
+                  },
+                  "properties": {},
+                  "required": [],
+                  "type": "object"
+                }
+              ]
+            },
+            "tags": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "uuid": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "required": [
+            "inputs",
+            "outputs",
+            "class",
+            "steps"
+          ],
+          "type": "object"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "additionalProperties": {
+            "title": "unknown"
+          },
+          "properties": {},
+          "required": [],
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "Shared1": {
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Shared11"
+              },
+              {
+                "$ref": "#/$defs/Shared5"
+              },
+              {
+                "$ref": "#/$defs/Shared10"
+              },
+              {
+                "$ref": "#/$defs/Shared12"
+              },
+              {
+                "$ref": "#/$defs/Shared8"
+              },
+              {
+                "$ref": "#/$defs/Shared13"
+              }
+            ]
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Shared11"
+              },
+              {
+                "$ref": "#/$defs/Shared5"
+              },
+              {
+                "$ref": "#/$defs/Shared10"
+              },
+              {
+                "$ref": "#/$defs/Shared12"
+              },
+              {
+                "$ref": "#/$defs/Shared8"
+              },
+              {
+                "$ref": "#/$defs/Shared13"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "properties": {},
+          "required": [],
+          "type": "object"
+        },
+        {
+          "additionalProperties": {
+            "title": "unknown"
+          },
+          "properties": {},
+          "required": [],
+          "type": "object"
+        }
+      ]
+    },
+    "Shared2": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "bold": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
+            },
+            "color": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "italic": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
+            },
+            "label": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "position": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "size": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "text": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "text_size": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "number"
+                }
+              ]
+            },
+            "type": {
+              "enum": [
+                "text"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "color": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "label": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "position": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "size": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "text": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "type": {
+              "enum": [
+                "markdown"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "color": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "contains_comments": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
+                  },
+                  "type": "array"
+                }
+              ]
+            },
+            "contains_steps": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
+                  },
+                  "type": "array"
+                }
+              ]
+            },
+            "label": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "position": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "size": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "title": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "type": {
+              "enum": [
+                "frame"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "color": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "label": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "line": {
+              "anyOf": [
+                {
+                  "items": {
+                    "items": {
+                      "type": "number"
+                    },
+                    "type": "array"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "position": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "size": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "thickness": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "number"
+                }
+              ]
+            },
+            "type": {
+              "enum": [
+                "freehand"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "Shared3": {
+      "additionalProperties": false,
+      "properties": {
+        "_plan_context": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "_plan_in": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "_plan_out": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "_plan_state": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "doc": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "errors": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "id": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "in": {
+          "$ref": "#/$defs/Shared16"
+        },
+        "label": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "out": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/Shared4"
+              },
+              "type": "array"
+            },
+            {
+              "additionalProperties": {
+                "$ref": "#/$defs/Shared4"
+              },
+              "properties": {},
+              "required": [],
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "position": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "left": {
+                  "type": "number"
+                },
+                "top": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "top",
+                "left"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "post_job_actions": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "title": "unknown"
+              },
+              "properties": {},
+              "required": [],
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "run": {
+          "$ref": "#/$defs/Shared0"
+        },
+        "runtime_inputs": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "state": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "title": "unknown"
+              },
+              "properties": {},
+              "required": [],
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tool_id": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "tool_shed_repository": {
+          "$ref": "#/$defs/Shared15"
+        },
+        "tool_state": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "additionalProperties": {
+                "title": "unknown"
+              },
+              "properties": {},
+              "required": [],
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tool_version": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "type": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "enum": [
+                "tool",
+                "subworkflow",
+                "pause",
+                "pick_value"
+              ],
+              "type": "string"
+            }
+          ]
+        },
+        "uuid": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "when": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "required": [],
+      "type": "object"
+    },
+    "Shared4": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "add_tags": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              ]
+            },
+            "change_datatype": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "delete_intermediate_datasets": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
+            },
+            "hide": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
+            },
+            "id": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "remove_tags": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              ]
+            },
+            "rename": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "set_columns": {
+              "anyOf": [
+                {
+                  "additionalProperties": {
+                    "title": "unknown"
+                  },
+                  "properties": {},
+                  "required": [],
+                  "type": "object"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [],
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "Shared5": {
+      "additionalProperties": false,
+      "properties": {
+        "collection_type": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "column_definitions": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "default_value": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "boolean"
+                      }
+                    ]
+                  },
+                  "description": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "optional": {
+                    "type": "boolean"
+                  },
+                  "restrictions": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "boolean"
+                            }
+                          ]
+                        },
+                        "type": "array"
+                      }
+                    ]
+                  },
+                  "suggestions": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "boolean"
+                            }
+                          ]
+                        },
+                        "type": "array"
+                      }
+                    ]
+                  },
+                  "type": {
+                    "enum": [
+                      "string",
+                      "int",
+                      "float",
+                      "boolean",
+                      "element_identifier"
+                    ],
+                    "type": "string"
+                  },
+                  "validators": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "items": {
+                          "title": "unknown"
+                        },
+                        "type": "array"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "name",
+                  "type",
+                  "optional"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "default": {
+          "title": "unknown"
+        },
+        "doc": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "fields": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "format": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "File",
+                          "null",
+                          "boolean",
+                          "int",
+                          "float",
+                          "string"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "items": {
+                          "enum": [
+                            "File",
+                            "null",
+                            "boolean",
+                            "int",
+                            "float",
+                            "string"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "name",
+                  "type"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "format": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "id": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "label": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "optional": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "position": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "left": {
+                  "type": "number"
+                },
+                "top": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "top",
+                "left"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "collection"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "Shared6": {
+      "anyOf": [
+        {
+          "items": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "address": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "alternateName": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "class": {
+                    "enum": [
+                      "Person"
+                    ],
+                    "type": "string"
+                  },
+                  "email": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "familyName": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "faxNumber": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "givenName": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "honorificPrefix": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "honorificSuffix": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "identifier": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "image": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "jobTitle": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "name": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "telephone": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "url": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "class"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "address": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "alternateName": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "class": {
+                    "enum": [
+                      "Organization"
+                    ],
+                    "type": "string"
+                  },
+                  "email": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "faxNumber": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "identifier": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "image": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "name": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "telephone": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "url": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "class"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "Shared7": {
+      "additionalProperties": false,
+      "properties": {
+        "doc": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "id": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "label": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "outputSource": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "type": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "enum": [
+                "null",
+                "boolean",
+                "int",
+                "long",
+                "float",
+                "double",
+                "string",
+                "integer",
+                "text",
+                "File",
+                "data",
+                "collection"
+              ],
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "required": [],
+      "type": "object"
+    },
+    "Shared8": {
+      "additionalProperties": false,
+      "properties": {
+        "default": {
+          "title": "unknown"
+        },
+        "doc": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "id": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "label": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "optional": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "position": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "left": {
+                  "type": "number"
+                },
+                "top": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "top",
+                "left"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "restrictOnConnections": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "boolean"
+            }
+          ]
+        },
+        "restrictions": {
+          "$ref": "#/$defs/Shared17"
+        },
+        "suggestions": {
+          "$ref": "#/$defs/Shared17"
+        },
+        "type": {
+          "enum": [
+            "text",
+            "string"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "Shared9": {
+      "additionalProperties": false,
+      "properties": {
+        "default": {
+          "title": "unknown"
+        },
+        "id": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "label": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "source": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
+        }
+      },
+      "required": [],
+      "type": "object"
+    },
+    "Shared10": {
+      "additionalProperties": false,
+      "properties": {
+        "default": {
+          "title": "unknown"
+        },
+        "doc": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "id": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "label": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "optional": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "position": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "left": {
+                  "type": "number"
+                },
+                "top": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "top",
+                "left"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "integer",
+            "int"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "Shared11": {
+      "additionalProperties": false,
+      "properties": {
+        "default": {
+          "title": "unknown"
+        },
+        "doc": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "format": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "id": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "label": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "optional": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "position": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "left": {
+                  "type": "number"
+                },
+                "top": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "top",
+                "left"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "type": {
+          "anyOf": [
+            {
+              "enum": [
+                "data",
+                "File"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [],
+      "type": "object"
+    },
+    "Shared12": {
+      "additionalProperties": false,
+      "properties": {
+        "default": {
+          "title": "unknown"
+        },
+        "doc": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "id": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "label": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "min": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "optional": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "position": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "left": {
+                  "type": "number"
+                },
+                "top": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "top",
+                "left"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "float"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "Shared13": {
+      "additionalProperties": false,
+      "properties": {
+        "default": {
+          "title": "unknown"
+        },
+        "doc": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "id": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "label": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "optional": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "position": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "left": {
+                  "type": "number"
+                },
+                "top": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "top",
+                "left"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "boolean"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "Shared14": {
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/Shared7"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Shared7"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "properties": {},
+          "required": [],
+          "type": "object"
+        },
+        {
+          "additionalProperties": {
+            "title": "unknown"
+          },
+          "properties": {},
+          "required": [],
+          "type": "object"
+        }
+      ]
+    },
+    "Shared15": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "changeset_revision": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "owner": {
+              "type": "string"
+            },
+            "tool_shed": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "changeset_revision",
+            "owner",
+            "tool_shed"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "Shared16": {
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/Shared9"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Shared9"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            ]
+          },
+          "properties": {},
+          "required": [],
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "Shared17": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "label": {
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "value"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          "type": "array"
+        }
+      ]
+    }
+  },
+  "type": "object",
+  "required": [
+    "inputs",
+    "outputs",
+    "class",
+    "steps"
+  ],
+  "properties": {
+    "id": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "label": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "doc": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "inputs": {
+      "$ref": "#/$defs/Shared1"
+    },
+    "outputs": {
+      "$ref": "#/$defs/Shared14"
+    },
+    "uuid": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "class": {
+      "type": "string",
+      "enum": [
+        "GalaxyWorkflowDraft"
+      ]
+    },
+    "steps": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Shared3"
+          }
+        },
+        {
+          "type": "object",
+          "required": [],
+          "properties": {},
+          "additionalProperties": {
+            "$ref": "#/$defs/Shared3"
+          }
+        }
+      ]
+    },
+    "report": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "required": [
+            "markdown"
+          ],
+          "properties": {
+            "markdown": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "tags": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "comments": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Shared2"
+          }
+        },
+        {
+          "type": "object",
+          "required": [],
+          "properties": {},
+          "additionalProperties": {
+            "$ref": "#/$defs/Shared2"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "creator": {
+      "$ref": "#/$defs/Shared6"
+    },
+    "license": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "release": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false
+}

--- a/casts/claude/skills/summarize-cwl-tool/SKILL.md
+++ b/casts/claude/skills/summarize-cwl-tool/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: summarize-cwl-tool
+description: "Derive a CommandLineTool description (container, baseCommand, IO) for a CWL target."
+---
+
+# summarize-cwl-tool
+
+Follow the procedure below and use the artifact/reference sections as the runtime contract.
+
+## When To Use
+
+- Derive a CommandLineTool description (container, baseCommand, IO) for a CWL target.
+
+## Inputs
+
+- No upstream artifact inputs declared. See the procedure for user-supplied runtime inputs.
+
+## Outputs
+
+- Write artifact `cwl-tool-summary` as `cwl-tool-summary.json`. Format: `json`. Compact CWL CommandLineTool summary: container, baseCommand, inputs, outputs, requirements, version metadata.
+
+## Required Tools
+
+- None declared. Procedure should not assume external CLIs are present.
+
+## Load Upfront
+
+- None declared.
+
+## Load On Demand
+
+- None declared.
+
+## Validation
+
+- None declared.
+
+## Procedure
+
+Read a tool's container, `baseCommand`, and IO evidence and emit a compact CWL CommandLineTool summary — container, baseCommand, inputs, outputs, requirements, and version metadata.
+
+## Runtime Notes
+
+- Do not read Foundry source files at runtime; use only files packaged in this skill bundle and user-supplied artifacts.
+- Preserve declared artifact filenames unless the user or harness supplies explicit paths.
+- Carry unresolved assumptions into the output artifact instead of silently inventing missing source evidence.

--- a/casts/claude/skills/summarize-cwl-tool/_provenance.json
+++ b/casts/claude/skills/summarize-cwl-tool/_provenance.json
@@ -1,0 +1,24 @@
+{
+  "provenance_schema_version": 3,
+  "cast_target": "claude",
+  "mold": {
+    "name": "summarize-cwl-tool",
+    "path": "content/molds/summarize-cwl-tool/index.md",
+    "revision": 2,
+    "content_hash": "75b3eaee693cac227b58e17d65f23de1e9bec7b8a5cb668d70fa9f9048235d3a",
+    "commit": "e487fe785f468afdf25f2b6bd140c3a115a12021"
+  },
+  "cast_at": "2026-07-24T13:51:18.092Z",
+  "refs": [],
+  "artifacts": {
+    "produces": [
+      {
+        "id": "cwl-tool-summary",
+        "kind": "json",
+        "default_filename": "cwl-tool-summary.json",
+        "description": "Compact CWL CommandLineTool summary: container, baseCommand, inputs, outputs, requirements, version metadata."
+      }
+    ],
+    "consumes": []
+  }
+}

--- a/casts/claude/skills/summarize-cwl-tool/_verify.json
+++ b/casts/claude/skills/summarize-cwl-tool/_verify.json
@@ -1,0 +1,4 @@
+{
+  "verify_schema_version": 1,
+  "entries": []
+}

--- a/casts/claude/skills/summarize-paper/SKILL.md
+++ b/casts/claude/skills/summarize-paper/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: summarize-paper
+description: "Extract methods, tools, sample data, and references from a paper."
+---
+
+# summarize-paper
+
+Follow the procedure below and use the artifact/reference sections as the runtime contract.
+
+## When To Use
+
+- Extract methods, tools, sample data, and references from a paper.
+
+## Inputs
+
+- No upstream artifact inputs declared. See the procedure for user-supplied runtime inputs.
+
+## Outputs
+
+- Write artifact `freeform-summary` as `freeform-summary.md`. Format: `markdown`. Methods, tools, sample data, references, and workflow intent extracted from a primary paper, normalized into the shared free-form source summary handoff.
+
+## Required Tools
+
+- None declared. Procedure should not assume external CLIs are present.
+
+## Load Upfront
+
+- None declared.
+
+## Load On Demand
+
+- None declared.
+
+## Validation
+
+- None declared.
+
+## Procedure
+
+Read a methods/tool paper and emit a free-form Markdown summary capturing the workflow's steps, tools, parameters, and sample/reference-data leads.
+
+Emit the same `freeform-summary` artifact shape used by interview-derived sources so downstream freeform-summary skills can operate on paper and interview starts without splitting the design/template tier.
+
+## Runtime Notes
+
+- Do not read Foundry source files at runtime; use only files packaged in this skill bundle and user-supplied artifacts.
+- Preserve declared artifact filenames unless the user or harness supplies explicit paths.
+- Carry unresolved assumptions into the output artifact instead of silently inventing missing source evidence.

--- a/casts/claude/skills/summarize-paper/_provenance.json
+++ b/casts/claude/skills/summarize-paper/_provenance.json
@@ -1,0 +1,24 @@
+{
+  "provenance_schema_version": 3,
+  "cast_target": "claude",
+  "mold": {
+    "name": "summarize-paper",
+    "path": "content/molds/summarize-paper/index.md",
+    "revision": 2,
+    "content_hash": "1e82e242caa7db18217cb489a6d16b5fe23c4a9a32578f7dbb0ebad229de73ec",
+    "commit": "e487fe785f468afdf25f2b6bd140c3a115a12021"
+  },
+  "cast_at": "2026-07-24T13:51:18.702Z",
+  "refs": [],
+  "artifacts": {
+    "produces": [
+      {
+        "id": "freeform-summary",
+        "kind": "markdown",
+        "default_filename": "freeform-summary.md",
+        "description": "Methods, tools, sample data, references, and workflow intent extracted from a primary paper, normalized into the shared free-form source summary handoff."
+      }
+    ],
+    "consumes": []
+  }
+}

--- a/casts/claude/skills/summarize-paper/_verify.json
+++ b/casts/claude/skills/summarize-paper/_verify.json
@@ -1,0 +1,4 @@
+{
+  "verify_schema_version": 1,
+  "entries": []
+}

--- a/casts/claude/skills/summary-to-cwl-template/SKILL.md
+++ b/casts/claude/skills/summary-to-cwl-template/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: summary-to-cwl-template
+description: "CWL Workflow skeleton with per-step TODOs from source and design handoffs."
+---
+
+# summary-to-cwl-template
+
+Follow the procedure below and use the artifact/reference sections as the runtime contract.
+
+## When To Use
+
+- CWL Workflow skeleton with per-step TODOs from source and design handoffs.
+
+## Inputs
+
+- No upstream artifact inputs declared. See the procedure for user-supplied runtime inputs.
+
+## Outputs
+
+- Write artifact `cwl-workflow-draft` as `cwl-workflow-draft.cwl`. Format: `yaml`. CWL Workflow skeleton: inputs, outputs, placeholder steps, rough connections, TODO slots for later implementation Molds.
+
+## Required Tools
+
+- None declared. Procedure should not assume external CLIs are present.
+
+## Load Upfront
+
+- None declared.
+
+## Load On Demand
+
+- None declared.
+
+## Validation
+
+- None declared.
+
+## Procedure
+
+Read the original source artifact, the source summary, and all prior source-target design handoffs from the pipeline run. Emit a CWL Workflow skeleton with inputs, outputs, placeholder steps, rough connections, and TODO slots for later implementation skills.
+
+The interface and data-flow briefs guide the skeleton, but they do not replace source evidence. Treat the prior-step index as the working context: source summary, interface brief, data-flow brief or freeform design brief, and any open questions carried forward.
+
+## Runtime Notes
+
+- Do not read Foundry source files at runtime; use only files packaged in this skill bundle and user-supplied artifacts.
+- Preserve declared artifact filenames unless the user or harness supplies explicit paths.
+- Carry unresolved assumptions into the output artifact instead of silently inventing missing source evidence.

--- a/casts/claude/skills/summary-to-cwl-template/_provenance.json
+++ b/casts/claude/skills/summary-to-cwl-template/_provenance.json
@@ -1,0 +1,24 @@
+{
+  "provenance_schema_version": 3,
+  "cast_target": "claude",
+  "mold": {
+    "name": "summary-to-cwl-template",
+    "path": "content/molds/summary-to-cwl-template/index.md",
+    "revision": 2,
+    "content_hash": "a2ab7a1706812d8501af7f65334002f292d5c762178a07bd9145ab2bfee4714e",
+    "commit": "e487fe785f468afdf25f2b6bd140c3a115a12021"
+  },
+  "cast_at": "2026-07-24T13:51:19.347Z",
+  "refs": [],
+  "artifacts": {
+    "produces": [
+      {
+        "id": "cwl-workflow-draft",
+        "kind": "yaml",
+        "default_filename": "cwl-workflow-draft.cwl",
+        "description": "CWL Workflow skeleton: inputs, outputs, placeholder steps, rough connections, TODO slots for later implementation Molds."
+      }
+    ],
+    "consumes": []
+  }
+}

--- a/casts/claude/skills/summary-to-cwl-template/_verify.json
+++ b/casts/claude/skills/summary-to-cwl-template/_verify.json
@@ -1,0 +1,4 @@
+{
+  "verify_schema_version": 1,
+  "entries": []
+}

--- a/casts/claude/skills/validate-cwl/SKILL.md
+++ b/casts/claude/skills/validate-cwl/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: validate-cwl
+description: "Run cwltool --validate / schema lint, classify failures, recommend fixes."
+---
+
+# validate-cwl
+
+Follow the procedure below and use the artifact/reference sections as the runtime contract.
+
+## When To Use
+
+- Run cwltool --validate / schema lint, classify failures, recommend fixes.
+
+## Inputs
+
+- No upstream artifact inputs declared. See the procedure for user-supplied runtime inputs.
+
+## Outputs
+
+- None declared.
+
+## Required Tools
+
+- None declared. Procedure should not assume external CLIs are present.
+
+## Load Upfront
+
+- None declared.
+
+## Load On Demand
+
+- None declared.
+
+## Validation
+
+- None declared.
+
+## Procedure
+
+Run `cwltool --validate` and schema lint over the assembled CWL workflow, classify each diagnostic, and recommend a concrete fix — routing failures back to the authoring step that owns them.
+
+## Runtime Notes
+
+- Do not read Foundry source files at runtime; use only files packaged in this skill bundle and user-supplied artifacts.
+- Preserve declared artifact filenames unless the user or harness supplies explicit paths.
+- Carry unresolved assumptions into the output artifact instead of silently inventing missing source evidence.

--- a/casts/claude/skills/validate-cwl/_provenance.json
+++ b/casts/claude/skills/validate-cwl/_provenance.json
@@ -1,0 +1,13 @@
+{
+  "provenance_schema_version": 3,
+  "cast_target": "claude",
+  "mold": {
+    "name": "validate-cwl",
+    "path": "content/molds/validate-cwl/index.md",
+    "revision": 2,
+    "content_hash": "9b74a3cba42368aa4e32f205294ad860a8df3c3c868ed6a3dcd34d78a9613e5d",
+    "commit": "e487fe785f468afdf25f2b6bd140c3a115a12021"
+  },
+  "cast_at": "2026-07-24T13:51:20.266Z",
+  "refs": []
+}

--- a/casts/claude/skills/validate-cwl/_verify.json
+++ b/casts/claude/skills/validate-cwl/_verify.json
@@ -1,0 +1,4 @@
+{
+  "verify_schema_version": 1,
+  "entries": []
+}

--- a/content/Dashboard.md
+++ b/content/Dashboard.md
@@ -23,6 +23,7 @@ Generated from `dashboard_sections.json` and content frontmatter. Do not edit by
 | [[author-galaxy-tool-wrapper]] | Author a new Galaxy user-defined tool YAML definition when discovery yields nothing acceptable. | reviewed | 2026-07-24 | 4 |
 | [[changeset-to-galaxy-test-plan]] | Carry an existing Galaxy workflow's tests forward as a regression baseline and augment them for a change-set's deltas, emitting a Galaxy test plan. | reviewed | 2026-07-24 | 2 |
 | [[compare-against-iwc-exemplar]] | Find nearest IWC exemplar(s) and surface a structural diff against the upstream Galaxy design briefs to guide template authoring. | reviewed | 2026-07-24 | 8 |
+| [[debug-cwl-workflow-output]] | Triage failing CWL run outputs; classify failure modes; propose fixes. | draft | 2026-07-24 | 2 |
 | [[debug-galaxy-workflow-output]] | Triage failing Galaxy run outputs; classify the failure surface and capture evidence before recommending repairs. | reviewed | 2026-07-24 | 5 |
 | [[discover-shed-tool]] | Search the Tool Shed for an existing wrapper, drill from hit to a pinnable changeset, classify candidates, and recommend or fall through. | reviewed | 2026-07-24 | 5 |
 | [[find-test-data]] | Search IWC fixtures and public sources for test data matching a data-flow shape. | reviewed | 2026-07-24 | 3 |
@@ -30,6 +31,8 @@ Generated from `dashboard_sections.json` and content frontmatter. Do not edit by
 | [[freeform-summary-to-galaxy-interface]] | Map a free-form source summary into a Galaxy workflow interface design brief. | reviewed | 2026-07-24 | 2 |
 | [[freeform-summary-to-galaxy-template]] | gxformat2 skeleton with per-step TODOs from a free-form summary and Galaxy design brief. | reviewed | 2026-07-24 | 5 |
 | [[freeform-summary-to-galaxy-test-plan]] | Synthesize a Galaxy workflow test plan from a free-form summary and the Galaxy design briefs. | reviewed | 2026-07-24 | 2 |
+| [[implement-cwl-tool-step]] | Convert an abstract step into a concrete CWL CommandLineTool + step. | draft | 2026-07-24 | 2 |
+| [[implement-cwl-workflow-test]] | Assemble CWL job file(s) and expected-output assertions. | draft | 2026-07-24 | 2 |
 | [[implement-galaxy-tool-step]] | Convert an abstract step into a concrete gxformat2 step using a tool summary. | reviewed | 2026-07-24 | 8 |
 | [[implement-galaxy-workflow-test]] | Assemble Galaxy workflow test fixtures and assertions. | reviewed | 2026-07-24 | 8 |
 | [[interview-to-freeform-summary]] | Normalize a free-form user interview into the shared freeform-summary workflow handoff. | reviewed | 2026-07-24 | 3 |
@@ -40,10 +43,14 @@ Generated from `dashboard_sections.json` and content frontmatter. Do not edit by
 | [[nextflow-summary-to-galaxy-template]] | gxformat2 skeleton with per-step TODOs from a Nextflow summary and prior Galaxy design briefs. | reviewed | 2026-07-24 | 8 |
 | [[nextflow-test-to-galaxy-test-plan]] | Translate Nextflow test evidence into a Galaxy workflow test plan. | reviewed | 2026-07-24 | 5 |
 | [[nextflow-to-test-data]] | Resolve a Nextflow pipeline's own declared test fixtures into Galaxy workflow test-data refs. | reviewed | 2026-07-24 | 2 |
+| [[paper-to-test-data]] | Derive workflow test inputs and expected outputs from a paper. | draft | 2026-07-24 | 2 |
 | [[run-workflow-test]] | Execute a workflow's tests via Planemo; emit structured pass/fail and outputs. | reviewed | 2026-07-24 | 6 |
+| [[summarize-cwl-tool]] | Derive a CommandLineTool description (container, baseCommand, IO) for a CWL target. | draft | 2026-07-24 | 2 |
 | [[summarize-galaxy-tool]] | Pull JSON schema, container, source, inputs/outputs for a Galaxy tool. | reviewed | 2026-07-24 | 8 |
 | [[summarize-galaxy-workflow]] | Read an existing Galaxy gxformat2 (or .ga) workflow and emit a structured summary for interview and change-set steps. | reviewed | 2026-07-24 | 2 |
 | [[summarize-nextflow]] | Read a Nextflow pipeline source tree (nf-core or ad-hoc DSL2) and emit a structured JSON summary for downstream translation Molds. | reviewed | 2026-07-24 | 14 |
+| [[summarize-paper]] | Extract methods, tools, sample data, and references from a paper. | draft | 2026-07-24 | 2 |
+| [[validate-cwl]] | Run cwltool --validate / schema lint, classify failures, recommend fixes. | draft | 2026-07-24 | 2 |
 | [[validate-galaxy-workflow]] | Run terminal gxwf validation on an assembled Galaxy workflow and classify workflow-level failures. | reviewed | 2026-07-24 | 4 |
 | [[cwl-to-test-data]] | Resolve a CWL workflow's own declared test cases into Galaxy workflow test-data refs. | draft | 2026-07-17 | 1 |
 | [[convert-nfcore-module-to-galaxy-tool]] | Convert one nf-core module dir into a Galaxy tool wrapper (tool.xml + macros.xml + _provenance.yml + remote-URL <test> blocks). | draft | 2026-06-19 | 4 |
@@ -58,13 +65,6 @@ Generated from `dashboard_sections.json` and content frontmatter. Do not edit by
 | [[summary-to-cwl-template]] | CWL Workflow skeleton with per-step TODOs from source and design handoffs. | draft | 2026-05-05 | 2 |
 | [[cwl-test-to-galaxy-test-plan]] | Translate CWL test fixtures into a Galaxy workflow test plan. | draft | 2026-05-03 | 2 |
 | [[nextflow-test-to-cwl-test-plan]] | Translate Nextflow test evidence into a CWL workflow test plan. | draft | 2026-05-03 | 1 |
-| [[debug-cwl-workflow-output]] | Triage failing CWL run outputs; classify failure modes; propose fixes. | draft | 2026-04-30 | 1 |
-| [[implement-cwl-tool-step]] | Convert an abstract step into a concrete CWL CommandLineTool + step. | draft | 2026-04-30 | 1 |
-| [[implement-cwl-workflow-test]] | Assemble CWL job file(s) and expected-output assertions. | draft | 2026-04-30 | 1 |
-| [[paper-to-test-data]] | Derive workflow test inputs and expected outputs from a paper. | draft | 2026-04-30 | 1 |
-| [[summarize-cwl-tool]] | Derive a CommandLineTool description (container, baseCommand, IO) for a CWL target. | draft | 2026-04-30 | 1 |
-| [[summarize-paper]] | Extract methods, tools, sample data, and references from a paper. | draft | 2026-04-30 | 1 |
-| [[validate-cwl]] | Run cwltool --validate / schema lint, classify failures, recommend fixes. | draft | 2026-04-30 | 1 |
 
 ## Patterns
 

--- a/content/molds/debug-cwl-workflow-output/index.md
+++ b/content/molds/debug-cwl-workflow-output/index.md
@@ -8,11 +8,11 @@ tags:
   - target/cwl
 status: draft
 created: 2026-04-30
-revised: 2026-04-30
-revision: 1
+revised: 2026-07-24
+revision: 2
 ai_generated: true
 summary: "Triage failing CWL run outputs; classify failure modes; propose fixes."
 ---
 # debug-cwl-workflow-output
 
-Stub. Replace with real Mold content per MOLD_SPEC once first walks are done.
+Triage a failing CWL run: classify the failure mode from logs and outputs and propose a fix routed to the authoring step responsible for it.

--- a/content/molds/implement-cwl-tool-step/index.md
+++ b/content/molds/implement-cwl-tool-step/index.md
@@ -8,8 +8,8 @@ tags:
   - target/cwl
 status: draft
 created: 2026-04-30
-revised: 2026-04-30
-revision: 1
+revised: 2026-07-24
+revision: 2
 ai_generated: true
 summary: "Convert an abstract step into a concrete CWL CommandLineTool + step."
 loop_endstate: "No shared endstate oracle yet; iterate over the tools enumerated in the CWL template, doing each by hand."
@@ -26,4 +26,4 @@ output_artifacts:
 ---
 # implement-cwl-tool-step
 
-Stub. Replace with real Mold content per MOLD_SPEC once first walks are done.
+Bind one abstract step to a concrete CWL CommandLineTool using its [[summarize-cwl-tool]] summary, replacing a single placeholder in the CWL workflow draft per loop iteration.

--- a/content/molds/implement-cwl-workflow-test/index.md
+++ b/content/molds/implement-cwl-workflow-test/index.md
@@ -8,8 +8,8 @@ tags:
   - target/cwl
 status: draft
 created: 2026-04-30
-revised: 2026-04-30
-revision: 1
+revised: 2026-07-24
+revision: 2
 ai_generated: true
 summary: "Assemble CWL job file(s) and expected-output assertions."
 input_artifacts:
@@ -25,4 +25,4 @@ output_artifacts:
 ---
 # implement-cwl-workflow-test
 
-Stub. Replace with real Mold content per MOLD_SPEC once first walks are done.
+Assemble the CWL job file(s) and expected-output assertions for the drafted workflow from its reviewed [[nextflow-test-to-cwl-test-plan]] test plan and the workflow's input/output ports.

--- a/content/molds/paper-to-test-data/index.md
+++ b/content/molds/paper-to-test-data/index.md
@@ -8,8 +8,8 @@ tags:
   - source/paper
 status: draft
 created: 2026-04-30
-revised: 2026-04-30
-revision: 1
+revised: 2026-07-24
+revision: 2
 ai_generated: true
 summary: "Derive workflow test inputs and expected outputs from a paper."
 input_artifacts:
@@ -23,4 +23,4 @@ output_artifacts:
 ---
 # paper-to-test-data
 
-Stub. Replace with real Mold content per MOLD_SPEC once first walks are done.
+Read the paper free-form summary from [[summarize-paper]] and derive concrete workflow test inputs and expected outputs — resolvable URLs, file shapes, and expected hashes — emitted as `test-data-refs`.

--- a/content/molds/summarize-cwl-tool/index.md
+++ b/content/molds/summarize-cwl-tool/index.md
@@ -8,8 +8,8 @@ tags:
   - target/cwl
 status: draft
 created: 2026-04-30
-revised: 2026-04-30
-revision: 1
+revised: 2026-07-24
+revision: 2
 ai_generated: true
 summary: "Derive a CommandLineTool description (container, baseCommand, IO) for a CWL target."
 loop_endstate: "No shared endstate oracle yet; iterate over the tools enumerated in the CWL template, doing each by hand."
@@ -21,4 +21,4 @@ output_artifacts:
 ---
 # summarize-cwl-tool
 
-Stub. Replace with real Mold content per MOLD_SPEC once first walks are done.
+Read a tool's container, `baseCommand`, and IO evidence and emit a compact CWL CommandLineTool summary — container, baseCommand, inputs, outputs, requirements, and version metadata.

--- a/content/molds/summarize-paper/index.md
+++ b/content/molds/summarize-paper/index.md
@@ -8,8 +8,8 @@ tags:
   - source/paper
 status: draft
 created: 2026-04-30
-revised: 2026-04-30
-revision: 1
+revised: 2026-07-24
+revision: 2
 ai_generated: true
 summary: "Extract methods, tools, sample data, and references from a paper."
 output_artifacts:
@@ -20,6 +20,6 @@ output_artifacts:
 ---
 # summarize-paper
 
-Stub. Replace with real Mold content per MOLD_SPEC once first walks are done.
+Read a methods/tool paper and emit a free-form Markdown summary capturing the workflow's steps, tools, parameters, and sample/reference-data leads.
 
 Emit the same `freeform-summary` artifact shape used by interview-derived sources so downstream freeform-summary Molds can operate on paper and interview starts without splitting the design/template tier.

--- a/content/molds/validate-cwl/index.md
+++ b/content/molds/validate-cwl/index.md
@@ -8,12 +8,12 @@ tags:
   - target/cwl
 status: draft
 created: 2026-04-30
-revised: 2026-04-30
-revision: 1
+revised: 2026-07-24
+revision: 2
 ai_generated: true
 summary: "Run cwltool --validate / schema lint, classify failures, recommend fixes."
 loop_endstate: "No shared endstate oracle yet; iterate over the tools enumerated in the CWL template, doing each by hand."
 ---
 # validate-cwl
 
-Stub. Replace with real Mold content per MOLD_SPEC once first walks are done.
+Run `cwltool --validate` and schema lint over the assembled CWL workflow, classify each diagnostic, and recommend a concrete fix — routing failures back to the authoring step that owns them.

--- a/tests/assemble-pipeline.test.ts
+++ b/tests/assemble-pipeline.test.ts
@@ -66,7 +66,8 @@ describe("assemble-pipeline (committed harnesses)", () => {
     const branch = assembly.phases.find((p: { kind: string }) => p.kind === "branch");
     expect(branch.pattern).toBe("test-data-resolution");
     expect(branch.chain).toEqual(["paper-to-test-data", "find-test-data", "user-supplied"]);
-    expect(branch.cast_present).toEqual([false, true, null]);
+    // Both chain molds are cast; the terminal free-text branch (`user-supplied`) projects null.
+    expect(branch.cast_present).toEqual([true, true, null]);
     const loop = assembly.phases.find((p: { loop?: boolean }) => p.loop === true);
     expect(loop.skill).toBe("advance-galaxy-draft-step");
   });


### PR DESCRIPTION
_Opened by Claude (AI assistant) on behalf of @jmchilton._

Follow-on to #369 (draft-status cleanup). Closes two remaining health gaps: molds whose body was still a placeholder stub, and molds with no cast.

## What changed

**Seeded 7 effectively-empty stub molds.** Each carried the placeholder body `Stub. Replace with real Mold content per MOLD_SPEC once first walks are done.` Each now opens with a verb-first one-line prompt (citing handoff Molds via `[[wiki-links]]`), `revision 1→2`, `revised→2026-07-24`. `status` stays `draft` — these CWL/paper paths haven't produced artifacts, so draft remains honest.

| Mold | One-liner gist |
|---|---|
| `validate-cwl` | Run `cwltool --validate`/schema lint, classify, recommend fixes |
| `paper-to-test-data` | Derive test inputs/outputs from the `summarize-paper` summary |
| `summarize-cwl-tool` | Emit a compact CWL CommandLineTool summary |
| `implement-cwl-tool-step` | Bind one abstract step to a concrete CommandLineTool |
| `debug-cwl-workflow-output` | Triage a failing CWL run, route the fix |
| `implement-cwl-workflow-test` | Assemble CWL job file(s) + expected-output assertions |
| `summarize-paper` | Emit a free-form Markdown paper summary |

**Cast all 14 previously-uncast molds** (the 7 stubs + 7 non-empty CWL molds). Every mold in the repo now has a Claude cast; the one-liners render into each `SKILL.md` `## Procedure`.

**Regenerated downstream generated files:** the 4 pipeline harnesses the new casts touched (`cast_present: false → true`) and `Dashboard.md` (revision bumps).

## Test note

`tests/assemble-pipeline.test.ts` hardcoded `cast_present: [false, true, null]`, using `paper-to-test-data` as its *uncast* example. Casting it flips that to `true`. Updated to `[true, true, null]`. With full cast coverage, no committed harness exercises the projection's `false` branch anymore — a follow-up could restore that via a synthetic uncast-mold unit test.

## Validation

- `npm run validate` — 0 errors
- `npm run test` — 151/151 pass
- `make check-assemble-pipelines` — all 7 pipelines clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)