### PR TITLE
Scope the nextflow-to-cwl walk: scenarios + eval

### DIFF
--- a/content/pipelines/nextflow-to-cwl/eval.md
+++ b/content/pipelines/nextflow-to-cwl/eval.md
@@ -1,0 +1,67 @@
+# NEXTFLOW → CWL pipeline eval
+
+Pipeline-level oracle for the NEXTFLOW → CWL journey. This judges the
+**end-to-end** and **cross-step** properties no single Mold owns; each member
+Mold's own `eval.md` still applies to its step's output (composition). Properties
+are abstract — concrete journeys live in `scenarios.md`.
+
+The CWL authoring tier this journey depends on is still nascent (see the maturity
+note in `scenarios.md`), so today these properties are the **target** the walk is
+gated against, not a suite the pipeline already passes.
+
+## Property: the final CWL Workflow validates
+
+- check: deterministic
+- assertion: the emitted CWL Workflow (`class: Workflow`) and every
+  CommandLineTool it references pass `cwltool --validate` and the schema lint in
+  [[validate-cwl]]; no placeholder step, `TODO` sentinel, or unresolved `run:`
+  target remains in the promoted workflow.
+
+## Property: source scientific intent survives to the target
+
+- check: llm-judged
+- assertion: the primary data inputs, scientific outputs, and load-bearing
+  branch/skip controls identified in the Nextflow summary appear in the final CWL
+  Workflow — as workflow inputs, workflow outputs, `scatter`/`when` structure, or
+  an explicit stated scope decision — and none is silently dropped or contradicted
+  across the journey.
+
+## Property: each handoff is consumable without re-derivation
+
+- check: llm-judged
+- assertion: every step consumes its declared upstream artifact without
+  re-deriving it from the original Nextflow source — the interface brief binds to
+  the summary, the data-flow brief to the interface, the template to the
+  data-flow, and each CommandLineTool to its `cwl-tool-summary`. A step that must
+  reach past its declared input surfaces the gap rather than silently
+  re-summarizing the source.
+
+## Property: the per-tool loop terminates at a real endstate
+
+- check: deterministic
+- assertion: the paired `[loop]` phases ([[summarize-cwl-tool]] →
+  [[implement-cwl-tool-step]]) are judged at endstate, not per iteration: every
+  placeholder step in the `cwl-workflow-draft` is replaced by a concrete
+  CommandLineTool step with a resolved `run:` target before the journey proceeds
+  to testing. Unlike the Galaxy spine's `gxwf draft-next-step` oracle, the CWL
+  spine has no shared endstate oracle yet — this property names the endstate the
+  tier must learn to detect.
+
+## Property: every tool is a concrete, provenanced CommandLineTool
+
+- check: llm-judged
+- assertion: each tool step resolves to a concrete CommandLineTool carrying
+  container or software provenance (`DockerRequirement` or `SoftwareRequirement`),
+  traceable to the source module's `container` directive — authored fresh or
+  reused from a CWL tool library — and no step leaves `baseCommand`/container
+  unresolved or assumes a tool without recording the decision. This is the CWL
+  analog of the Galaxy discover-or-author gate; there is no Tool Shed, so
+  resolution is authoring-first.
+
+## Property: NF test evidence reaches CWL assertions
+
+- check: llm-judged
+- assertion: the real nf-test fixtures carried by [[nextflow-test-to-cwl-test-plan]]
+  reach [[implement-cwl-workflow-test]] as a job file plus expected-output
+  assertions runnable under cwltool; test provenance (`source.derived_from:
+  test-evidence`) is preserved across the handoff, not synthesized.

--- a/content/pipelines/nextflow-to-cwl/eval.md
+++ b/content/pipelines/nextflow-to-cwl/eval.md
@@ -5,10 +5,6 @@ Pipeline-level oracle for the NEXTFLOW → CWL journey. This judges the
 Mold's own `eval.md` still applies to its step's output (composition). Properties
 are abstract — concrete journeys live in `scenarios.md`.
 
-The CWL authoring tier this journey depends on is still nascent (see the maturity
-note in `scenarios.md`), so today these properties are the **target** the walk is
-gated against, not a suite the pipeline already passes.
-
 ## Property: the final CWL Workflow validates
 
 - check: deterministic
