### PR TITLE
State where each kind's notes live, once

### DIFF
--- a/packages/note-schema/src/collections.ts
+++ b/packages/note-schema/src/collections.ts
@@ -1,0 +1,114 @@
+// Where each kind's notes LIVE — the one path→kind routing table.
+//
+// Two things currently decide which files are notes, and they are written twice: the Astro
+// loader's glob in site/src/content.config.ts, and `walk.ts`'s SKIP_FILES / DIR_NOTE_TYPES in
+// the validator. Nothing makes them agree, and they do not: `content/prompts/**` is walked by
+// the validator and globbed by neither, so two notes are checked and never published.
+//
+// This is that table, stated once. A collection maps a directory (plus the glob selecting note
+// files within it) to the ONE kind every note there declares. Both consumers route from here,
+// so a directory the site publishes and a directory the validator checks cannot drift apart.
+//
+// A collection is a LOCATION; a kind is what a note IS. They are deliberately not one-to-one:
+// `cli/<tool>/index.md` is a cli-tool and `cli/<tool>/<command>.md` is a cli-command, one
+// directory holding two kinds. The reverse (two collections, one kind) is equally allowed —
+// it is how a browse route can exist without inventing a kind for it.
+
+/** One collection: a directory, the note files in it, and the kind they all declare. */
+export interface CollectionDefinition {
+  /** Repo-relative directory holding this collection's notes. */
+  base: string;
+  /** Globs relative to `base` selecting note files. Later `!`-prefixed entries exclude. */
+  pattern: readonly string[];
+  /** The `type:` every note in this collection declares. Must be a kind in KINDS. */
+  kind: string;
+}
+
+/**
+ * Every collection this Foundry publishes and validates.
+ *
+ * Keys are kebab-case to match the kind vocabulary (`source-pattern`, `cli-tool`) rather than
+ * the camelCase an identifier would want — they are looked up as strings, never as properties.
+ */
+export const COLLECTIONS = {
+  molds: { base: "content/molds", pattern: ["**/index.md"], kind: "mold" },
+  patterns: { base: "content/patterns", pattern: ["**/*.md"], kind: "pattern" },
+  "source-patterns": {
+    base: "content/source-patterns",
+    pattern: ["**/*.md"],
+    kind: "source-pattern",
+  },
+  // One directory, two kinds, separated by filename. `index.md` is the tool; every other
+  // markdown file beside it is one of that tool's commands. This is the case that makes a
+  // directory→kind rule insufficient on its own.
+  "cli-tools": { base: "content/cli", pattern: ["*/index.md"], kind: "cli-tool" },
+  "cli-commands": { base: "content/cli", pattern: ["*/*.md", "!*/index.md"], kind: "cli-command" },
+  pipelines: { base: "content/pipelines", pattern: ["**/index.md"], kind: "pipeline" },
+  research: { base: "content/research", pattern: ["**/*.md"], kind: "research" },
+  schemas: { base: "content/schemas", pattern: ["**/*.md"], kind: "schema" },
+  prompts: { base: "content/prompts", pattern: ["**/*.md"], kind: "prompt" },
+} as const satisfies Record<string, CollectionDefinition>;
+
+export type CollectionName = keyof typeof COLLECTIONS;
+
+/** Collection names, for a consumer that needs to iterate every collection. */
+export const COLLECTION_NAMES = Object.keys(COLLECTIONS) as readonly CollectionName[];
+
+// The three glob constructs the table above uses, and nothing more. Astro's loader matches
+// these patterns with picomatch; this matches them for the validator, which has no globber.
+// Two implementations of the same patterns is exactly the drift this module exists to end, so
+// the routing test pins this one against the real corpus — if it and picomatch ever disagreed
+// about a file, the published collection sizes would stop matching the walked file count.
+function globToRegExp(pattern: string): RegExp {
+  let out = "";
+  for (let i = 0; i < pattern.length; i += 1) {
+    const rest = pattern.slice(i);
+    if (rest.startsWith("**/")) {
+      out += "(?:[^/]+/)*"; // zero or more leading path segments
+      i += 2;
+    } else if (pattern[i] === "*") {
+      out += "[^/]*"; // one segment, no separators
+    } else if (".+^${}()|[]\\?".includes(pattern[i]!)) {
+      out += `\\${pattern[i]}`;
+    } else {
+      out += pattern[i];
+    }
+  }
+  return new RegExp(`^${out}$`);
+}
+
+/**
+ * The collection a repo-relative path belongs to, or `undefined` if it is not a note.
+ *
+ * A path matching more than one collection is a table bug rather than a caller error — the
+ * routing test asserts it cannot happen, so the first match is the only match.
+ */
+export function collectionOf(repoRelPath: string): CollectionName | undefined {
+  const normalized = repoRelPath.split("\\").join("/");
+  for (const name of COLLECTION_NAMES) {
+    if (matchesCollection(normalized, COLLECTIONS[name])) return name;
+  }
+  return undefined;
+}
+
+/** Whether a repo-relative path is one of this collection's note files. */
+export function matchesCollection(repoRelPath: string, collection: CollectionDefinition): boolean {
+  const prefix = `${collection.base}/`;
+  if (!repoRelPath.startsWith(prefix)) return false;
+  const withinBase = repoRelPath.slice(prefix.length);
+  let matched = false;
+  for (const pattern of collection.pattern) {
+    const negated = pattern.startsWith("!");
+    const re = globToRegExp(negated ? pattern.slice(1) : pattern);
+    if (!re.test(withinBase)) continue;
+    if (negated) return false;
+    matched = true;
+  }
+  return matched;
+}
+
+/** The kind a repo-relative path routes to, or `undefined` if it is not a note. */
+export function kindOf(repoRelPath: string): string | undefined {
+  const name = collectionOf(repoRelPath);
+  return name && COLLECTIONS[name].kind;
+}

