### PR TITLE
Type `refine` so a typo'd rule cannot go silently dead

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "foundry",
   "version": "0.0.0",
   "private": true,
-  "description": "Galaxy Workflow Foundry — knowledge base + casting pipeline for Galaxy workflows.",
+  "description": "Galaxy Workflow Foundry \u2014 knowledge base + casting pipeline for Galaxy workflows.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",
   "scripts": {
@@ -39,6 +39,9 @@
     "site:preview": "pnpm --filter foundry-site preview"
   },
   "devDependencies": {
+    "@changesets/changelog-github": "^0.6.0",
+    "@changesets/cli": "^2.31.0",
+    "@eslint/js": "^10.0.1",
     "@galaxy-foundry/build-cli": "workspace:*",
     "@galaxy-foundry/foundry": "workspace:*",
     "@galaxy-foundry/license-policy": "^0.1.0",
@@ -48,9 +51,6 @@
     "@galaxy-foundry/summarize-nextflow": "workspace:*",
     "@galaxy-foundry/tag-registry": "^0.1.0",
     "@galaxy-foundry/wiki-links": "^0.1.0",
-    "@changesets/changelog-github": "^0.6.0",
-    "@changesets/cli": "^2.31.0",
-    "@eslint/js": "^10.0.1",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.10.0",
     "ajv": "^8.17.1",
@@ -62,7 +62,8 @@
     "tsx": "^4.19.0",
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.59.1",
-    "vitest": "^2.1.0"
+    "vitest": "^2.1.0",
+    "zod": "^3.25.76"
   },
   "dependencies": {
     "@galaxy-tool-util/cli": "^1.10.0",

--- a/packages/note-schema/src/index.ts
+++ b/packages/note-schema/src/index.ts
@@ -7,8 +7,10 @@ export {
   KINDS,
   KINDS_BY_NAME,
   buildKindContext,
+  defineKind,
   type KindContext,
   type KindDefinition,
+  type KindShape,
 } from "./types/index.js";
 
 export {

--- a/packages/note-schema/src/note-schema.ts
+++ b/packages/note-schema/src/note-schema.ts
@@ -32,7 +32,7 @@ export function buildNoteSchema(options: BuildNoteSchemaOptions) {
 
   return z.discriminatedUnion("type", members).superRefine((d, issues) => {
     const definition = KINDS_BY_NAME.get((d as { type: string }).type);
-    definition?.refine?.(d as Record<string, unknown>, issues, ctx);
+    definition?.refine?.(d as never, issues, ctx);
   });
 }
 

--- a/packages/note-schema/src/types/context.ts
+++ b/packages/note-schema/src/types/context.ts
@@ -203,7 +203,21 @@ export interface KindDefinition<T extends KindShape = KindShape> {
   /** A strict object carrying a `type:` literal — a union member, and the `.shape` the
    *  manifest generator walks to derive this kind's required-metadata table. */
   build: (ctx: KindContext) => z.ZodObject<T, "strict">;
-  refine?: (data: Record<string, unknown>, ctx: z.RefinementCtx, kctx: KindContext) => void;
+  /**
+   * Cross-field rules over this kind's own fields — the constraints a shape cannot state,
+   * because whether one field is valid depends on another's value (a `source-specific` mold
+   * must name a `source`; a schema note vendoring an external upstream must name a license).
+   *
+   * `data` is this kind's INFERRED frontmatter, not `Record<string, unknown>`. That matters
+   * more than it reads: every rule here is conditional, so a rule that never fires looks
+   * exactly like a rule with nothing to complain about. Untyped, `d.axis === "source-specifc"`
+   * compiled clean and the mold rule was silently dead.
+   */
+  refine?: (
+    data: z.infer<z.ZodObject<T, "strict">>,
+    ctx: z.RefinementCtx,
+    kctx: KindContext,
+  ) => void;
 }
 
 /**

--- a/packages/note-schema/src/types/schema/schema.ts
+++ b/packages/note-schema/src/types/schema/schema.ts
@@ -34,8 +34,7 @@ export const kind = defineKind({
   // it must name the license, and (where the policy row says the text travels with it) point
   // at the vendored copy. An upstream inside this repo is our own and needs neither.
   refine: (d, ctx, kctx) => {
-    const upstream = typeof d.upstream === "string" ? d.upstream : "";
-    const external = upstream && !upstream.includes("github.com/galaxyproject/foundry/");
+    const external = d.upstream && !d.upstream.includes("github.com/galaxyproject/foundry/");
     if (!external) return;
     if (!d.license) {
       ctx.addIssue({
@@ -45,12 +44,12 @@ export const kind = defineKind({
       });
       return;
     }
-    const row = resolveLicenseRow(kctx.registries.licensePolicy, d.license as string);
+    const row = resolveLicenseRow(kctx.registries.licensePolicy, d.license);
     if (row.license_file && !d.license_file) {
       ctx.addIssue({
         code: "custom",
         path: ["license_file"],
-        message: `license ${String(d.license)} requires a \`license_file\``,
+        message: `license ${d.license} requires a \`license_file\``,
       });
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       vitest:
         specifier: ^2.1.0
         version: 2.1.9(@types/node@22.19.17)(lightningcss@1.30.2)
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
 
   packages/build-cli:
     dependencies:

--- a/tests/kind-refine.test-d.ts
+++ b/tests/kind-refine.test-d.ts
@@ -1,0 +1,58 @@
+// `refine` receives its kind's INFERRED frontmatter, asserted where that fact lives: the
+// typecheck.
+//
+// Every refine rule is conditional — it fires only when some other field takes a particular
+// value — so a rule that never fires is indistinguishable from a rule with nothing to
+// complain about. While `data` was `Record<string, unknown>`, comparing `d.axis` to a
+// misspelled literal compiled clean and the mold rule was silently dead. Nothing at runtime
+// can catch that: the corpus just quietly stops being checked.
+//
+// Checked by `tsc --noEmit` at the repo root (`npm run typecheck`, which CI runs), because
+// the root tsconfig includes tests/. vitest does not collect this file — its include is
+// `tests/**/*.test.ts`, and `.test-d.ts` does not match.
+
+import { z } from "zod";
+
+import { defineKind, type KindContext } from "@galaxy-foundry/note-schema";
+
+const axes = ["source-specific", "target-specific", "tool-specific", "generic"] as const;
+
+const build = (ctx: KindContext) =>
+  z
+    .object({
+      type: z.literal("probe"),
+      axis: z.enum(axes),
+      source: z.string().optional(),
+      ...ctx.base,
+    })
+    .strict();
+
+/** A rule comparing against a real axis value — types line up, so this compiles. */
+export const wellTyped = defineKind({
+  kind: "probe",
+  title: "Probe",
+  layer: "instance",
+  summary: "Asserts refine sees this kind's own fields.",
+  build,
+  refine: (d, ctx) => {
+    if (d.axis === "source-specific" && !d.source) {
+      ctx.addIssue({ code: "custom", path: ["source"], message: "needs a source" });
+    }
+  },
+});
+
+export const misspelledLiteral = defineKind({
+  kind: "probe",
+  title: "Probe",
+  layer: "instance",
+  summary: "Asserts a typo'd literal is a compile error, not a dead rule.",
+  build,
+  refine: (d, ctx) => {
+    // @ts-expect-error — "source-specifc" is not one of the four axis values, so this
+    // comparison has no overlap. If it ever stops erroring, `refine` has been widened back
+    // to an untyped payload and every conditional rule can rot without a test noticing.
+    if (d.axis === "source-specifc" && !d.source) {
+      ctx.addIssue({ code: "custom", path: ["source"], message: "unreachable" });
+    }
+  },
+});


### PR DESCRIPTION
> **Posted by Claude (AI assistant) on jmchilton's behalf** — not authored by them personally.

Phase 3 of the GWF↔SGF kind-contract convergence.

**Scope reduced.** This PR originally carried a second commit (`5781d7a`) replacing `z.discriminatedUnion` with a hand-written dispatcher. That commit has been dropped — see the note at the bottom. What remains is the bug fix.

---

## `refine` gets its kind's inferred frontmatter

`refine`'s `data` was `Record<string, unknown>`. That is not a style wart — **it made a validator rule silently dead.**

Every refine rule is *conditional*: it fires only when another field takes a particular value. So a rule that never fires is indistinguishable from a rule with nothing to complain about. Demonstrated on the real tree:

```ts
if (d.axis === "source-specifc" && !d.source)   // typo, missing 'i'
```

**Compiles clean, exit 0.** The mold axis rule would sit there looking enforced while bad molds passed validation. Typed:

```
error TS2367: This comparison appears to be unintentional because the types
'"generic" | "source-specific" | "target-specific" | "tool-specific"'
and '"source-specifc"' have no overlap.
```

`discriminatedUnion` is untouched. The one cast moves from the callee's signature to the single dispatch site, where looking the member up by `d.type` already made it correct. Also drops a now-needless `typeof` guard and `as string` in the `schema` kind.

**Guarded**: `tests/kind-refine.test-d.ts` puts a typo'd literal under `@ts-expect-error`, so widening the signature back fails the typecheck. Verified in both directions. Checked by the root `tsc` (CI runs it); vitest doesn't collect `.test-d.ts`. Needed adding `zod` to root devDependencies, alongside the `ajv`/`gray-matter` mirrors already there.

## Verification

| check | result |
|---|---|
| validator over the corpus | **byte-for-byte unchanged** — 226 files, 0 errors, 202 warnings |
| `entry.data` inference | **still the precise nine-member union** |
| root + packages typecheck | 0 errors |
| `astro check` | 0 errors, 66 files |
| tests | 152 root · all package suites |
| site build | 365 pages |

**On `entry.data`**: 0 `astro check` errors does *not* prove inference survived — if `entry.data` degraded to `any`, that is also 0 errors, and the site's one consumer already casts `entry.data as any` so it could not have caught it either. Proved with a temporary probe instead: accessing an unknown field errored with all nine kinds' shapes enumerated, and a real field typed as `string`.

## Why the dispatcher commit was dropped

Two reasons, both found after it was written:

1. **Its stated premise measured false.** The claimed payoff was better error messages. `discriminatedUnion` already produced precise, single-issue, correctly-pathed errors naming all nine kinds. Worth ~nothing.
2. **Its remaining benefit is about to be obsolete.** GWF is moving to per-kind Astro collections routed by path (the shape SGF already has), which removes the dispatcher's only caller. Carrying a hand-written dispatcher through that migration would be adding code in order to delete it.

`71d024d` is standalone and unaffected — its own message records that `discriminatedUnion` is untouched.