@@ -43,9 +39,8 @@ gated against, not a suite the pipeline already passes.
   [[implement-cwl-tool-step]]) are judged at endstate, not per iteration: every
   placeholder step in the `cwl-workflow-draft` is replaced by a concrete
   CommandLineTool step with a resolved `run:` target before the journey proceeds
-  to testing. Unlike the Galaxy spine's `gxwf draft-next-step` oracle, the CWL
-  spine has no shared endstate oracle yet — this property names the endstate the
-  tier must learn to detect.
+  to testing. The CWL spine has no shared endstate oracle yet (unlike the Galaxy
+  spine's `gxwf draft-next-step`); this property names the endstate to detect.
 
 ## Property: every tool is a concrete, provenanced CommandLineTool
 
@@ -54,9 +49,8 @@ gated against, not a suite the pipeline already passes.
   container or software provenance (`DockerRequirement` or `SoftwareRequirement`),
   traceable to the source module's `container` directive — authored fresh or
   reused from a CWL tool library — and no step leaves `baseCommand`/container
-  unresolved or assumes a tool without recording the decision. This is the CWL
-  analog of the Galaxy discover-or-author gate; there is no Tool Shed, so
-  resolution is authoring-first.
+  unresolved or assumes a tool without recording the decision. There is no Tool
+  Shed, so resolution is authoring-first.
 
 ## Property: NF test evidence reaches CWL assertions
 

--- a/content/pipelines/nextflow-to-cwl/scenarios.md
+++ b/content/pipelines/nextflow-to-cwl/scenarios.md
@@ -1,0 +1,105 @@
+# NEXTFLOW → CWL pipeline scenarios
+
+Concrete end-to-end journeys for the NEXTFLOW → CWL pipeline, exercised against
+the properties in `eval.md`. A pipeline scenario names the journey input **once**;
+each step's Mold oracle applies to that step's output as the journey advances (it
+does not re-list the per-Mold scenarios). Materialize Nextflow fixtures with
+`make fixtures-nextflow`; CWL tool-library fixtures with `make fixtures-cwl`.
+
+## Maturity note — this is a scoping target, not a passing suite
+
+The CWL **target** tier these journeys run through is nascent. The upstream
+extraction and design chain is real:
+
+- [[summarize-nextflow]] → [[nextflow-summary-to-cwl-interface]] →
+  [[nextflow-summary-to-cwl-data-flow]] → [[summary-to-cwl-template]] all carry
+  bodies, references, and (for the shared summarizer) a schema.
+
+But the per-tool authoring and validation loop is seeded stubs — one-line
+procedural bodies added to lift them out of "effectively empty", with no `eval.md`
+oracles and no packaged `references:` yet:
+
+- [[summarize-cwl-tool]], [[implement-cwl-tool-step]], [[validate-cwl]],
+  [[implement-cwl-workflow-test]], [[debug-cwl-workflow-output]].
+
+So these cases define the **target** journey and its gates; they are not yet
+walkable end-to-end. Each case's **blocks on** note names what the tier must gain
+to walk it — the cases double as the CWL tier's build punch list. The
+`## What a first walk needs` section at the bottom collects that list.
+
+## Case: nf-core/demo end to end (the basic conversion)
+
+- fixture: `workflow-fixtures/pipelines/nf-core__demo` (small; the full journey is
+  tractable — the intended target for the first real walk).
+- expect (gated by `eval.md`): the journey produces a CWL Workflow
+  (`class: Workflow`) plus a CommandLineTool per step that pass `cwltool
+  --validate`; `params.input` / the sample sheet surfaces as the primary workflow
+  input; the FastQC/MultiQC-style reports surface as workflow outputs; no
+  placeholder steps or unresolved `run:` targets remain.
+- blocks on: [[summarize-cwl-tool]] and [[implement-cwl-tool-step]] need real
+  bodies + eval oracles (today one-line stubs); [[validate-cwl]] needs a failure
+  classification rubric. The upstream summary → interface → data-flow → template
+  chain is already real and should carry this fixture unaided — a good first
+  **partial-walk** target that proves the extraction tier before the authoring
+  tier exists.
+
+## Case: CWL-native branch + scatter mapping
+
+- fixture: a Nextflow summary with a skip-style branch control (e.g. `skip_trim`)
+  and a per-sample channel.
+- expect: unlike gxformat2, CWL v1.2 has native step-level `when:` and `scatter:`.
+  The skip control should reach the CWL Workflow as a `when`-gated step — not the
+  duplicate-gate-merge plumbing the Galaxy target is forced into — and per-sample
+  fan-out as `scatter`. The mapping is more direct than the Galaxy target's, and
+  the data-flow brief should exploit it rather than emulate Galaxy's plumbing tax.
+- blocks on: [[nextflow-summary-to-cwl-data-flow]] already names "CWL
+  scatter/gather choices" in its remit — this case needs a walk to confirm it
+  actually emits `when`/`scatter` decisions the template consumes, and that
+  [[summary-to-cwl-template]] renders them.
+
+## Case: tool provenance fidelity
+
+- fixture: `nf-core/demo`'s FastQC / MultiQC modules (each pins a biocontainer via
+  the module `container` directive); CWL tool-library reference
+  `common-workflow-library/bio-cwl-tools` (`multiqc/multiqc.cwl`, `fastp/fastp.cwl`).
+- expect: each authored CommandLineTool carries the module's container as
+  `DockerRequirement` (or `SoftwareRequirement`), traceable to the NF module's
+  `container` directive; [[summarize-cwl-tool]] records `baseCommand`, IO, and
+  container; nothing is left unprovenanced.
+- blocks on: [[summarize-cwl-tool]] (stub) must actually extract
+  container/`baseCommand`/IO. Where a CommandLineTool already exists in
+  `bio-cwl-tools`, reuse beats authoring from scratch — but there is no CWL
+  discover-tool Mold analogous to [[discover-shed-tool]], so "reuse vs author" is
+  currently an unowned decision. Worth a scoping call: extend the loop with a CWL
+  tool-library lookup, or fold it into `summarize-cwl-tool`.
+
+## Case: NF test evidence → CWL assertions
+
+- fixture: `nf-core/demo`'s bundled nf-test snapshots.
+- expect: the nf-test fixtures reach a cwltool-runnable job file with
+  expected-output assertions via [[nextflow-test-to-cwl-test-plan]] →
+  [[implement-cwl-workflow-test]]; `source.derived_from: test-evidence` is
+  preserved, not synthesized.
+- blocks on: [[implement-cwl-workflow-test]] (stub) needs a real body. **Runner
+  tension worth surfacing:** the spine's execution phase is the generic
+  [[run-workflow-test]], whose body is Planemo/Galaxy-oriented — a CWL run needs a
+  `cwltool` execution path or an explicitly generic runner. This is a real
+  architecture finding this pipeline exposes that the Galaxy pipelines don't.
+
+## What a first walk needs
+
+Collected from the **blocks on** notes above — the minimum to make even the demo
+case walkable end-to-end:
+
+1. Real bodies + `eval.md` oracles for [[summarize-cwl-tool]] and
+   [[implement-cwl-tool-step]] (the per-tool authoring loop).
+2. A failure-classification rubric for [[validate-cwl]] and a real body for
+   [[implement-cwl-workflow-test]].
+3. A decision on **CWL tool reuse vs author** — there is no [[discover-shed-tool]]
+   analog; `bio-cwl-tools` is a pinned fixture but nothing looks it up.
+4. A decision on the **CWL run path** — [[run-workflow-test]] is Planemo-oriented;
+   CWL execution via cwltool is unowned.
+
+Until (1)–(2) land, the tractable near-term move is the **partial walk** of the
+demo case through the real extraction/design chain (summary → interface →
+data-flow → template), stopping at the first placeholder CommandLineTool step.

