### PR TITLE
Consume @galaxy-foundry/kind-manifest instead of a local copy

### DIFF
--- a/packages/note-schema/package.json
+++ b/packages/note-schema/package.json
@@ -37,6 +37,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@galaxy-foundry/kind-manifest": "^0.2.1",
     "js-yaml": "^4.1.0",
     "zod": "^3.25.76"
   },

--- a/packages/note-schema/src/index.ts
+++ b/packages/note-schema/src/index.ts
@@ -15,11 +15,15 @@ export {
   buildKindManifest,
   describeFields,
   describeType,
+  parseKindManifest,
+  withRevision,
   KIND_MANIFEST_VERSION,
+  MANIFEST_SOURCE,
   type BuildKindManifestOptions,
   type KindManifest,
   type ManifestField,
   type ManifestKind,
+  type ManifestSource,
 } from "./kind-manifest.js";
 
 export {

--- a/packages/note-schema/src/kind-manifest.ts
+++ b/packages/note-schema/src/kind-manifest.ts
@@ -1,105 +1,49 @@
-// Derive the kind manifest — the machine-readable form of "what kinds does this Foundry
-// define, and what metadata does each require".
+// This Foundry's kind manifest — the machine-readable form of "what kinds does this
+// Foundry define, and what metadata does each require".
 //
-// `fields` is DERIVED from the zod shape, never hand-written. A hand-maintained
-// required-metadata table is a second encoding of the schema and drifts the first week; this
-// one cannot, because it is read off the same object the validator runs.
+// The FORMAT, the zod-shape deriver, and the reader all live in
+// @galaxy-foundry/kind-manifest, because they are shared across instances (spec:
+// galaxyproject/foundry-pattern, `content/pattern/standing-up-a-foundry.instructions.txt`).
+// What stays here is the part that is genuinely ours: which kinds exist, and how this
+// instance's registries resolve into the context they are built against.
 //
-// The FORMAT is shared across Foundry instances (spec: galaxyproject/foundry-pattern,
-// `content/pattern/standing-up-a-foundry.instructions.txt`), so treat a format change as a
-// cross-repo change. The kinds in it are this instance's own.
+// `fields` is still DERIVED from the zod shape, never hand-written — that has just moved
+// one repo over, along with the synthetic-shape tests that prove the deriver right.
 
-import type { z } from "zod";
+import {
+  buildKindManifest as deriveKindManifest,
+  type KindManifest,
+  type ManifestSource,
+} from "@galaxy-foundry/kind-manifest";
 
 import { buildKindContext } from "./types/context.js";
 import type { BuildKindContextOptions } from "./types/context.js";
 import { KINDS } from "./types/index.js";
 
-export const KIND_MANIFEST_VERSION = 1;
-
-export interface ManifestField {
-  name: string;
-  required: boolean;
-  /** A readable rendering of the zod type, for the catalog's metadata table. */
-  type: string;
-}
-
-export interface ManifestKind {
-  kind: string;
-  title: string;
-  /** Which layer the kind belongs to. Deliberately not `origin` — see `KindDefinition`. */
-  layer: "substrate" | "instance";
-  summary: string;
-  /** The body of the kind's kind.md, verbatim. Supplied by the caller, which knows the paths. */
-  doc?: string;
-  fields: ManifestField[];
-}
-
-export interface KindManifest {
-  instance: string;
-  version: number;
-  kinds: ManifestKind[];
-}
+export {
+  describeFields,
+  describeType,
+  KIND_MANIFEST_VERSION,
+  parseKindManifest,
+  withRevision,
+  type KindManifest,
+  type ManifestField,
+  type ManifestKind,
+  type ManifestSource,
+} from "@galaxy-foundry/kind-manifest";
 
 /**
- * Render a zod type as a short readable string.
+ * Where this Foundry's manifest lives, so a consumer vendoring a copy does not have to
+ * hard-code our identity on our behalf.
  *
- * Deliberately shallow: this feeds a human-facing metadata table, not a code generator, so
- * `string[]` beats a faithful but unreadable expansion of every refinement.
+ * Deliberately no `revision`: the manifest is a committed artifact whose CI gate
+ * regenerates it and string-compares, so anything in it that varies with the current
+ * commit makes `--check` fail on every commit. Whoever takes a snapshot records that.
  */
-export function describeType(schema: z.ZodTypeAny): string {
-  const def = schema._def as { typeName?: string; [k: string]: unknown };
-  switch (def.typeName) {
-    case "ZodOptional":
-    case "ZodNullable":
-    case "ZodDefault":
-      return describeType((def.innerType ?? def.type) as z.ZodTypeAny);
-    case "ZodEffects":
-      return describeType(def.schema as z.ZodTypeAny);
-    case "ZodLazy":
-      return "any";
-    case "ZodString":
-      return "string";
-    case "ZodNumber":
-      return "number";
-    case "ZodBoolean":
-      return "boolean";
-    case "ZodDate":
-      return "date";
-    case "ZodLiteral":
-      return JSON.stringify((def as { value: unknown }).value);
-    case "ZodEnum":
-      return ((def as { values: string[] }).values ?? []).join(" | ");
-    case "ZodArray":
-      return `${describeType(def.type as z.ZodTypeAny)}[]`;
-    case "ZodUnion":
-    case "ZodDiscriminatedUnion": {
-      const opts = (def.options ?? []) as z.ZodTypeAny[];
-      const rendered = [...new Set(opts.map(describeType))];
-      return rendered.length > 3 ? "one of several shapes" : rendered.join(" | ");
-    }
-    case "ZodObject":
-      return "object";
-    default:
-      return "any";
-  }
-}
-
-/**
- * Walk a kind's object shape into the manifest's field list, sorted required-first.
- *
- * `required` answers "must an author write this key", so a field carrying `.default()` counts
- * as optional — zod reports it optional and the note validates without it.
- */
-export function describeFields(shape: z.ZodRawShape): ManifestField[] {
-  return Object.entries(shape)
-    .map(([name, field]) => ({
-      name,
-      required: !field.isOptional(),
-      type: describeType(field),
-    }))
-    .sort((a, b) => Number(b.required) - Number(a.required) || a.name.localeCompare(b.name));
-}
+export const MANIFEST_SOURCE: ManifestSource = {
+  repo: "galaxyproject/foundry",
+  path: "packages/note-schema/src/types/kinds.generated.json",
+};
 
 export interface BuildKindManifestOptions extends BuildKindContextOptions {
   /** Slug identifying this Foundry in a cross-instance catalog. */
@@ -114,16 +58,19 @@ export function buildKindManifest({
   ...registries
 }: BuildKindManifestOptions): KindManifest {
   const ctx = buildKindContext(registries);
-  return {
+  return deriveKindManifest({
     instance,
-    version: KIND_MANIFEST_VERSION,
-    kinds: KINDS.map((definition) => ({
-      kind: definition.kind,
-      title: definition.title,
-      layer: definition.layer,
-      summary: definition.summary,
-      doc: docs[definition.kind],
-      fields: describeFields(definition.build(ctx).shape),
-    })),
-  };
+    source: MANIFEST_SOURCE,
+    kinds: KINDS.map((definition) => {
+      const doc = docs[definition.kind];
+      return {
+        kind: definition.kind,
+        title: definition.title,
+        layer: definition.layer,
+        summary: definition.summary,
+        shape: definition.build(ctx).shape,
+        ...(doc === undefined ? {} : { doc }),
+      };
+    }),
+  });
 }

--- a/packages/note-schema/src/types/kinds.generated.json
+++ b/packages/note-schema/src/types/kinds.generated.json
@@ -958,5 +958,9 @@
         }
       ]
     }
