### PR TITLE
Tags: adopt the shared facets: registry format

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -34,7 +34,7 @@ Authoritative term definitions live in `content/meta/glossary.md`; this section 
 
 - **Note** — a single `.md` file with frontmatter under the foundry's content root. Identity = filename stem, used as the wiki-link target.
 - **Type** — the single note-kind discriminator (`type:` in frontmatter): `mold | pattern | source-pattern | cli-tool | cli-command | pipeline | research | schema | prompt`. The `buildNoteSchema` discriminated union and the whole site (`data.type`) key off it; note-kind is never re-encoded as a tag. Within a type, further shape comes from typed fields (Molds use `axis`, `source`, `target`, `tool`), not a subtype.
-- **Tag** — controlled label declared in `meta_tags.yml`, reserved for **cross-cutting facets only** (never note-kind): hierarchical `source/*`, `target/*`, `tool/*`, `cli/*`, `topic/*`, plus flat flags like `meta`. Further subject-area families bloom as content lands — see §4.
+- **Tag** — controlled label declared in `meta_tags.yml`, reserved for **cross-cutting facets only** (never note-kind). Every tag is declared by a facet — `source`, `target`, `tool`, `cli`, `topic`, `prompt`, `meta` — which is what makes it valid; the slash in `source/paper` is naming convention, not a rule. Further subject-area facets bloom as content lands — see §4.
 - **Mold** — `content/molds/<slug>/index.md`. Directory-based note: `index.md` is the only top-level frontmatter-bearing file; siblings (`eval.md`, `usage.md`, `refinement.md`, `refinements/`, `examples/`, optional `casting.md` / `cast-skill-verification.md` / `changes.md`) ride along verbatim. Files under `refinements/` are the one carve-out: each refinement-journal entry carries small structured frontmatter. Content shape: typed reference manifest in frontmatter + procedural body skeleton.
 - **Pattern** — single `.md` under `content/patterns/`. Reference content. IWC citations live in the body as URLs; see `CORPUS_INGESTION.md`. Wiki-linked from Molds.
 - **Source-pattern** — single `.md` under `content/source-patterns/<source>/`. Reference content mapping source-system structures to target-system constructs, with `source_pattern_kind`, `source`, `target`, and `implemented_by_patterns` frontmatter.
@@ -77,26 +77,36 @@ Source of truth: the `buildNoteSchema` discriminated union in `@galaxy-foundry/n
 
 ## 4. Tag system
 
-`meta_tags.yml` is a flat YAML dict whose **keys** are the entire allowed tag vocabulary; each value is `{ description: "..." }`. Tags are cross-cutting facets only — note-kind is the `type:` discriminator, not a tag. Hierarchy is purely textual (slash-delimited); a bare key (no slash) is a flat flag. Every key carries a `description`, and there is **no open or prefix-wildcard family** — a tag is registered with a gloss or it does not validate, so this file is the complete, permanent catalog of what the corpus can carry. Examples:
+`meta_tags.yml` groups the entire allowed tag vocabulary into **facets** — each declaring a `label`, a `description`, and its `values` (tag → one-line gloss). Tags are cross-cutting facets only; note-kind is the `type:` discriminator, never a tag.
 
 ```yaml