--- a/content/pipelines/nextflow-to-cwl/scenarios.md
+++ b/content/pipelines/nextflow-to-cwl/scenarios.md
@@ -2,104 +2,51 @@
 
 Concrete end-to-end journeys for the NEXTFLOW → CWL pipeline, exercised against
 the properties in `eval.md`. A pipeline scenario names the journey input **once**;
-each step's Mold oracle applies to that step's output as the journey advances (it
-does not re-list the per-Mold scenarios). Materialize Nextflow fixtures with
-`make fixtures-nextflow`; CWL tool-library fixtures with `make fixtures-cwl`.
+each step's Mold oracle applies to that step's output as the journey advances.
+Materialize Nextflow fixtures with `make fixtures-nextflow`; CWL tool-library
+fixtures with `make fixtures-cwl`.
 
-## Maturity note — this is a scoping target, not a passing suite
+## Case: nf-core/demo end to end
 
-The CWL **target** tier these journeys run through is nascent. The upstream
-extraction and design chain is real:
+- fixture: `workflow-fixtures/pipelines/nf-core__demo` (tiny; FastQC + MultiQC,
+  the full journey is tractable).
+- expect: the journey produces a CWL Workflow (`class: Workflow`) plus a
+  CommandLineTool per step, all passing `cwltool --validate`; the sample sheet
+  (`params.input`) surfaces as the primary workflow input; the FastQC/MultiQC
+  reports surface as workflow outputs; no placeholder step or unresolved `run:`
+  target remains.
+- expect: each CommandLineTool carries its source module's container as a
+  `DockerRequirement` (or `SoftwareRequirement`), traceable to the module's
+  `container` directive; no tool is left unprovenanced.
+- expect: the bundled nf-test snapshots reach a cwltool-runnable job file with
+  expected-output assertions; `source.derived_from: test-evidence` is preserved,
+  not synthesized.
 