-  ]
+  ],
+  "source": {
+    "repo": "galaxyproject/foundry",
+    "path": "packages/note-schema/src/types/kinds.generated.json"
+  }
 }

--- a/packages/note-schema/test/kind-manifest.test.ts
+++ b/packages/note-schema/test/kind-manifest.test.ts
@@ -1,79 +1,99 @@
-// The manifest's `fields` are DERIVED from the zod shapes, and `check:kinds` cannot catch a
-// bug in that derivation: it regenerates with the same code and string-compares, so a wrong
-// manifest stays "up to date" forever. These tests are what actually pins the derivation —
-// and they matter more than most, because the manifest's consumer is another repository.
+// What this instance owes the manifest format, now that the format itself lives in
+// @galaxy-foundry/kind-manifest.
+//
+// The synthetic-shape suite that used to live here — does `describeType` unwrap a
+// defaulted array, does a refined string still render as `string` — moved to that package
+// along with the renderer it exercises. Re-testing a dependency's unit behaviour here
+// would just be the duplication this extraction removed, in a new place.
+//
+// What is still ours, and only testable here: that OUR kinds resolve against OUR
+// registries into a manifest that is well-formed, complete, and stable enough for the
+// `check:kinds` gate to mean something.
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
-import { z } from "zod";
 
