### PR TITLE
Tags: drop the iwc/* family — closed registry, no open declarations

### DIFF
--- a/content/research/gxy-sketches-alignment.md
+++ b/content/research/gxy-sketches-alignment.md
@@ -5,8 +5,8 @@ tags:
   - meta
 status: draft
 created: 2026-04-30
-revised: 2026-05-05
-revision: 1
+revised: 2026-07-24
+revision: 2
 ai_generated: true
 related_molds:
   - "[[summarize-nextflow]]"
@@ -87,7 +87,9 @@ When the Foundry's `summarize-paper` / `summarize-nextflow` / `summarize-cwl` (a
 
 The Foundry's `ecosystem` vocabulary should be a superset: gxy-sketches has `nf-core | iwc | snakemake-workflows | wdl`. The Foundry's source axis is currently `paper | nextflow | cwl`; if the Foundry adds an IWC summarizer (§5), use `iwc` not a new term.
 
-### 4. Domain ↔ `iwc/*` vocabulary mapping
+### 4. Domain ↔ `iwc/*` vocabulary mapping — **OBSOLETE**
+
+**Resolved (2026-07): the `iwc/*` tag family was dropped.** It was declared in `meta_tags.yml` as a seed-on-demand family and never carried a single note — patterns cite IWC by URL in the body instead (`CORPUS_INGESTION.md`). There are now no `iwc/*` keys to hang a mapping on, and the registry admits no open families at all, so anyone reviving this would first have to author the categories as registered, glossed keys. The original analysis is retained for context.
 
 gxy-sketches' fixed `domain` enum overlaps heavily with Foundry's `iwc/*` tag family (`iwc/variant-calling`, `iwc/rna-seq`, …). They will not be identical — gxy-sketches' `domain` is a single value chosen by the LLM; the Foundry's `iwc/*` is a multi-tag classification seeded from IWC directory layout (see `CORPUS_INGESTION.md`). Document the mapping in `meta_tags.yml` descriptions for `iwc/*` keys; do not force a merge.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -34,7 +34,7 @@ Authoritative term definitions live in `content/meta/glossary.md`; this section 
 
 - **Note** — a single `.md` file with frontmatter under the foundry's content root. Identity = filename stem, used as the wiki-link target.
 - **Type** — the single note-kind discriminator (`type:` in frontmatter): `mold | pattern | source-pattern | cli-tool | cli-command | pipeline | research | schema | prompt`. The `buildNoteSchema` discriminated union and the whole site (`data.type`) key off it; note-kind is never re-encoded as a tag. Within a type, further shape comes from typed fields (Molds use `axis`, `source`, `target`, `tool`), not a subtype.
-- **Tag** — controlled label declared in `meta_tags.yml`, reserved for **cross-cutting facets only** (never note-kind): hierarchical `source/*`, `target/*`, `tool/*`, `cli/*`, `topic/*`, `iwc/*`, plus flat flags like `meta`. Further subject-area families bloom as content lands — see §4.
+- **Tag** — controlled label declared in `meta_tags.yml`, reserved for **cross-cutting facets only** (never note-kind): hierarchical `source/*`, `target/*`, `tool/*`, `cli/*`, `topic/*`, plus flat flags like `meta`. Further subject-area families bloom as content lands — see §4.
 - **Mold** — `content/molds/<slug>/index.md`. Directory-based note: `index.md` is the only top-level frontmatter-bearing file; siblings (`eval.md`, `usage.md`, `refinement.md`, `refinements/`, `examples/`, optional `casting.md` / `cast-skill-verification.md` / `changes.md`) ride along verbatim. Files under `refinements/` are the one carve-out: each refinement-journal entry carries small structured frontmatter. Content shape: typed reference manifest in frontmatter + procedural body skeleton.
 - **Pattern** — single `.md` under `content/patterns/`. Reference content. IWC citations live in the body as URLs; see `CORPUS_INGESTION.md`. Wiki-linked from Molds.
 - **Source-pattern** — single `.md` under `content/source-patterns/<source>/`. Reference content mapping source-system structures to target-system constructs, with `source_pattern_kind`, `source`, `target`, and `implemented_by_patterns` frontmatter.
@@ -60,7 +60,7 @@ Source of truth: the `buildNoteSchema` discriminated union in `@galaxy-foundry/n
 | `type` | Required-extra | Facet tag(s) | Directory |
 |---|---|---|---|
 | `mold` | `name`, `axis` | `source/*`, `target/*`, `tool/*` per axis | `content/molds/<slug>/index.md` only |
-| `pattern` | `title`, `pattern_kind`, `evidence` | `target/*`, `topic/*`, optional `iwc/*` | `content/patterns/` |
+| `pattern` | `title`, `pattern_kind`, `evidence` | `target/*`, `topic/*` | `content/patterns/` |
 | `source-pattern` | `title`, `source`, `target`, `source_pattern_kind`, `implemented_by_patterns` | `source/*`, `target/*` | `content/source-patterns/<source>/` |
 | `cli-tool` | `tool`, `origin`, `package`, `invoke` | `cli/<tool>` | `content/cli/<tool>/index.md` |
 | `cli-command` | `tool`, `command` | `cli/<tool>` | `content/cli/<tool>/` |
@@ -77,17 +77,17 @@ Source of truth: the `buildNoteSchema` discriminated union in `@galaxy-foundry/n
 
 ## 4. Tag system
 
-`meta_tags.yml` is a flat YAML dict whose **keys** are the entire allowed tag vocabulary; each value is `{ description: "..." }`. Tags are cross-cutting facets only — note-kind is the `type:` discriminator, not a tag. Hierarchy is purely textual (slash-delimited); a bare key (no slash) is a flat flag. Examples:
+`meta_tags.yml` is a flat YAML dict whose **keys** are the entire allowed tag vocabulary; each value is `{ description: "..." }`. Tags are cross-cutting facets only — note-kind is the `type:` discriminator, not a tag. Hierarchy is purely textual (slash-delimited); a bare key (no slash) is a flat flag. Every key carries a `description`, and there is **no open or prefix-wildcard family** — a tag is registered with a gloss or it does not validate, so this file is the complete, permanent catalog of what the corpus can carry. Examples:
 
 ```yaml
 meta:
   description: "Foundry-meta note — about the Foundry's own tooling or an external harness it evaluates"
 target/galaxy:
   description: "Mold targets Galaxy"
-iwc/variant-calling:
-  description: "Variant-calling workflows (DNA-seq, somatic, germline)"
-iwc/rna-seq:
-  description: "RNA-seq quantification, splicing, differential expression"
+cli/gxwf:
+  description: "gxwf CLI (Galaxy workflow design-time tooling)"
+topic/collection-transform:
+  description: "Galaxy collection transformation pattern map"
 ```
 
 `buildNoteSchema` takes the registry keys (`loadTags` from `@galaxy-foundry/note-schema`) and enforces tag membership in the zod schema it builds, so there is no static tag enum to maintain. Vocabulary changes touch one file; the schema code stays static. The separation is load-bearing.
@@ -95,11 +95,10 @@ iwc/rna-seq:
 Tag families (facets only — note-kind is `type`, never a tag):
 - **`meta` (flat flag)** — Foundry-meta notes: the Foundry's own tooling / casting system, or an external harness/tool it evaluates. The one non-hierarchical tag.
 - **Prompt tags** (`prompt/*`) — classify reusable upstream or Foundry-authored prompt families, e.g. `prompt/galaxy-internal` for prompts sourced from Galaxy's internal agent prompt library.
-- **`iwc/*` (IWC domain coverage)** — not used as an aggregation surface. Pattern work relies on corpus citations in bodies.
 - **`cli/*` (CLI affiliation)** — every `cli-tool` and `cli-command` note carries `cli/<tool>` (e.g., `cli/gxwf`, `cli/planemo`). Drives per-tool browse pages and action-Mold reference surfaces.
 - **Source/target/tool axis tags** (`source/paper`, `source/nextflow`, `source/cwl`, `target/galaxy`, `target/cwl`, `tool/gxwf`, `tool/planemo`) — complement typed Mold and source-pattern fields and drive browse surfaces.
 
-**Subject-area tags beyond `iwc/*` are demand-driven.** A general Galaxy code/feature taxonomy (collections, tools, conditionals, ...) is not committed up front. Tag families bloom as patterns surface real cross-cutting needs.
+**Subject-area tags are demand-driven.** A general Galaxy code/feature taxonomy (collections, tools, conditionals, ...) is not committed up front. Tag families bloom as patterns surface real cross-cutting needs — and each one arrives as registered keys with glosses, never as an open family declared in advance. An `iwc/*` family (IWC corpus categories, seeded from the clone's directory layout) was declared this way and carried zero notes: patterns cite IWC by URL in the body instead (`CORPUS_INGESTION.md`), so it was dropped rather than filled in.
 
 Every note still carries at least one tag (`tags` is `minItems: 1`), but that tag is always a facet — there is no note-kind tag and no type↔tag coherence check.
 
@@ -409,7 +408,7 @@ foundry/
 ├── README.md
 ├── CLAUDE.md
 ├── Makefile
-├── meta_tags.yml                         # tag registry (incl. iwc/*)
+├── meta_tags.yml                         # tag registry (closed; every key glossed)
 ├── reference_contract.yml                # Mold reference-kind contract
 ├── vendored_upstreams.yml                # synced upstream artifact registry
 ├── dashboard_sections.json               # single source for Obsidian + Astro dashboards

--- a/meta_tags.yml
+++ b/meta_tags.yml
@@ -2,7 +2,8 @@
 # Validator + site inject these keys into the shared note-schema zod contract at build time.
 # Tags are cross-cutting facets only; note-kind is the `type:` discriminator, not a tag.
 # Hierarchy is purely textual (slash-delimited); a bare key (no slash) is a flat flag.
-# See INITIAL_ARCHITECTURE.md §4.
+# Every key is registered with a description: there is no open/prefix-wildcard family, so
+# this file is the complete catalog of what the corpus can carry. See docs/ARCHITECTURE.md §4.
 
 # --- meta (flat flag) ---
 meta:
@@ -48,11 +49,6 @@ tool/gxwf:
   description: "Mold wraps gxwf CLI surface"
 tool/planemo:
   description: "Mold wraps Planemo CLI surface"
-
-# --- iwc/* (subject-area: IWC corpus categories) ---
-# Seeded once from top-level dirs of <iwc-clone>/workflows/.
-# See INITIAL_CORPUS_INGESTION.md.
-# Add iwc/<category> entries here as patterns and Molds reference them.
 
 # --- topic/* (Foundry-authored pattern/MOC topics) ---
 topic/galaxy-transform:


### PR DESCRIPTION
> ℹ️ Filed by Claude (AI assistant) on behalf of @jmchilton — not authored by them personally.

## Why

Part of the cross-instance tag-handling sync (galaxyproject/foundry-pattern#12, unblocked now that #373, #374 and jmchilton/statistical-genomics-foundry#100 have landed).

Both Foundries are converging on one rule: **every tag is registered with a gloss, permanently.** An undocumented tag has nothing for the browse surface to render and nothing for a reader to learn from, so there is no open / free-form / prefix-wildcard family in either registry. `iwc/*` was this repo's only open-ended declaration.

## `iwc/*` was advertised but never usable

It lived in `meta_tags.yml` as a comment block inviting entries on demand:

```yaml
# --- iwc/* (subject-area: IWC corpus categories) ---
# Seeded once from top-level dirs of <iwc-clone>/workflows/.
# Add iwc/<category> entries here as patterns and Molds reference them.
```

Two problems:

1. **Zero notes carry an `iwc/*` tag** (grep-verified across `content/**`).
2. It was never *fillable*. `loadTags` keys off the registry's exact top-level keys, and no `iwc/<category>` key was ever registered — so any note trying to use one would have failed validation. The family was simultaneously advertised and impossible to use.

Nobody hit this because the real practice is documented elsewhere: patterns cite IWC by URL in the page body (`CORPUS_INGESTION.md`), which is what ARCHITECTURE §4 already conceded — "not used as an aggregation surface."

## Changes

- **`meta_tags.yml`** — drop the `iwc/*` comment block. Header now states the closed posture outright (every key glossed, no wildcard family) instead of leaving it implicit in the loader, and points at `docs/ARCHITECTURE.md` rather than a nonexistent `INITIAL_ARCHITECTURE.md`.
- **`docs/ARCHITECTURE.md`** — remove `iwc/*` from the §2 Tag bullet, the §3 `pattern` row's facet column, the §4 example YAML (swapped for real registered keys), the §4 tag-families list, and the repo-tree comment. The demand-driven paragraph now records *why* the family was dropped rather than filled in.
- **`content/research/gxy-sketches-alignment.md`** — its §4 proposed hanging a gxy-sketches `domain`-enum mapping off `iwc/*` descriptions. Marked `**OBSOLETE**` using that note's own §5 `**CLOSED**` convention, with the original analysis retained. `revision` bumped to 2.

No code changes — the loader already had no wildcard branch to remove.

## Verification

- `npm test` — 150/150 pass
- `npm run typecheck` (astro check) — 0 errors, 0 warnings
- `npm run validate` — **226 files, 0 errors, 202 warnings**, byte-identical to the stashed baseline on the unmodified tree, so nothing regressed
- `npm run build` (site) — 365 pages

## Related

- galaxyproject/foundry-pattern#11 — specifies the shared registry format both instances implement against
- jmchilton/statistical-genomics-foundry#102 — the sibling change, removing that repo's `open:` loader support

🤖 Generated with [Claude Code](https://claude.com/claude-code)