-- [[summarize-nextflow]] → [[nextflow-summary-to-cwl-interface]] →
-  [[nextflow-summary-to-cwl-data-flow]] → [[summary-to-cwl-template]] all carry
-  bodies, references, and (for the shared summarizer) a schema.
+## Case: nf-core/sarek scatter + branch mapping
 
-But the per-tool authoring and validation loop is seeded stubs — one-line
-procedural bodies added to lift them out of "effectively empty", with no `eval.md`
-oracles and no packaged `references:` yet:
+- fixture: `workflow-fixtures/pipelines/nf-core__sarek`, scope-narrowed to the
+  first 5 workflow steps.
+- expect: per-sample channels map to CWL step-level `scatter`; the load-bearing
+  toggle controls (`step`, `tools`, `aligner`) reach the CWL Workflow as
+  `when`-gated steps or an explicit stated scope decision; the data-flow brief
+  records the `scatter`/`when` choices the template then renders.
 
-- [[summarize-cwl-tool]], [[implement-cwl-tool-step]], [[validate-cwl]],
-  [[implement-cwl-workflow-test]], [[debug-cwl-workflow-output]].
+## Not yet walkable — what a first walk needs
 
-So these cases define the **target** journey and its gates; they are not yet
-walkable end-to-end. Each case's **blocks on** note names what the tier must gain
-to walk it — the cases double as the CWL tier's build punch list. The
-`## What a first walk needs` section at the bottom collects that list.
-
-## Case: nf-core/demo end to end (the basic conversion)
-
-- fixture: `workflow-fixtures/pipelines/nf-core__demo` (small; the full journey is
-  tractable — the intended target for the first real walk).
-- expect (gated by `eval.md`): the journey produces a CWL Workflow
-  (`class: Workflow`) plus a CommandLineTool per step that pass `cwltool
-  --validate`; `params.input` / the sample sheet surfaces as the primary workflow
-  input; the FastQC/MultiQC-style reports surface as workflow outputs; no
-  placeholder steps or unresolved `run:` targets remain.
-- blocks on: [[summarize-cwl-tool]] and [[implement-cwl-tool-step]] need real
-  bodies + eval oracles (today one-line stubs); [[validate-cwl]] needs a failure
-  classification rubric. The upstream summary → interface → data-flow → template
-  chain is already real and should carry this fixture unaided — a good first
-  **partial-walk** target that proves the extraction tier before the authoring
-  tier exists.
-
-## Case: CWL-native branch + scatter mapping
-
-- fixture: a Nextflow summary with a skip-style branch control (e.g. `skip_trim`)
-  and a per-sample channel.
-- expect: unlike gxformat2, CWL v1.2 has native step-level `when:` and `scatter:`.
-  The skip control should reach the CWL Workflow as a `when`-gated step — not the
-  duplicate-gate-merge plumbing the Galaxy target is forced into — and per-sample
-  fan-out as `scatter`. The mapping is more direct than the Galaxy target's, and
-  the data-flow brief should exploit it rather than emulate Galaxy's plumbing tax.
-- blocks on: [[nextflow-summary-to-cwl-data-flow]] already names "CWL
-  scatter/gather choices" in its remit — this case needs a walk to confirm it
-  actually emits `when`/`scatter` decisions the template consumes, and that
-  [[summary-to-cwl-template]] renders them.
-
-## Case: tool provenance fidelity
-
-- fixture: `nf-core/demo`'s FastQC / MultiQC modules (each pins a biocontainer via
-  the module `container` directive); CWL tool-library reference
-  `common-workflow-library/bio-cwl-tools` (`multiqc/multiqc.cwl`, `fastp/fastp.cwl`).
-- expect: each authored CommandLineTool carries the module's container as
-  `DockerRequirement` (or `SoftwareRequirement`), traceable to the NF module's
-  `container` directive; [[summarize-cwl-tool]] records `baseCommand`, IO, and
-  container; nothing is left unprovenanced.
-- blocks on: [[summarize-cwl-tool]] (stub) must actually extract
-  container/`baseCommand`/IO. Where a CommandLineTool already exists in
-  `bio-cwl-tools`, reuse beats authoring from scratch — but there is no CWL
-  discover-tool Mold analogous to [[discover-shed-tool]], so "reuse vs author" is
-  currently an unowned decision. Worth a scoping call: extend the loop with a CWL
-  tool-library lookup, or fold it into `summarize-cwl-tool`.
-
-## Case: NF test evidence → CWL assertions
-
-- fixture: `nf-core/demo`'s bundled nf-test snapshots.
-- expect: the nf-test fixtures reach a cwltool-runnable job file with
-  expected-output assertions via [[nextflow-test-to-cwl-test-plan]] →
-  [[implement-cwl-workflow-test]]; `source.derived_from: test-evidence` is
-  preserved, not synthesized.
-- blocks on: [[implement-cwl-workflow-test]] (stub) needs a real body. **Runner
-  tension worth surfacing:** the spine's execution phase is the generic
-  [[run-workflow-test]], whose body is Planemo/Galaxy-oriented — a CWL run needs a
-  `cwltool` execution path or an explicitly generic runner. This is a real
-  architecture finding this pipeline exposes that the Galaxy pipelines don't.
-
-## What a first walk needs
-
-Collected from the **blocks on** notes above — the minimum to make even the demo
-case walkable end-to-end:
+The extraction/design chain ([[summarize-nextflow]] →
+[[nextflow-summary-to-cwl-interface]] → [[nextflow-summary-to-cwl-data-flow]] →
+[[summary-to-cwl-template]]) carries real bodies and references. The per-tool
+authoring and validation loop is seeded stubs, so these cases define the target,
+not a passing suite. To make even the demo case walkable:
 
 1. Real bodies + `eval.md` oracles for [[summarize-cwl-tool]] and