-import { describeFields, describeType } from "../src/kind-manifest.js";
+import {
+  KINDS,
+  KIND_MANIFEST_VERSION,
+  MANIFEST_SOURCE,
+  buildKindManifest,
+  loadLicensePolicy,
+  loadReferenceContract,
+  loadTagRegistry,
+  parseKindManifest,
+} from "../src/index.js";
 
-describe("describeType", () => {
-  it("renders the primitive types", () => {
-    expect(describeType(z.string())).toBe("string");
-    expect(describeType(z.number())).toBe("number");
-    expect(describeType(z.boolean())).toBe("boolean");
-    expect(describeType(z.coerce.date())).toBe("date");
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "../../..");
+
+const registries = {
+  tags: loadTagRegistry(path.join(repoRoot, "meta_tags.yml")),
+  contract: loadReferenceContract(path.join(repoRoot, "reference_contract.yml")),
+  licensePolicy: loadLicensePolicy(repoRoot),
+};
+
+const INSTANCE = "galaxy-workflow-foundry";
+const manifest = buildKindManifest({ instance: INSTANCE, ...registries });
+
+describe("this Foundry's manifest", () => {
+  it("names every kind the barrel declares, in barrel order", () => {
+    expect(manifest.kinds.map((k) => k.kind)).toEqual(KINDS.map((d) => d.kind));
   });
 
-  it("renders a literal as its JSON value", () => {
-    expect(describeType(z.literal("mold"))).toBe('"mold"');
+  it("stamps the instance slug and the format version", () => {
+    expect(manifest.instance).toBe(INSTANCE);
+    expect(manifest.version).toBe(KIND_MANIFEST_VERSION);
   });
 
-  it("renders an enum as its members", () => {
-    expect(describeType(z.enum(["npm", "pypi"]))).toBe("npm | pypi");
+  it("declares where it lives, so a consumer need not hard-code our identity", () => {
+    expect(manifest.source).toEqual(MANIFEST_SOURCE);
+    expect(MANIFEST_SOURCE.repo).toBe("galaxyproject/foundry");
   });
 
-  it("renders arrays by element type", () => {
-    expect(describeType(z.array(z.string()))).toBe("string[]");
-    expect(describeType(z.array(z.object({ ref: z.string() })))).toBe("object[]");
+  // The manifest is committed and CI regenerates it with `--check`, which string-compares.
+  // Anything in it that varies between two runs at the same commit breaks that gate for
+  // everyone, and the failure looks like an unrelated stale-file error.
+  it("is byte-identical across builds, so --check can pass", () => {
+    const again = buildKindManifest({ instance: INSTANCE, ...registries });
+    expect(JSON.stringify(again)).toBe(JSON.stringify(manifest));
   });
 
-  it("unwraps optional, nullable, and default to the inner type", () => {
-    expect(describeType(z.string().optional())).toBe("string");
-    expect(describeType(z.string().nullable())).toBe("string");
-    expect(describeType(z.string().default("x"))).toBe("string");
+  it("gives every kind a title, a summary, and at least one field", () => {
+    for (const kind of manifest.kinds) {
+      expect(kind.title, kind.kind).toBeTruthy();
+      expect(kind.summary, kind.kind).toBeTruthy();
+      expect(kind.fields.length, kind.kind).toBeGreaterThan(0);
+    }
   });
 
-  it("unwraps effects — a refined string is still a string", () => {
-    const tag = z.string().refine((v) => v.length > 0);
-    expect(describeType(tag)).toBe("string");
-    expect(describeType(z.array(tag))).toBe("string[]");
+  // A `type` discriminator that did not resolve to its own literal means the kind was built
+  // against the wrong context — the manifest would look fine and be wrong.
+  it("renders each kind's `type` field as its own literal", () => {
+    for (const kind of manifest.kinds) {
+      const type = kind.fields.find((f) => f.name === "type");
+      expect(type?.type, kind.kind).toBe(JSON.stringify(kind.kind));
+    }
   });
 
-  it("collapses a union, and gives up readably once it is wide", () => {
-    expect(describeType(z.union([z.string(), z.number()]))).toBe("string | number");
-    // Same rendering twice is one member, not two.
-    expect(describeType(z.union([z.string(), z.string().min(1)]))).toBe("string");
-    expect(describeType(z.union([z.string(), z.number(), z.boolean(), z.array(z.string())]))).toBe(
-      "one of several shapes",
-    );
-  });
-});
-
-describe("describeFields", () => {
-  const fields = describeFields({
-    type: z.literal("example"),
-    zebra: z.string(),
-    alpha: z.string(),
-    maybe: z.string().optional(),
-    defaulted: z.string().default("x"),
+  it("carries a doc body only for the kinds it was given one for", () => {
+    const first = KINDS[0]!.kind;
+    const withDocs = buildKindManifest({
+      instance: INSTANCE,
+      docs: { [first]: "# Doc" },
+      ...registries,
+    });
+    expect(withDocs.kinds.find((k) => k.kind === first)?.doc).toBe("# Doc");
+    for (const kind of withDocs.kinds.filter((k) => k.kind !== first)) {
+      expect(Object.hasOwn(kind, "doc"), kind.kind).toBe(false);
+    }
   });
 
-  it("sorts required first, then alphabetically", () => {
-    expect(fields.map((f) => f.name)).toEqual(["alpha", "type", "zebra", "defaulted", "maybe"]);
-  });
-
-  it("marks a plain field required and an optional one not", () => {
-    expect(fields.find((f) => f.name === "alpha")?.required).toBe(true);
-    expect(fields.find((f) => f.name === "maybe")?.required).toBe(false);
-  });
-
-  it("treats a defaulted field as optional — an author need not write it", () => {
-    expect(fields.find((f) => f.name === "defaulted")?.required).toBe(false);
-  });
-
-  it("carries the rendered type through", () => {
-    expect(fields.find((f) => f.name === "type")?.type).toBe('"example"');
+  // The round trip a consumer actually performs: our JSON, their reader. If what we emit
+  // stops satisfying the shared schema, this fails here rather than in another repo.
+  it("survives the shared reader after a JSON round trip", () => {
+    expect(parseKindManifest(JSON.parse(JSON.stringify(manifest)))).toEqual(manifest);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ importers:
 
   packages/note-schema:
     dependencies:
+      '@galaxy-foundry/kind-manifest':
+        specifier: ^0.2.1
+        version: 0.2.1(zod@3.25.76)
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.1
@@ -936,6 +939,12 @@ packages:
 
   '@fontsource/atkinson-hyperlegible@5.2.8':
     resolution: {integrity: sha512-HciLcJ5DIK/OVOdo71EbEN4NnvDFlp6/SpAxtcbWf2aAdcsOuPqITxj5KNEXb48qSPSdnnZdGGnSJChPKi3/bA==}
+
+  '@galaxy-foundry/kind-manifest@0.2.1':
+    resolution: {integrity: sha512-a/H/xFryorwsgu0S2kiWlp4rNQvFfaRo2R/BcKPJI+u4u7gzzQuahQk34OS9+BIOG0d0q8ce0i/ElRBvtlA1Gg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      zod: ^3.25.0
 
   '@galaxy-tool-util/cli@1.10.0':
     resolution: {integrity: sha512-K4KDHl/AsBudimBpmIjT6u85qFExY+XKKehiWeaEJcB8CPkvZULkf5JjwW2gLvB3HVxo2bnD7bWeZmVNFMNWdQ==}
@@ -4174,6 +4183,10 @@ snapshots:
       levn: 0.4.1
 
   '@fontsource/atkinson-hyperlegible@5.2.8': {}
+
+  '@galaxy-foundry/kind-manifest@0.2.1(zod@3.25.76)':
+    dependencies:
+      zod: 3.25.76
 
   '@galaxy-tool-util/cli@1.10.0':
     dependencies:


### PR DESCRIPTION
> **Posted by Claude (AI assistant) on behalf of @jmchilton** — authored by Claude, not by them personally.

Consume [`@galaxy-foundry/kind-manifest`](https://www.npmjs.com/package/@galaxy-foundry/kind-manifest) instead of keeping a local copy of the shared manifest format.

## Why

The kind-manifest FORMAT is declared shared by the pattern's own checklist — *"the FORMAT is SHARED ACROSS INSTANCES, the kinds in it are yours"*. It had four independent encodings: the prose spec, this repo's `kind-manifest.ts`, statistical-genomics-foundry's, and a fourth hand-written copy of the types in the foundry-pattern site that consumes both.

This repo's and SGF's copies were **character-for-character identical apart from quote style**, and so were their `describeType` / `describeFields` test suites. That is not convergent evolution; that is one file living in two places.

## What changes

- `packages/note-schema/src/kind-manifest.ts` becomes a thin adapter. `buildKindManifest` **keeps its exact signature** (`{ instance, docs, ...registries }`), so no caller changes.
- What stays here is what is genuinely ours: which kinds exist, and how our registries resolve into the context they are built against. The package deliberately takes *built shapes*, not a context — resolving a kind's schema needs an instance's registries, and no two instances do it the same way.
- `MANIFEST_SOURCE` is new: this Foundry declares its own `repo` and `path` so a consumer vendoring a copy does not hard-code our identity on our behalf. The pattern site currently does `manifest.source = {...}` on data it read.
- `kinds.generated.json` gains exactly that `source` block — **a 5-line diff**, nothing else moves.

### No `revision` in `MANIFEST_SOURCE`, deliberately

A manifest is a committed artifact and `check:kinds` regenerates it and string-compares. A file carrying the revision it was generated at can never match the revision CI regenerates it at, so `--check` would fail on every commit. `revision` is also the wrong party's fact — it answers *"which snapshot is this"*, which only whoever took the snapshot can say. The consumer records it.

This was found by wiring this PR, and fixed upstream in the package before this branch was finished.

## The test file

`test/kind-manifest.test.ts` is now an **integration** test rather than a duplicate unit suite. The synthetic-shape cases — does `describeType` unwrap a defaulted array, is a refined string still `string` — moved to the package along with the renderer they exercise. Re-testing a dependency's unit behaviour here would just be the duplication this removes, in a new place.

What replaced them is only testable here: our kinds against our registries, every kind's `type` field resolving to its own literal, byte-stability across builds so the `--check` gate means something, and a round trip through the shared reader so a format break fails in this repo rather than in another one.

## Verification

- `pnpm packages-test` — 204 tests across 6 packages, including 54 in `note-schema`
- `pnpm packages-typecheck` — all 6 packages clean
- `pnpm packages-lint`, `pnpm packages-format` — clean
- `pnpm run check:kinds` — up to date

## Merge order

Independent of the SGF PR; either order is fine. Both should land **before** the corresponding foundry-pattern change, whose vendored data carries `source` blocks these branches produce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
