### PR TITLE
Install the reference contract's inherited half from foundry-lib

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -168,7 +168,7 @@ The frontmatter contract is the zod schema built by `buildNoteSchema` in `@galax
 
   Other inline phase kinds — e.g., `gate` for an approval / scope-confirmation checkpoint — are coined when they first appear inline. The phase-kind set is **open**; we don't pre-enumerate. `branch` and `gate` are unrelated behaviors and don't share an umbrella.
 
-**Mold = typed reference manifest.** A Mold's frontmatter declares operational dependencies through `references:` plus explicit IO schema fields. `MOLD_SPEC.md` owns the authoring contract, and `reference_contract.yml` owns the vocabulary for kind, usage timing, load behavior, transform mode, and evidence labels. Producer-owned `output_artifacts[].schema` links resolve to `type: schema` notes; consumers inherit schema contracts through shared artifact `id`s. The validator resolves each kind with its own check; casting dispatches per kind — see `COMPILATION_PIPELINE.md`.
+**Mold = typed reference manifest.** A Mold's frontmatter declares operational dependencies through `references:` plus explicit IO schema fields. `MOLD_SPEC.md` owns the authoring contract. `reference_contract.yml` owns the vocabulary for kind — the one part that varies by domain — while usage timing, load behavior, transform mode, and evidence labels describe the compilation machinery and are inherited from `@galaxy-foundry/reference-contract`. Producer-owned `output_artifacts[].schema` links resolve to `type: schema` notes; consumers inherit schema contracts through shared artifact `id`s. The validator resolves each kind with its own check; casting dispatches per kind — see `COMPILATION_PIPELINE.md`.
 
 **Wiki-link frontmatter fields** (regex `^\[\[.+\]\]$`):
 - `parent_pattern` (single, optional).
@@ -217,7 +217,7 @@ Hidden directories skipped. Casts directory (`casts/`) is **always skipped** —
 
 The **license → redistribution-policy table** goes one step further: it is shared across Foundry *instances*, not just across our own consumers, so it ships in `@galaxy-foundry/license-policy` rather than sitting at our repo root. `bundledPolicy()` reads the copy inside that dependency; changing a row is a version bump there, not an edit here. What stays ours is *coherence* — whether a given note is consistent with its licence (`validateSchemaVendoring`) — because that rule genuinely differs between instances.
 
-`tests/validate.test.ts` (Vitest) builds the *real* shared schema (from `meta_tags.yml` + `reference_contract.yml` + the packaged license table) and exercises `validateData` (unit) and `validateDirectory` (integration with `tmp` directories).
+`tests/validate.test.ts` (Vitest) builds the *real* shared schema (from `meta_tags.yml` + `reference_contract.yml` + the packaged reference-contract and license tables) and exercises `validateData` (unit) and `validateDirectory` (integration with `tmp` directories).
 
 ## 7. Wiki links
 

--- a/docs/COMPILATION_PIPELINE.md
+++ b/docs/COMPILATION_PIPELINE.md
@@ -27,7 +27,7 @@ Verbatim-copy paths are deterministic; LLM-driven condensation is reserved for k
 
 ### Typed reference manifest
 
-Molds declare operational dependencies through the object-shaped `references` manifest. `MOLD_SPEC.md` is canonical for field requirements and authoring rules; `reference_contract.yml` is canonical for vocabulary labels and descriptions. Casting reads the manifest, resolves each reference by `kind`, and writes the target-specific reference layout described below.
+Molds declare operational dependencies through the object-shaped `references` manifest. `MOLD_SPEC.md` is canonical for field requirements and authoring rules; the reference contract is canonical for vocabulary labels and descriptions — `reference_contract.yml` for `kind`, `@galaxy-foundry/reference-contract` for the four inherited vocabularies. Casting reads the manifest, resolves each reference by `kind`, and writes the target-specific reference layout described below.
 
 Mold IO contracts live on `input_artifacts[]` / `output_artifacts[]`. Producer-owned `output_artifacts[].schema` wiki-links point at schema notes that casting packages; consumers inherit those contracts by binding to the same artifact `id`.
 

--- a/docs/MOLDS.md
+++ b/docs/MOLDS.md
@@ -2,7 +2,7 @@
 
 Mold inventory for the Galaxy Workflow Foundry, derived as the **union of phases** across the harness pipelines in `HARNESS_PIPELINES.md`. CLI command knowledge is reference content used by action Molds, not a separate whole-CLI Mold tier. Each Mold is atomic at the harness-step tier (not necessarily small in content).
 
-This is the inventory, not the Mold source-layout contract. `MOLD_SPEC.md` owns Mold authoring rules, the procedural Mold body, and the `references:` manifest; `reference_contract.yml` owns the typed-reference vocabulary and labels. Mold IO contracts live on `input_artifacts[]` / `output_artifacts[]`; producer-owned `output_artifacts[].schema` wiki-links attach schemas to emitted artifact IDs. Cast skills are deterministic renderings of Mold body + artifact contracts + typed references, so any improvement to a generated skill belongs back in the Mold or its referenced notes.
+This is the inventory, not the Mold source-layout contract. `MOLD_SPEC.md` owns Mold authoring rules, the procedural Mold body, and the `references:` manifest; `reference_contract.yml` owns the reference `kinds`, and `@galaxy-foundry/reference-contract` the four vocabularies every Foundry shares. Mold IO contracts live on `input_artifacts[]` / `output_artifacts[]`; producer-owned `output_artifacts[].schema` wiki-links attach schemas to emitted artifact IDs. Cast skills are deterministic renderings of Mold body + artifact contracts + typed references, so any improvement to a generated skill belongs back in the Mold or its referenced notes.
 
 ## Bucketing axes
 

--- a/docs/MOLD_SPEC.md
+++ b/docs/MOLD_SPEC.md
@@ -1,6 +1,6 @@
 # Mold Spec
 
-This document is the source-layout contract for Mold authoring. The shared zod schema in `@galaxy-foundry/note-schema` (`buildNoteSchema`) is the frontmatter contract, and `reference_contract.yml` remains the controlled vocabulary for typed references.
+This document is the source-layout contract for Mold authoring. The shared zod schema in `@galaxy-foundry/note-schema` (`buildNoteSchema`) is the frontmatter contract, and the reference contract remains the controlled vocabulary for typed references — `kinds` at `reference_contract.yml`, the other four vocabularies from `@galaxy-foundry/reference-contract`.
 
 ## Source Layout
 
@@ -94,7 +94,7 @@ Conditional fields:
 - `trigger` is required when `load: on-demand`.
 - `purpose` is strongly recommended for generated-skill instructions and reviewer context.
 
-`reference_contract.yml` owns labels, descriptions, and allowed values. Casting consumes the manifest by kind; see `COMPILATION_PIPELINE.md` for output layout and provenance.
+The reference contract owns labels, descriptions, and allowed values: `reference_contract.yml` for `kind`, and `@galaxy-foundry/reference-contract` for `used_at`, `load`, `mode` and `evidence`, which are the same in every Foundry. Casting consumes the manifest by kind; see `COMPILATION_PIPELINE.md` for output layout and provenance.
 
 ## Eval, Scenario, Usage, Refinement: what goes where
 

--- a/packages/note-schema/package.json
+++ b/packages/note-schema/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@galaxy-foundry/kind-manifest": "^0.2.1",
     "@galaxy-foundry/license-policy": "^0.1.0",
+    "@galaxy-foundry/reference-contract": "^0.1.0",
     "js-yaml": "^4.1.0",
     "zod": "^3.25.76"
   },

--- a/packages/note-schema/src/reference-contract.ts
+++ b/packages/note-schema/src/reference-contract.ts
@@ -1,49 +1,39 @@
-// Loader for reference_contract.yml — the controlled vocabulary behind a note's
-// `references[]` entries (kinds, used_at, load, modes, evidence). Canonical
-// source of truth; the validator, the caster, and the site all import it here.
+// This Foundry's typed-reference vocabulary — the five controlled lists behind a note's
+// `references[]` entries. The validator, the caster, and the site all read it here.
+//
+// Four of the five are not ours. `used_at`, `load`, `modes` and `evidence` describe the
+// compilation machinery rather than any domain, so they are the same in every Foundry and
+// ship as data in @galaxy-foundry/reference-contract (spec: galaxyproject/foundry-pattern,
+// `content/pattern/anatomy-of-an-instance.md`). The fifth, `kinds`, is exactly what varies
+// by domain — we author `cli-tool` and `schema` refs, a sibling Foundry authors neither —
+// so it stays in reference_contract.yml at the repo root.
+//
+// What is left here is the composition, behind the signature callers already use.
 
-import { existsSync, readFileSync } from "node:fs";
-import path from "node:path";
+import {
+  buildReferenceContract,
+  loadInstanceKinds,
+  findReferenceContractPath,
+  type ReferenceContract,
+} from "@galaxy-foundry/reference-contract";
 
-import yaml from "js-yaml";
+export {
+  contractKeys,
+  findReferenceContractPath,
+  type ReferenceContract,
+  // The site names the type of a single vocabulary entry when it renders a pill.
+  type ContractTerm as ReferenceContractTerm,
+} from "@galaxy-foundry/reference-contract";
 
-export interface ReferenceContractTerm {
-  label: string;
-  description: string;
-  href: string;
-  ref_shape?: "wiki-link" | "path";
-}
-
-export interface ReferenceContract {
-  kinds: Record<string, ReferenceContractTerm>;
-  used_at: Record<string, ReferenceContractTerm>;
-  load: Record<string, ReferenceContractTerm>;
-  modes: Record<string, ReferenceContractTerm>;
-  evidence: Record<string, ReferenceContractTerm>;
-}
-
-export function findReferenceContractPath(startDir = process.cwd()): string {
-  let dir = path.resolve(startDir);
-  while (true) {
-    const candidate = path.join(dir, "reference_contract.yml");
-    if (existsSync(candidate)) return candidate;
-    const parent = path.dirname(dir);
-    if (parent === dir) throw new Error("reference_contract.yml not found");
-    dir = parent;
-  }
-}
-
+/**
+ * The full contract: this repo's `kinds` composed with the four inherited vocabularies.
+ *
+ * Still takes a path to reference_contract.yml, unchanged from when that file held all
+ * five vocabularies — every caller passes the repo root's copy, and the inherited half
+ * needs no locating because it travels with the package.
+ */
 export function loadReferenceContract(
   contractPath = findReferenceContractPath(),
 ): ReferenceContract {
-  const data = yaml.load(readFileSync(contractPath, "utf8")) as ReferenceContract | null;
-  if (!data) throw new Error(`empty reference contract: ${contractPath}`);
-  return data;
-}
-
-export function contractKeys(
-  contract: ReferenceContract,
-  group: keyof ReferenceContract,
-): string[] {
-  return Object.keys(contract[group]);
+  return buildReferenceContract({ kinds: loadInstanceKinds(contractPath) });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,6 +161,9 @@ importers:
       '@galaxy-foundry/license-policy':
         specifier: ^0.1.0
         version: 0.1.0
+      '@galaxy-foundry/reference-contract':
+        specifier: ^0.1.0
+        version: 0.1.0
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.1
@@ -251,6 +254,9 @@ importers:
       '@galaxy-foundry/note-schema':
         specifier: workspace:*
         version: link:../packages/note-schema
+      '@galaxy-foundry/reference-contract':
+        specifier: ^0.1.0
+        version: 0.1.0
       '@galaxy-tool-util/cli':
         specifier: ^1.8.1
         version: 1.10.0
@@ -960,6 +966,10 @@ packages:
 
   '@galaxy-foundry/license-policy@0.1.0':
     resolution: {integrity: sha512-dn4D0TgbK9mbpww4gVj6j1NYVRKIy5GFqmx7aJZcaPqhiNlRrqvab7+NyOSmRY4dYUjCQa1uLVKuVJFhN8DFzQ==}
+    engines: {node: '>=20'}
+
+  '@galaxy-foundry/reference-contract@0.1.0':
+    resolution: {integrity: sha512-rOfkD8PQ02HW5p3AoiK1WZXbAV7YO6qa9xUvFhXiQcAXjId8ugF0+fpXCJLrDsVH9mAFXSXNhTbrGhqvYBeeiw==}
     engines: {node: '>=20'}
 
   '@galaxy-tool-util/cli@1.10.0':
@@ -4205,6 +4215,10 @@ snapshots:
       zod: 3.25.76
 
   '@galaxy-foundry/license-policy@0.1.0':
+    dependencies:
+      js-yaml: 4.1.1
+
+  '@galaxy-foundry/reference-contract@0.1.0':
     dependencies:
       js-yaml: 4.1.1
 

--- a/reference_contract.yml
+++ b/reference_contract.yml
@@ -1,3 +1,16 @@
+# The reference kinds this Foundry authors — the `kind:` of an entry in a Mold's
+# `references[]` manifest.
+#
+# Only `kinds` lives here. The other four vocabularies a reference entry names —
+# `used_at`, `load`, `modes`, `evidence` — describe the compilation machinery rather
+# than any domain, so they are the same in every Foundry and ship as data in
+# @galaxy-foundry/reference-contract. packages/note-schema/src/reference-contract.ts
+# composes the two halves.
+#
+# `kinds` stays here because it is the half that genuinely varies. It is also the half
+# that carries its own `href`: these kinds are specified in this repo's MOLD_SPEC, while
+# the inherited four are specified in the Foundry Pattern and link there.
+
 kinds:
   pattern:
     label: Pattern
@@ -34,55 +47,3 @@ kinds:
     description: Background synthesis loaded by explicit progressive-disclosure metadata.
     href: https://github.com/galaxyproject/foundry/blob/main/docs/MOLD_SPEC.md#typed-reference-manifest
     ref_shape: wiki-link
-
-used_at:
-  cast-time:
-    label: Cast Time
-    description: Used while building the cast artifact.
-    href: https://github.com/galaxyproject/foundry/blob/main/docs/MOLD_SPEC.md#typed-reference-manifest
-  runtime:
-    label: Runtime
-    description: Consulted by the generated skill while doing work.
-    href: https://github.com/galaxyproject/foundry/blob/main/docs/MOLD_SPEC.md#typed-reference-manifest
-  both:
-    label: Both
-    description: Used during casting and available to the generated skill at runtime.
-    href: https://github.com/galaxyproject/foundry/blob/main/docs/MOLD_SPEC.md#typed-reference-manifest
-
-load:
-  upfront:
-    label: Upfront
-    description: Loaded with the generated skill's initial context or main instructions.
-    href: https://github.com/galaxyproject/foundry/blob/main/docs/MOLD_SPEC.md#typed-reference-manifest
-  on-demand:
-    label: On Demand
-    description: Loaded only when the reference trigger applies.
-    href: https://github.com/galaxyproject/foundry/blob/main/docs/MOLD_SPEC.md#typed-reference-manifest
-
-modes:
-  verbatim:
-    label: Verbatim
-    description: Copied without LLM rewrite.
-    href: https://github.com/galaxyproject/foundry/blob/main/docs/MOLD_SPEC.md#typed-reference-manifest
-  condense:
-    label: Condense
-    description: LLM condensation is required before final packaging; generic handling is not complete yet.
-    href: https://github.com/galaxyproject/foundry/blob/main/docs/MOLD_SPEC.md#typed-reference-manifest
-  sidecar:
-    label: Sidecar
-    description: Transformed into a structured runtime artifact beside the generated skill.
-    href: https://github.com/galaxyproject/foundry/blob/main/docs/MOLD_SPEC.md#typed-reference-manifest
-
-evidence:
-  hypothesis:
-    label: Hypothesis
-    description: Added because it seems useful; not yet proven by a real cast run.
-    href: https://github.com/galaxyproject/foundry/blob/main/docs/MOLD_SPEC.md#typed-reference-manifest
-  corpus-observed:
-    label: Corpus Observed
-    description: Grounded in survey or research over real workflows, upstream source, or runtime behavior.
-    href: https://github.com/galaxyproject/foundry/blob/main/docs/MOLD_SPEC.md#typed-reference-manifest
-  cast-validated:
-    label: Cast Validated
-    description: A generated skill used this reference successfully on real data.
-    href: https://github.com/galaxyproject/foundry/blob/main/docs/MOLD_SPEC.md#typed-reference-manifest

--- a/site/package.json
+++ b/site/package.json
@@ -15,6 +15,7 @@
     "@galaxy-foundry/foundry": "workspace:*",
     "@galaxy-foundry/license-policy": "^0.1.0",
     "@galaxy-foundry/note-schema": "workspace:*",
+    "@galaxy-foundry/reference-contract": "^0.1.0",
     "@galaxy-tool-util/cli": "^1.8.1",
     "@galaxy-tool-util/schema": "^1.7.2",
     "@tailwindcss/typography": "^0.5.19",

--- a/site/src/lib/registries.ts
+++ b/site/src/lib/registries.ts
@@ -13,6 +13,15 @@ const repoRoot = path.resolve('..');
 // The license table is the exception: it is shared across Foundry instances rather than
 // authored here, so it ships in @galaxy-foundry/license-policy instead of at our root.
 export const licensePolicy = bundledPolicy();
+
+// Only `kinds` is at our root — the other four vocabularies ship in
+// @galaxy-foundry/reference-contract and note-schema composes the two halves.
+//
+// That package is a direct dependency of site/ even though nothing here imports it by
+// name, and it has to be. It reads its shipped YAML relative to `import.meta.url`; reached
+// only through the linked workspace package, Vite inlines it into an SSR chunk, and the
+// path resolves against site/dist/chunks/ instead of node_modules — an ENOENT that only
+// appears in `astro build`, never in tests or typecheck. Declaring it keeps it external.
 export const referenceContract = loadReferenceContract(path.join(repoRoot, 'reference_contract.yml'));
 // The tag registry answers membership itself (declared by its facets, never parsed off the
 // `/` prefix) and carries the facet labels/descriptions the /tags pages group and render by.


### PR DESCRIPTION
> **Posted by Claude (AI assistant) on behalf of @jmchilton** — authored by Claude, not by them personally.

Adopts `@galaxy-foundry/reference-contract@0.1.0`. `reference_contract.yml` drops from **88 lines to 49** and holds `kinds` only. Companion to the same change in the sibling Foundry (jmchilton/statistical-genomics-foundry#112).

## The split

A reference entry names five vocabularies. Four of them — `used_at`, `load`, `modes`, `evidence` — describe the compilation machinery, which does not vary by domain. The fifth, `kinds`, is exactly what does: we author `cli-tool` and `schema` refs and the sibling instance authors neither, so inheriting our list would leave it declaring vocabulary no Mold uses.

`packages/note-schema/src/reference-contract.ts` becomes the composition point:

```ts
export function loadReferenceContract(
  contractPath = findReferenceContractPath(),
): ReferenceContract {
  return buildReferenceContract({ kinds: loadInstanceKinds(contractPath) });
}
```

**The signature is unchanged**, so `validate.ts`, `generate-kind-manifest.ts`, `site/src/lib/registries.ts`, the build-cli re-export shim, the `scripts/lib` alias and five test files are untouched. No `narrow` — we author terms in all four inherited vocabularies, `condense` included.

## `href`

`kinds` keep their own hrefs into this repo's `MOLD_SPEC.md`; the inherited four now link to the Foundry Pattern, which is where they are actually specified. The package prefers a term's own `href` over the table's `spec_url`, so this falls out rather than needing configuration. Verified on the composed contract:

```
kinds     | pattern, cli-tool, cli-command, schema, prompt, example, research
          href -> …/galaxyproject/foundry/blob/main/docs/MOLD_SPEC.md#typed-reference-manifest
