### PR TITLE
Give validate-cwl an input contract

### DIFF
--- a/casts/claude/skills/validate-cwl/SKILL.md
+++ b/casts/claude/skills/validate-cwl/SKILL.md
@@ -13,7 +13,7 @@ Follow the procedure below and use the artifact/reference sections as the runtim
 
 ## Inputs
 
-- No upstream artifact inputs declared. See the procedure for user-supplied runtime inputs.
+- Read artifact `cwl-workflow-draft`. Produced by `implement-cwl-tool-step`, `summary-to-cwl-template`. Assembled CWL Workflow to validate — the `cwl-workflow-draft.cwl` from implement-cwl-tool-step (`class: Workflow`); the build result `cwltool --validate` and schema lint run against.
 
 ## Outputs
 

--- a/casts/claude/skills/validate-cwl/_provenance.json
+++ b/casts/claude/skills/validate-cwl/_provenance.json
@@ -4,10 +4,23 @@
   "mold": {
     "name": "validate-cwl",
     "path": "content/molds/validate-cwl/index.md",
-    "revision": 2,
-    "content_hash": "9b74a3cba42368aa4e32f205294ad860a8df3c3c868ed6a3dcd34d78a9613e5d",
-    "commit": "e487fe785f468afdf25f2b6bd140c3a115a12021"
+    "revision": 3,
+    "content_hash": "a5ce29374816394f67661d637605401d0f164ef5d93db344a73f5b6f19702c78",
+    "commit": "540e04c26b41b02336b3581b55521b916c7fe330"
   },
-  "cast_at": "2026-07-24T13:51:20.266Z",
-  "refs": []
+  "cast_at": "2026-07-24T14:19:42.025Z",
+  "refs": [],
+  "artifacts": {
+    "produces": [],
+    "consumes": [
+      {
+        "id": "cwl-workflow-draft",
+        "description": "Assembled CWL Workflow to validate — the `cwl-workflow-draft.cwl` from [[implement-cwl-tool-step]] (`class: Workflow`); the build result `cwltool --validate` and schema lint run against.",
+        "producers": [
+          "implement-cwl-tool-step",
+          "summary-to-cwl-template"
+        ]
+      }
+    ]
+  }
 }

--- a/content/Dashboard.md
+++ b/content/Dashboard.md
@@ -50,7 +50,7 @@ Generated from `dashboard_sections.json` and content frontmatter. Do not edit by
 | [[summarize-galaxy-workflow]] | Read an existing Galaxy gxformat2 (or .ga) workflow and emit a structured summary for interview and change-set steps. | reviewed | 2026-07-24 | 2 |
 | [[summarize-nextflow]] | Read a Nextflow pipeline source tree (nf-core or ad-hoc DSL2) and emit a structured JSON summary for downstream translation Molds. | reviewed | 2026-07-24 | 14 |
 | [[summarize-paper]] | Extract methods, tools, sample data, and references from a paper. | draft | 2026-07-24 | 2 |
-| [[validate-cwl]] | Run cwltool --validate / schema lint, classify failures, recommend fixes. | draft | 2026-07-24 | 2 |
+| [[validate-cwl]] | Run cwltool --validate / schema lint, classify failures, recommend fixes. | draft | 2026-07-24 | 3 |
 | [[validate-galaxy-workflow]] | Run terminal gxwf validation on an assembled Galaxy workflow and classify workflow-level failures. | reviewed | 2026-07-24 | 4 |
 | [[cwl-to-test-data]] | Resolve a CWL workflow's own declared test cases into Galaxy workflow test-data refs. | draft | 2026-07-17 | 1 |
 | [[convert-nfcore-module-to-galaxy-tool]] | Convert one nf-core module dir into a Galaxy tool wrapper (tool.xml + macros.xml + _provenance.yml + remote-URL <test> blocks). | draft | 2026-06-19 | 4 |

--- a/content/molds/validate-cwl/index.md
+++ b/content/molds/validate-cwl/index.md
@@ -9,10 +9,13 @@ tags:
 status: draft
 created: 2026-04-30
 revised: 2026-07-24
-revision: 2
+revision: 3
 ai_generated: true
 summary: "Run cwltool --validate / schema lint, classify failures, recommend fixes."
 loop_endstate: "No shared endstate oracle yet; iterate over the tools enumerated in the CWL template, doing each by hand."
+input_artifacts:
+  - id: cwl-workflow-draft
+    description: "Assembled CWL Workflow to validate — the `cwl-workflow-draft.cwl` from [[implement-cwl-tool-step]] (`class: Workflow`); the build result `cwltool --validate` and schema lint run against."
 ---
 # validate-cwl
 


### PR DESCRIPTION
_Opened by Claude (AI assistant) on behalf of @jmchilton._

CWL analog of #372. `validate-cwl` is the terminal CWL validation phase in `nextflow-to-cwl` and `paper-to-cwl`, but declared no I/O contract.

## Change

Add the `cwl-workflow-draft` input artifact to `validate-cwl`:

```yaml
input_artifacts:
  - id: cwl-workflow-draft
    description: "Assembled CWL Workflow to validate — the cwl-workflow-draft.cwl
      from [[implement-cwl-tool-step]] (class: Workflow); the build result
      cwltool --validate and schema lint run against."
```

Shared `id: cwl-workflow-draft` → inherits `implement-cwl-tool-step`'s assembled build result (the same artifact `implement-cwl-workflow-test` consumes). Unlike the Galaxy path, the CWL corner has no concrete-extraction step, so `cwl-workflow-draft` *is* the assembled workflow the validator runs against.

`revision 2→3`, `status` stays `draft` (CWL path hasn't produced artifacts yet).

## Validation

- `npm run validate` — 0 errors
- `npm run test` — 151/151 pass
- `make check-assemble-pipelines` — all 7 pipelines clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)