--- a/packages/note-schema/src/index.ts
+++ b/packages/note-schema/src/index.ts
@@ -4,6 +4,16 @@
 export { buildNoteSchema, type BuildNoteSchemaOptions, type NoteSchema } from "./note-schema.js";
 
 export {
+  COLLECTIONS,
+  COLLECTION_NAMES,
+  collectionOf,
+  kindOf,
+  matchesCollection,
+  type CollectionDefinition,
+  type CollectionName,
+} from "./collections.js";
+
+export {
   KINDS,
   KINDS_BY_NAME,
   buildKindContext,

--- a/tests/collection-routing.test.ts
+++ b/tests/collection-routing.test.ts
@@ -1,0 +1,106 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  COLLECTIONS,
+  COLLECTION_NAMES,
+  collectionOf,
+  KINDS,
+  matchesCollection,
+} from "@galaxy-foundry/note-schema";
+import { readMarkdown } from "../packages/build-cli/src/lib/frontmatter.js";
+import { findMdFiles } from "../packages/build-cli/src/lib/walk.js";
+
+// The path→kind table and the corpus must agree BOTH ways, and the table must agree with
+// itself.
+//
+// Ported from the statistical-genomics-foundry instance, which has carried the
+// "routes every note kind to at least one collection" invariant since it split its content
+// into per-kind collections. Nothing here is domain-specific; it is the check any Foundry
+// wants once location decides which schema a note is parsed against.
+//
+// Three distinct failures this catches:
+//   1. a kind with no collection — unauthorable, its schema can never run;
+//   2. a note file no collection claims — walked by the validator, published by nothing;
+//   3. a note whose declared `type:` is not the kind its location routes to.
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "..");
+
+/** Every walked note, as (repo-relative path, declared type). */
+const corpus = (() => {
+  const notes: { rel: string; type: string }[] = [];
+  for (const file of findMdFiles(path.join(repoRoot, "content"))) {
+    const { hasFrontmatter, meta } = readMarkdown(file);
+    if (!hasFrontmatter) continue;
+    const type = meta?.type;
+    if (typeof type !== "string") continue;
+    notes.push({ rel: path.relative(repoRoot, file).split(path.sep).join("/"), type });
+  }
+  return notes;
+})();
+
+describe("collection routing (path table vs corpus)", () => {
+  // Guards the walk itself. Every assertion below is "no violations found", so an empty
+  // corpus would report a clean bill of health we did not earn.
+  it("found notes to route", () => {
+    expect(corpus.length).toBeGreaterThan(100);
+  });
+
+  // The converse of "every kind has notes": every kind must have somewhere to PUT notes. A
+  // kind no collection routes to is unauthorable — its schema can never run against real
+  // content, so nothing would ever notice it was unreachable.
+  it("routes every note kind to at least one collection", () => {
+    const routed = new Set<string>(COLLECTION_NAMES.map((n) => COLLECTIONS[n].kind));
+    const unroutable = KINDS.map((k) => k.kind).filter((k) => !routed.has(k));
+    expect(unroutable, `\nkinds with no collection: ${unroutable.join(", ")}`).toEqual([]);
+  });
+
+  // Every collection's `kind` must be a kind that exists — the other direction of the same
+  // rule, which a typo in the table would otherwise satisfy silently.
+  it("routes every collection to a kind that exists", () => {
+    const known = new Set(KINDS.map((k) => k.kind));
+    const bogus = COLLECTION_NAMES.filter((n) => !known.has(COLLECTIONS[n].kind));
+    expect(bogus, `\ncollections naming no kind: ${bogus.join(", ")}`).toEqual([]);
+  });
+
+  // A note the validator checks but no collection claims is checked and never published.
+  // This is the drift that existed while the Astro glob and `walk.ts` were two separate
+  // rules, and the reason this table exists.
+  it("claims every note the validator walks", () => {
+    const orphans = corpus.filter((n) => !collectionOf(n.rel)).map((n) => n.rel);
+    expect(orphans, `\nwalked but in no collection:\n  ${orphans.join("\n  ")}`).toEqual([]);
+  });
+
+  // Location picks the schema; the `type:` literal in that schema asserts the note agrees.
+  // Checking it here too means a misfiled note is named as misfiled rather than reported as
+  // a wrong-literal failure buried in the validator's output.
+  it("routes every note to the kind it declares", () => {
+    const misfiled = corpus
+      .filter((n) => {
+        const name = collectionOf(n.rel);
+        return name !== undefined && COLLECTIONS[name].kind !== n.type;
+      })
+      .map(
+        (n) =>
+          `${n.rel} declares '${n.type}' but routes to '${COLLECTIONS[collectionOf(n.rel)!].kind}'`,
+      );
+    expect(misfiled, `\n${misfiled.join("\n")}`).toEqual([]);
+  });
+
+  // `collectionOf` returns the FIRST match, so overlapping collections would route by table
+  // order — a rule nobody wrote down. The two `content/cli` collections are the near miss:
+  // they share a base and are kept disjoint only by the `!*/index.md` exclusion.
+  it("claims each note for exactly one collection", () => {
+    const overlapping = corpus
+      .map((n) => ({
+        rel: n.rel,
+        names: COLLECTION_NAMES.filter((c) => matchesCollection(n.rel, COLLECTIONS[c])),
+      }))
+      .filter((r) => r.names.length > 1)
+      .map((r) => `${r.rel}: ${r.names.join(", ")}`);
+    expect(overlapping, `\nclaimed by several collections:\n  ${overlapping.join("\n  ")}`).toEqual(
+      [],
+    );
+  });
+});