modes     | verbatim, condense, sidecar
          href -> …/galaxyproject/foundry-pattern/blob/main/content/pattern/anatomy-of-an-instance.md
```

That fp URL is a GitHub blob link because fp hosting is not finalized (`astro.config.mjs` still has placeholder `site`/`base`). It is now user-visible on every Mold page's contract pills, which makes it the forcing function on that decision.

## One real bug, found only by `astro build`

The package resolves its shipped YAML relative to `import.meta.url`. Reached **only through the linked workspace package**, Vite inlines it into an SSR chunk, and that path resolves against `site/dist/chunks/` instead of `node_modules`:

```
ENOENT: no such file or directory, open '…/site/dist/data/reference-contract.yml'
  at bundledVocabularies (…/site/dist/chunks/registries_Dq-7fkTO.mjs:103:46)
```

Fix is one line — `site/` declares the package directly, which keeps it external. That is why `@galaxy-foundry/license-policy` never hit this despite using the identical `bundled*()` pattern: `site/package.json` already listed it.

**Worth flagging as a pattern-level trap.** Tests, `typecheck`, `packages-typecheck`, lint and the tarball smoke all passed while this was broken — the smoke test unpacks and imports a tarball, which is precisely the arrangement that works. Only `astro build` reproduces it. Every future foundry-lib package that ships data alongside its code inherits the same trap, and each consumer reached transitively will hit it. `registries.ts` now carries the explanation.

## Verification

| | |
|---|---|
| `test` | 152 passed (11 files) |
| `packages-test`, `packages-typecheck`, `packages-lint`, `packages-format` | pass |
| `typecheck` | 0 errors, 66 Astro files |
| `validate` | 226 files, **0 errors** |
| `check:kinds` | up to date (9 kinds) |
| `cast summarize-nextflow --check` | clean: no drift, no errors |
| `smoke:packages` | ok |
| `site:build` | 365 pages |

Red-to-green: the inherited blocks came out of the YAML first, which failed the suite; the package went in after.

**`check:planemo-cli` reports drift on `planemo-test.md`.** Not from this change — I checked out `origin/main` in the same worktree and reproduced it identically. It tracks the locally installed planemo version.

## Related

- jmchilton/foundry-lib#7 — the package
- jmchilton/statistical-genomics-foundry#112 — the sibling instance, which does use `narrow` to decline `condense`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