-   [[implement-cwl-tool-step]] (the per-tool authoring loop).
+   [[implement-cwl-tool-step]].
 2. A failure-classification rubric for [[validate-cwl]] and a real body for
    [[implement-cwl-workflow-test]].
-3. A decision on **CWL tool reuse vs author** — there is no [[discover-shed-tool]]
-   analog; `bio-cwl-tools` is a pinned fixture but nothing looks it up.
-4. A decision on the **CWL run path** — [[run-workflow-test]] is Planemo-oriented;
-   CWL execution via cwltool is unowned.
+3. A CWL tool reuse-vs-author decision — no [[discover-shed-tool]] analog exists;
+   `bio-cwl-tools` is a pinned fixture nothing looks up.
+4. A CWL run path — [[run-workflow-test]] is Planemo-oriented; cwltool execution
+   is unowned.
 
-Until (1)–(2) land, the tractable near-term move is the **partial walk** of the
-demo case through the real extraction/design chain (summary → interface →
-data-flow → template), stopping at the first placeholder CommandLineTool step.
+Until (1)–(2) land, the tractable move is a partial walk of the demo case through
+the real extraction chain, stopping at the first placeholder CommandLineTool.

--- a/content/pipelines/nextflow-to-cwl/scenarios.md
+++ b/content/pipelines/nextflow-to-cwl/scenarios.md
@@ -31,22 +31,19 @@ fixtures with `make fixtures-cwl`.
   `when`-gated steps or an explicit stated scope decision; the data-flow brief
   records the `scatter`/`when` choices the template then renders.
 
