### PR TITLE
Give every note kind its own directory

### DIFF
--- a/.claude/commands/review-mold.md
+++ b/.claude/commands/review-mold.md
@@ -16,8 +16,8 @@ Before reading anything, run `npm run validate` and capture its output. Do **not
 - Frontmatter schema + tag registration.
 - Wiki-link resolution and target-type matching for `patterns`, `cli_commands`, `related_patterns`, `related_molds`.
 - `references[].kind` → target `type` matching (`pattern`, `cli-command`, `prompt`, `research`, `schema`, `example`).
-- `evidence: hypothesis` requires `verification`.
-- `load: on-demand` requires `trigger` (warning).
+- `evidence: hypothesis` requires `verification` (schema error).
+- `load: on-demand` requires `trigger` (schema error).
 - Schema refs require `package` + `package_export` on the target note.
 - Bidirectional `related_notes` backlinks.
 

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Validate content
         run: npm run validate
 
+      - name: Check the kind manifest is current
+        run: npm run check:kinds
+
       - name: Typecheck root and site
         run: npm run typecheck
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "check:dashboard": "tsx packages/build-cli/src/bin/foundry-build.ts generate-dashboard --root . --check",
     "index": "tsx packages/build-cli/src/bin/foundry-build.ts generate-index --root .",
     "check:index": "tsx packages/build-cli/src/bin/foundry-build.ts generate-index --root . --check",
+    "kinds": "tsx scripts/generate-kind-manifest.ts",
+    "check:kinds": "tsx scripts/generate-kind-manifest.ts --check",
     "check:vendored": "tsx scripts/sync-vendored-upstreams.ts --check",
     "sync:vendored": "tsx scripts/sync-vendored-upstreams.ts --update",
     "cast": "tsx packages/build-cli/src/bin/foundry-build.ts cast --root .",

--- a/packages/build-cli/src/commands/validate.ts
+++ b/packages/build-cli/src/commands/validate.ts
@@ -283,20 +283,10 @@ function validateTypedReference(
   if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return;
   const ref = raw as Record<string, unknown>;
   if (typeof ref.kind !== "string" || typeof ref.ref !== "string") return;
-  if (ref.evidence === "hypothesis" && typeof ref.verification !== "string") {
-    findings.push({
-      path: filePath,
-      severity: "error",
-      message: `references[${index}]: evidence=hypothesis requires verification`,
-    });
-  }
-  if (ref.load === "on-demand" && typeof ref.trigger !== "string") {
-    findings.push({
-      path: filePath,
-      severity: "warning",
-      message: `references[${index}]: load=on-demand should describe the trigger`,
-    });
-  }
+  // The two intra-reference rules (hypothesis => verification, on-demand => trigger) are
+  // NOT checked here: they are cross-field rules over one reference object, which the note
+  // schema already raises path-anchored issues for. Only the CROSS-FILE checks below —
+  // which need the slug map and cannot live in a schema — belong in this pass.
 
   const expectedTypes: Record<string, string> = {
     pattern: "pattern",

--- a/packages/note-schema/src/index.ts
+++ b/packages/note-schema/src/index.ts
@@ -4,6 +4,25 @@
 export { buildNoteSchema, type BuildNoteSchemaOptions, type NoteSchema } from "./note-schema.js";
 
 export {
+  KINDS,
+  KINDS_BY_NAME,
+  buildKindContext,
+  type KindContext,
+  type KindDefinition,
+} from "./types/index.js";
+
+export {
+  buildKindManifest,
+  describeFields,
+  describeType,
+  KIND_MANIFEST_VERSION,
+  type BuildKindManifestOptions,
+  type KindManifest,
+  type ManifestField,
+  type ManifestKind,
+} from "./kind-manifest.js";
+
+export {
   loadReferenceContract,
   findReferenceContractPath,
   contractKeys,

--- a/packages/note-schema/src/kind-manifest.ts
+++ b/packages/note-schema/src/kind-manifest.ts
@@ -1,0 +1,123 @@
+// Derive the kind manifest — the machine-readable form of "what kinds does this Foundry
+// define, and what metadata does each require".
+//
+// `fields` is DERIVED from the zod shape, never hand-written. A hand-maintained
+// required-metadata table is a second encoding of the schema and drifts the first week; this
+// one cannot, because it is read off the same object the validator runs.
+//
+// The FORMAT is shared across Foundry instances (spec: galaxyproject/foundry-pattern,
+// `content/pattern/standing-up-a-foundry.instructions.txt`), so treat a format change as a
+// cross-repo change. The kinds in it are this instance's own.
+
+import type { z } from "zod";
+
+import { buildKindContext } from "./types/context.js";
+import type { BuildKindContextOptions } from "./types/context.js";
+import { KINDS } from "./types/index.js";
+
+export const KIND_MANIFEST_VERSION = 1;
+
+export interface ManifestField {
+  name: string;
+  required: boolean;
+  /** A readable rendering of the zod type, for the catalog's metadata table. */
+  type: string;
+}
+
+export interface ManifestKind {
+  kind: string;
+  title: string;
+  origin: "substrate" | "instance";
+  summary: string;
+  /** The body of the kind's kind.md, verbatim. Supplied by the caller, which knows the paths. */
+  doc?: string;
+  fields: ManifestField[];
+}
+
+export interface KindManifest {
+  instance: string;
+  version: number;
+  kinds: ManifestKind[];
+}
+
+/**
+ * Render a zod type as a short readable string.
+ *
+ * Deliberately shallow: this feeds a human-facing metadata table, not a code generator, so
+ * `string[]` beats a faithful but unreadable expansion of every refinement.
+ */
+export function describeType(schema: z.ZodTypeAny): string {
+  const def = schema._def as { typeName?: string; [k: string]: unknown };
+  switch (def.typeName) {
+    case "ZodOptional":
+    case "ZodNullable":
+    case "ZodDefault":
+      return describeType((def.innerType ?? def.type) as z.ZodTypeAny);
+    case "ZodEffects":
+      return describeType(def.schema as z.ZodTypeAny);
+    case "ZodLazy":
+      return "any";
+    case "ZodString":
+      return "string";
+    case "ZodNumber":
+      return "number";
+    case "ZodBoolean":
+      return "boolean";
+    case "ZodDate":
+      return "date";
+    case "ZodLiteral":
+      return JSON.stringify((def as { value: unknown }).value);
+    case "ZodEnum":
+      return ((def as { values: string[] }).values ?? []).join(" | ");
+    case "ZodArray":
+      return `${describeType(def.type as z.ZodTypeAny)}[]`;
+    case "ZodUnion":
+    case "ZodDiscriminatedUnion": {
+      const opts = (def.options ?? []) as z.ZodTypeAny[];
+      const rendered = [...new Set(opts.map(describeType))];
+      return rendered.length > 3 ? "one of several shapes" : rendered.join(" | ");
+    }
+    case "ZodObject":
+      return "object";
+    default:
+      return "any";
+  }
+}
+
+/** Walk a kind's object shape into the manifest's field list, sorted required-first. */
+export function describeFields(shape: z.ZodRawShape): ManifestField[] {
+  return Object.entries(shape)
+    .map(([name, field]) => ({
+      name,
+      required: !field.isOptional(),
+      type: describeType(field),
+    }))
+    .sort((a, b) => Number(b.required) - Number(a.required) || a.name.localeCompare(b.name));
+}
+
+export interface BuildKindManifestOptions extends BuildKindContextOptions {
+  /** Slug identifying this Foundry in a cross-instance catalog. */
+  instance: string;
+  /** kind name -> kind.md body. The caller reads these; this module stays filesystem-free. */
+  docs?: Record<string, string>;
+}
+
+export function buildKindManifest({
+  instance,
+  docs = {},
+  ...registries
+}: BuildKindManifestOptions): KindManifest {
+  const ctx = buildKindContext(registries);
+  return {
+    instance,
+    version: KIND_MANIFEST_VERSION,
+    kinds: KINDS.map((definition) => ({
+      kind: definition.kind,
+      title: definition.title,
+      origin: definition.origin,
+      summary: definition.summary,
+      doc: docs[definition.kind],
+      fields: describeFields(definition.build(ctx).shape),
+    })),
+  };
+}

--- a/packages/note-schema/src/note-schema.ts
+++ b/packages/note-schema/src/note-schema.ts
@@ -92,8 +92,23 @@ export function buildNoteSchema({ tags, contract, licensePolicy }: BuildNoteSche
     })
     .strict()
     .superRefine((ref, ctx) => {
+      // Both cross-field rules the reference contract's vocabularies imply. `on-demand`
+      // without a `trigger` names no condition under which the cast should read the note,
+      // so the reference is unreachable at runtime; it was a /review-mold warning here and
+      // a schema rule in the sibling Foundry, and the whole corpus already satisfies it.
+      if (ref.load === "on-demand" && !ref.trigger) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["trigger"],
+          message: `on-demand ref "${ref.ref}" requires a trigger`,
+        });
+      }
       if (ref.evidence === "hypothesis" && !ref.verification) {
-        ctx.addIssue({ code: "custom", message: "hypothesis references require `verification`" });
+        ctx.addIssue({
+          code: "custom",
+          path: ["verification"],
+          message: `hypothesis-evidence ref "${ref.ref}" requires a verification`,
+        });
       }
     });
 

--- a/packages/note-schema/src/note-schema.ts
+++ b/packages/note-schema/src/note-schema.ts
@@ -1,373 +1,40 @@
-// The single source of truth for Foundry note frontmatter. This zod schema
-// replaces the former hand-written meta_schema.yml (ajv) + site zod pair; the
-// validator (`@galaxy-foundry/build-cli`) and the Astro site both build it from
-// the same three registries so the two encodings can no longer drift.
+// The single source of truth for Foundry note frontmatter. This zod schema replaces the
+// former hand-written meta_schema.yml (ajv) + site zod pair; the validator
+// (`@galaxy-foundry/build-cli`) and the Astro site both build it from the same three
+// registries so the two encodings can no longer drift.
 //
-// `buildNoteSchema` is a factory: the controlled enums (tags, reference-contract
-// vocab, license ids) live in YAML registries loaded at call time and injected
-// here, mirroring how the old validator injected them into the JSON Schema.
+// This module is now only the ASSEMBLER. Each note kind is defined — and documented, and
+// exemplified — in its own directory under src/types/; see src/types/index.ts for the
+// enumeration and src/types/context.ts for the shared envelope every kind spreads.
+//
+// `buildNoteSchema` is a factory: the controlled enums (tags, reference-contract vocab,
+// license ids) live in YAML registries loaded at call time and injected here, mirroring how
+// the old validator injected them into the JSON Schema.
 
 import { z } from "zod";
 
-import { contractKeys, type ReferenceContract } from "./reference-contract.js";
-import { isValidLicenseId, resolveLicenseRow, type LicensePolicy } from "./license-policy.js";
-import { type TagRegistry } from "./tags.js";
+import { buildKindContext, type BuildKindContextOptions } from "./types/context.js";
+import { KINDS, KINDS_BY_NAME, type BuiltKinds } from "./types/index.js";
 
-export interface BuildNoteSchemaOptions {
-  /** Controlled tag vocabulary (meta_tags.yml). Membership is declared by the registry's
-   *  facets, so the schema asks the registry rather than matching a prefix itself. */
-  tags: TagRegistry;
-  /** Reference-contract registries (reference_contract.yml). */
-  contract: ReferenceContract;
-  /** License → redistribution-policy table (license-policy.yml). */
-  licensePolicy: LicensePolicy;
-}
+export type BuildNoteSchemaOptions = BuildKindContextOptions;
 