### PR DESCRIPTION
> **Posted by Claude (AI assistant) on jmchilton's behalf** — not authored by them personally.

Step 1 of converging GWF onto the per-kind collection routing the statistical-genomics-foundry instance already has. **No behavior changes here** — `content.config.ts` and `walk.ts` are untouched. This adds the table they will both route from, and the test that proves it is honest.

## The bug it found immediately

Two rules currently decide which files are notes. They are written twice and nothing compares them:

- `site/src/content.config.ts` — the Astro loader's glob
- `packages/build-cli/src/lib/walk.ts` — `SKIP_FILES` / `DIR_NOTE_TYPES`

**They disagree.** `content/prompts/**` is walked by the validator and globbed by neither. The `prompt` kind — its schema, its catalog entry, and two MIT-vendored notes with full attribution and a pinned upstream SHA — has never been published by the site. It is validated on every CI run and is invisible to every reader.

Nothing noticed because nothing had ever asked the question.

## What this adds

`packages/note-schema/src/collections.ts` — one table mapping a directory plus a glob to the **one kind** every note there declares:

```
  47 molds           →  mold             6 cli-tools     →  cli-tool
  54 patterns        →  pattern         26 cli-commands  →  cli-command
   7 source-patterns →  source-pattern   7 pipelines     →  pipeline
  63 research        →  research        14 schemas       →  schema
                                          2 prompts      →  prompt
total walked: 226 | routed: 226 | orphan: 0
```

It partitions the corpus exactly — every walked file claimed, none claimed twice — and **no note declares a `type:` other than the one its location routes to.**

A collection is a LOCATION; a kind is what a note IS. Deliberately not one-to-one: `content/cli/` holds two kinds, separated by `index.md` vs not. That is the case that makes a directory→kind rule insufficient on its own, and it is why the table carries globs rather than bare directories.

`collectionOf()` needs to match those globs and the validator has no globber (neither `picomatch` nor `minimatch` resolves at the root), so there is a ~15-line matcher for the three constructs the table uses. Two implementations of the same patterns is exactly the drift this module exists to end, so the test pins this one against the real corpus: if it and Astro's picomatch ever disagreed about a file, the routed count would stop matching the walked count.

## Red to green

The invariant is ported from SGF's `registry-drift.test.ts`, which has carried it since that instance split content into per-kind collections. Nothing about it is domain-specific — it is what any Foundry wants once location decides which schema a note is parsed against.

It went red on the real gap:

```
kinds with no collection: prompt

walked but in no collection:
  content/prompts/galaxy/custom-tool-critic.md
  content/prompts/galaxy/custom-tool-structured.md
```

Green after adding the `prompts` collection.

Six tests: kind→collection and collection→kind both ways, every walked note claimed, claimed exactly once, and declared `type` matching the routed kind — plus a non-vacuity guard, since every other assertion is "no violations found" and an empty corpus would otherwise report a clean bill of health we did not earn.

## Verification

| check | result |
|---|---|
| root tests | 158 (was 152) |
| root + site typecheck | 0 errors |
| `astro check` | 0 errors, 66 files |
| packages typecheck | clean |
| behavior | unchanged — nothing routes from the table yet |

## What follows

1. **this PR** — the table + its invariant
2. split `content.config.ts` into nine collections (**this is where the 2 prompt notes become visible**), written out explicitly rather than looped — a loop collapses Astro's per-collection inference
3. a corpus helper for the ~15 genuinely cross-kind pages (tags, licenses, dashboard, glossary, the catch-all detail route, wiki-link/backlink/artifact builders)
4. per-kind list pages onto their own collections — drops ~29 of the 56 `entry.data as any` casts
5. `walk.ts` routes from the table instead of being a second rule

The remaining ~23 casts live in the generic note-detail page and its body components, which render *any* kind through shared components. Those are cross-kind by construction and stay that way under either architecture — worth fixing with a narrowing helper, but that is independent of this work.