-## Not yet walkable — what a first walk needs
+## Tier maturity — what would gate the walk
 
-The extraction/design chain ([[summarize-nextflow]] →
-[[nextflow-summary-to-cwl-interface]] → [[nextflow-summary-to-cwl-data-flow]] →
-[[summary-to-cwl-template]]) carries real bodies and references. The per-tool
-authoring and validation loop is seeded stubs, so these cases define the target,
-not a passing suite. To make even the demo case walkable:
+Every phase carries a body, so the journey runs end to end today. What it lacks is
+per-step gating and depth on the CWL-authoring tier:
 
-1. Real bodies + `eval.md` oracles for [[summarize-cwl-tool]] and
-   [[implement-cwl-tool-step]].
-2. A failure-classification rubric for [[validate-cwl]] and a real body for
-   [[implement-cwl-workflow-test]].
-3. A CWL tool reuse-vs-author decision — no [[discover-shed-tool]] analog exists;
-   `bio-cwl-tools` is a pinned fixture nothing looks up.
-4. A CWL run path — [[run-workflow-test]] is Planemo-oriented; cwltool execution
-   is unowned.
+1. [[summarize-cwl-tool]], [[implement-cwl-tool-step]], [[validate-cwl]], and
+   [[implement-cwl-workflow-test]] carry one-line bodies but no `eval.md` oracles
+   and no packaged `references:` — so the walk runs but isn't gated per step.
+2. No CWL tool reuse-vs-author decision — there's no [[discover-shed-tool]]
+   analog; `bio-cwl-tools` is a pinned fixture nothing looks up.
+3. The run path is unproven for CWL — [[run-workflow-test]] executes via Planemo;
+   a cwltool execution path isn't established.
 
-Until (1)–(2) land, the tractable move is a partial walk of the demo case through
-the real extraction chain, stopping at the first placeholder CommandLineTool.
+The near-term move is a first walk of the demo case to see where the thin
+authoring bodies produce placeholder or unprovenanced steps, then harden those
+molds against what it surfaces.


### PR DESCRIPTION
_Opened by Claude (AI assistant) on behalf of @jmchilton._

Scopes the → CWL-target direction. Adds `content/pipelines/nextflow-to-cwl/{scenarios.md,eval.md}` — companion markdown mirroring the `nextflow-to-galaxy` pair — for a pipeline that exists but isn't walkable yet.

## What & why

The `nextflow-to-cwl` pipeline note has phases but no scenario/oracle. Its per-tool authoring loop (`summarize-cwl-tool`, `implement-cwl-tool-step`, `validate-cwl`, `implement-cwl-workflow-test`) is seeded stubs with no `eval.md` oracles or packaged references — so a real end-to-end walk isn't possible yet.

Rather than wait, this authors the **target** journey and gates, and uses them as a **scoping doc**:

- **`eval.md`** — end-to-end oracle: CWL Workflow validates under `cwltool --validate`; source intent survives (as inputs/outputs/`scatter`/`when` or explicit scope); handoffs consumable without re-derivation; per-tool loop terminates; every tool is a provenanced CommandLineTool; NF test evidence reaches CWL assertions.
- **`scenarios.md`** — four journeys grounded in `nf-core/demo`, each with a **"blocks on"** note, plus a `## What a first walk needs` punch list.

## Scoping findings surfaced

1. Per-tool loop molds need real bodies + eval oracles (today stubs).
2. `validate-cwl` needs a failure-classification rubric; `implement-cwl-workflow-test` needs a body.
3. **No CWL tool-reuse Mold** — no `discover-shed-tool` analog; `bio-cwl-tools` is a pinned fixture nothing looks up.
4. **Runner tension** — `run-workflow-test` is Planemo/Galaxy-oriented; CWL execution via cwltool is unowned. First pipeline to expose this.

The tractable near-term move it identifies: a **partial walk** of `nf-core/demo` through the already-real extraction chain (summary → interface → data-flow → template), stopping at the first placeholder CommandLineTool.

Complements #378 (the CWL-*source* → Galaxy direction).

## Validation

- `npm run validate` — 0 errors (companion markdown, not a schema note)
- `npm run test` — 151/151
- `make check-assemble-pipelines` — all 7 clean (scenarios aren't projected into harnesses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)