-const wikiLink = z.string().regex(/^\[\[.+\]\]$/, { message: "must be a [[wiki-link]]" });
+export function buildNoteSchema(options: BuildNoteSchemaOptions) {
+  const ctx = buildKindContext(options);
 
-// Sibling-relative raw prompt file consumed by casting.
-const promptFile = z
-  .string()
-  .regex(/^[A-Za-z0-9._/-]+$/, { message: "must be a sibling-relative path" });
+  // zod's discriminatedUnion accepts ZodObject members only, so each kind contributes a plain
+  // strict object here and its cross-field rules run in the dispatch below. The rules still
+  // LIVE in the kind's directory — this only decides when they fire.
+  //
+  // The assertion is the one place a cast is unavoidable: `.map` over a tuple returns an
+  // array, losing the per-element types the site's frontmatter inference depends on. The
+  // mapped type restores exactly what `.map` erased — same order, same length, same elements.
+  type Member = BuiltKinds[number];
+  const members = KINDS.map((k) => k.build(ctx)) as unknown as readonly [Member, ...Member[]];
 
-// Repo-relative path under LICENSES/ to a verbatim upstream LICENSE.
-const licenseFile = z.string().regex(/^LICENSES\/[A-Za-z0-9._-]+(\.LICENSE|\.txt)?$/, {
-  message: "must be a LICENSES/<file> path",
-});
-
-// Package bin / subcommand names.
-const binName = z.string().regex(/^[A-Za-z0-9._-]+$/);
-
-// Sibling filenames a multi-file note bundles; casting copies them verbatim.
-const companions = z
-  .array(z.string().regex(/^[A-Za-z0-9._-]+$/, { message: "must be a sibling filename" }))
-  .min(1)
-  .refine((a) => new Set(a).size === a.length, { message: "companions must be unique" });
-
-const artifactId = z.string().regex(/^[a-z][a-z0-9-]*$/, { message: "must be a kebab id" });
-const toolSlug = z.string().regex(/^[a-z][a-z0-9-]*$/);
-const sourceKinds = [
-  "paper",
-  "nextflow",
-  "cwl",
-  "snakemake",
-  "interview",
-  "freeform",
-  "galaxy",
-] as const;
-
-export function buildNoteSchema({ tags, contract, licensePolicy }: BuildNoteSchemaOptions) {
-  // Tag membership check (meta_tags.yml): valid iff some facet declares the tag under
-  // its `values`. Never a prefix match — `target/not-a-real-thing` is as invalid as
-  // `nonsense`, and a bare key like `meta` is as valid as a slashed one.
-  const tag = z.string().superRefine((t: string, ctx: z.RefinementCtx) => {
-    if (!tags.isValidTag(t)) {
-      ctx.addIssue({ code: "custom", message: `unknown tag '${t}' (not in meta_tags.yml)` });
-    }
+  return z.discriminatedUnion("type", members).superRefine((d, issues) => {
+    const definition = KINDS_BY_NAME.get((d as { type: string }).type);
+    definition?.refine?.(d as Record<string, unknown>, issues, ctx);
   });
-
-  // SPDX id from license-policy.yml, or a LicenseRef-<slug> escape hatch.
-  const licenseId = z.string().refine((v: string) => isValidLicenseId(licensePolicy, v), {
-    message: "must be an SPDX id from license-policy.yml or a LicenseRef-<slug>",
-  });
-
-  function registryEnum(group: keyof ReferenceContract) {
-    const values = contractKeys(contract, group);
-    return z.string().refine((v: string) => values.includes(v), {
-      message: `must be one of: ${values.join(", ")}`,
-    });
-  }
-
-  const typedReference = z
-    .object({
-      kind: registryEnum("kinds"),
-      ref: z.string().min(1),
-      used_at: registryEnum("used_at"),
-      load: registryEnum("load"),
-      mode: registryEnum("modes"),
-      evidence: registryEnum("evidence"),
-      purpose: z.string().min(1).optional(),
-      trigger: z.string().min(1).optional(),
-      verification: z.string().min(1).optional(),
-    })
-    .strict()
-    .superRefine((ref, ctx) => {
-      // Both cross-field rules the reference contract's vocabularies imply. `on-demand`
-      // without a `trigger` names no condition under which the cast should read the note,
-      // so the reference is unreachable at runtime; it was a /review-mold warning here and
-      // a schema rule in the sibling Foundry, and the whole corpus already satisfies it.
-      if (ref.load === "on-demand" && !ref.trigger) {
-        ctx.addIssue({
-          code: "custom",
-          path: ["trigger"],
-          message: `on-demand ref "${ref.ref}" requires a trigger`,
-        });
-      }
-      if (ref.evidence === "hypothesis" && !ref.verification) {
-        ctx.addIssue({
-          code: "custom",
-          path: ["verification"],
-          message: `hypothesis-evidence ref "${ref.ref}" requires a verification`,
-        });
-      }
-    });
-
-  const iwcExemplarStep = z
-    .object({
-      label: z.string().min(1).optional(),
-      id: z.union([z.string().min(1), z.number().int()]).optional(),
-    })
-    .strict()
-    .refine((step) => step.label || step.id !== undefined, {
-      message: "step needs `label` or `id`",
-    });
-
-  const iwcExemplar = z
-    .object({
-      workflow: z.string().min(1),
-      steps: z.array(iwcExemplarStep).min(1).optional(),
-      why: z.string().min(1),
-      confidence: z.enum(["high", "medium", "low"]),
-    })
-    .strict();
-
-  const baseFields = {
-    tags: z.array(tag).min(1),
-    status: z.enum(["draft", "reviewed", "revised", "stale", "archived"]),
-    created: z.coerce.date(),
-    revised: z.coerce.date(),
-    revision: z.number().int().min(1),
-    ai_generated: z.boolean(),
-    summary: z.string().min(20).max(160),
-    title: z.string().optional(),
-    aliases: z.array(z.string()).optional(),
-    sources: z.array(z.string().min(1)).min(1).optional(),
-    related_notes: z.array(wikiLink).optional(),
-    related_patterns: z.array(wikiLink).optional(),
-    related_molds: z.array(wikiLink).optional(),
-  };
-
-  // Pipeline phase: Mold-shape or branch-shape. Branch can have branches[] or chain[].
-  const branchItem: z.ZodType<unknown> = z.lazy(() =>
-    z.union([
-      wikiLink,
-      z.string(), // free-text terminal like "user-supplied"
-      z.object({ fallthrough: wikiLink }).strict(),
-    ]),
-  );
-
-  const moldPhase = z
-    .object({
-      mold: wikiLink,
-      loop: z.boolean().optional(),
-    })
-    .strict();
-
-  const branchPhase = z
-    .object({
-      branch: z.string(),
-      loop: z.boolean().optional(),
-      branches: z.array(branchItem).optional(),
-      chain: z.array(branchItem).optional(),
-    })
-    .strict()
-    .refine((p) => p.branches || p.chain, {
-      message: "branch phase needs `branches` or `chain`",
-    });
-
-  const phase = z.union([moldPhase, branchPhase]);
-
-  const outputArtifact = z
-    .object({
-      id: artifactId,
-      kind: z.enum(["json", "markdown", "yaml", "text", "other"]),
-      default_filename: z.string().min(1),
-      schema: wikiLink.optional(),
-      description: z.string().min(20),
-    })
-    .strict();
-
-  const inputArtifact = z
-    .object({
-      id: artifactId,
-      description: z.string().min(20),
-    })
-    .strict();
-
-  const moldSchema = z
-    .object({
-      type: z.literal("mold"),
-      name: z.string(),
-      axis: z.enum(["source-specific", "target-specific", "tool-specific", "generic"]),
-      source: z.enum(sourceKinds).optional(),
-      target: z.enum(["galaxy", "cwl", "web", "generic"]).optional(),
-      tool: z
-        .string()
-        .regex(/^[a-z][a-z0-9-]*$/)
-        .optional(),
-      output_artifacts: z.array(outputArtifact).optional(),
-      input_artifacts: z.array(inputArtifact).optional(),
-      loop_endstate: z.string().min(10).optional(),
-      references: z.array(typedReference).optional(),
-      ...baseFields,
-    })
-    .strict();
-
-  const patternSchema = z
-    .object({
-      ...baseFields,
-      type: z.literal("pattern"),
-      pattern_kind: z.enum(["operation", "recipe", "moc"]),
-      evidence: z.enum([
-        "corpus-observed",
-        "structurally-verified",
-        "corpus-and-verified",
-        "hypothesis",
-      ]),
-      title: z.string(),
-      parent_pattern: wikiLink.optional(),
-      verification_paths: z.array(z.string()).optional(),
-      iwc_exemplars: z.array(iwcExemplar).optional(),
-      companions: companions.optional(),
-    })
-    .strict();
-
-  const sourcePatternSchema = z
-    .object({
-      ...baseFields,
-      type: z.literal("source-pattern"),
-      title: z.string(),
-      source: z.enum(sourceKinds),
-      target: z.enum(["galaxy", "cwl", "web", "generic"]),
-      source_pattern_kind: z.enum([
-        "moc",
-        "channel-shape",
-        "operator",
-        "lifecycle",
-        "review-trigger",
-      ]),
-      implemented_by_patterns: z.array(wikiLink).min(1),
-      review_triggers: z.array(z.string().min(1)).optional(),
-    })
-    .strict();
-
-  const cliCommandSchema = z
-    .object({
-      type: z.literal("cli-command"),
-      tool: toolSlug,
-      command: z.string(),
-      package: z.string().optional(),
-      upstream: z.string().optional(),
-      ...baseFields,
-    })
-    .strict();
-
-  const cliToolSchema = z
-    .object({
-      type: z.literal("cli-tool"),
-      tool: toolSlug,
-      origin: z.enum(["npm", "pypi"]),
-      package: z.string(),
-      package_version: z.string().optional(),
-      invoke: z.string().regex(/^[A-Za-z0-9._-]+$/),
-      invoke_fallback: z.string().optional(),
-      availability_check: z.string().optional(),
-      docs_url: z.string().optional(),
-      ...baseFields,
-    })
-    .strict();
-
-  const pipelineSchema = z
-    .object({
-      ...baseFields,
-      type: z.literal("pipeline"),
-      title: z.string(),
-      phases: z.array(phase).min(1),
-      harness_notes: z.array(z.string().min(10)).optional(),
-    })
-    .strict();
-
-  const researchSchema = z
-    .object({
-      type: z.literal("research"),
-      component: z.string().optional(),
-      companions: companions.optional(),
-      license: licenseId.optional(),
-      license_file: licenseFile.optional(),
-      ...baseFields,
-    })
-    .strict();
-
-  const schemaNoteSchema = z
-    .object({
-      ...baseFields,
-      type: z.literal("schema"),
-      name: z.string(),
-      title: z.string(),
-      package: z.string().optional(),
-      upstream: z.string().optional(),
-      package_export: z.string().optional(),
-      validator_bin: binName.optional(),
-      validator_subcommand: binName.optional(),
-      license: licenseId.optional(),
-      license_file: licenseFile.optional(),
-    })
-    .strict();
-
-  const promptSchema = z
-    .object({
-      ...baseFields,
-      type: z.literal("prompt"),
-      title: z.string(),
-      prompt_file: promptFile,
-      license: licenseId.optional(),
-      license_file: licenseFile.optional(),
-    })
-    .strict();
-
-  return z
-    .discriminatedUnion("type", [
-      moldSchema,
-      patternSchema,
-      sourcePatternSchema,
-      cliToolSchema,
-      cliCommandSchema,
-      pipelineSchema,
-      researchSchema,
-      schemaNoteSchema,
-      promptSchema,
-    ])
-    .superRefine((d, ctx) => {
-      if (d.type === "mold") {
-        if (d.axis === "source-specific" && !d.source)
-          ctx.addIssue({ code: "custom", message: "source-specific mold requires `source`" });
-        if (d.axis === "target-specific" && !d.target)
-          ctx.addIssue({ code: "custom", message: "target-specific mold requires `target`" });
-        if (d.axis === "tool-specific" && !d.tool)
-          ctx.addIssue({ code: "custom", message: "tool-specific mold requires `tool`" });
-        return;
-      }
-      // Schema notes redistributing external upstream content must carry a license,
-      // and (for verbatim-carry licenses) a license_file. Mirrors the validator.
-      if (d.type === "schema") {
-        const upstream = d.upstream ?? "";
-        const external = upstream && !upstream.includes("github.com/galaxyproject/foundry/");
-        if (!external) return;
-        if (!d.license) {
-          ctx.addIssue({
-            code: "custom",
-            message: "vendored schema with external upstream requires `license`",
-          });
-          return;
-        }
-        if (resolveLicenseRow(licensePolicy, d.license).license_file && !d.license_file) {
-          ctx.addIssue({
-            code: "custom",
-            message: `license ${d.license} requires a \`license_file\``,
-          });
-        }
-      }
-    });
 }
 
 export type NoteSchema = ReturnType<typeof buildNoteSchema>;

--- a/packages/note-schema/src/types/cli-command/example.md
+++ b/packages/note-schema/src/types/cli-command/example.md
@@ -1,0 +1,27 @@
+---
+type: cli-command
+tool: gxwf
+command: validate
+package: "@galaxy-tool-util/cli"
+tags:
+  - target/galaxy
+status: reviewed
+created: 2026-07-26
+revised: 2026-07-26
+revision: 1
+ai_generated: true
+summary: Check a Galaxy workflow file against the gxformat2 schema and report the first failure.
+---
+
+# `gxwf validate`
+
+## Usage
+
+```
+gxwf validate <workflow.ga|workflow.gxwf.yml>
+```
+
+## Gotchas
+
+- Exits non-zero on the first schema failure; it is not an exhaustive report, so re-run after
+  each fix rather than trying to collect every problem in one pass.

--- a/packages/note-schema/src/types/cli-command/kind.md
+++ b/packages/note-schema/src/types/cli-command/kind.md
@@ -1,0 +1,25 @@
+# CLI Command
+
+A **CLI Command** note is a manual page for one subcommand, authored so a cast reads the real
+flags instead of inventing plausible ones.
+
+This is the kind that most directly buys correctness: hallucinated command-line flags are
+syntactically perfect and completely wrong, and no amount of prompt care fixes that. Writing the
+page down and referencing it does.
+
+## Why each required field is required
+
+- **`tool`** — the `cli-tool` slug this command belongs to. The join key.
+- **`command`** — the subcommand itself. Together with `tool` it identifies the page.
+- The **base envelope** — as on every kind.
+
+## Optional fields
+
+- **`package`** / **`upstream`** — where the command's implementation lives, for the reader who
+  needs to check the page against the source.
+
+## Body convention
+
+The validator warns when the body omits a `## Gotchas` section. That is deliberate: the flags
+are recoverable from `--help`, but the failure modes are exactly what a cast cannot discover on
+its own, and they are the reason the note is worth its tokens.

--- a/packages/note-schema/src/types/cli-command/schema.ts
+++ b/packages/note-schema/src/types/cli-command/schema.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+import { type KindContext, defineKind } from "../context.js";
+
+export const kind = defineKind({
+  kind: "cli-command",
+  title: "CLI Command",
+  origin: "instance",
+  summary:
+    "One subcommand of a CLI tool, authored as a manual page a cast can read instead of guessing at flags.",
+
+  build: (ctx: KindContext) =>
+    z
+      .object({
+        type: z.literal("cli-command"),
+        tool: ctx.toolSlug,
+        command: z.string(),
+        package: z.string().optional(),
+        upstream: z.string().optional(),
+        ...ctx.base,
+      })
+      .strict(),
+});

--- a/packages/note-schema/src/types/cli-tool/example.md
+++ b/packages/note-schema/src/types/cli-tool/example.md
@@ -1,0 +1,22 @@
+---
+type: cli-tool
+tool: gxwf
+origin: npm
+package: "@galaxy-tool-util/cli"
+invoke: gxwf
+invoke_fallback: npx --yes @galaxy-tool-util/cli gxwf
+availability_check: gxwf --version
+tags:
+  - target/galaxy
+status: reviewed
+created: 2026-07-26
+revised: 2026-07-26
+revision: 1
+ai_generated: true
+summary: Validate, lint, and convert Galaxy workflow files from the command line.
+---
+
+# gxwf
+
+The package name and the binary name differ, which is exactly why `invoke` is its own required
+field rather than something a cast is expected to infer from `package`.

--- a/packages/note-schema/src/types/cli-tool/kind.md
+++ b/packages/note-schema/src/types/cli-tool/kind.md
@@ -1,0 +1,25 @@
+# CLI Tool
+
+A **CLI Tool** note describes one external command-line program the casting pipeline may
+invoke: where it comes from, how to run it, and how to tell whether it is present.
+
+It pairs with `cli-command`: the tool note is the *installation and invocation* record, the
+command notes are the manual pages. One `cli-tool` typically has several `cli-command` siblings.
+
+## Why each required field is required
+
+- **`tool`** — the kebab slug the `cli-command` notes join on. This is the whole reason the two
+  kinds can stay separate.
+- **`origin`** (`npm` | `pypi`) and **`package`** — how to install it. A tool a cast is told to
+  run but not told how to obtain is a runtime failure waiting for the first clean machine.
+- **`invoke`** — the actual binary name, which is frequently *not* the package name.
+- The **base envelope** — as on every kind.
+
+## Optional fields
+
+- **`package_version`** — pin it when a cast depends on version-specific behaviour.
+- **`invoke_fallback`** — a second way to run it (`npx …`, `python -m …`) when the binary is not
+  on `PATH`.
+- **`availability_check`** — the command that answers "is it here?", so the cast can check
+  rather than fail mid-run.
+- **`docs_url`** — upstream documentation.

--- a/packages/note-schema/src/types/cli-tool/schema.ts
+++ b/packages/note-schema/src/types/cli-tool/schema.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+import { type KindContext, defineKind } from "../context.js";
+
+export const kind = defineKind({
+  kind: "cli-tool",
+  title: "CLI Tool",
+  origin: "instance",
+  summary:
+    "One external command-line tool the casting pipeline may invoke — how to install it, how to run it, how to tell it is present.",
+
+  build: (ctx: KindContext) =>
+    z
+      .object({
+        type: z.literal("cli-tool"),
+        tool: ctx.toolSlug,
+        origin: z.enum(["npm", "pypi"]),
+        package: z.string(),
+        package_version: z.string().optional(),
+        invoke: z.string().regex(/^[A-Za-z0-9._-]+$/),
+        invoke_fallback: z.string().optional(),
+        availability_check: z.string().optional(),
+        docs_url: z.string().optional(),
+        ...ctx.base,
+      })
+      .strict(),
+});

--- a/packages/note-schema/src/types/context.ts
+++ b/packages/note-schema/src/types/context.ts
@@ -1,0 +1,212 @@
+// The shared kind context — everything a kind directory draws from, in one place.
+//
+// This is the substrate half of the frontmatter contract. A field primitive lives here when
+// MORE THAN ONE kind uses it; a primitive used by exactly one kind lives in that kind's own
+// directory, where the only reader who needs it will find it. `base` is the note envelope
+// every kind carries.
+//
+// Kinds receive this rather than importing the registries themselves, so a kind can be tested
+// against a synthetic registry — which is the one thing a kind test always needs.
+
+import { z } from "zod";
+
+import { contractKeys, type ReferenceContract } from "./../reference-contract.js";
+import { type LicensePolicy, isValidLicenseId } from "./../license-policy.js";
+import { type TagRegistry } from "./../tags.js";
+
+export interface BuildKindContextOptions {
+  /** Controlled tag vocabulary (meta_tags.yml). Membership is declared by the registry's
+   *  facets, so the schema asks the registry rather than matching a prefix itself. */
+  tags: TagRegistry;
+  /** Reference-contract registries (reference_contract.yml). */
+  contract: ReferenceContract;
+  /** License → redistribution-policy table (license-policy.yml). */
+  licensePolicy: LicensePolicy;
+}
+
+/** Source formats this Foundry converts FROM. Shared by `mold` and `source-pattern`. */
+export const sourceKinds = [
+  "paper",
+  "nextflow",
+  "cwl",
+  "snakemake",
+  "interview",
+  "freeform",
+  "galaxy",
+] as const;
+
+/** Formats this Foundry converts TO. Shared by `mold` and `source-pattern`. */
+export const targetKinds = ["galaxy", "cwl", "web", "generic"] as const;
+
+export interface KindContext {
+  /** The raw registries, for the few cross-field rules that must consult a policy row. */
+  registries: BuildKindContextOptions;
+
+  /** A `[[wiki-link]]`. */
+  wikiLink: z.ZodString;
+  /** One registered tag. */
+  tag: z.ZodType<string>;
+  /** Repo-relative path under LICENSES/ to a verbatim upstream LICENSE. */
+  licenseFile: z.ZodString;
+  /** An SPDX id from license-policy.yml, or a `LicenseRef-<slug>` escape hatch. */
+  licenseId: z.ZodType<string>;
+  /** Package bin / subcommand names. Shared by `schema` and (as a slug) the cli kinds. */
+  toolSlug: z.ZodString;
+  /** Sibling filenames a multi-file note bundles; casting copies them verbatim. */
+  companions: z.ZodType<string[]>;
+  /** One entry of a Mold's typed reference manifest. */
+  reference: z.ZodType<unknown>;
+
+  /** THE BASE ENVELOPE — the fields every kind in this instance carries. Kinds spread it. */
+  base: {
+    tags: z.ZodType<string[]>;
+    status: z.ZodEnum<["draft", "reviewed", "revised", "stale", "archived"]>;
+    created: z.ZodType<Date, z.ZodTypeDef, unknown>;
+    revised: z.ZodType<Date, z.ZodTypeDef, unknown>;
+    revision: z.ZodNumber;
+    ai_generated: z.ZodBoolean;
+    summary: z.ZodString;
+    title: z.ZodOptional<z.ZodString>;
+    aliases: z.ZodOptional<z.ZodArray<z.ZodString>>;
+    sources: z.ZodOptional<z.ZodArray<z.ZodString>>;
+    related_notes: z.ZodOptional<z.ZodArray<z.ZodString>>;
+    related_patterns: z.ZodOptional<z.ZodArray<z.ZodString>>;
+    related_molds: z.ZodOptional<z.ZodArray<z.ZodString>>;
+  };
+}
+
+export function buildKindContext(options: BuildKindContextOptions): KindContext {
+  const { tags, contract, licensePolicy } = options;
+
+  const wikiLink = z.string().regex(/^\[\[.+\]\]$/, { message: "must be a [[wiki-link]]" });
+
+  // Tag membership check (meta_tags.yml): valid iff some facet declares the tag under its
+  // `values`. Never a prefix match — `target/not-a-real-thing` is as invalid as `nonsense`,
+  // and a bare key like `meta` is as valid as a slashed one.
+  const tag = z.string().superRefine((t: string, ctx: z.RefinementCtx) => {
+    if (!tags.isValidTag(t)) {
+      ctx.addIssue({ code: "custom", message: `unknown tag '${t}' (not in meta_tags.yml)` });
+    }
+  });
+
+  const licenseId = z.string().refine((v: string) => isValidLicenseId(licensePolicy, v), {
+    message: "must be an SPDX id from license-policy.yml or a LicenseRef-<slug>",
+  });
+
+  const licenseFile = z.string().regex(/^LICENSES\/[A-Za-z0-9._-]+(\.LICENSE|\.txt)?$/, {
+    message: "must be a LICENSES/<file> path",
+  });
+
+  const toolSlug = z.string().regex(/^[a-z][a-z0-9-]*$/);
+
+  const companions = z
+    .array(z.string().regex(/^[A-Za-z0-9._-]+$/, { message: "must be a sibling filename" }))
+    .min(1)
+    .refine((a) => new Set(a).size === a.length, { message: "companions must be unique" });
+
+  function registryEnum(group: keyof ReferenceContract) {
+    const values = contractKeys(contract, group);
+    return z.string().refine((v: string) => values.includes(v), {
+      message: `must be one of: ${values.join(", ")}`,
+    });
+  }
+
+  const reference = z
+    .object({
+      kind: registryEnum("kinds"),
+      ref: z.string().min(1),
+      used_at: registryEnum("used_at"),
+      load: registryEnum("load"),
+      mode: registryEnum("modes"),
+      evidence: registryEnum("evidence"),
+      purpose: z.string().min(1).optional(),
+      trigger: z.string().min(1).optional(),
+      verification: z.string().min(1).optional(),
+    })
+    .strict()
+    .superRefine((ref, ctx) => {
+      // Both cross-field rules the reference contract's vocabularies imply. `on-demand`
+      // without a `trigger` names no condition under which the cast should read the note,
+      // so the reference is unreachable at runtime.
+      if (ref.load === "on-demand" && !ref.trigger) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["trigger"],
+          message: `on-demand ref "${ref.ref}" requires a trigger`,
+        });
+      }
+      if (ref.evidence === "hypothesis" && !ref.verification) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["verification"],
+          message: `hypothesis-evidence ref "${ref.ref}" requires a verification`,
+        });
+      }
+    });
+
+  return {
+    registries: options,
+    wikiLink,
+    tag,
+    licenseFile,
+    licenseId,
+    toolSlug,
+    companions,
+    reference,
+    base: {
+      tags: z.array(tag).min(1),
+      status: z.enum(["draft", "reviewed", "revised", "stale", "archived"]),
+      created: z.coerce.date(),
+      revised: z.coerce.date(),
+      revision: z.number().int().min(1),
+      ai_generated: z.boolean(),
+      summary: z.string().min(20).max(160),
+      title: z.string().optional(),
+      aliases: z.array(z.string()).optional(),
+      sources: z.array(z.string().min(1)).min(1).optional(),
+      related_notes: z.array(wikiLink).optional(),
+      related_patterns: z.array(wikiLink).optional(),
+      related_molds: z.array(wikiLink).optional(),
+    },
+  };
+}
+
+/**
+ * What a `types/<kind>/schema.ts` exports.
+ *
+ * `build` returns a plain strict ZodObject rather than the refined schema, for two reasons:
+ * zod's `discriminatedUnion` only accepts ZodObject members (a `.superRefine` would wrap it
+ * in ZodEffects), and the manifest generator walks `.shape` to derive the required-metadata
+ * table. Per-kind cross-field rules go in `refine`, which the assembler dispatches by `type`
+ * after the union resolves — so the rule still LIVES in the kind's directory.
+ */
+/** Any shape that can be a member of the `type`-discriminated union. */
+export type KindShape = { type: z.ZodTypeAny } & z.ZodRawShape;
+
+export interface KindDefinition<T extends KindShape = KindShape> {
+  /** The `type:` discriminator value. MUST equal the directory name. */
+  kind: string;
+  /** Display name for the kind catalog. */
+  title: string;
+  /** `substrate` = a kind the Foundry pattern's other instances also declare;
+   *  `instance` = one this domain added. The cross-instance catalog groups by this. */
+  origin: "substrate" | "instance";
+  /** One line: what a note of this kind IS. Rendered in the catalog. */
+  summary: string;
+  /** A strict object carrying a `type:` literal — a union member, and the `.shape` the
+   *  manifest generator walks to derive this kind's required-metadata table. */
+  build: (ctx: KindContext) => z.ZodObject<T, "strict">;
+  refine?: (data: Record<string, unknown>, ctx: z.RefinementCtx, kctx: KindContext) => void;
+}
+
+/**
+ * Identity helper a kind directory wraps its definition in.
+ *
+ * It exists purely to INFER the object shape rather than widen it. Annotating a kind as
+ * `: KindDefinition` erases which fields it declares, and that erasure propagates all the way
+ * to the Astro site, where `entry.data.tags` degrades to `any`. Inferring keeps each kind's
+ * frontmatter type precise for every consumer of the assembled union.
+ */
+export function defineKind<T extends KindShape>(definition: KindDefinition<T>): KindDefinition<T> {
+  return definition;
+}