-meta:
-  description: "Foundry-meta note — about the Foundry's own tooling or an external harness it evaluates"
-target/galaxy:
-  description: "Mold targets Galaxy"
-cli/gxwf:
-  description: "gxwf CLI (Galaxy workflow design-time tooling)"
-topic/collection-transform:
-  description: "Galaxy collection transformation pattern map"
+version: 1
+facets:
+  meta:
+    label: Meta
+    description: Foundry-meta notes — the Foundry's own tooling, or an external harness it evaluates.
+    values:
+      meta: "Foundry-meta note — about the Foundry's own tooling, casting system, or an external harness/tool it evaluates"
+  target:
+    label: Target
+    description: What system a Mold produces for.
+    values:
+      target/galaxy: "Mold targets Galaxy"
 ```
 
-`buildNoteSchema` takes the registry keys (`loadTags` from `@galaxy-foundry/note-schema`) and enforces tag membership in the zod schema it builds, so there is no static tag enum to maintain. Vocabulary changes touch one file; the schema code stays static. The separation is load-bearing.
+Three rules carry the weight:
 
-Tag families (facets only — note-kind is `type`, never a tag):
-- **`meta` (flat flag)** — Foundry-meta notes: the Foundry's own tooling / casting system, or an external harness/tool it evaluates. The one non-hierarchical tag.
-- **Prompt tags** (`prompt/*`) — classify reusable upstream or Foundry-authored prompt families, e.g. `prompt/galaxy-internal` for prompts sourced from Galaxy's internal agent prompt library.
-- **`cli/*` (CLI affiliation)** — every `cli-tool` and `cli-command` note carries `cli/<tool>` (e.g., `cli/gxwf`, `cli/planemo`). Drives per-tool browse pages and action-Mold reference surfaces.
-- **Source/target/tool axis tags** (`source/paper`, `source/nextflow`, `source/cwl`, `target/galaxy`, `target/cwl`, `tool/gxwf`, `tool/planemo`) — complement typed Mold and source-pattern fields and drive browse surfaces.
+- **Membership is declared, not parsed.** A tag is valid because its facet lists it under `values`, never because its text starts with a facet name — `target/not-a-real-thing` is as invalid as `nonsense`. The slash is therefore a naming convention, and a bare key like `meta` is an ordinary member rather than a special "flat flag" case. The browse pages group by the *declaring* facet, which is what makes an "other" bucket impossible rather than merely empty.
+- **Every facet is closed.** Each tag is listed with a gloss, and there is no open/free-form/prefix-wildcard family. A tag is registered and documented, or it does not validate — so this file is the complete, permanent catalog of what the corpus can carry, and `/tags` always has something to render beside every entry.
+- **`tags` is `minItems: 1`.** Every note carries at least one tag, always a facet. There is no note-kind tag and no type↔tag coherence check.
+
+`buildNoteSchema` takes the registry (`loadTagRegistry` from `@galaxy-foundry/note-schema`) and asks it for membership, so there is no static tag enum to maintain. Vocabulary changes touch one file; the schema code stays static. The separation is load-bearing.
+
+The facets today: `meta` (Foundry-meta notes), `prompt` (reusable prompt families), `cli` (CLI affiliation — every `cli-tool`/`cli-command` note carries one, driving per-tool browse pages), `source` / `target` (what a Mold consumes and produces for), `tool` (which CLI surface a Mold wraps — distinct from `cli`, which says what a note is *about*), and `topic` (Foundry-authored pattern/MOC subject maps).
+
+`tests/registry-drift.test.ts` checks the converse of what the schema checks: the schema rejects a note carrying an unregistered tag, and the drift test rejects a registered tag carried by zero notes, or a facet with no members in use. It is a corpus-level test rather than a `validateDirectory` check because that runs against arbitrary directories — including fixtures where nearly every registered tag is legitimately unused.
+
+The registry **format** is shared across Foundry instances (spec: [galaxyproject/foundry-pattern](https://github.com/galaxyproject/foundry-pattern), `content/pattern/standing-up-a-foundry.instructions.txt`), so a format change is a cross-repo change. The facet **vocabulary** above is ours; the Statistical Genomics Foundry's is `family`/`role`/`domain`/`topic`, and only `topic` collides by name — ours groups pattern maps, theirs sits beneath a `domain`.
 
 **Subject-area tags are demand-driven.** A general Galaxy code/feature taxonomy (collections, tools, conditionals, ...) is not committed up front. Tag families bloom as patterns surface real cross-cutting needs — and each one arrives as registered keys with glosses, never as an open family declared in advance. An `iwc/*` family (IWC corpus categories, seeded from the clone's directory layout) was declared this way and carried zero notes: patterns cite IWC by URL in the body instead (`CORPUS_INGESTION.md`), so it was dropped rather than filled in.
 

--- a/meta_tags.yml
+++ b/meta_tags.yml
@@ -1,63 +1,84 @@
 # meta_tags.yml — controlled tag vocabulary.
-# Validator + site inject these keys into the shared note-schema zod contract at build time.
-# Tags are cross-cutting facets only; note-kind is the `type:` discriminator, not a tag.
-# Hierarchy is purely textual (slash-delimited); a bare key (no slash) is a flat flag.
-# Every key is registered with a description: there is no open/prefix-wildcard family, so
-# this file is the complete catalog of what the corpus can carry. See docs/ARCHITECTURE.md §4.
+# Validator + site inject this registry into the shared note-schema zod contract at build time.
+#
+# Tags are cross-cutting facets only; note-kind is the `type:` discriminator, never a tag.
+#
+# Membership is DECLARED, not parsed off the `/` prefix: a tag is valid because its facet
+# lists it under `values`, never because its text starts with a facet name. The slash is
+# therefore a naming convention, and a bare key (no slash, e.g. `meta`) is an ordinary
+# member — not a special "flat flag" case. Browse pages group by the DECLARING facet, so
+# no tag can fall through into an "other" bucket.
+#
+# Every facet is a CLOSED enum: each tag is listed here with a one-line gloss, so every tag
+# the corpus can carry is documented and browsable. There is no open/free-form/wildcard
+# family — an `iwc/*` one was declared once, carried zero notes, and was dropped.
+#
+# The FORMAT is shared across Foundry instances (spec: galaxyproject/foundry-pattern,
+# content/pattern/standing-up-a-foundry.instructions.txt) — treat a format change as a
+# cross-repo change. The facet VOCABULARY below is ours. See docs/ARCHITECTURE.md §4.
 
-# --- meta (flat flag) ---
-meta:
-  description: "Foundry-meta note — about the Foundry's own tooling, casting system, or an external harness/tool it evaluates"
+version: 1
 
-# --- Prompt classifications ---
-prompt/galaxy-internal:
-  description: "Prompt sourced from Galaxy's internal agent prompt library"
-# --- CLI affiliation (for cli-tool and cli-command notes) ---
-cli/gxwf:
-  description: "gxwf CLI (Galaxy workflow design-time tooling)"
-cli/galaxy-tool-cache:
-  description: "galaxy-tool-cache CLI (fetch/cache/inspect Galaxy tool metadata)"
-cli/planemo:
-  description: "Planemo CLI (Galaxy workflow runtime testing)"
-cli/cwltool:
-  description: "cwltool reference runner / validator for CWL"
-cli/cwl-utils:
-  description: "cwl-utils CLI (cwl-normalizer and friends)"
-cli/foundry:
-  description: "Foundry-shipped CLI bins (validators and harness tooling)"
+facets:
+  meta:
+    label: Meta
+    description: >-
+      Foundry-meta notes — about the Foundry's own tooling and casting system, or an
+      external harness/tool it evaluates. The one facet whose member carries no slash.
+    values:
+      meta: "Foundry-meta note — about the Foundry's own tooling, casting system, or an external harness/tool it evaluates"
 
-# --- Mold axis tags (provisional — may graduate to typed fields) ---
-source/paper:
-  description: "Mold consumes paper-shaped input"
-source/interview:
-  description: "Mold or pipeline starts from a free-form user interview"
-source/freeform:
-  description: "Mold consumes a normalized free-form source summary"
-source/nextflow:
-  description: "Mold consumes Nextflow-shaped input"
-source/cwl:
-  description: "Mold consumes CWL-shaped input"
-source/galaxy:
-  description: "Mold consumes an existing Galaxy gxformat2/.ga workflow as its source"
-source/snakemake:
-  description: "Source-pattern or Mold consumes Snakemake-shaped input"
-target/galaxy:
-  description: "Mold targets Galaxy"
-target/cwl:
-  description: "Mold targets CWL"
-tool/gxwf:
-  description: "Mold wraps gxwf CLI surface"
-tool/planemo:
-  description: "Mold wraps Planemo CLI surface"
+  prompt:
+    label: Prompt
+    description: Reusable upstream or Foundry-authored prompt families.
+    values:
+      prompt/galaxy-internal: "Prompt sourced from Galaxy's internal agent prompt library"
 
-# --- topic/* (Foundry-authored pattern/MOC topics) ---
-topic/galaxy-transform:
-  description: "Galaxy data-shape transformation pattern maps"
-topic/collection-transform:
-  description: "Galaxy collection transformation pattern map"
-topic/tabular-transform:
-  description: "Galaxy tabular transformation pattern map"
-topic/interval-transform:
-  description: "Galaxy genomic interval transformation pattern map"
-topic/sequence-transform:
-  description: "Galaxy sequence-record (FASTA) transformation pattern map"
+  cli:
+    label: CLI
+    description: >-
+      CLI affiliation — every cli-tool and cli-command note carries one. Drives per-tool
+      browse pages and action-Mold reference surfaces.
+    values:
+      cli/gxwf: "gxwf CLI (Galaxy workflow design-time tooling)"
+      cli/galaxy-tool-cache: "galaxy-tool-cache CLI (fetch/cache/inspect Galaxy tool metadata)"
+      cli/planemo: "Planemo CLI (Galaxy workflow runtime testing)"
+      cli/cwltool: "cwltool reference runner / validator for CWL"
+      cli/cwl-utils: "cwl-utils CLI (cwl-normalizer and friends)"
+      cli/foundry: "Foundry-shipped CLI bins (validators and harness tooling)"
+
+  source:
+    label: Source
+    description: What shape of input a Mold or source-pattern consumes.
+    values:
+      source/paper: "Mold consumes paper-shaped input"
+      source/interview: "Mold or pipeline starts from a free-form user interview"
+      source/freeform: "Mold consumes a normalized free-form source summary"
+      source/nextflow: "Mold consumes Nextflow-shaped input"
+      source/cwl: "Mold consumes CWL-shaped input"
+      source/galaxy: "Mold consumes an existing Galaxy gxformat2/.ga workflow as its source"
+
+  target:
+    label: Target
+    description: What system a Mold produces for.
+    values:
+      target/galaxy: "Mold targets Galaxy"
+      target/cwl: "Mold targets CWL"
+
+  tool:
+    label: Tool
+    description: >-
+      Which CLI surface a Mold wraps. Distinct from `cli/*`, which says what a cli-tool or
+      cli-command note is *about*.
+    values:
+      tool/planemo: "Mold wraps Planemo CLI surface"
+
+  topic:
+    label: Topic
+    description: Foundry-authored pattern/MOC topics — the subject maps patterns group under.
+    values:
+      topic/galaxy-transform: "Galaxy data-shape transformation pattern maps"
+      topic/collection-transform: "Galaxy collection transformation pattern map"
+      topic/tabular-transform: "Galaxy tabular transformation pattern map"
+      topic/interval-transform: "Galaxy genomic interval transformation pattern map"
+      topic/sequence-transform: "Galaxy sequence-record (FASTA) transformation pattern map"

--- a/packages/build-cli/src/commands/validate.ts
+++ b/packages/build-cli/src/commands/validate.ts
@@ -16,7 +16,7 @@ import {
 import { readMarkdown } from "../lib/frontmatter.js";
 import { loadLicensePolicy, resolveLicenseRow } from "../lib/license-policy.js";
 import { parsePhases, phaseMoldPaths, type ParsedPhase } from "../lib/pipeline-phases.js";
-import { loadTags } from "../lib/schema.js";
+import { loadTagRegistry } from "../lib/schema.js";
 import type { FileMeta, Frontmatter, ValidationResult } from "../lib/types.js";
 import { fileSlug, findMdFiles } from "../lib/walk.js";
 import { resolveWikiLink, slugify, WIKI_LINK_RE } from "../lib/wiki-links.js";
@@ -132,6 +132,11 @@ interface CrossFileFinding {
   message: string;
   severity: "error" | "warning";
 }
+
+// Registry drift — "is a registered tag carried by nothing?" — is deliberately NOT checked
+// here. validateDirectory runs against arbitrary directories, including small fixtures, where
+// almost every registered tag is legitimately unused; the question only means anything against
+// the whole corpus. It lives in tests/registry-drift.test.ts instead.
 
 function buildSlugMap(files: FileMeta[]): Map<string, string> {
   const m = new Map<string, string>();
@@ -1380,7 +1385,7 @@ export function validateDirectory(opts: ValidateOptions): {
   const repoRoot =
     path.basename(opts.directory) === "content" ? path.dirname(opts.directory) : opts.directory;
   const schema = buildNoteSchema({
-    tags: loadTags(opts.tagsPath),
+    tags: loadTagRegistry(opts.tagsPath),
     contract: loadReferenceContract(),
     licensePolicy: loadLicensePolicy(repoRoot),
   });

--- a/packages/build-cli/src/index.ts
+++ b/packages/build-cli/src/index.ts
@@ -20,6 +20,6 @@ export {
   type ParsedPhases,
   type PhaseFinding,
 } from "./lib/pipeline-phases.js";
-export { loadTags } from "./lib/schema.js";
+export { loadTagRegistry, type TagRegistry } from "./lib/schema.js";
 export { fileSlug, findMdFiles } from "./lib/walk.js";
 export { resolveWikiLink, slugify, stripBrackets, WIKI_LINK_RE } from "./lib/wiki-links.js";

--- a/packages/build-cli/src/lib/schema.ts
+++ b/packages/build-cli/src/lib/schema.ts
@@ -1,4 +1,4 @@
 // Re-export of the shared tags loader. The frontmatter contract itself now lives
 // in @galaxy-foundry/note-schema (buildNoteSchema); the former ajv `loadSchema`
 // + meta_schema.yml were retired when the validator went native-zod.
-export { loadTags } from "@galaxy-foundry/note-schema";
+export { loadTagRegistry, type TagRegistry } from "@galaxy-foundry/note-schema";

--- a/packages/note-schema/README.md
+++ b/packages/note-schema/README.md
@@ -16,10 +16,14 @@ encoding but not the other).
 The controlled enums are injected at call time from the repo-root registries so
 the schema and the registries can never diverge:
 
-- `meta_tags.yml` → allowed `tags[]`
+- `meta_tags.yml` → allowed `tags[]` (facets, each declaring its members and their glosses)
 - `reference_contract.yml` → allowed `references[]` vocab
 - `license-policy.yml` → allowed `license` ids
 
-The registry loaders (`loadTags`, `loadReferenceContract`, `loadLicensePolicy`,
+The registry loaders (`loadTagRegistry`, `loadReferenceContract`, `loadLicensePolicy`,
 `resolveLicenseRow`, `isValidLicenseId`) are exported from here too, so the
 validator, the caster, and the site's license UI share one implementation.
+
+`loadTagRegistry` returns a registry object rather than a bare list: tag membership
+is *declared* by a facet's `values`, never parsed off the `/` prefix, so callers ask
+it (`isValidTag`, `facetOf`, `tagDescription`, `facets`) instead of matching strings.

--- a/packages/note-schema/src/index.ts
+++ b/packages/note-schema/src/index.ts
@@ -25,4 +25,12 @@ export {
   type RedistributionPolicy,
 } from "./license-policy.js";
 
-export { loadTags } from "./tags.js";
+export {
+  loadTagRegistry,
+  tagRegistry,
+  buildTagIndex,
+  type TagRegistry,
+  type TagRegistryFile,
+  type Facet,
+  type FacetInfo,
+} from "./tags.js";

--- a/packages/note-schema/src/note-schema.ts
+++ b/packages/note-schema/src/note-schema.ts
@@ -11,10 +11,12 @@ import { z } from "zod";
 
 import { contractKeys, type ReferenceContract } from "./reference-contract.js";
 import { isValidLicenseId, resolveLicenseRow, type LicensePolicy } from "./license-policy.js";
+import { type TagRegistry } from "./tags.js";
 
 export interface BuildNoteSchemaOptions {
-  /** Controlled tag vocabulary (meta_tags.yml keys). */
-  tags: string[];
+  /** Controlled tag vocabulary (meta_tags.yml). Membership is declared by the registry's
+   *  facets, so the schema asks the registry rather than matching a prefix itself. */
+  tags: TagRegistry;
   /** Reference-contract registries (reference_contract.yml). */
   contract: ReferenceContract;
   /** License → redistribution-policy table (license-policy.yml). */
