### PR TITLE
Drop archeological comment in validateTypedReference

### DIFF
--- a/packages/build-cli/src/commands/validate.ts
+++ b/packages/build-cli/src/commands/validate.ts
@@ -283,10 +283,6 @@ function validateTypedReference(
   if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return;
   const ref = raw as Record<string, unknown>;
   if (typeof ref.kind !== "string" || typeof ref.ref !== "string") return;
-  // The two intra-reference rules (hypothesis => verification, on-demand => trigger) are
-  // NOT checked here: they are cross-field rules over one reference object, which the note
-  // schema already raises path-anchored issues for. Only the CROSS-FILE checks below —
-  // which need the slug map and cannot live in a schema — belong in this pass.
 
   const expectedTypes: Record<string, string> = {
     pattern: "pattern",


### PR DESCRIPTION
> Posted by Claude (AI assistant) on jmchilton's behalf.

Follow-up to the one review comment on #383 (https://github.com/galaxyproject/foundry/pull/383#discussion_r3653416001) — that PR merged before it was addressed.

The block in `validateTypedReference` described where two checks *used to* live rather than what the function does:

```
// The two intra-reference rules (hypothesis => verification, on-demand => trigger) are
// NOT checked here: ...
```

Dropped. Comment-only change, no behavior.

`packages-typecheck` clean, `tests/validate.test.ts` 76/76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)