--- a/packages/note-schema/src/types/index.ts
+++ b/packages/note-schema/src/types/index.ts
@@ -1,0 +1,53 @@
+// The barrel — the ONE enumeration of the note kinds this Foundry defines.
+//
+// Adding a kind is: add a directory beside this file, add one line here. Nothing else.
+//
+// STATIC imports, deliberately. A runtime glob would have to work identically under
+// tsc-to-dist, under vitest, and inside Astro's bundler, and nothing does all three; a
+// missed directory is caught by test/kind-directories.test.ts instead, which asserts this
+// list and the directory listing agree in BOTH directions.
+
+import { kind as cliCommand } from "./cli-command/schema.js";
+import { kind as cliTool } from "./cli-tool/schema.js";
+import { kind as mold } from "./mold/schema.js";
+import { kind as pattern } from "./pattern/schema.js";
+import { kind as pipeline } from "./pipeline/schema.js";
+import { kind as prompt } from "./prompt/schema.js";
+import { kind as research } from "./research/schema.js";
+import { kind as schemaNote } from "./schema/schema.js";
+import { kind as sourcePattern } from "./source-pattern/schema.js";
+
+import { type KindDefinition } from "./context.js";
+
+// NOT annotated `: readonly KindDefinition[]`. That annotation would widen every element to
+// the default shape and the erasure would propagate to the Astro site, where `entry.data.tags`
+// degrades to `any`. Left inferred, this is a tuple of nine precisely-typed kinds.
+export const KINDS = [
+  mold,
+  pattern,
+  sourcePattern,
+  cliTool,
+  cliCommand,
+  pipeline,
+  research,
+  schemaNote,
+  prompt,
+] as const;
+
+type BuiltKind<K> = K extends { build: (...args: never[]) => infer R } ? R : never;
+
+/** Each kind's union member, in barrel order, with its shape preserved. */
+export type BuiltKinds = { -readonly [I in keyof typeof KINDS]: BuiltKind<(typeof KINDS)[I]> };
+
+/** Kind definitions by their `type:` discriminator value. */
+export const KINDS_BY_NAME: ReadonlyMap<string, KindDefinition> = new Map(
+  KINDS.map((k) => [k.kind, k as KindDefinition]),
+);
+
+export {
+  buildKindContext,
+  defineKind,
+  type KindContext,
+  type KindDefinition,
+  type KindShape,
+} from "./context.js";