@@ -55,11 +57,11 @@ const sourceKinds = [
 ] as const;
 
 export function buildNoteSchema({ tags, contract, licensePolicy }: BuildNoteSchemaOptions) {
-  const tagSet = new Set(tags);
-
-  // Tag membership check (meta_tags.yml). Mirrors the old ajv tags.items.enum.
+  // Tag membership check (meta_tags.yml): valid iff some facet declares the tag under
+  // its `values`. Never a prefix match — `target/not-a-real-thing` is as invalid as
+  // `nonsense`, and a bare key like `meta` is as valid as a slashed one.
   const tag = z.string().superRefine((t: string, ctx: z.RefinementCtx) => {
-    if (!tagSet.has(t)) {
+    if (!tags.isValidTag(t)) {
       ctx.addIssue({ code: "custom", message: `unknown tag '${t}' (not in meta_tags.yml)` });
     }
   });

--- a/packages/note-schema/src/tags.ts
+++ b/packages/note-schema/src/tags.ts
@@ -1,11 +1,89 @@
-// Loader for meta_tags.yml — the controlled tag vocabulary. Every note's
-// `tags[]` entry must be a top-level key here.
+// Loader for meta_tags.yml — the controlled tag vocabulary.
+//
+// The FORMAT is shared across Foundry instances (spec: galaxyproject/foundry-pattern,
+// `content/pattern/standing-up-a-foundry.instructions.txt`), so treat a format change as
+// a cross-repo change. The facet VOCABULARY in meta_tags.yml is this instance's own.
 
 import { readFileSync } from "node:fs";
 
 import yaml from "js-yaml";
 
-export function loadTags(tagsPath: string): string[] {
-  const data = yaml.load(readFileSync(tagsPath, "utf8")) as Record<string, unknown> | null;
-  return data ? Object.keys(data) : [];
+/** One declared grouping of tags: a browse axis with its members and their glosses. */
+export interface Facet {
+  label: string;
+  description: string;
+  /** tag -> one-line gloss. The keys are the tags themselves, not leaf names. */
+  values?: Record<string, string>;
+}
+
+export interface TagRegistryFile {
+  version: number;
+  facets: Record<string, Facet>;
+}
+
+export interface FacetInfo {
+  key: string;
+  label: string;
+  description: string;
+}
+
+interface TagEntry {
+  /** The facet that DECLARED this tag — not whatever precedes its slash. */
+  facet: string;
+  gloss: string;
+}
+
+/**
+ * Flatten a registry to `tag -> { facet, gloss }`.
+ *
+ * This is the one place membership is decided, and it is decided by DECLARATION: a tag is
+ * valid because some facet lists it under `values`, never because its text happens to
+ * start with a facet name. So the slash in `target/galaxy` is a naming convention rather
+ * than a rule, and a bare key like `meta` is an ordinary member of its facet — no flat-flag
+ * special case anywhere in the loader, the schema, or the browse pages.
+ */
+export function buildTagIndex(file: TagRegistryFile): Map<string, TagEntry> {
+  const index = new Map<string, TagEntry>();
+  for (const [facet, f] of Object.entries(file?.facets ?? {})) {
+    for (const [tag, gloss] of Object.entries(f.values ?? {})) index.set(tag, { facet, gloss });
+  }
+  return index;
+}
+
+export interface TagRegistry {
+  /** Valid iff the tag is an exact key under some facet's `values`. Every facet is
+   *  closed — no open/prefix-wildcard family — so every usable tag has a gloss. */
+  isValidTag(tag: string): boolean;
+  /** Facets in declared order; the tag index groups by these. */
+  facets(): FacetInfo[];
+  /** The facet that declared this tag, or undefined if unregistered. Callers group by
+   *  this rather than by prefix, which is what makes an "other" bucket impossible. */
+  facetOf(tag: string): string | undefined;
+  facetLabel(key: string | undefined): string;
+  /** A tag's registry gloss. Every valid tag has one. */
+  tagDescription(tag: string): string | undefined;
+  /** Every registered tag, in declaration order. */
+  allTags(): string[];
+}
+
+export function tagRegistry(file: TagRegistryFile): TagRegistry {
+  const index = buildTagIndex(file);
+  const facetMap = file?.facets ?? {};
+  return {
+    isValidTag: (tag) => index.has(tag),
+    facets: () =>
+      Object.entries(facetMap).map(([key, f]) => ({
+        key,
+        label: f.label,
+        description: f.description,
+      })),
+    facetOf: (tag) => index.get(tag)?.facet,
+    facetLabel: (key) => (key && facetMap[key]?.label) || (key ?? ""),
+    tagDescription: (tag) => index.get(tag)?.gloss,
+    allTags: () => [...index.keys()],
+  };
+}
+
+export function loadTagRegistry(tagsPath: string): TagRegistry {
+  return tagRegistry(yaml.load(readFileSync(tagsPath, "utf8")) as TagRegistryFile);
 }

--- a/packages/note-schema/test/note-schema.test.ts
+++ b/packages/note-schema/test/note-schema.test.ts
@@ -7,7 +7,7 @@ import {
   buildNoteSchema,
   loadLicensePolicy,
   loadReferenceContract,
-  loadTags,
+  loadTagRegistry,
 } from "../src/index.js";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
@@ -15,7 +15,7 @@ const repoRoot = path.resolve(here, "../../..");
 
 function realSchema() {
   return buildNoteSchema({
-    tags: loadTags(path.join(repoRoot, "meta_tags.yml")),
+    tags: loadTagRegistry(path.join(repoRoot, "meta_tags.yml")),
     contract: loadReferenceContract(path.join(repoRoot, "reference_contract.yml")),
     licensePolicy: loadLicensePolicy(repoRoot),
   });

--- a/packages/note-schema/test/tags.test.ts
+++ b/packages/note-schema/test/tags.test.ts
@@ -1,0 +1,89 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { buildTagIndex, loadTagRegistry, tagRegistry, type TagRegistryFile } from "../src/index.js";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "../../..");
+const real = loadTagRegistry(path.join(repoRoot, "meta_tags.yml"));
+
+// Membership is DECLARED — a tag is valid because some facet lists it under `values`,
+// never because its text starts with a facet name. A synthetic registry proves the
+// properties the real one cannot: it has exactly one bare tag, so "bare keys work" and
+// "prefix-lookalikes are rejected" need cases the vocabulary does not naturally supply.
+const synthetic: TagRegistryFile = {
+  version: 1,
+  facets: {
+    meta: { label: "Meta", description: "Foundry-meta notes.", values: { meta: "A meta note." } },
+    target: {
+      label: "Target",
+      description: "What a Mold produces for.",
+      values: { "target/x": "An X." },
+    },
+    empty: { label: "Empty", description: "Declares no members." },
+  },
+};
+
+describe("tag registry format", () => {
+  it("resolves a bare key exactly like a slashed one", () => {
+    const index = buildTagIndex(synthetic);
+    expect(index.get("meta")).toEqual({ facet: "meta", gloss: "A meta note." });
+    expect(index.get("target/x")).toEqual({ facet: "target", gloss: "An X." });
+  });
+
+  // The whole point of declared membership: this must NOT validate, or membership would
+  // be prefix-parsing wearing a new name.
+  it("rejects an undeclared tag that merely looks namespaced", () => {
+    expect(tagRegistry(synthetic).isValidTag("target/unlisted")).toBe(false);
+  });
+
+  it("tolerates a facet with no values block", () => {
+    expect(
+      tagRegistry(synthetic)
+        .facets()
+        .map((f) => f.key),
+    ).toContain("empty");
+    expect(tagRegistry(synthetic).allTags()).not.toContain("empty");
+  });
+
+  it("attributes a tag to the facet that declared it, not its prefix", () => {
+    const r = tagRegistry({
+      version: 1,
+      // `cli/gxwf` declared under `tool`, deliberately: prefix-parsing would say "cli".
+      facets: { tool: { label: "Tool", description: "…", values: { "cli/gxwf": "gxwf." } } },
+    });
+    expect(r.facetOf("cli/gxwf")).toBe("tool");
+    expect(r.facetLabel(r.facetOf("cli/gxwf"))).toBe("Tool");
+  });
+});
+
+describe("the real registry (meta_tags.yml)", () => {
+  it("validates its own tags and rejects an unregistered one", () => {
+    expect(real.isValidTag("target/galaxy")).toBe(true);
+    expect(real.isValidTag("meta")).toBe(true);
+    expect(real.isValidTag("target/not-a-real-thing")).toBe(false);
+    expect(real.isValidTag("nonsense")).toBe(false);
+  });
+
+  // Closed forever: an undocumented tag has nothing for the browse surface to render.
+  it("gives every registered tag a non-empty gloss and a declaring facet", () => {
+    const bad = real
+      .allTags()
+      .filter((t) => !real.tagDescription(t)?.trim() || real.facetOf(t) === undefined);
+    expect(bad).toEqual([]);
+  });
+
+  it("declares no open facets", () => {
+    const raw = loadTagRegistry(path.join(repoRoot, "meta_tags.yml"));
+    // `open` was never a concept in this loader and must not become one silently: the
+    // sibling Foundry removed its support, so a stray `open: true` here would be inert.
+    for (const f of raw.facets()) expect(Object.keys(f)).toEqual(["key", "label", "description"]);
+  });
+
+  it("gives every facet a label and description for the browse surface", () => {
+    const bare = real.facets().filter((f) => !f.label?.trim() || !f.description?.trim());
+    expect(bare).toEqual([]);
+  });
+});

--- a/site/src/lib/registries.ts
+++ b/site/src/lib/registries.ts
@@ -4,11 +4,13 @@
 // validator also uses — so the site and the validator can no longer drift.
 import path from 'node:path';
 
-import { loadLicensePolicy, loadReferenceContract, loadTags } from '@galaxy-foundry/note-schema';
+import { loadLicensePolicy, loadReferenceContract, loadTagRegistry } from '@galaxy-foundry/note-schema';
 
 // Astro builds run from the site/ directory; the registries live at the repo root.
 const repoRoot = path.resolve('..');
 
 export const licensePolicy = loadLicensePolicy(repoRoot);
 export const referenceContract = loadReferenceContract(path.join(repoRoot, 'reference_contract.yml'));
-export const tags = loadTags(path.join(repoRoot, 'meta_tags.yml'));
+// The tag registry answers membership itself (declared by its facets, never parsed off the
+// `/` prefix) and carries the facet labels/descriptions the /tags pages group and render by.
+export const tags = loadTagRegistry(path.join(repoRoot, 'meta_tags.yml'));

--- a/site/src/pages/tags/[...tag].astro
+++ b/site/src/pages/tags/[...tag].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import Base from '../../layouts/Base.astro';
+import { tags as registry } from '../../lib/registries';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 
@@ -15,6 +16,11 @@ export async function getStaticPaths() {
 
 const { tag } = Astro.props;
 const allNotes = await getCollection('content');
+
+// Declaring facet + registry gloss, resolved from meta_tags.yml rather than parsed off
+// the tag text — so this stays correct for a bare tag like `meta`.
+const facetLabel = registry.facetLabel(registry.facetOf(tag));
+const gloss = registry.tagDescription(tag);
 
 const notes = allNotes
   .filter(n => n.data.tags.includes(tag) && n.data.status !== 'archived')
@@ -44,7 +50,9 @@ function noteTitle(n: typeof allNotes[number]): string {
 }
 ---
 <Base title={`Tag: ${tag}`}>
-  <h1 class="mb-4 text-2xl font-bold">Tag: <span class="tag">{tag}</span></h1>
+  <div class="mb-1 text-xs font-semibold uppercase tracking-wider text-(--color-text-secondary)">{facetLabel}</div>
+  <h1 class="mb-2 text-2xl font-bold">Tag: <span class="tag">{tag}</span></h1>
+  {gloss && <p class="mb-2 text-(--color-text-secondary)">{gloss}</p>}
   <p class="mb-4 text-(--color-text-secondary)">{notes.length} note{notes.length !== 1 ? 's' : ''}</p>
 
   {coTags.length > 0 && (

--- a/site/src/pages/tags/index.astro
+++ b/site/src/pages/tags/index.astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import Base from '../../layouts/Base.astro';
+import { tags as registry } from '../../lib/registries';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const allNotes = await getCollection('content');
@@ -15,32 +16,34 @@ for (const note of allNotes) {
 
 const sorted = [...tagCounts.entries()].sort((a, b) => a[0].localeCompare(b[0]));
 
-const sourceTags = sorted.filter(([t]) => t.startsWith('source/'));
-const targetTags = sorted.filter(([t]) => t.startsWith('target/'));
-const topicTags = sorted.filter(([t]) => t.startsWith('topic/'));
-const toolTags = sorted.filter(([t]) => t.startsWith('tool/') || t.startsWith('cli/'));
-const seen = new Set([...sourceTags, ...targetTags, ...topicTags, ...toolTags].map(([t]) => t));
-const otherTags = sorted.filter(([t]) => !seen.has(t));
-
-const groups = [
-  { label: 'Source', tags: sourceTags },
-  { label: 'Target', tags: targetTags },
-  { label: 'Topic', tags: topicTags },
-  { label: 'Tool / CLI', tags: toolTags },
-  { label: 'Other', tags: otherTags },
-];
+// Groups come from meta_tags.yml in its declared facet order, and each tag lands in the
+// facet that DECLARED it — not the one its text happens to start with. That is why there
+// is no "Other" bucket to fall into: every tag in use is registered, so every tag has a
+// facet. The per-tag glosses the registry has always carried are rendered here too.
+const groups = registry.facets().map(f => ({
+  ...f,
+  tags: sorted.filter(([t]) => registry.facetOf(t) === f.key),
+}));
 ---
 <Base title="Tags">
   <h1 class="mb-4 text-2xl font-bold">Tags</h1>
+  <p class="mb-6 text-(--color-text-secondary)">
+    Cross-cutting facets only — a note's kind is its <code>type</code>, never a tag. Every tag
+    below is registered and glossed in <code>meta_tags.yml</code>.
+  </p>
 
   {groups.map(g => g.tags.length > 0 && (
     <>
-      <h2 class="mt-8 mb-3 text-xl font-semibold border-b-2 border-(--color-accent)/20 pb-2">{g.label}</h2>
-      <ul class="list-none my-2 mb-6 p-0 flex flex-wrap gap-2">
+      <h2 class="mt-8 mb-1 text-xl font-semibold border-b-2 border-(--color-accent)/20 pb-2">{g.label}</h2>
+      <p class="mb-3 text-sm text-(--color-text-secondary)">{g.description}</p>
+      <ul class="list-none my-2 mb-6 p-0 grid gap-3 sm:grid-cols-2">
         {g.tags.map(([tag, count]) => (
-          <li class="flex items-center gap-1">
-            <a href={`${base}/tags/${tag}/`} class="no-underline"><span class="tag">{tag}</span></a>
-            <span class="text-xs text-(--color-text-secondary)">({count})</span>
+          <li>
+            <a href={`${base}/tags/${tag}/`} class="no-underline flex items-baseline gap-2">
+              <span class="tag">{tag}</span>
+              <span class="text-xs text-(--color-text-secondary)">({count})</span>
+            </a>
+            <div class="mt-0.5 text-sm text-(--color-text-secondary)">{registry.tagDescription(tag)}</div>
           </li>
         ))}
       </ul>

--- a/tests/registry-drift.test.ts
+++ b/tests/registry-drift.test.ts
@@ -1,0 +1,62 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { loadTagRegistry } from "@galaxy-foundry/note-schema";
+import { readMarkdown } from "../packages/build-cli/src/lib/frontmatter.js";
+import { findMdFiles } from "../packages/build-cli/src/lib/walk.js";
+
+// The registry and the corpus must agree BOTH ways.
+//
+// The schema rejects a note carrying an unregistered tag; that direction is cheap and the
+// validator already covers it. This is the converse — nothing registered is carried by zero
+// notes. Dead vocabulary is otherwise only found by diffing two instances by hand, which is
+// the manual pass this exists to retire (galaxyproject/foundry-pattern#12).
+//
+// It lives here rather than in `validateDirectory` on purpose: that runs against arbitrary
+// directories, including small fixtures where nearly every registered tag is legitimately
+// unused. The question only means anything against the whole corpus.
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "..");
+const registry = loadTagRegistry(path.join(repoRoot, "meta_tags.yml"));
+
+const tagsInUse = (() => {
+  const inUse = new Set<string>();
+  for (const file of findMdFiles(path.join(repoRoot, "content"))) {
+    const { meta } = readMarkdown(file);
+    const tags = meta?.tags;
+    if (!Array.isArray(tags)) continue;
+    for (const t of tags) if (typeof t === "string") inUse.add(t);
+  }
+  return inUse;
+})();
+
+describe("registry drift (authored vocabulary vs corpus)", () => {
+  // Guards the walk itself: if the frontmatter reader stopped matching, every assertion
+  // below would pass vacuously and report a clean bill of health we did not earn.
+  it("found tags in use to check against", () => {
+    expect(tagsInUse.size).toBeGreaterThan(10);
+  });
+
+  it("has no registered tag carried by zero notes", () => {
+    const dead = registry.allTags().filter((t) => !tagsInUse.has(t));
+    expect(dead, `\nregistered but unused: ${dead.join(", ")}`).toEqual([]);
+  });
+
+  // A facet whose members are all unused renders as nothing on /tags — a browse axis that
+  // exists only in the registry.
+  it("has no facet with zero members in use", () => {
+    const empty = registry
+      .facets()
+      .map((f) => f.key)
+      .filter((key) => ![...tagsInUse].some((t) => registry.facetOf(t) === key));
+    expect(empty, `\nfacets with no tags in use: ${empty.join(", ")}`).toEqual([]);
+  });
+
+  // The schema enforces this per-note; asserting it over the corpus catches a tag that
+  // slipped in via a path the schema does not cover (generated notes, hand-edited casts).
+  it("has no tag in use that the registry does not declare", () => {
+    const unregistered = [...tagsInUse].filter((t) => !registry.isValidTag(t));
+    expect(unregistered, `\nin use but unregistered: ${unregistered.join(", ")}`).toEqual([]);
+  });
+});

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -6,7 +6,7 @@ import {
   buildNoteSchema,
   loadLicensePolicy,
   loadReferenceContract,
-  loadTags,
+  loadTagRegistry,
 } from "@galaxy-foundry/note-schema";
 import { validateData, validateDirectory } from "../packages/build-cli/src/commands/validate.js";
 
@@ -16,7 +16,7 @@ const TAGS_PATH = path.join(repoRoot, "meta_tags.yml");
 
 function loadRealSchema() {
   return buildNoteSchema({
-    tags: loadTags(TAGS_PATH),
+    tags: loadTagRegistry(TAGS_PATH),
     contract: loadReferenceContract(path.join(repoRoot, "reference_contract.yml")),
     licensePolicy: loadLicensePolicy(repoRoot),
   });


### PR DESCRIPTION
meta_tags.yml goes from a flat key->description dict to facets, each declaring a label, description, and its values (tag -> gloss). Membership becomes DECLARED rather than parsed: a tag is valid because its facet lists it, never because its text starts with a facet name. loadTags(): string[] becomes loadTagRegistry(): TagRegistry, and buildNoteSchema asks the registry instead of a Set.

What that buys, beyond matching the sibling Foundry:
- `target/not-a-real-thing` is as invalid as `nonsense`;
- the bare `meta` tag stops being a documented special case — it is just a value whose key has no slash;
- /tags groups by the DECLARING facet, so the five hardcoded groups and the "Other" bucket are gone. Other was structurally reachable before; now it cannot arise, because every registered tag has a facet;
- the per-tag descriptions the registry has always carried are finally rendered, on both the index cards and the tag detail page, alongside the facet label.

Drops source/snakemake and tool/gxwf — registered, carried by nothing.

Adds tests/registry-drift.test.ts: registered-but-unused tags, facets with no members in use, and tags in use the registry does not declare. It is a corpus-level test, NOT a validateDirectory check — that runs against arbitrary directories including fixtures, where nearly every registered tag is legitimately unused. Wiring it into the validator first produced 27 spurious warnings against a two-note fixture, which is what moved it here.

Declared membership is proven on a synthetic registry, including a facet that declares a tag whose prefix names a different facet — the case that separates declaration from prefix-parsing and that the real vocabulary cannot supply.