### PR TITLE
Give debug-cwl-workflow-output an I/O contract

### DIFF
--- a/casts/claude/skills/debug-cwl-workflow-output/SKILL.md
+++ b/casts/claude/skills/debug-cwl-workflow-output/SKILL.md
@@ -13,11 +13,11 @@ Follow the procedure below and use the artifact/reference sections as the runtim
 
 ## Inputs
 
-- No upstream artifact inputs declared. See the procedure for user-supplied runtime inputs.
+- Read artifact `workflow-test-result`. Produced by `run-workflow-test`. Structured run handoff from run-workflow-test: test result, run/job/artifact context, and the observed CWL failure modality.
 
 ## Outputs
 
-- None declared.
+- Write artifact `cwl-workflow-debug-report` as `cwl-workflow-debug-report.md`. Format: `markdown`. CWL failure-surface classification with captured run/job/output evidence and a recommended next step or reference-gap follow-up.
 
 ## Required Tools
 

--- a/casts/claude/skills/debug-cwl-workflow-output/_provenance.json
+++ b/casts/claude/skills/debug-cwl-workflow-output/_provenance.json
@@ -4,10 +4,29 @@
   "mold": {
     "name": "debug-cwl-workflow-output",
     "path": "content/molds/debug-cwl-workflow-output/index.md",
-    "revision": 2,
-    "content_hash": "dd86078aac141070bbd438dd5eaab775c880515996d2e336131d4b80522dbc83",
-    "commit": "e487fe785f468afdf25f2b6bd140c3a115a12021"
+    "revision": 3,
+    "content_hash": "368710e2c3c15d34ac9a9552cb498fa1619522e2924f0c3ee0c0a6111361c25f",
+    "commit": "540e04c26b41b02336b3581b55521b916c7fe330"
   },
-  "cast_at": "2026-07-24T13:51:12.321Z",
-  "refs": []
+  "cast_at": "2026-07-24T14:25:52.402Z",
+  "refs": [],
+  "artifacts": {
+    "produces": [
+      {
+        "id": "cwl-workflow-debug-report",
+        "kind": "markdown",
+        "default_filename": "cwl-workflow-debug-report.md",
+        "description": "CWL failure-surface classification with captured run/job/output evidence and a recommended next step or reference-gap follow-up."
+      }
+    ],
+    "consumes": [
+      {
+        "id": "workflow-test-result",
+        "description": "Structured run handoff from [[run-workflow-test]]: test result, run/job/artifact context, and the observed CWL failure modality.",
+        "producers": [
+          "run-workflow-test"
+        ]
+      }
+    ]
+  }
 }

--- a/content/Dashboard.md
+++ b/content/Dashboard.md
@@ -23,7 +23,7 @@ Generated from `dashboard_sections.json` and content frontmatter. Do not edit by
 | [[author-galaxy-tool-wrapper]] | Author a new Galaxy user-defined tool YAML definition when discovery yields nothing acceptable. | reviewed | 2026-07-24 | 4 |
 | [[changeset-to-galaxy-test-plan]] | Carry an existing Galaxy workflow's tests forward as a regression baseline and augment them for a change-set's deltas, emitting a Galaxy test plan. | reviewed | 2026-07-24 | 2 |
 | [[compare-against-iwc-exemplar]] | Find nearest IWC exemplar(s) and surface a structural diff against the upstream Galaxy design briefs to guide template authoring. | reviewed | 2026-07-24 | 8 |
-| [[debug-cwl-workflow-output]] | Triage failing CWL run outputs; classify failure modes; propose fixes. | draft | 2026-07-24 | 2 |
+| [[debug-cwl-workflow-output]] | Triage failing CWL run outputs; classify failure modes; propose fixes. | draft | 2026-07-24 | 3 |
 | [[debug-galaxy-workflow-output]] | Triage failing Galaxy run outputs; classify the failure surface and capture evidence before recommending repairs. | reviewed | 2026-07-24 | 5 |
 | [[discover-shed-tool]] | Search the Tool Shed for an existing wrapper, drill from hit to a pinnable changeset, classify candidates, and recommend or fall through. | reviewed | 2026-07-24 | 5 |
 | [[find-test-data]] | Search IWC fixtures and public sources for test data matching a data-flow shape. | reviewed | 2026-07-24 | 3 |

--- a/content/molds/debug-cwl-workflow-output/index.md
+++ b/content/molds/debug-cwl-workflow-output/index.md
@@ -9,9 +9,17 @@ tags:
 status: draft
 created: 2026-04-30
 revised: 2026-07-24
-revision: 2
+revision: 3
 ai_generated: true
 summary: "Triage failing CWL run outputs; classify failure modes; propose fixes."
+input_artifacts:
+  - id: workflow-test-result
+    description: "Structured run handoff from [[run-workflow-test]]: test result, run/job/artifact context, and the observed CWL failure modality."
+output_artifacts:
+  - id: cwl-workflow-debug-report
+    kind: markdown
+    default_filename: cwl-workflow-debug-report.md
+    description: "CWL failure-surface classification with captured run/job/output evidence and a recommended next step or reference-gap follow-up."
 ---
 # debug-cwl-workflow-output
 


### PR DESCRIPTION
_Opened by Claude (AI assistant) on behalf of @jmchilton._

CWL parity with `debug-galaxy-workflow-output` (which declares I/O). `debug-cwl-workflow-output` is the terminal triage phase in `nextflow-to-cwl` and `paper-to-cwl` — right after the generic `run-workflow-test` — but declared no I/O.

## Change

```yaml
input_artifacts:
  - id: workflow-test-result        # shared id -> inherits run-workflow-test
output_artifacts:
  - id: cwl-workflow-debug-report   # target-specific report
```

The input `workflow-test-result` is the same run handoff `debug-galaxy-workflow-output` consumes — both CWL pipelines route through the generic `run-workflow-test` producer. Output is a CWL-specific failure-surface report (distinct id, since CWL failure surfaces differ from Galaxy's and nothing downstream consumes it).

`revision 2→3`, `status` stays `draft`.

## Validation

- `npm run validate` — 0 errors
- `npm run test` — 151/151 pass
- `make check-assemble-pipelines` — all 7 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)