--- a/packages/note-schema/src/types/kinds.generated.json
+++ b/packages/note-schema/src/types/kinds.generated.json
@@ -1,0 +1,962 @@
+{
+  "instance": "galaxy-workflow-foundry",
+  "version": 1,
+  "kinds": [
+    {
+      "kind": "mold",
+      "title": "Mold",
+      "origin": "substrate",
+      "summary": "One repeatable action, described as a typed reference manifest that casting compiles into a skill artifact.",
+      "doc": "# Mold\n\nA **Mold** describes *one repeatable action* — not a document, not a tutorial, but a unit of\nwork worth casting into a skill artifact. Its body says how to do the action; its frontmatter\ndeclares the *typed reference manifest* naming every note the cast must carry, and how.\n\nMolds are the substrate's centre of gravity. Everything else in the corpus exists so a Mold can\ncite it.\n\n## Why each required field is required\n\n- **`name`** — the stable slug the pipeline and the cast bundle address the Mold by. Distinct\n  from `title`, which is prose for a reader.\n- **`axis`** — which dimension the Mold is specialized along, and therefore how a caller\n  *selects* it. `source-specific` / `target-specific` / `tool-specific` each require the\n  matching field (`source` / `target` / `tool`): an axis that names no subject is a Mold\n  nothing can be selected by, so the schema rejects it rather than letting it sit unfindable.\n  `generic` requires none — it applies everywhere.\n- The **base envelope** (`tags`, `status`, `created`, `revised`, `revision`, `ai_generated`,\n  `summary`) — as on every kind. `summary` is bounded 20–160 characters because it is printed\n  in every browse row; unbounded, half the catalog renders as a bare name and the other half\n  as a paragraph.\n\n## The optional fields that carry the weight\n\n- **`references`** — the manifest. Each entry draws `kind` / `used_at` / `load` / `mode` /\n  `evidence` from `reference_contract.yml`. Two rules the schema enforces: `load: on-demand`\n  requires a `trigger` (a reference the cast is never told to read is unreachable), and\n  `evidence: hypothesis` requires a `verification` (an unmarked guess is the failure mode the\n  field exists to prevent).\n- **`input_artifacts` / `output_artifacts`** — the Mold's declared IO, which is what lets\n  Molds be composed into a pipeline phase without reading their bodies. An output may name a\n  `schema` note, making the handoff machine-checkable.\n- **`loop_endstate`** — for a Mold that runs until a condition holds, the condition. Prose,\n  but *required* prose once the Mold loops: \"until it passes\" is not an end state.",
+      "fields": [
+        {
+          "name": "ai_generated",
+          "required": true,
+          "type": "boolean"
+        },
+        {
+          "name": "axis",
+          "required": true,
+          "type": "source-specific | target-specific | tool-specific | generic"
+        },
+        {
+          "name": "created",
+          "required": true,
+          "type": "date"
+        },
+        {
+          "name": "name",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "revised",
+          "required": true,
+          "type": "date"
+        },
+        {
+          "name": "revision",
+          "required": true,
+          "type": "number"
+        },
+        {
+          "name": "status",
+          "required": true,
+          "type": "draft | reviewed | revised | stale | archived"
+        },
+        {
+          "name": "summary",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "tags",
+          "required": true,
+          "type": "string[]"
+        },
+        {
+          "name": "type",
+          "required": true,
+          "type": "\"mold\""
+        },
+        {
+          "name": "aliases",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "input_artifacts",
+          "required": false,
+          "type": "object[]"
+        },
+        {
+          "name": "loop_endstate",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "output_artifacts",
+          "required": false,
+          "type": "object[]"
+        },
+        {
+          "name": "references",
+          "required": false,
+          "type": "object[]"
+        },
+        {
+          "name": "related_molds",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "related_notes",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "related_patterns",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "source",
+          "required": false,
+          "type": "paper | nextflow | cwl | snakemake | interview | freeform | galaxy"
+        },
+        {
+          "name": "sources",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "target",
+          "required": false,
+          "type": "galaxy | cwl | web | generic"
+        },
+        {
+          "name": "title",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "tool",
+          "required": false,
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "kind": "pattern",
+      "title": "Pattern",
+      "origin": "substrate",
+      "summary": "One reusable piece of domain knowledge a Mold can reference, graded by how strongly the corpus supports it.",
+      "doc": "# Pattern\n\nA **Pattern** is one reusable piece of domain knowledge, authored so that a Mold can *cite* it\ninstead of restating it. Patterns are the corpus a cast is grounded in: if a Mold's body starts\nexplaining how something generally works, that explanation wants to be a Pattern.\n\n## Why each required field is required\n\n- **`title`** — patterns are read by humans browsing the corpus, and a slug is not a title.\n- **`pattern_kind`** — `operation` (one transformation), `recipe` (an assembled sequence), or\n  `moc` (a map of content: a hub note whose job is to point at others). The three are browsed\n  and cast differently, so the distinction is declared rather than guessed from the body.\n- **`evidence`** — how strongly the corpus supports the claim: `corpus-observed`,\n  `structurally-verified`, `corpus-and-verified`, or `hypothesis`. **`hypothesis` is legal**,\n  and that is the point: a speculative pattern that is *marked* speculative can be safely\n  loaded and later verified, while an unmarked one silently anchors every cast that reads it.\n  This field is what keeps the corpus honest as it grows faster than it is checked.\n- The **base envelope** — as on every kind.\n\n## Optional fields\n\n- **`iwc_exemplars`** — citations into the IWC workflow corpus that exhibit the pattern, each\n  with a `why` and a `confidence`. This is what makes `corpus-observed` checkable rather than\n  asserted: the exemplar names the workflow, and a reviewer can go look.\n- **`parent_pattern`** — a `[[wiki-link]]` to the more general pattern this specializes.\n- **`verification_paths`** — how someone would confirm the claim.\n- **`companions`** — sibling files the cast copies verbatim beside the note.",
+      "fields": [
+        {
+          "name": "ai_generated",
+          "required": true,
+          "type": "boolean"
+        },
+        {
+          "name": "created",
+          "required": true,
+          "type": "date"
+        },
+        {
+          "name": "evidence",
+          "required": true,
+          "type": "corpus-observed | structurally-verified | corpus-and-verified | hypothesis"
+        },
+        {
+          "name": "pattern_kind",
+          "required": true,
+          "type": "operation | recipe | moc"
+        },
+        {
+          "name": "revised",
+          "required": true,
+          "type": "date"
+        },
+        {
+          "name": "revision",
+          "required": true,
+          "type": "number"
+        },
+        {
+          "name": "status",
+          "required": true,
+          "type": "draft | reviewed | revised | stale | archived"
+        },
+        {
+          "name": "summary",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "tags",
+          "required": true,
+          "type": "string[]"
+        },
+        {
+          "name": "title",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "type",
+          "required": true,
+          "type": "\"pattern\""
+        },
+        {
+          "name": "aliases",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "companions",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "iwc_exemplars",
+          "required": false,
+          "type": "object[]"
+        },
+        {
+          "name": "parent_pattern",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "related_molds",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "related_notes",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "related_patterns",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "sources",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "verification_paths",
+          "required": false,
+          "type": "string[]"
+        }
+      ]
+    },
+    {
+      "kind": "source-pattern",
+      "title": "Source Pattern",
+      "origin": "instance",
+      "summary": "A shape recurring in one SOURCE ecosystem, held separate from the target-side patterns that implement it.",
+      "doc": "# Source Pattern\n\nA **Source Pattern** is a shape that recurs in one *source* ecosystem — a Nextflow channel\nidiom, a CWL scatter convention — held deliberately separate from the target-side `pattern`\nnotes that say what to *do* about it.\n\nThe split exists because the two sides have different lifetimes. A source ecosystem changes on\nits own schedule; when it does, the source-pattern notes go stale together, and the target-side\npatterns they point at usually do not. Merging them into one kind would make every upstream\nchange look like a change to Galaxy knowledge.\n\nThis kind is **instance-specific**: it only makes sense for a Foundry whose work is *conversion*\nbetween two named ecosystems.\n\n## Why each required field is required\n\n- **`source`** and **`target`** — the pair the pattern bridges. Both required: a source shape\n  with no stated target is an observation about someone else's ecosystem, not knowledge this\n  Foundry can act on.\n- **`source_pattern_kind`** — `moc`, `channel-shape`, `operator`, `lifecycle`, or\n  `review-trigger`. What sort of recurring thing it is, and therefore when it gets consulted.\n- **`implemented_by_patterns`** — at least one `[[wiki-link]]` to the target-side Pattern that\n  handles it. **`min(1)` is the load-bearing rule of this kind**: a source shape nothing\n  implements is a note that can never be acted on, and the link is what makes the source/target\n  split navigable in both directions instead of a one-way pile.\n- **`title`** and the **base envelope** — as on every kind.\n\n## Optional fields\n\n- **`review_triggers`** — conditions under which a converted workflow should be looked at again\n  because this shape was involved.",
+      "fields": [
+        {
+          "name": "ai_generated",
+          "required": true,
+          "type": "boolean"
+        },
+        {
+          "name": "created",
+          "required": true,
+          "type": "date"
+        },
+        {
+          "name": "implemented_by_patterns",
+          "required": true,
+          "type": "string[]"
+        },
+        {
+          "name": "revised",
+          "required": true,
+          "type": "date"
+        },
+        {
+          "name": "revision",
+          "required": true,
+          "type": "number"
+        },
+        {
+          "name": "source",
+          "required": true,
+          "type": "paper | nextflow | cwl | snakemake | interview | freeform | galaxy"
+        },
+        {
+          "name": "source_pattern_kind",
+          "required": true,
+          "type": "moc | channel-shape | operator | lifecycle | review-trigger"
+        },
+        {
+          "name": "status",
+          "required": true,
+          "type": "draft | reviewed | revised | stale | archived"
+        },
+        {
+          "name": "summary",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "tags",
+          "required": true,
+          "type": "string[]"
+        },
+        {
+          "name": "target",
+          "required": true,
+          "type": "galaxy | cwl | web | generic"
+        },
+        {
+          "name": "title",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "type",
+          "required": true,
+          "type": "\"source-pattern\""
+        },
+        {
+          "name": "aliases",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "related_molds",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "related_notes",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "related_patterns",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "review_triggers",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "sources",
+          "required": false,
+          "type": "string[]"
+        }
+      ]
+    },
+    {
+      "kind": "cli-tool",
+      "title": "CLI Tool",
+      "origin": "instance",
+      "summary": "One external command-line tool the casting pipeline may invoke — how to install it, how to run it, how to tell it is present.",
+      "doc": "# CLI Tool\n\nA **CLI Tool** note describes one external command-line program the casting pipeline may\ninvoke: where it comes from, how to run it, and how to tell whether it is present.\n\nIt pairs with `cli-command`: the tool note is the *installation and invocation* record, the\ncommand notes are the manual pages. One `cli-tool` typically has several `cli-command` siblings.\n\n## Why each required field is required\n\n- **`tool`** — the kebab slug the `cli-command` notes join on. This is the whole reason the two\n  kinds can stay separate.\n- **`origin`** (`npm` | `pypi`) and **`package`** — how to install it. A tool a cast is told to\n  run but not told how to obtain is a runtime failure waiting for the first clean machine.\n- **`invoke`** — the actual binary name, which is frequently *not* the package name.\n- The **base envelope** — as on every kind.\n\n## Optional fields\n\n- **`package_version`** — pin it when a cast depends on version-specific behaviour.\n- **`invoke_fallback`** — a second way to run it (`npx …`, `python -m …`) when the binary is not\n  on `PATH`.\n- **`availability_check`** — the command that answers \"is it here?\", so the cast can check\n  rather than fail mid-run.\n- **`docs_url`** — upstream documentation.",
+      "fields": [
+        {
+          "name": "ai_generated",
+          "required": true,
+          "type": "boolean"
+        },
+        {
+          "name": "created",
+          "required": true,
+          "type": "date"
+        },
+        {
+          "name": "invoke",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "origin",
+          "required": true,
+          "type": "npm | pypi"
+        },
+        {
+          "name": "package",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "revised",
+          "required": true,
+          "type": "date"
+        },
+        {
+          "name": "revision",
+          "required": true,
+          "type": "number"
+        },
+        {
+          "name": "status",
+          "required": true,
+          "type": "draft | reviewed | revised | stale | archived"
+        },
+        {
+          "name": "summary",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "tags",
+          "required": true,
+          "type": "string[]"
+        },
+        {
+          "name": "tool",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "type",
+          "required": true,
+          "type": "\"cli-tool\""
+        },
+        {
+          "name": "aliases",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "availability_check",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "docs_url",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "invoke_fallback",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "package_version",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "related_molds",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "related_notes",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "related_patterns",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "sources",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "title",
+          "required": false,
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "kind": "cli-command",
+      "title": "CLI Command",
+      "origin": "instance",
+      "summary": "One subcommand of a CLI tool, authored as a manual page a cast can read instead of guessing at flags.",
+      "doc": "# CLI Command\n\nA **CLI Command** note is a manual page for one subcommand, authored so a cast reads the real\nflags instead of inventing plausible ones.\n\nThis is the kind that most directly buys correctness: hallucinated command-line flags are\nsyntactically perfect and completely wrong, and no amount of prompt care fixes that. Writing the\npage down and referencing it does.\n\n## Why each required field is required\n\n- **`tool`** — the `cli-tool` slug this command belongs to. The join key.\n- **`command`** — the subcommand itself. Together with `tool` it identifies the page.\n- The **base envelope** — as on every kind.\n\n## Optional fields\n\n- **`package`** / **`upstream`** — where the command's implementation lives, for the reader who\n  needs to check the page against the source.\n\n## Body convention\n\nThe validator warns when the body omits a `## Gotchas` section. That is deliberate: the flags\nare recoverable from `--help`, but the failure modes are exactly what a cast cannot discover on\nits own, and they are the reason the note is worth its tokens.",
+      "fields": [
+        {
+          "name": "ai_generated",
+          "required": true,
+          "type": "boolean"
+        },
+        {
+          "name": "command",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "created",
+          "required": true,
+          "type": "date"
+        },
+        {
+          "name": "revised",
+          "required": true,
+          "type": "date"
+        },
+        {
+          "name": "revision",
+          "required": true,
+          "type": "number"
+        },
+        {
+          "name": "status",
+          "required": true,
+          "type": "draft | reviewed | revised | stale | archived"
+        },
+        {
+          "name": "summary",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "tags",
+          "required": true,
+          "type": "string[]"
+        },
+        {
+          "name": "tool",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "type",
+          "required": true,
+          "type": "\"cli-command\""
+        },
+        {
+          "name": "aliases",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "package",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "related_molds",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "related_notes",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "related_patterns",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "sources",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "title",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "upstream",
+          "required": false,
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "kind": "pipeline",
+      "title": "Pipeline",
+      "origin": "instance",
+      "summary": "An ordered end-to-end protocol composing Molds into phases — the optional composition layer, for domains whose work is a journey.",
+      "doc": "# Pipeline\n\nA **Pipeline** composes Molds into an ordered end-to-end protocol. It is the *composition\nlayer*, and it is optional: a Foundry whose actions stand alone needs no Pipelines at all.\n\nKeep it thin. The Pipeline names phases and their order; it does not restate what the Molds do.\nAnything a phase explains about the work itself belongs in the Mold.\n\nThis kind is **instance-specific**. Workflow construction is inherently sequential, so Pipelines\nearn their keep here; a domain whose Molds are a standalone toolkit should not adopt this kind\njust because the parent has it.\n\n## Why each required field is required\n\n- **`title`** — the protocol's name, as a reader navigating the map sees it.\n- **`phases`** (min 1) — the ordered steps. Each phase is one of two shapes:\n  - a **Mold phase** — `{ mold: \"[[slug]]\", loop?: true }`;\n  - a **branch phase** — `{ branch: \"<question>\", branches: [...] | chain: [...] }`, which must\n    carry `branches` or `chain`. A branch that names a decision but lists no alternatives is a\n    phase nothing can execute, so the schema rejects it.\n\n  A branch item may be a `[[wiki-link]]`, free text for a terminal outcome\n  (`\"user-supplied\"`), or `{ fallthrough: \"[[slug]]\" }` for the default arm.\n- The **base envelope** — as on every kind.\n\n## Optional fields\n\n- **`harness_notes`** — what the orchestrator running this pipeline needs to know that is not\n  in any single phase.",
+      "fields": [
+        {
+          "name": "ai_generated",
+          "required": true,
+          "type": "boolean"
+        },
+        {
+          "name": "created",
+          "required": true,
+          "type": "date"
+        },
+        {
+          "name": "phases",
+          "required": true,
+          "type": "object[]"
+        },
+        {
+          "name": "revised",
+          "required": true,
+          "type": "date"
+        },
+        {
+          "name": "revision",
+          "required": true,
+          "type": "number"
+        },
+        {
+          "name": "status",
+          "required": true,
+          "type": "draft | reviewed | revised | stale | archived"
+        },
+        {
+          "name": "summary",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "tags",
+          "required": true,
+          "type": "string[]"
+        },
+        {
+          "name": "title",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "type",
+          "required": true,
+          "type": "\"pipeline\""
+        },
+        {
+          "name": "aliases",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "harness_notes",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "related_molds",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "related_notes",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "related_patterns",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "sources",
+          "required": false,
+          "type": "string[]"
+        }
+      ]
+    },
+    {
+      "kind": "research",
+      "title": "Research Note",
+      "origin": "instance",
+      "summary": "A captured finding about the domain or its tooling — the grounding a Mold cites rather than inventing.",
+      "doc": "# Research Note\n\nA **Research Note** captures a finding about the domain or its tooling — the grounding a Mold\ncites instead of inventing. It is the loosest kind on purpose: research arrives before you know\nwhat shape it wants, and forcing it into a stricter kind on arrival loses it.\n\nThe discipline is not in the frontmatter, it is in the grading: a research note is good enough\nonly if the target skill could be **rebuilt from the note alone** — no re-reading the source, no\nmodel memory. Hold the numbers, thresholds, exact procedure, and named decision criteria.\n\n## Why each required field is required\n\nOnly the **base envelope**. A research note is `type` plus the envelope; everything else is\noptional, because the kind's job is to accept a finding, not to interrogate it.\n\n`summary` still applies (20–160 characters), and it does the most work here: with no `title`\nrequired, the summary is what a browsing reader has to go on.\n\n## Optional fields\n\n- **`component`** — the subsystem the finding is about, when it is about one.\n- **`license`** / **`license_file`** — required *in practice* whenever the note redistributes\n  someone else's text. The id resolves against `license-policy.yml`; where the policy row says\n  the licence text travels with the content, `license_file` points at the vendored copy under\n  `LICENSES/`.\n- **`companions`** — sibling files the cast copies verbatim beside the note.",
+      "fields": [
+        {
+          "name": "ai_generated",
+          "required": true,
+          "type": "boolean"
+        },
+        {
+          "name": "created",
+          "required": true,
+          "type": "date"
+        },
+        {
+          "name": "revised",
+          "required": true,
+          "type": "date"
+        },
+        {
+          "name": "revision",
+          "required": true,
+          "type": "number"
+        },
+        {
+          "name": "status",
+          "required": true,
+          "type": "draft | reviewed | revised | stale | archived"
+        },
+        {
+          "name": "summary",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "tags",
+          "required": true,
+          "type": "string[]"
+        },
+        {
+          "name": "type",
+          "required": true,
+          "type": "\"research\""
+        },
+        {
+          "name": "aliases",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "companions",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "component",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "license",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "license_file",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "related_molds",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "related_notes",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "related_patterns",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "sources",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "title",
+          "required": false,
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "kind": "schema",
+      "title": "Schema Note",
+      "origin": "instance",
+      "summary": "A machine-checkable contract a cast can validate against, plus the validator that decides it.",
+      "doc": "# Schema Note\n\nA **Schema Note** documents a machine-checkable contract a cast can validate its output\nagainst, and names the validator that decides it. It is how a Mold's `output_artifacts` stop\nbeing a promise and start being a check.\n\n## Why each required field is required\n\n- **`name`** — the slug a Mold's `output_artifacts[].schema` wiki-link resolves to.\n- **`title`** — prose, for the reader.\n- The **base envelope** — as on every kind.\n\n## Optional fields\n\n- **`package`** / **`package_export`** — where the schema is importable from. The validator\n  requires both on any note a `references[].kind: schema` entry points at: a schema you cannot\n  import is a schema no cast can run.\n- **`validator_bin`** / **`validator_subcommand`** — the command that checks against it.\n- **`upstream`** — where the schema came from, if it is vendored.\n- **`license`** / **`license_file`** — see the rule below.\n\n## The cross-field rule this kind enforces\n\nA schema note whose `upstream` points **outside this repository** is redistributing someone\nelse's work, so it **must** declare a `license`. And where that licence's row in\n`license-policy.yml` says the text travels with the content, it must also declare a\n`license_file` pointing at the vendored copy under `LICENSES/`.\n\nAn `upstream` inside `github.com/galaxyproject/foundry/` is our own work and needs neither —\nwhich is why the rule keys off *where upstream points*, not on whether the field is present.",
+      "fields": [
+        {
+          "name": "ai_generated",
+          "required": true,
+          "type": "boolean"
+        },
+        {
+          "name": "created",
+          "required": true,
+          "type": "date"
+        },
+        {
+          "name": "name",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "revised",
+          "required": true,
+          "type": "date"
+        },
+        {
+          "name": "revision",
+          "required": true,
+          "type": "number"
+        },
+        {
+          "name": "status",
+          "required": true,
+          "type": "draft | reviewed | revised | stale | archived"
+        },
+        {
+          "name": "summary",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "tags",
+          "required": true,
+          "type": "string[]"
+        },
+        {
+          "name": "title",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "type",
+          "required": true,
+          "type": "\"schema\""
+        },
+        {
+          "name": "aliases",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "license",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "license_file",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "package",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "package_export",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "related_molds",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "related_notes",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "related_patterns",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "sources",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "upstream",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "validator_bin",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "validator_subcommand",
+          "required": false,
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "kind": "prompt",
+      "title": "Prompt",
+      "origin": "instance",
+      "summary": "A raw upstream prompt carried verbatim in a sibling file, with the note recording where it came from and under what license.",
+      "doc": "# Prompt\n\nA **Prompt** note carries a raw upstream prompt — someone else's, verbatim — in a sibling file,\nand records where it came from and under what licence.\n\nThe verbatim file is the whole point. A prompt paraphrased is a different prompt, so the text\nlives untouched in its own file and the note carries the provenance around it. Casting copies\nthe file across unchanged.\n\n## Why each required field is required\n\n- **`title`** — prose, for the reader.\n- **`prompt_file`** — the sibling-relative path to the raw text. Separate from the note body so\n  the prompt is never accidentally reflowed, summarized, or wiki-linked by an editor working on\n  the note.\n- The **base envelope** — as on every kind.\n\n## Optional fields\n\n- **`license`** / **`license_file`** — optional in the schema, but a prompt taken from an\n  external project is redistributed text: name the licence, and vendor the licence file under\n  `LICENSES/` where the policy row calls for it. The schema does not force this the way the\n  `schema` kind does, because a prompt authored here has no upstream to name.",
+      "fields": [
+        {
+          "name": "ai_generated",
+          "required": true,
+          "type": "boolean"
+        },
+        {
+          "name": "created",
+          "required": true,
+          "type": "date"
+        },
+        {
+          "name": "prompt_file",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "revised",
+          "required": true,
+          "type": "date"
+        },
+        {
+          "name": "revision",
+          "required": true,
+          "type": "number"
+        },
+        {
+          "name": "status",
+          "required": true,
+          "type": "draft | reviewed | revised | stale | archived"
+        },
+        {
+          "name": "summary",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "tags",
+          "required": true,
+          "type": "string[]"
+        },
+        {
+          "name": "title",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "type",
+          "required": true,
+          "type": "\"prompt\""
+        },
+        {
+          "name": "aliases",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "license",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "license_file",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "related_molds",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "related_notes",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "related_patterns",
+          "required": false,
+          "type": "string[]"
+        },
+        {
+          "name": "sources",
+          "required": false,
+          "type": "string[]"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/note-schema/src/types/mold/example.md
+++ b/packages/note-schema/src/types/mold/example.md
@@ -1,0 +1,32 @@
+---
+type: mold
+name: summarize-cwl-workflow
+axis: source-specific
+source: cwl
+tags:
+  - target/galaxy
+status: draft
+created: 2026-07-26
+revised: 2026-07-26
+revision: 1
+ai_generated: true
+summary: Read a CWL workflow and emit the structured summary the Galaxy interface Molds consume.
+output_artifacts:
+  - id: workflow-summary
+    kind: json
+    default_filename: summary.json
+    description: One record per CWL step, with its inputs, outputs, and the tool it runs.
+references:
+  - kind: cli-command
+    ref: "[[validate-summary-cwl]]"
+    used_at: runtime
+    load: on-demand
+    mode: verbatim
+    evidence: cast-validated
+    trigger: Before emitting the summary, to check it against the schema.
+---
+
+# Summarize a CWL workflow
+
+A minimal but complete Mold: one action, one declared output artifact, and one reference the
+cast is told exactly when to read.

--- a/packages/note-schema/src/types/mold/kind.md
+++ b/packages/note-schema/src/types/mold/kind.md
@@ -1,0 +1,35 @@
+# Mold
+
+A **Mold** describes *one repeatable action* — not a document, not a tutorial, but a unit of
+work worth casting into a skill artifact. Its body says how to do the action; its frontmatter
+declares the *typed reference manifest* naming every note the cast must carry, and how.
+
+Molds are the substrate's centre of gravity. Everything else in the corpus exists so a Mold can
+cite it.
+
+## Why each required field is required
+
+- **`name`** — the stable slug the pipeline and the cast bundle address the Mold by. Distinct
+  from `title`, which is prose for a reader.
+- **`axis`** — which dimension the Mold is specialized along, and therefore how a caller
+  *selects* it. `source-specific` / `target-specific` / `tool-specific` each require the
+  matching field (`source` / `target` / `tool`): an axis that names no subject is a Mold
+  nothing can be selected by, so the schema rejects it rather than letting it sit unfindable.
+  `generic` requires none — it applies everywhere.
+- The **base envelope** (`tags`, `status`, `created`, `revised`, `revision`, `ai_generated`,
+  `summary`) — as on every kind. `summary` is bounded 20–160 characters because it is printed
+  in every browse row; unbounded, half the catalog renders as a bare name and the other half
+  as a paragraph.
+
+## The optional fields that carry the weight
+
+- **`references`** — the manifest. Each entry draws `kind` / `used_at` / `load` / `mode` /
+  `evidence` from `reference_contract.yml`. Two rules the schema enforces: `load: on-demand`
+  requires a `trigger` (a reference the cast is never told to read is unreachable), and
+  `evidence: hypothesis` requires a `verification` (an unmarked guess is the failure mode the
+  field exists to prevent).
+- **`input_artifacts` / `output_artifacts`** — the Mold's declared IO, which is what lets
+  Molds be composed into a pipeline phase without reading their bodies. An output may name a
+  `schema` note, making the handoff machine-checkable.
+- **`loop_endstate`** — for a Mold that runs until a condition holds, the condition. Prose,
+  but *required* prose once the Mold loops: "until it passes" is not an end state.

--- a/packages/note-schema/src/types/mold/schema.ts
+++ b/packages/note-schema/src/types/mold/schema.ts
@@ -1,0 +1,76 @@
+import { z } from "zod";
+
+import { sourceKinds, targetKinds, type KindContext, defineKind } from "../context.js";
+
+// Mold-local primitives: the declared IO of one casting action. Nothing else declares
+// artifacts, so they stay here rather than in the shared context.
+const artifactId = z.string().regex(/^[a-z][a-z0-9-]*$/, { message: "must be a kebab id" });
+
+const outputArtifact = z
+  .object({
+    id: artifactId,
+    kind: z.enum(["json", "markdown", "yaml", "text", "other"]),
+    default_filename: z.string().min(1),
+    schema: z
+      .string()
+      .regex(/^\[\[.+\]\]$/)
+      .optional(),
+    description: z.string().min(20),
+  })
+  .strict();
+
+const inputArtifact = z
+  .object({
+    id: artifactId,
+    description: z.string().min(20),
+  })
+  .strict();
+
+export const kind = defineKind({
+  kind: "mold",
+  title: "Mold",
+  origin: "substrate",
+  summary:
+    "One repeatable action, described as a typed reference manifest that casting compiles into a skill artifact.",
+
+  build: (ctx: KindContext) =>
+    z
+      .object({
+        type: z.literal("mold"),
+        name: z.string(),
+        // Which dimension the Mold is specialized along. The `refine` below makes each
+        // value require the field that names the specialization — an axis that names no
+        // subject is a Mold nothing can be selected by.
+        axis: z.enum(["source-specific", "target-specific", "tool-specific", "generic"]),
+        source: z.enum(sourceKinds).optional(),
+        target: z.enum(targetKinds).optional(),
+        tool: ctx.toolSlug.optional(),
+        output_artifacts: z.array(outputArtifact).optional(),
+        input_artifacts: z.array(inputArtifact).optional(),
+        loop_endstate: z.string().min(10).optional(),
+        references: z.array(ctx.reference).optional(),
+        ...ctx.base,
+      })
+      .strict(),
+
+  refine: (d, ctx) => {
+    if (d.axis === "source-specific" && !d.source)
+      ctx.addIssue({
+        code: "custom",
+        path: ["source"],
+        message: "source-specific mold requires `source`",
+      });
+    if (d.axis === "target-specific" && !d.target)
+      ctx.addIssue({
+        code: "custom",
+        path: ["target"],
+        message: "target-specific mold requires `target`",
+      });
+    if (d.axis === "tool-specific" && !d.tool)
+      ctx.addIssue({
+        code: "custom",
+        path: ["tool"],
+        message: "tool-specific mold requires `tool`",
+      });
+  },
+});

--- a/packages/note-schema/src/types/pattern/example.md
+++ b/packages/note-schema/src/types/pattern/example.md
@@ -1,0 +1,23 @@
+---
+type: pattern
+title: Collection inputs map over their elements
+pattern_kind: operation
+evidence: corpus-observed
+tags:
+  - target/galaxy
+status: reviewed
+created: 2026-07-26
+revised: 2026-07-26
+revision: 2
+ai_generated: true
+summary: A tool given a collection where it declares a single dataset runs once per element, implicitly.
+iwc_exemplars:
+  - workflow: rnaseq-pe
+    why: The trimming step receives a paired collection and maps without an explicit map-over step.
+    confidence: high
+---
+
+# Collection inputs map over their elements
+
+The claim is `corpus-observed` and names the workflow it was observed in, so the grading can be
+checked rather than taken on trust.

--- a/packages/note-schema/src/types/pattern/kind.md
+++ b/packages/note-schema/src/types/pattern/kind.md
@@ -1,0 +1,27 @@
+# Pattern
+
+A **Pattern** is one reusable piece of domain knowledge, authored so that a Mold can *cite* it
+instead of restating it. Patterns are the corpus a cast is grounded in: if a Mold's body starts
+explaining how something generally works, that explanation wants to be a Pattern.
+
+## Why each required field is required
+
+- **`title`** — patterns are read by humans browsing the corpus, and a slug is not a title.
+- **`pattern_kind`** — `operation` (one transformation), `recipe` (an assembled sequence), or
+  `moc` (a map of content: a hub note whose job is to point at others). The three are browsed
+  and cast differently, so the distinction is declared rather than guessed from the body.
+- **`evidence`** — how strongly the corpus supports the claim: `corpus-observed`,
+  `structurally-verified`, `corpus-and-verified`, or `hypothesis`. **`hypothesis` is legal**,
+  and that is the point: a speculative pattern that is *marked* speculative can be safely
+  loaded and later verified, while an unmarked one silently anchors every cast that reads it.
+  This field is what keeps the corpus honest as it grows faster than it is checked.
+- The **base envelope** — as on every kind.
+
+## Optional fields
+
+- **`iwc_exemplars`** — citations into the IWC workflow corpus that exhibit the pattern, each
+  with a `why` and a `confidence`. This is what makes `corpus-observed` checkable rather than
+  asserted: the exemplar names the workflow, and a reviewer can go look.
+- **`parent_pattern`** — a `[[wiki-link]]` to the more general pattern this specializes.
+- **`verification_paths`** — how someone would confirm the claim.
+- **`companions`** — sibling files the cast copies verbatim beside the note.

--- a/packages/note-schema/src/types/pattern/schema.ts
+++ b/packages/note-schema/src/types/pattern/schema.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+
+import { type KindContext, defineKind } from "../context.js";
+
+// Pattern-local: a citation into the IWC corpus, naming the workflow (and optionally the
+// steps) that exhibit the pattern. Only patterns carry corpus exemplars.
+const iwcExemplarStep = z
+  .object({
+    label: z.string().min(1).optional(),
+    id: z.union([z.string().min(1), z.number().int()]).optional(),
+  })
+  .strict()
+  .refine((step) => step.label || step.id !== undefined, {
+    message: "step needs `label` or `id`",
+  });
+
+const iwcExemplar = z
+  .object({
+    workflow: z.string().min(1),
+    steps: z.array(iwcExemplarStep).min(1).optional(),
+    why: z.string().min(1),
+    confidence: z.enum(["high", "medium", "low"]),
+  })
+  .strict();
+
+export const kind = defineKind({
+  kind: "pattern",
+  title: "Pattern",
+  origin: "substrate",
+  summary:
+    "One reusable piece of domain knowledge a Mold can reference, graded by how strongly the corpus supports it.",
+
+  build: (ctx: KindContext) =>
+    z
+      .object({
+        ...ctx.base,
+        type: z.literal("pattern"),
+        pattern_kind: z.enum(["operation", "recipe", "moc"]),
+        // How well-supported the claim is. `hypothesis` is legal but must be declared —
+        // an unmarked guess is the failure mode this field exists to prevent.
+        evidence: z.enum([
+          "corpus-observed",
+          "structurally-verified",
+          "corpus-and-verified",
+          "hypothesis",
+        ]),
+        title: z.string(),
+        parent_pattern: ctx.wikiLink.optional(),
+        verification_paths: z.array(z.string()).optional(),
+        iwc_exemplars: z.array(iwcExemplar).optional(),
+        companions: ctx.companions.optional(),
+      })
+      .strict(),
+});

--- a/packages/note-schema/src/types/pipeline/example.md
+++ b/packages/note-schema/src/types/pipeline/example.md
@@ -1,0 +1,27 @@
+---
+type: pipeline
+title: CWL workflow to Galaxy
+tags:
+  - target/galaxy
+status: draft
+created: 2026-07-26
+revised: 2026-07-26
+revision: 1
+ai_generated: true
+summary: Summarize a CWL workflow, choose the interface strategy, then build and validate the Galaxy workflow.
+phases:
+  - mold: "[[summarize-cwl-workflow]]"
+  - branch: Does every step map to an installed Galaxy tool?
+    branches:
+      - "[[cwl-summary-to-galaxy-interface]]"
+      - fallthrough: "[[freeform-summary-to-galaxy-interface]]"
+  - mold: "[[validate-galaxy-workflow]]"
+    loop: true
+harness_notes:
+  - The final phase loops until validation passes; cap the attempts and surface the last error.
+---
+
+# CWL workflow to Galaxy
+
+Three phases, one of them a branch and one of them a loop — the whole grammar, and no
+restatement of what any Mold does.

--- a/packages/note-schema/src/types/pipeline/kind.md
+++ b/packages/note-schema/src/types/pipeline/kind.md
@@ -1,0 +1,29 @@
+# Pipeline
+
+A **Pipeline** composes Molds into an ordered end-to-end protocol. It is the *composition
+layer*, and it is optional: a Foundry whose actions stand alone needs no Pipelines at all.
+
+Keep it thin. The Pipeline names phases and their order; it does not restate what the Molds do.
+Anything a phase explains about the work itself belongs in the Mold.
+
+This kind is **instance-specific**. Workflow construction is inherently sequential, so Pipelines
+earn their keep here; a domain whose Molds are a standalone toolkit should not adopt this kind
+just because the parent has it.
+
+## Why each required field is required
+
+- **`title`** — the protocol's name, as a reader navigating the map sees it.
+- **`phases`** (min 1) — the ordered steps. Each phase is one of two shapes:
+  - a **Mold phase** — `{ mold: "[[slug]]", loop?: true }`;
+  - a **branch phase** — `{ branch: "<question>", branches: [...] | chain: [...] }`, which must
+    carry `branches` or `chain`. A branch that names a decision but lists no alternatives is a
+    phase nothing can execute, so the schema rejects it.
+
+  A branch item may be a `[[wiki-link]]`, free text for a terminal outcome
+  (`"user-supplied"`), or `{ fallthrough: "[[slug]]" }` for the default arm.
+- The **base envelope** — as on every kind.
+
+## Optional fields
+
+- **`harness_notes`** — what the orchestrator running this pipeline needs to know that is not
+  in any single phase.

--- a/packages/note-schema/src/types/pipeline/schema.ts
+++ b/packages/note-schema/src/types/pipeline/schema.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+
+import { type KindContext, defineKind } from "../context.js";
+
+// Pipeline-local: a phase is either a Mold to run or a branch over alternatives. Nothing
+// else composes Molds, so the phase grammar stays here.
+const branchItem: z.ZodType<unknown> = z.lazy(() =>
+  z.union([
+    z.string().regex(/^\[\[.+\]\]$/),
+    z.string(), // free-text terminal like "user-supplied"
+    z.object({ fallthrough: z.string().regex(/^\[\[.+\]\]$/) }).strict(),
+  ]),
+);
+
+const moldPhase = z
+  .object({
+    mold: z.string().regex(/^\[\[.+\]\]$/, { message: "must be a [[wiki-link]]" }),
+    loop: z.boolean().optional(),
+  })
+  .strict();
+
+const branchPhase = z
+  .object({
+    branch: z.string(),
+    loop: z.boolean().optional(),
+    branches: z.array(branchItem).optional(),
+    chain: z.array(branchItem).optional(),
+  })
+  .strict()
+  .refine((p) => p.branches || p.chain, {
+    message: "branch phase needs `branches` or `chain`",
+  });
+
+const phase = z.union([moldPhase, branchPhase]);
+
+export const kind = defineKind({
+  kind: "pipeline",
+  title: "Pipeline",
+  origin: "instance",
+  summary:
+    "An ordered end-to-end protocol composing Molds into phases — the optional composition layer, for domains whose work is a journey.",
+
+  build: (ctx: KindContext) =>
+    z
+      .object({
+        ...ctx.base,
+        type: z.literal("pipeline"),
+        title: z.string(),
+        phases: z.array(phase).min(1),
+        harness_notes: z.array(z.string().min(10)).optional(),
+      })
+      .strict(),
+});

--- a/packages/note-schema/src/types/prompt/example.md
+++ b/packages/note-schema/src/types/prompt/example.md
@@ -1,0 +1,20 @@
+---
+type: prompt
+title: Galaxy custom tool critic
+prompt_file: custom-tool-critic.upstream.prompt
+license: MIT
+license_file: LICENSES/galaxy.LICENSE
+tags:
+  - target/galaxy
+status: reviewed
+created: 2026-07-26
+revised: 2026-07-26
+revision: 1
+ai_generated: true
+summary: Upstream Galaxy prompt that reviews a generated tool XML for correctness and idiom.
+---
+
+# Galaxy custom tool critic
+
+The prompt text itself is in `custom-tool-critic.upstream.prompt`, untouched; this note holds
+only the provenance around it.

--- a/packages/note-schema/src/types/prompt/kind.md
+++ b/packages/note-schema/src/types/prompt/kind.md
@@ -1,0 +1,23 @@
+# Prompt
+
+A **Prompt** note carries a raw upstream prompt — someone else's, verbatim — in a sibling file,
+and records where it came from and under what licence.
+
+The verbatim file is the whole point. A prompt paraphrased is a different prompt, so the text
+lives untouched in its own file and the note carries the provenance around it. Casting copies
+the file across unchanged.
+
+## Why each required field is required
+
+- **`title`** — prose, for the reader.
+- **`prompt_file`** — the sibling-relative path to the raw text. Separate from the note body so
+  the prompt is never accidentally reflowed, summarized, or wiki-linked by an editor working on
+  the note.
+- The **base envelope** — as on every kind.
+
+## Optional fields
+
+- **`license`** / **`license_file`** — optional in the schema, but a prompt taken from an
+  external project is redistributed text: name the licence, and vendor the licence file under
+  `LICENSES/` where the policy row calls for it. The schema does not force this the way the
+  `schema` kind does, because a prompt authored here has no upstream to name.

--- a/packages/note-schema/src/types/prompt/schema.ts
+++ b/packages/note-schema/src/types/prompt/schema.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+import { type KindContext, defineKind } from "../context.js";
+
+// Prompt-local: the sibling-relative raw prompt file casting copies verbatim.
+const promptFile = z
+  .string()
+  .regex(/^[A-Za-z0-9._/-]+$/, { message: "must be a sibling-relative path" });
+
+export const kind = defineKind({
+  kind: "prompt",
+  title: "Prompt",
+  origin: "instance",
+  summary:
+    "A raw upstream prompt carried verbatim in a sibling file, with the note recording where it came from and under what license.",
+
+  build: (ctx: KindContext) =>
+    z
+      .object({
+        ...ctx.base,
+        type: z.literal("prompt"),
+        title: z.string(),
+        prompt_file: promptFile,
+        license: ctx.licenseId.optional(),
+        license_file: ctx.licenseFile.optional(),
+      })
+      .strict(),
+});

--- a/packages/note-schema/src/types/research/example.md
+++ b/packages/note-schema/src/types/research/example.md
@@ -1,0 +1,17 @@
+---
+type: research
+component: gxformat2
+tags:
+  - target/galaxy
+status: draft
+created: 2026-07-26
+revised: 2026-07-26
+revision: 1
+ai_generated: true
+summary: gxformat2 rejects duplicate step labels, so generated labels must be made unique before emit.
+---
+
+# Duplicate step labels are rejected
+
+Recoverable on its own terms: it states the exact constraint and what the generator has to do
+about it, so a Mold citing this note does not need the source that produced it.

--- a/packages/note-schema/src/types/research/kind.md
+++ b/packages/note-schema/src/types/research/kind.md
@@ -1,0 +1,26 @@
+# Research Note
+
+A **Research Note** captures a finding about the domain or its tooling — the grounding a Mold
+cites instead of inventing. It is the loosest kind on purpose: research arrives before you know
+what shape it wants, and forcing it into a stricter kind on arrival loses it.
+
+The discipline is not in the frontmatter, it is in the grading: a research note is good enough
+only if the target skill could be **rebuilt from the note alone** — no re-reading the source, no
+model memory. Hold the numbers, thresholds, exact procedure, and named decision criteria.
+
+## Why each required field is required
+
+Only the **base envelope**. A research note is `type` plus the envelope; everything else is
+optional, because the kind's job is to accept a finding, not to interrogate it.
+
+`summary` still applies (20–160 characters), and it does the most work here: with no `title`
+required, the summary is what a browsing reader has to go on.
+
+## Optional fields
+
+- **`component`** — the subsystem the finding is about, when it is about one.
+- **`license`** / **`license_file`** — required *in practice* whenever the note redistributes
+  someone else's text. The id resolves against `license-policy.yml`; where the policy row says
+  the licence text travels with the content, `license_file` points at the vendored copy under
+  `LICENSES/`.
+- **`companions`** — sibling files the cast copies verbatim beside the note.

--- a/packages/note-schema/src/types/research/schema.ts
+++ b/packages/note-schema/src/types/research/schema.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+import { type KindContext, defineKind } from "../context.js";
+
+export const kind = defineKind({
+  kind: "research",
+  title: "Research Note",
+  origin: "instance",
+  summary:
+    "A captured finding about the domain or its tooling — the grounding a Mold cites rather than inventing.",
+
+  build: (ctx: KindContext) =>
+    z
+      .object({
+        type: z.literal("research"),
+        component: z.string().optional(),
+        companions: ctx.companions.optional(),
+        license: ctx.licenseId.optional(),
+        license_file: ctx.licenseFile.optional(),
+        ...ctx.base,
+      })
+      .strict(),
+});

--- a/packages/note-schema/src/types/schema/example.md
+++ b/packages/note-schema/src/types/schema/example.md
@@ -1,0 +1,23 @@
+---
+type: schema
+name: workflow-summary
+title: Workflow Summary
+package: "@galaxy-foundry/note-schema"
+package_export: workflowSummarySchema
+validator_bin: foundry-build
+validator_subcommand: validate
+upstream: https://github.com/galaxyproject/foundry/tree/main/packages/note-schema
+tags:
+  - target/galaxy
+status: reviewed
+created: 2026-07-26
+revised: 2026-07-26
+revision: 1
+ai_generated: true
+summary: The structured summary shape the source-reading Molds emit and the interface Molds consume.
+---
+
+# Workflow Summary
+
+`upstream` points inside this repository, so no `license` is required. Point it at an external
+project and the schema demands one — that is the rule this kind carries.

--- a/packages/note-schema/src/types/schema/kind.md
+++ b/packages/note-schema/src/types/schema/kind.md
@@ -1,0 +1,30 @@
+# Schema Note
+
+A **Schema Note** documents a machine-checkable contract a cast can validate its output
+against, and names the validator that decides it. It is how a Mold's `output_artifacts` stop
+being a promise and start being a check.
+
+## Why each required field is required
+
+- **`name`** — the slug a Mold's `output_artifacts[].schema` wiki-link resolves to.
+- **`title`** — prose, for the reader.
+- The **base envelope** — as on every kind.
+
+## Optional fields
+
+- **`package`** / **`package_export`** — where the schema is importable from. The validator
+  requires both on any note a `references[].kind: schema` entry points at: a schema you cannot
+  import is a schema no cast can run.
+- **`validator_bin`** / **`validator_subcommand`** — the command that checks against it.
+- **`upstream`** — where the schema came from, if it is vendored.
+- **`license`** / **`license_file`** — see the rule below.
+
+## The cross-field rule this kind enforces
+
+A schema note whose `upstream` points **outside this repository** is redistributing someone
+else's work, so it **must** declare a `license`. And where that licence's row in
+`license-policy.yml` says the text travels with the content, it must also declare a
+`license_file` pointing at the vendored copy under `LICENSES/`.
+
+An `upstream` inside `github.com/galaxyproject/foundry/` is our own work and needs neither —
+which is why the rule keys off *where upstream points*, not on whether the field is present.

--- a/packages/note-schema/src/types/schema/schema.ts
+++ b/packages/note-schema/src/types/schema/schema.ts
@@ -1,0 +1,57 @@
+import { z } from "zod";
+
+import { resolveLicenseRow } from "../../license-policy.js";
+import { type KindContext, defineKind } from "../context.js";
+
+// Schema-local: package bin / subcommand names for the validator this note documents.
+const binName = z.string().regex(/^[A-Za-z0-9._-]+$/);
+
+export const kind = defineKind({
+  kind: "schema",
+  title: "Schema Note",
+  origin: "instance",
+  summary:
+    "A machine-checkable contract a cast can validate against, plus the validator that decides it.",
+
+  build: (ctx: KindContext) =>
+    z
+      .object({
+        ...ctx.base,
+        type: z.literal("schema"),
+        name: z.string(),
+        title: z.string(),
+        package: z.string().optional(),
+        upstream: z.string().optional(),
+        package_export: z.string().optional(),
+        validator_bin: binName.optional(),
+        validator_subcommand: binName.optional(),
+        license: ctx.licenseId.optional(),
+        license_file: ctx.licenseFile.optional(),
+      })
+      .strict(),
+
+  // A schema note vendoring an EXTERNAL upstream is redistributing someone else's work, so
+  // it must name the license, and (where the policy row says the text travels with it) point
+  // at the vendored copy. An upstream inside this repo is our own and needs neither.
+  refine: (d, ctx, kctx) => {
+    const upstream = typeof d.upstream === "string" ? d.upstream : "";
+    const external = upstream && !upstream.includes("github.com/galaxyproject/foundry/");
+    if (!external) return;
+    if (!d.license) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["license"],
+        message: "vendored schema with external upstream requires `license`",
+      });
+      return;
+    }
+    const row = resolveLicenseRow(kctx.registries.licensePolicy, d.license as string);
+    if (row.license_file && !d.license_file) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["license_file"],
+        message: `license ${String(d.license)} requires a \`license_file\``,
+      });
+    }
+  },
+});

--- a/packages/note-schema/src/types/source-pattern/example.md
+++ b/packages/note-schema/src/types/source-pattern/example.md
@@ -1,0 +1,24 @@
+---
+type: source-pattern
+title: Nextflow fromFilePairs emits a keyed pair channel
+source: nextflow
+target: galaxy
+source_pattern_kind: channel-shape
+implemented_by_patterns:
+  - "[[paired-collection-input]]"
+tags:
+  - target/galaxy
+status: draft
+created: 2026-07-26
+revised: 2026-07-26
+revision: 1
+ai_generated: true
+summary: fromFilePairs yields (sampleId, [r1, r2]) tuples, which convert to a paired dataset collection.
+review_triggers:
+  - The converted workflow declares two separate FASTQ inputs where the source had one channel.
+---
+
+# `fromFilePairs` emits a keyed pair channel
+
+Names a shape on the source side and links the target-side Pattern that implements it — the
+`min(1)` link is what keeps this note actionable.

--- a/packages/note-schema/src/types/source-pattern/kind.md
+++ b/packages/note-schema/src/types/source-pattern/kind.md
@@ -1,0 +1,31 @@
+# Source Pattern
+
+A **Source Pattern** is a shape that recurs in one *source* ecosystem — a Nextflow channel
+idiom, a CWL scatter convention — held deliberately separate from the target-side `pattern`
+notes that say what to *do* about it.
+
+The split exists because the two sides have different lifetimes. A source ecosystem changes on
+its own schedule; when it does, the source-pattern notes go stale together, and the target-side
+patterns they point at usually do not. Merging them into one kind would make every upstream
+change look like a change to Galaxy knowledge.
+
+This kind is **instance-specific**: it only makes sense for a Foundry whose work is *conversion*
+between two named ecosystems.
+
+## Why each required field is required
+
+- **`source`** and **`target`** — the pair the pattern bridges. Both required: a source shape
+  with no stated target is an observation about someone else's ecosystem, not knowledge this
+  Foundry can act on.
+- **`source_pattern_kind`** — `moc`, `channel-shape`, `operator`, `lifecycle`, or
+  `review-trigger`. What sort of recurring thing it is, and therefore when it gets consulted.
+- **`implemented_by_patterns`** — at least one `[[wiki-link]]` to the target-side Pattern that
+  handles it. **`min(1)` is the load-bearing rule of this kind**: a source shape nothing
+  implements is a note that can never be acted on, and the link is what makes the source/target
+  split navigable in both directions instead of a one-way pile.
+- **`title`** and the **base envelope** — as on every kind.
+
+## Optional fields
+
+- **`review_triggers`** — conditions under which a converted workflow should be looked at again
+  because this shape was involved.

--- a/packages/note-schema/src/types/source-pattern/schema.ts
+++ b/packages/note-schema/src/types/source-pattern/schema.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+
+import { sourceKinds, targetKinds, type KindContext, defineKind } from "../context.js";
+
+export const kind = defineKind({
+  kind: "source-pattern",
+  title: "Source Pattern",
+  origin: "instance",
+  summary:
+    "A shape recurring in one SOURCE ecosystem, held separate from the target-side patterns that implement it.",
+
+  build: (ctx: KindContext) =>
+    z
+      .object({
+        ...ctx.base,
+        type: z.literal("source-pattern"),
+        title: z.string(),
+        source: z.enum(sourceKinds),
+        target: z.enum(targetKinds),
+        source_pattern_kind: z.enum([
+          "moc",
+          "channel-shape",
+          "operator",
+          "lifecycle",
+          "review-trigger",
+        ]),
+        // min(1): a source-side shape nothing implements is an observation, not a pattern.
+        // The link is what makes the source/target split navigable in both directions.
+        implemented_by_patterns: z.array(ctx.wikiLink).min(1),
+        review_triggers: z.array(z.string().min(1)).optional(),
+      })
+      .strict(),
+});

--- a/packages/note-schema/test/kind-directories.test.ts
+++ b/packages/note-schema/test/kind-directories.test.ts
@@ -1,0 +1,95 @@
+// The types/ layout must actually hold, or the isolation it buys is imaginary.
+//
+// Four things are asserted per kind: the barrel and the directory listing agree BOTH ways,
+// `kind` matches the directory name, kind.md and example.md exist, and example.md's
+// frontmatter parses against that kind's own schema. The last one is what keeps the
+// documentation executable — an example that stopped validating is a kind whose docs lie.
+
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import yaml from "js-yaml";
+import { describe, expect, it } from "vitest";
+
+import {
+  KINDS,
+  buildNoteSchema,
+  loadLicensePolicy,
+  loadReferenceContract,
+  loadTagRegistry,
+} from "../src/index.js";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const typesDir = path.resolve(here, "../src/types");
+const repoRoot = path.resolve(here, "../../..");
+
+/** Directories under types/ are kinds; loose files (context.ts, index.ts) are not. */
+const kindDirs = readdirSync(typesDir, { withFileTypes: true })
+  .filter((e) => e.isDirectory())
+  .map((e) => e.name)
+  .sort();
+
+function frontmatter(file: string): Record<string, unknown> {
+  const text = readFileSync(file, "utf8");
+  const m = /^---\n([\s\S]*?)\n---/.exec(text);
+  if (!m) throw new Error(`${file} has no frontmatter block`);
+  // js-yaml, not a bespoke parser: an unquoted date must coerce exactly as Astro's loader
+  // does, so the footgun surfaces here rather than in production.
+  return yaml.load(m[1]) as Record<string, unknown>;
+}
+
+describe("types/ kind directories", () => {
+  // Guards against a path change turning every assertion below into a vacuous pass.
+  it("finds kind directories at all", () => {
+    expect(kindDirs.length).toBeGreaterThan(1);
+  });
+
+  it("the barrel enumerates exactly the directories on disk", () => {
+    // Both directions. A directory the barrel forgot is a kind that silently does not exist;
+    // a barrel entry with no directory is a stale import.
+    expect(KINDS.map((k) => k.kind).sort()).toEqual(kindDirs);
+  });
+
+  it("declares no duplicate kind names", () => {
+    expect(new Set(KINDS.map((k) => k.kind)).size).toBe(KINDS.length);
+  });
+
+  const schema = buildNoteSchema({
+    tags: loadTagRegistry(path.join(repoRoot, "meta_tags.yml")),
+    contract: loadReferenceContract(path.join(repoRoot, "reference_contract.yml")),
+    licensePolicy: loadLicensePolicy(repoRoot),
+  });
+
+  for (const definition of KINDS) {
+    describe(definition.kind, () => {
+      const dir = path.join(typesDir, definition.kind);
+
+      it("has kind.md and example.md beside its schema", () => {
+        expect(existsSync(path.join(dir, "schema.ts"))).toBe(true);
+        expect(existsSync(path.join(dir, "kind.md"))).toBe(true);
+        expect(existsSync(path.join(dir, "example.md"))).toBe(true);
+      });
+
+      it("declares a summary the catalog can render", () => {
+        expect(definition.summary.length).toBeGreaterThan(20);
+        expect(definition.title.length).toBeGreaterThan(0);
+      });
+
+      it("example.md declares this kind and validates against it", () => {
+        const fm = frontmatter(path.join(dir, "example.md"));
+        expect(fm.type).toBe(definition.kind);
+
+        const result = schema.safeParse(fm);
+        if (!result.success) {
+          throw new Error(
+            `${definition.kind}/example.md does not validate:\n` +
+              result.error.issues
+                .map((i) => `  ${i.path.join(".") || "(root)"}: ${i.message}`)
+                .join("\n"),
+          );
+        }
+      });
+    });
+  }
+});

--- a/packages/note-schema/test/note-schema.test.ts
+++ b/packages/note-schema/test/note-schema.test.ts
@@ -91,6 +91,48 @@ describe("buildNoteSchema", () => {
     expect(r.success).toBe(false);
   });
 
+  const moldWithRef = (ref: Record<string, unknown>) =>
+    base({
+      type: "mold",
+      tags: ["target/galaxy"],
+      name: "x",
+      axis: "generic",
+      references: [
+        {
+          kind: "pattern",
+          ref: "[[some-pattern]]",
+          used_at: "cast-time",
+          load: "upfront",
+          mode: "condense",
+          evidence: "corpus-observed",
+          ...ref,
+        },
+      ],
+    });
+
+  it("requires a trigger on an on-demand reference", () => {
+    const r = schema.safeParse(moldWithRef({ load: "on-demand" }));
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues.some((i) => /requires a trigger/.test(i.message))).toBe(true);
+    }
+  });
+
+  it("accepts an on-demand reference that names its trigger", () => {
+    const r = schema.safeParse(
+      moldWithRef({ load: "on-demand", trigger: "When emitting the tool XML." }),
+    );
+    expect(r.success).toBe(true);
+  });
+
+  it("requires a verification on a hypothesis reference", () => {
+    const r = schema.safeParse(moldWithRef({ evidence: "hypothesis" }));
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues.some((i) => /requires a verification/.test(i.message))).toBe(true);
+    }
+  });
+
   it("requires source on a source-specific mold", () => {
     const r = schema.safeParse(
       base({

--- a/scripts/generate-kind-manifest.ts
+++ b/scripts/generate-kind-manifest.ts
@@ -1,0 +1,71 @@
+// Regenerate the kind manifest — packages/note-schema/src/types/kinds.generated.json.
+//
+// Usage:
+//   tsx scripts/generate-kind-manifest.ts [--check]
+//
+// --check: exit non-zero if the committed file is stale; do not write.
+//
+// The manifest is the machine-readable answer to "what note kinds does this Foundry define,
+// and what metadata does each require". Its `fields` are derived from the zod shapes, so the
+// file cannot drift from the schema — only from the schema's last regeneration, which is what
+// --check catches in CI.
+//
+// It is committed rather than built on demand because its consumer is another repository: the
+// foundry-pattern site renders both instances' manifests side by side as a kind catalog, and
+// it must be able to read them from a checkout without installing either instance's toolchain.
+
+import { readFileSync, readdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import {
+  buildKindManifest,
+  loadLicensePolicy,
+  loadReferenceContract,
+  loadTagRegistry,
+} from "@galaxy-foundry/note-schema";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const TYPES_DIR = path.join(REPO_ROOT, "packages/note-schema/src/types");
+const OUTPUT = path.join(TYPES_DIR, "kinds.generated.json");
+const INSTANCE = "galaxy-workflow-foundry";
+
+/** kind name -> kind.md body, read from the directories the barrel enumerates. */
+function loadDocs(): Record<string, string> {
+  const docs: Record<string, string> = {};
+  for (const entry of readdirSync(TYPES_DIR, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    docs[entry.name] = readFileSync(path.join(TYPES_DIR, entry.name, "kind.md"), "utf8").trim();
+  }
+  return docs;
+}
+
+const manifest = buildKindManifest({
+  instance: INSTANCE,
+  docs: loadDocs(),
+  tags: loadTagRegistry(path.join(REPO_ROOT, "meta_tags.yml")),
+  contract: loadReferenceContract(path.join(REPO_ROOT, "reference_contract.yml")),
+  licensePolicy: loadLicensePolicy(REPO_ROOT),
+});
+
+const rendered = `${JSON.stringify(manifest, null, 2)}\n`;
+
+if (process.argv.includes("--check")) {
+  let current = "";
+  try {
+    current = readFileSync(OUTPUT, "utf8");
+  } catch {
+    current = "";
+  }
+  if (current !== rendered) {
+    console.error(
+      `${path.relative(REPO_ROOT, OUTPUT)} is stale — run \`npm run kinds\` and commit the result.`,
+    );
+    process.exit(1);
+  }
+  console.log(`${path.relative(REPO_ROOT, OUTPUT)} is up to date (${manifest.kinds.length} kinds).`);
+} else {
+  writeFileSync(OUTPUT, rendered);
+  console.log(`Wrote ${path.relative(REPO_ROOT, OUTPUT)} (${manifest.kinds.length} kinds).`);
+}

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -647,6 +647,7 @@ describe("validateDirectory (cross-file)", () => {
             load: "on-demand",
             mode: "verbatim",
             evidence: "corpus-observed",
+            trigger: "When the component is in scope.",
           },
           {
             kind: "pattern",
@@ -985,7 +986,7 @@ describe("validateDirectory (cross-file)", () => {
     expect(r.errors).toBeGreaterThanOrEqual(1);
   });
 
-  it("warns when on-demand references omit triggers", () => {
+  it("rejects on-demand references that omit triggers", () => {
     writeFm(path.join(dir, "molds/m/index.md"), {
       ...baseRequired({
         type: "mold",
@@ -1012,8 +1013,10 @@ describe("validateDirectory (cross-file)", () => {
       directory: dir,
       tagsPath: TAGS_PATH,
     });
-    expect(r.errors).toBe(0);
-    expect(r.warnings).toBeGreaterThanOrEqual(1);
+    // An error, not a warning: an on-demand reference that names no trigger states no
+    // condition under which the cast should read it, so it is unreachable at runtime.
+    // Enforced by the note schema, which is why the validator no longer re-encodes it.
+    expect(r.errors).toBeGreaterThanOrEqual(1);
   });
 
   it("flags Mold source layout drift", () => {


### PR DESCRIPTION
> ℹ️ Opened by Claude (AI assistant) on behalf of @jmchilton — not authored by them personally.

Implements PART 3 of the shared standing-up spec ([galaxyproject/foundry-pattern#13](https://github.com/galaxyproject/foundry-pattern/issues/13)). The sibling Foundry implements the same contract against its own five kinds — writing it twice is what the spec is for.

## Commit 1 — `on-demand ⇒ trigger` becomes a schema rule

The sibling has enforced this in zod since its schema was written; here it was a `/review-mold` bullet and a validator **warning**. The corpus was already fully compliant — **304 on-demand references, every one with a trigger** — so promoting it costs nothing and closes the last cross-field divergence between the two reference manifests.

An on-demand reference with no trigger names no condition under which the cast should read the note, so it is unreachable at runtime. That is an error, not a style warning.

Drops the validator's copies of **both** intra-reference rules (this one and `hypothesis ⇒ verification`, which the schema already raised). They are cross-field rules over a single reference object, which is what the schema is for; the validator keeps only the cross-file checks that need the slug map.

Red-checked: neutering the rule fails the new negative fixture.

## Commit 2 — one directory per kind

`note-schema.ts` held nine kinds in one 358-line discriminated union. Adding a kind meant editing the middle of it, and "what is a Mold, and why does it require `axis`" was answered nowhere — the schema said WHAT, never WHY.

Each kind now owns `src/types/<kind>/` with `schema.ts`, `kind.md`, and `example.md`. `note-schema.ts` is 40 lines of assembler.

### What the split forced into the open

- **`src/types/context.ts`** is the base envelope plus the field primitives, and writing it down decided a boundary that was previously accidental: a primitive shared by >1 kind is context, a primitive used by exactly one kind moves into that kind's directory. `outputArtifact` → `mold/`, `iwcExemplar` → `pattern/`, the phase grammar → `pipeline/`, `promptFile` → `prompt/`.
- **Per-kind cross-field rules moved to the kind that owns them** — the mold `axis` rules to `mold/`, the vendored-schema license rule to `schema/`. They run through a `refine` slot the assembler dispatches by `type`, because `discriminatedUnion` takes `ZodObject` members only and a `.superRefine` would wrap each member in `ZodEffects`.
- **Kinds are built by a factory over the context**, not module constants, so a kind can be validated against a synthetic registry.

### Inference had to be defended

Annotating a kind `: KindDefinition` widens its shape, and the erasure reaches the Astro site as `entry.data.tags: any`. Kinds go through a `defineKind` identity helper that infers, `KINDS` is left an inferred tuple, and one documented cast restores what `.map` erases. `astro check`: 0 errors, same as before.

### The manifest

`src/types/kinds.generated.json` — kind, `origin` (substrate vs instance-specific), summary, `kind.md` body, and a **required-metadata table derived from the zod shape** rather than hand-written. `npm run kinds` regenerates it; `npm run check:kinds` runs in CI.

Its consumer is another repo: the pattern site renders this manifest beside the sibling's as a cross-instance kind catalog, which is Phase 2 of the same issue.

### The layout is held up by a test

`test/kind-directories.test.ts`: the barrel and the directory listing must agree in **both** directions, and each `example.md` must parse against its own kind's schema — which makes the documentation executable and gives every kind a positive baseline it did not have before.

## Verified

- `npm run test` — 154 passed
- `npm run packages-test` — note-schema 46 (was 16)
- `npm run typecheck` — 0 errors (root + site)
- `npm run validate` — 226 files, **0 errors**
- `npm run check:kinds` — manifest current, 9 kinds

🤖 Generated with [Claude Code](https://claude.com/claude-code)