### PR TITLE
Publish notes from one collection per kind

### DIFF
--- a/packages/note-schema/src/index.ts
+++ b/packages/note-schema/src/index.ts
@@ -1,7 +1,14 @@
 // Public surface for @galaxy-foundry/note-schema — the single source of truth
 // for Foundry note frontmatter, shared by the validator and the Astro site.
 
-export { buildNoteSchema, type BuildNoteSchemaOptions, type NoteSchema } from "./note-schema.js";
+export {
+  buildNoteSchema,
+  buildKindSchemas,
+  type Assembled,
+  type BuildNoteSchemaOptions,
+  type KindSchemas,
+  type NoteSchema,
+} from "./note-schema.js";
 
 export {
   COLLECTIONS,
@@ -14,6 +21,7 @@ export {
 } from "./collections.js";
 
 export {
+  DEFINITIONS,
   KINDS,
   KINDS_BY_NAME,
   buildKindContext,

--- a/packages/note-schema/src/note-schema.ts
+++ b/packages/note-schema/src/note-schema.ts
@@ -12,8 +12,14 @@
 
 import { z } from "zod";
 
-import { buildKindContext, type BuildKindContextOptions } from "./types/context.js";
-import { KINDS, KINDS_BY_NAME, type BuiltKinds } from "./types/index.js";
+import {
+  buildKindContext,
+  type BuildKindContextOptions,
+  type KindContext,
+  type KindDefinition,
+  type KindShape,
+} from "./types/context.js";
+import { DEFINITIONS, KINDS, KINDS_BY_NAME, type BuiltKinds } from "./types/index.js";
 
 export type BuildNoteSchemaOptions = BuildKindContextOptions;
 
@@ -37,3 +43,61 @@ export function buildNoteSchema(options: BuildNoteSchemaOptions) {
 }
 
 export type NoteSchema = ReturnType<typeof buildNoteSchema>;
+
+/**
+ * One kind's assembled schema: parses that kind's frontmatter, yields that kind's own output.
+ *
+ * Stated as ONE type rather than left to inference, because inference over the optional
+ * `refine` slot yields a UNION of "refined" and "not" — and a union is what turns an ordinary
+ * field access on an Astro page into an error, since it would have to hold on both arms.
+ */
+export type Assembled<T extends KindShape> = z.ZodType<
+  z.infer<z.ZodObject<T, "strict">>,
+  z.ZodTypeDef,
+  z.input<z.ZodObject<T, "strict">>
+>;
+
+/**
+ * Assemble one kind into the schema its collection validates with.
+ *
+ * `build` returns the bare strict object so the manifest generator can walk its `.shape`;
+ * `refine` is applied here, to that kind's schema alone, so a cross-field rule sees only its
+ * own kind's fields.
+ */
+function assemble<T extends KindShape>(
+  definition: KindDefinition<T>,
+  ctx: KindContext,
+): Assembled<T> {
+  const object = definition.build(ctx);
+  const { refine } = definition;
+  // No cast on `d`. Assembling one kind at a time is what makes `superRefine`'s argument
+  // already exactly the payload `refine` declares — which is the whole point of applying the
+  // rule to its own kind's schema rather than after a union resolves.
+  const refined = refine ? object.superRefine((d, issues) => refine(d, issues, ctx)) : object;
+  return refined as Assembled<T>;
+}
+
+/**
+ * Every kind's schema, by kind name — what a per-collection Astro loader validates with.
+ *
+ * Assembled ONE BY ONE rather than by mapping over KINDS or DEFINITIONS. A `.map` produces a
+ * homogeneous array and every kind's shape collapses to the widest common type, which is how
+ * the pages end up with `entry.data: unknown`. Named properties keep each kind precise, at the
+ * cost of one line per kind — the same trade `DEFINITIONS` itself makes, for the same reason.
+ */
+export function buildKindSchemas(options: BuildNoteSchemaOptions) {
+  const ctx = buildKindContext(options);
+  return {
+    mold: assemble(DEFINITIONS.mold, ctx),
+    pattern: assemble(DEFINITIONS.pattern, ctx),
+    "source-pattern": assemble(DEFINITIONS["source-pattern"], ctx),
+    "cli-tool": assemble(DEFINITIONS["cli-tool"], ctx),
+    "cli-command": assemble(DEFINITIONS["cli-command"], ctx),
+    pipeline: assemble(DEFINITIONS.pipeline, ctx),
+    research: assemble(DEFINITIONS.research, ctx),
+    schema: assemble(DEFINITIONS.schema, ctx),
+    prompt: assemble(DEFINITIONS.prompt, ctx),
+  };
+}
+
+export type KindSchemas = ReturnType<typeof buildKindSchemas>;

--- a/packages/note-schema/src/types/index.ts
+++ b/packages/note-schema/src/types/index.ts
@@ -34,6 +34,29 @@ export const KINDS = [
   prompt,
 ] as const;
 
+/**
+ * The same kinds, reachable BY NAME with their shapes intact.
+ *
+ * `KINDS_BY_NAME` cannot serve this purpose. A Map has one value type for every entry, so a
+ * lookup through it yields the widened `KindDefinition` and every field the caller knew about
+ * is gone. Named properties keep each kind precisely typed, which is what lets a per-collection
+ * schema carry its own frontmatter type all the way to the Astro pages.
+ *
+ * Keys are the `type:` discriminator values, so `DEFINITIONS[COLLECTIONS[c].kind]` resolves to
+ * exactly one kind rather than to a union of nine.
+ */
+export const DEFINITIONS = {
+  mold,
+  pattern,
+  "source-pattern": sourcePattern,
+  "cli-tool": cliTool,
+  "cli-command": cliCommand,
+  pipeline,
+  research,
+  schema: schemaNote,
+  prompt,
+} as const;
+
 type BuiltKind<K> = K extends { build: (...args: never[]) => infer R } ? R : never;
 
 /** Each kind's union member, in barrel order, with its shape preserved. */

--- a/packages/note-schema/test/kind-directories.test.ts
+++ b/packages/note-schema/test/kind-directories.test.ts
@@ -13,7 +13,7 @@ import yaml from "js-yaml";
 import { describe, expect, it } from "vitest";
 
 import { bundledPolicy } from "@galaxy-foundry/license-policy";
-import { KINDS, buildNoteSchema, loadReferenceContract } from "../src/index.js";
+import { DEFINITIONS, KINDS, buildNoteSchema, loadReferenceContract } from "../src/index.js";
 import { loadTagRegistry } from "@galaxy-foundry/tag-registry";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
@@ -49,6 +49,19 @@ describe("types/ kind directories", () => {
 
   it("declares no duplicate kind names", () => {
     expect(new Set(KINDS.map((k) => k.kind)).size).toBe(KINDS.length);
+  });
+
+  // DEFINITIONS is the by-name view the per-collection schemas are built from. It is written
+  // out by hand rather than derived from KINDS, because deriving it through a `.map` or a Map
+  // widens every entry to the default shape — the erasure this whole arrangement exists to
+  // avoid. Hand-written means it can disagree with the barrel, so: both directions, and each
+  // key must be the kind it points at rather than merely a kind that exists.
+  it("the by-name view holds exactly the barrel's kinds, keyed by their own names", () => {
+    expect(Object.keys(DEFINITIONS).sort()).toEqual(KINDS.map((k) => k.kind).sort());
+    const mismatched = Object.entries(DEFINITIONS)
+      .filter(([name, definition]) => definition.kind !== name)
+      .map(([name, definition]) => `${name} -> ${definition.kind}`);
+    expect(mismatched, `\nkeys not matching their kind: ${mismatched.join(", ")}`).toEqual([]);
   });
 
   const schema = buildNoteSchema({

--- a/site/src/components/CliCommandBody.astro
+++ b/site/src/components/CliCommandBody.astro
@@ -1,9 +1,9 @@
 ---
-import type { CollectionEntry } from 'astro:content';
+import { type NoteEntry } from '../lib/notes';
 import { cliRegistry } from '../lib/cli-registry';
 
 interface Props {
-  entry: CollectionEntry<'content'>;
+  entry: NoteEntry;
 }
 
 const { entry } = Astro.props;

--- a/site/src/components/IncomingRefs.astro
+++ b/site/src/components/IncomingRefs.astro
@@ -1,9 +1,9 @@
 ---
-import type { CollectionEntry } from 'astro:content';
+import { type NoteEntry } from '../lib/notes';
 import type { Backlink } from '../lib/wiki-links';
 
 interface Props {
-  incoming: (Backlink & { source: CollectionEntry<'content'> })[];
+  incoming: (Backlink & { source: NoteEntry })[];
 }
 
 const { incoming } = Astro.props;
@@ -18,7 +18,7 @@ const FIELD_LABELS: Record<string, string> = {
   output_artifact_schema: 'schema of artifact output',
 };
 
-function fileTitle(entry: CollectionEntry<'content'>): string {
+function fileTitle(entry: NoteEntry): string {
   const data = entry.data as any;
   if (data.title) return data.title;
   if (data.name) return data.name;

--- a/site/src/components/LicenseBox.astro
+++ b/site/src/components/LicenseBox.astro
@@ -1,11 +1,11 @@
 ---
-import type { CollectionEntry } from 'astro:content';
+import { type NoteEntry } from '../lib/notes';
 import { licenseIdFromFile } from '../lib/licenses';
 import { resolveLicenseRow } from '@galaxy-foundry/license-policy';
 import { licensePolicy } from '../lib/registries';
 
 interface Props {
-  entry: CollectionEntry<'content'>;
+  entry: NoteEntry;
 }
 
 const { entry } = Astro.props;

--- a/site/src/components/MoldBody.astro
+++ b/site/src/components/MoldBody.astro
@@ -1,15 +1,15 @@
 ---
-import type { CollectionEntry } from 'astro:content';
+import { type NoteEntry } from '../lib/notes';
 import { resolveWikiLink, type WikiLinkTarget } from '../lib/wiki-links';
 import ReferenceContract from './ReferenceContract.astro';
 import CastArtifacts from './CastArtifacts.astro';
 import { artifactHref, type ArtifactGraph } from '../lib/artifacts';
 
 interface Props {
-  entry: CollectionEntry<'content'>;
+  entry: NoteEntry;
   linkMap: Map<string, WikiLinkTarget>;
   artifactGraph?: ArtifactGraph;
-  entryById?: Map<string, CollectionEntry<'content'>>;
+  entryById?: Map<string, NoteEntry>;
 }
 
 const { entry, linkMap, artifactGraph, entryById } = Astro.props;

--- a/site/src/components/MoldHealth.astro
+++ b/site/src/components/MoldHealth.astro
@@ -1,14 +1,14 @@
 ---
+import { type NoteEntry } from '../lib/notes';
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import type { CollectionEntry } from 'astro:content';
 import HealthPanel from './HealthPanel.astro';
 import { resolveWikiLinkId, WIKI_LINK_RE, type WikiLinkTarget } from '../lib/wiki-links';
 
 interface Props {
-  entry: CollectionEntry<'content'>;
+  entry: NoteEntry;
   linkMap: Map<string, WikiLinkTarget>;
-  entryById: Map<string, CollectionEntry<'content'>>;
+  entryById: Map<string, NoteEntry>;
 }
 
 interface HealthItem {

--- a/site/src/components/NoteHeader.astro
+++ b/site/src/components/NoteHeader.astro
@@ -1,8 +1,8 @@
 ---
-import type { CollectionEntry } from 'astro:content';
+import { type NoteEntry } from '../lib/notes';
 
 interface Props {
-  entry: CollectionEntry<'content'>;
+  entry: NoteEntry;
   pageTitle: string;
   typeLabel: string;
   eyebrow?: string;

--- a/site/src/components/NoteMeta.astro
+++ b/site/src/components/NoteMeta.astro
@@ -1,9 +1,9 @@
 ---
-import type { CollectionEntry } from 'astro:content';
+import { type NoteEntry } from '../lib/notes';
 import { resolveWikiLink, type WikiLinkTarget } from '../lib/wiki-links';
 
 interface Props {
-  entry: CollectionEntry<'content'>;
+  entry: NoteEntry;
   linkMap: Map<string, WikiLinkTarget>;
   mode?: 'full' | 'related-only';
 }

--- a/site/src/components/PatternBody.astro
+++ b/site/src/components/PatternBody.astro
@@ -1,9 +1,9 @@
 ---
-import type { CollectionEntry } from 'astro:content';
+import { type NoteEntry } from '../lib/notes';
 import { resolveWikiLink, type WikiLinkTarget } from '../lib/wiki-links';
 
 interface Props {
-  entry: CollectionEntry<'content'>;
+  entry: NoteEntry;
   linkMap: Map<string, WikiLinkTarget>;
   placement?: 'before' | 'after';
 }

--- a/site/src/components/PatternHealth.astro
+++ b/site/src/components/PatternHealth.astro
@@ -1,12 +1,12 @@
 ---
-import type { CollectionEntry } from 'astro:content';
+import { type NoteEntry } from '../lib/notes';
 import HealthPanel from './HealthPanel.astro';
 import { resolveWikiLinkId, type WikiLinkTarget } from '../lib/wiki-links';
 
 interface Props {
-  entry: CollectionEntry<'content'>;
+  entry: NoteEntry;
   linkMap: Map<string, WikiLinkTarget>;
-  entryById: Map<string, CollectionEntry<'content'>>;
+  entryById: Map<string, NoteEntry>;
 }
 
 interface HealthItem {

--- a/site/src/components/PatternSpotlight.astro
+++ b/site/src/components/PatternSpotlight.astro
@@ -1,8 +1,8 @@
 ---
-import { getCollection } from 'astro:content';
+import { getAllNotes } from '../lib/notes';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
-const all = await getCollection('content');
+const all = await getAllNotes();
 const patterns = all
   .filter(n => n.data.type === 'pattern' && n.data.status !== 'archived')
   .sort((a, b) => {

--- a/site/src/components/PipelineBody.astro
+++ b/site/src/components/PipelineBody.astro
@@ -1,12 +1,12 @@
 ---
-import type { CollectionEntry } from 'astro:content';
+import { type NoteEntry } from '../lib/notes';
 import type { WikiLinkTarget } from '../lib/wiki-links';
 import PhaseGraph from './PhaseGraph.astro';
 import StopGapBanner from './StopGapBanner.astro';
 import { loadAssembly, assemblyStats } from '../lib/casts';
 
 interface Props {
-  entry: CollectionEntry<'content'>;
+  entry: NoteEntry;
   linkMap: Map<string, WikiLinkTarget>;
 }
 

--- a/site/src/components/PipelineMatrix.astro
+++ b/site/src/components/PipelineMatrix.astro
@@ -1,8 +1,8 @@
 ---
-import { getCollection } from 'astro:content';
+import { getAllNotes } from '../lib/notes';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
-const all = await getCollection('content');
+const all = await getAllNotes();
 const pipelines = all.filter(n => n.data.type === 'pipeline' && n.data.status !== 'archived');
 
 const SOURCES = ['paper', 'cwl', 'nextflow'] as const;

--- a/site/src/components/ResearchBody.astro
+++ b/site/src/components/ResearchBody.astro
@@ -1,8 +1,8 @@
 ---
-import type { CollectionEntry } from 'astro:content';
+import { type NoteEntry } from '../lib/notes';
 
 interface Props {
-  entry: CollectionEntry<'content'>;
+  entry: NoteEntry;
 }
 
 const { entry } = Astro.props;

--- a/site/src/components/RunPipelines.astro
+++ b/site/src/components/RunPipelines.astro
@@ -3,7 +3,7 @@
 // runnable harness-card grid. Mounted on /usage/ (variant="full") above the
 // Mold casts, and on /pipelines/ (variant="text") below the catalog table.
 // Single source for the run story — edit here, both surfaces follow.
-import { getCollection } from 'astro:content';
+import { getAllNotes } from '../lib/notes';
 import StopGapBanner from './StopGapBanner.astro';
 import { loadAssembly, assemblyStats } from '../lib/casts';
 
@@ -13,7 +13,7 @@ interface Props {
 const { variant = 'full' } = Astro.props;
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 
-const pipelines = (await getCollection('content'))
+const pipelines = (await getAllNotes())
   .filter(n => n.data.type === 'pipeline' && n.data.status !== 'archived')
   .map(p => {
     const slug = p.id.split('/').pop()!;

--- a/site/src/components/SchemaBody.astro
+++ b/site/src/components/SchemaBody.astro
@@ -1,9 +1,9 @@
 ---
-import type { CollectionEntry } from 'astro:content';
+import { type NoteEntry } from '../lib/notes';
 import { schemaRegistry } from '../lib/schema-registry';
 
 interface Props {
-  entry: CollectionEntry<'content'>;
+  entry: NoteEntry;
 }
 
 const { entry } = Astro.props;

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -1,12 +1,17 @@
 import { defineCollection } from 'astro:content';
 import { glob } from 'astro/loaders';
-import { buildNoteSchema } from '@galaxy-foundry/note-schema';
+import { COLLECTIONS, buildKindSchemas, type CollectionName } from '@galaxy-foundry/note-schema';
 import { licensePolicy, referenceContract, tags } from './lib/registries';
 
-// The frontmatter contract is the single zod schema from @galaxy-foundry/note-schema,
-// built from the same registries the validator uses. There is no site-local schema
-// to keep in lockstep — the former hand-written mirror is gone.
-const noteSchema = buildNoteSchema({ tags, contract: referenceContract, licensePolicy });
+// One collection per kind, routed by path. The directory a note lives in picks the schema it
+// parses against; the `type:` literal in that schema asserts the note agrees, so location is a
+// CHECKED assumption rather than an inference.
+//
+// Bases and globs both come from COLLECTIONS in the shared package, which the validator's walk
+// routes from too — one table, so a directory the site publishes and a directory the validator
+// checks cannot drift apart. They had: `content/prompts/**` was walked by the validator and
+// globbed by nothing, so the prompt kind was validated on every run and published by nothing.
+const schemas = buildKindSchemas({ tags, contract: referenceContract, licensePolicy });
 
 function slugifyPath(entry: string): string {
   return entry.replace(/\.md$/, '').split('/')
@@ -15,29 +20,45 @@ function slugifyPath(entry: string): string {
     .join('/');
 }
 
-const content = defineCollection({
-  loader: glob({
-    pattern: [
-      'cli/**/*.md',
-      'molds/**/index.md',
-      'patterns/**/*.md',
-      'source-patterns/**/*.md',
-      'pipelines/**/index.md',
-      'research/**/*.md',
-      'schemas/**/*.md',
-      '!Dashboard.md',
-      '!Index.md',
-      '!log.md',
-      '!meta/glossary.md',
-    ],
-    base: '../content',
+// Entry ids stay exactly what the single `content` collection produced: the slugified path
+// relative to content/, with `/index` stripped. A per-collection loader sees paths relative to
+// its OWN base, so the base's path has to go back on before slugifying — without it every note
+// loses its leading segment and every URL on the site moves.
+//
+// The old glob's `!Dashboard.md` / `!Index.md` / `!log.md` / `!meta/glossary.md` exclusions are
+// gone rather than dropped: those files sit at content/ root and in content/meta/, and no
+// collection's base reaches them.
+function load(name: CollectionName) {
+  const { base, pattern } = COLLECTIONS[name];
+  const prefix = base.replace(/^content\//, '');
+  return glob({
+    pattern: [...pattern],
+    base: `../${base}`,
     generateId({ entry }) {
-      let id = slugifyPath(entry);
-      if (id.endsWith('/index')) id = id.slice(0, -'/index'.length);
-      return id;
+      const id = slugifyPath(`${prefix}/${entry}`);
+      return id.endsWith('/index') ? id.slice(0, -'/index'.length) : id;
     },
-  }),
-  schema: noteSchema,
-});
+  });
+}
 
-export const collections = { content };
+// Written out per collection rather than mapped over COLLECTIONS. A loop produces one
+// homogeneous collection type and every kind's frontmatter collapses to the widest common
+// shape — which is how `entry.data` degrades to `unknown` on the pages. Naming each schema
+// keeps each collection's type precise.
+export const collections = {
+  molds: defineCollection({ loader: load('molds'), schema: schemas.mold }),
+  patterns: defineCollection({ loader: load('patterns'), schema: schemas.pattern }),
+  'source-patterns': defineCollection({
+    loader: load('source-patterns'),
+    schema: schemas['source-pattern'],
+  }),
+  'cli-tools': defineCollection({ loader: load('cli-tools'), schema: schemas['cli-tool'] }),
+  'cli-commands': defineCollection({
+    loader: load('cli-commands'),
+    schema: schemas['cli-command'],
+  }),
+  pipelines: defineCollection({ loader: load('pipelines'), schema: schemas.pipeline }),
+  research: defineCollection({ loader: load('research'), schema: schemas.research }),
+  schemas: defineCollection({ loader: load('schemas'), schema: schemas.schema }),
+  prompts: defineCollection({ loader: load('prompts'), schema: schemas.prompt }),
+};

--- a/site/src/lib/artifacts.ts
+++ b/site/src/lib/artifacts.ts
@@ -1,4 +1,4 @@
-import type { CollectionEntry } from 'astro:content';
+import { type NoteEntry } from './notes';
 import { resolveWikiLinkId, type WikiLinkTarget } from './wiki-links';
 
 export interface OutputArtifactDecl {
@@ -87,7 +87,7 @@ function collectMoldRefsFromPhase(phase: unknown): string[] {
 }
 
 export function buildArtifactGraph(
-  entries: CollectionEntry<'content'>[],
+  entries: NoteEntry[],
   linkMap: Map<string, WikiLinkTarget>,
 ): ArtifactGraph {
   const graph: ArtifactGraph = new Map();

--- a/site/src/lib/notes.ts
+++ b/site/src/lib/notes.ts
@@ -1,0 +1,69 @@
+// The whole corpus, for the pages that genuinely want every kind at once.
+//
+// Notes live in one collection per kind, so a per-kind page asks for its own collection and
+// gets precise frontmatter with no narrowing. But much of this site is cross-kind by
+// construction — tags, licenses, the dashboard, the glossary, the catch-all note route, and
+// the wiki-link/backlink/artifact graphs all range over everything. `getAllNotes` is what they
+// ask instead, and `NoteEntry` is the union they get.
+//
+// This is the direction that stays cheap. Assembling the union from per-kind collections is
+// one function; recovering per-kind precision from a single mixed collection would be a
+// narrowing call at every use site.
+
+import { getCollection, type CollectionEntry } from 'astro:content';
+import type { CollectionName } from '@galaxy-foundry/note-schema';
+
+/**
+ * Every collection holding notes. Mirrors COLLECTIONS in @galaxy-foundry/note-schema.
+ *
+ * The ORDER is load-bearing and matches the glob pattern order the single `content` collection
+ * used. `buildWikiLinkMap` keys by basename and overwrites, so when two notes share a basename
+ * the last one walked wins — and exactly one pair does: `cli/foundry/summarize-nextflow.md` and
+ * `molds/summarize-nextflow/index.md`. Listing the cli collections first keeps the mold winning
+ * `[[summarize-nextflow]]`, as it has been.
+ *
+ * That the corpus can contain an ambiguous slug at all is a real problem, but it is this
+ * module's job to not silently change the answer, not to pick a different one.
+ */
+export const NOTE_COLLECTIONS = [
+  'cli-tools',
+  'cli-commands',
+  'molds',
+  'patterns',
+  'source-patterns',
+  'pipelines',
+  'research',
+  'schemas',
+  'prompts',
+] as const;
+
+export type NoteCollection = (typeof NOTE_COLLECTIONS)[number];
+
+// This list exists separately from COLLECTIONS only because its ORDER is load-bearing (see
+// above) and COLLECTIONS is keyed for lookup, not iteration. Separate means it can drift, so
+// the two are proved to name the same collections at compile time: a collection added to the
+// package and forgotten here would otherwise just quietly stop being published.
+// `false`, not `never`, on mismatch: `never extends true` is TRUE, so a `never` here would
+// satisfy MustBeTrue and the whole guard would pass vacuously.
+type SameSet<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+type MustBeTrue<T extends true> = T;
+export type _CollectionsCovered = MustBeTrue<SameSet<NoteCollection, CollectionName>>;
+
+/** A note of any kind — the union `entry.data` resolves to for a cross-kind consumer. */
+export type NoteEntry = CollectionEntry<NoteCollection>;
+
+/**
+ * Every note in the corpus, in collection order then id order.
+ *
+ * Sorted rather than left in load order: several callers build maps and lists straight off
+ * this, and a stable order keeps generated pages from reshuffling between builds.
+ */
+export async function getAllNotes(): Promise<NoteEntry[]> {
+  const perCollection = await Promise.all(
+    NOTE_COLLECTIONS.map(async name => {
+      const entries: NoteEntry[] = await getCollection(name);
+      return entries.sort((a, b) => a.id.localeCompare(b.id));
+    }),
+  );
+  return perCollection.flat();
+}

--- a/site/src/lib/wiki-links.ts
+++ b/site/src/lib/wiki-links.ts
@@ -1,5 +1,5 @@
+import { type NoteEntry } from './notes';
 import { resolveWikiLink as resolve, slugify } from '@galaxy-foundry/wiki-links';
-import type { CollectionEntry } from 'astro:content';
 
 // Components asking "is this string a wiki link at all?" get the package's answer, not their
 // own regex. Re-exported here so a component has one import for everything link-shaped.
@@ -16,7 +16,7 @@ export interface WikiLinkTarget {
 }
 
 /** Map from slugified note basename → target. */
-export function buildWikiLinkMap(entries: CollectionEntry<'content'>[]): Map<string, WikiLinkTarget> {
+export function buildWikiLinkMap(entries: NoteEntry[]): Map<string, WikiLinkTarget> {
   const map = new Map<string, WikiLinkTarget>();
   for (const entry of entries) {
     const basename = entry.id.split('/').pop()!;
@@ -76,7 +76,7 @@ export interface Backlink {
 
 /** Build target entry ID → notes that link to it via frontmatter wiki-link fields. */
 export function buildBacklinkMap(
-  entries: CollectionEntry<'content'>[],
+  entries: NoteEntry[],
   linkMap: Map<string, WikiLinkTarget>
 ): Map<string, Backlink[]> {
   const map = new Map<string, Backlink[]>();

--- a/site/src/pages/[...slug].astro
+++ b/site/src/pages/[...slug].astro
@@ -1,5 +1,6 @@
 ---
-import { getCollection, render } from 'astro:content';
+import { getAllNotes } from '../lib/notes';
+import { render } from 'astro:content';
 import Base from '../layouts/Base.astro';
 import NoteHeader from '../components/NoteHeader.astro';
 import NoteMeta from '../components/NoteMeta.astro';
@@ -17,7 +18,7 @@ import { buildWikiLinkMap, buildBacklinkMap } from '../lib/wiki-links';
 import { buildArtifactGraph } from '../lib/artifacts';
 
 export async function getStaticPaths() {
-  const entries = await getCollection('content');
+  const entries = await getAllNotes();
   return entries.map(entry => ({
     params: { slug: entry.id },
     props: { entry },
@@ -27,7 +28,7 @@ export async function getStaticPaths() {
 const { entry } = Astro.props;
 const { Content } = await render(entry);
 
-const allEntries = await getCollection('content');
+const allEntries = await getAllNotes();
 const linkMap = buildWikiLinkMap(allEntries);
 const backlinkMap = buildBacklinkMap(allEntries, linkMap);
 const artifactGraph = buildArtifactGraph(allEntries, linkMap);

--- a/site/src/pages/artifacts/[id].astro
+++ b/site/src/pages/artifacts/[id].astro
@@ -1,11 +1,11 @@
 ---
-import { getCollection } from 'astro:content';
+import { getAllNotes } from '../../lib/notes';
 import Base from '../../layouts/Base.astro';
 import { buildWikiLinkMap, resolveWikiLink } from '../../lib/wiki-links';
 import { buildArtifactGraph } from '../../lib/artifacts';
 
 export async function getStaticPaths() {
-  const entries = await getCollection('content');
+  const entries = await getAllNotes();
   const linkMap = buildWikiLinkMap(entries);
   const graph = buildArtifactGraph(entries, linkMap);
   return Array.from(graph.values()).map(node => ({
@@ -15,7 +15,7 @@ export async function getStaticPaths() {
 }
 
 const { id } = Astro.props;
-const entries = await getCollection('content');
+const entries = await getAllNotes();
 const linkMap = buildWikiLinkMap(entries);
 const graph = buildArtifactGraph(entries, linkMap);
 const node = graph.get(id);

--- a/site/src/pages/artifacts/index.astro
+++ b/site/src/pages/artifacts/index.astro
@@ -1,10 +1,10 @@
 ---
-import { getCollection } from 'astro:content';
+import { getAllNotes } from '../../lib/notes';
 import Base from '../../layouts/Base.astro';
 import { buildWikiLinkMap } from '../../lib/wiki-links';
 import { buildArtifactGraph, artifactHref } from '../../lib/artifacts';
 
-const entries = await getCollection('content');
+const entries = await getAllNotes();
 const linkMap = buildWikiLinkMap(entries);
 const graph = buildArtifactGraph(entries, linkMap);
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');

--- a/site/src/pages/dashboard/index.astro
+++ b/site/src/pages/dashboard/index.astro
@@ -1,18 +1,21 @@
 ---
-import { getCollection } from 'astro:content';
+import { getAllNotes } from '../../lib/notes';
 import Base from '../../layouts/Base.astro';
 import sections from '../../../../dashboard_sections.json';
 import { designDocsByCategory } from '../../lib/design-docs';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
-const allNotes = await getCollection('content');
+const allNotes = await getAllNotes();
 const infrastructureDocs = designDocsByCategory('infrastructure');
 
+// Ties broken by id, matching the validator's own sortByRevisedDesc. Without it, notes
+// sharing a revised date fall back to whatever order the loader happened to yield, so a
+// section's rows move whenever the corpus is walked differently.
 const dashboardSections = sections.map(s => ({
   label: s.label,
   notes: allNotes
     .filter(n => n.data.type === s.type && n.data.status !== 'archived')
-    .sort((a, b) => b.data.revised.getTime() - a.data.revised.getTime()),
+    .sort((a, b) => b.data.revised.getTime() - a.data.revised.getTime() || a.id.localeCompare(b.id)),
 }));
 const activeDashboardSections = dashboardSections.filter(s => s.notes.length > 0);
 const activeNotes = allNotes.filter(n => n.data.status !== 'archived');

--- a/site/src/pages/glossary.astro
+++ b/site/src/pages/glossary.astro
@@ -1,11 +1,11 @@
 ---
-import { getCollection } from 'astro:content';
+import { getAllNotes } from '../lib/notes';
 import Base from '../layouts/Base.astro';
 import { buildWikiLinkMap } from '../lib/wiki-links';
 import { renderContentDoc } from '../lib/render-vault-doc';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
-const allEntries = await getCollection('content');
+const allEntries = await getAllNotes();
 const linkMap = buildWikiLinkMap(allEntries);
 const html = renderContentDoc('meta/glossary.md', linkMap, base);
 ---

--- a/site/src/pages/index/index.astro
+++ b/site/src/pages/index/index.astro
@@ -1,10 +1,10 @@
 ---
-import { getCollection } from 'astro:content';
+import { getAllNotes } from '../../lib/notes';
 import Base from '../../layouts/Base.astro';
 import { DESIGN_DOC_GROUPS, designDocsByCategory } from '../../lib/design-docs';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
-const allNotes = await getCollection('content');
+const allNotes = await getAllNotes();
 const designDocGroups = DESIGN_DOC_GROUPS.map(group => ({
   ...group,
   docs: designDocsByCategory(group.category),

--- a/site/src/pages/licenses/[id].astro
+++ b/site/src/pages/licenses/[id].astro
@@ -1,5 +1,5 @@
 ---
-import { getCollection } from 'astro:content';
+import { getAllNotes } from '../../lib/notes';
 import Base from '../../layouts/Base.astro';
 import { getLicenses, licenseIdFromFile } from '../../lib/licenses';
 import { resolveLicenseRow } from '@galaxy-foundry/license-policy';
@@ -16,7 +16,7 @@ const { license } = Astro.props;
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 
 // Notes that redistribute content under this LICENSES/ file, with their SPDX id.
-const entries = await getCollection('content');
+const entries = await getAllNotes();
 const users = entries
   .filter(e => {
     const lf = (e.data as any).license_file;

--- a/site/src/pages/licenses/index.astro
+++ b/site/src/pages/licenses/index.astro
@@ -1,5 +1,5 @@
 ---
-import { getCollection } from 'astro:content';
+import { getAllNotes } from '../../lib/notes';
 import Base from '../../layouts/Base.astro';
 import { getLicenses, licenseIdFromFile } from '../../lib/licenses';
 
@@ -7,7 +7,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const licenses = getLicenses();
 
 // Count redistributing notes per license file.
-const entries = await getCollection('content');
+const entries = await getAllNotes();
 const counts = new Map<string, number>();
 for (const e of entries) {
   const lf = (e.data as any).license_file;

--- a/site/src/pages/log.astro
+++ b/site/src/pages/log.astro
@@ -1,11 +1,11 @@
 ---
-import { getCollection } from 'astro:content';
+import { getAllNotes } from '../lib/notes';
 import Base from '../layouts/Base.astro';
 import { buildWikiLinkMap } from '../lib/wiki-links';
 import { renderContentDoc } from '../lib/render-vault-doc';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
-const allEntries = await getCollection('content');
+const allEntries = await getAllNotes();
 const linkMap = buildWikiLinkMap(allEntries);
 const html = renderContentDoc('log.md', linkMap, base);
 ---

--- a/site/src/pages/molds/index.astro
+++ b/site/src/pages/molds/index.astro
@@ -1,11 +1,11 @@
 ---
-import { getCollection } from 'astro:content';
+import { getAllNotes } from '../../lib/notes';
 import { existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import Base from '../../layouts/Base.astro';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
-const all = await getCollection('content');
+const all = await getAllNotes();
 const molds = all.filter(n => n.data.type === 'mold' && n.data.status !== 'archived');
 const evalCount = molds.filter(m => hasEval(m.id)).length;
 

--- a/site/src/pages/patterns/index.astro
+++ b/site/src/pages/patterns/index.astro
@@ -1,9 +1,9 @@
 ---
-import { getCollection } from 'astro:content';
+import { getAllNotes } from '../../lib/notes';
 import Base from '../../layouts/Base.astro';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
-const all = await getCollection('content');
+const all = await getAllNotes();
 const patterns = all
   .filter(n => n.data.type === 'pattern' && n.data.status !== 'archived')
   .sort((a, b) => (a.data as any).title.localeCompare((b.data as any).title));

--- a/site/src/pages/pipelines/[slug]/harness.astro
+++ b/site/src/pages/pipelines/[slug]/harness.astro
@@ -1,6 +1,6 @@
 ---
+import { getAllNotes } from '../../../lib/notes';
 import { readFileSync } from 'node:fs';
-import { getCollection } from 'astro:content';
 import Base from '../../../layouts/Base.astro';
 import StopGapBanner from '../../../components/StopGapBanner.astro';
 import {
@@ -11,7 +11,7 @@ import {
 } from '../../../lib/casts';
 
 export async function getStaticPaths() {
-  const pipelines = (await getCollection('content')).filter(e => e.data.type === 'pipeline');
+  const pipelines = (await getAllNotes()).filter(e => e.data.type === 'pipeline');
   return pipelines
     .map(p => {
       const slug = p.id.split('/').pop()!;

--- a/site/src/pages/pipelines/index.astro
+++ b/site/src/pages/pipelines/index.astro
@@ -1,10 +1,10 @@
 ---
-import { getCollection } from 'astro:content';
+import { getAllNotes } from '../../lib/notes';
 import Base from '../../layouts/Base.astro';
 import RunPipelines from '../../components/RunPipelines.astro';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
-const all = await getCollection('content');
+const all = await getAllNotes();
 const pipelines = all
   .filter(n => n.data.type === 'pipeline' && n.data.status !== 'archived')
   .sort((a, b) => (a.data as any).title.localeCompare((b.data as any).title));

--- a/site/src/pages/raw/[...slug].md.ts
+++ b/site/src/pages/raw/[...slug].md.ts
@@ -1,13 +1,13 @@
+import { getAllNotes } from '../../lib/notes';
 import { existsSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import type { APIRoute, GetStaticPaths } from 'astro';
-import { getCollection } from 'astro:content';
 
 // Sibling artifacts served alongside a directory note's index.md.
 const SIBLINGS = ['eval', 'scenarios'] as const;
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  const entries = await getCollection('content');
+  const entries = await getAllNotes();
   const paths = entries.map(entry => ({
     params: { slug: entry.id },
     props: { body: entry.body ?? '' },

--- a/site/src/pages/source-patterns/nextflow/index.astro
+++ b/site/src/pages/source-patterns/nextflow/index.astro
@@ -1,9 +1,9 @@
 ---
-import { getCollection } from 'astro:content';
+import { getAllNotes } from '../../../lib/notes';
 import Base from '../../../layouts/Base.astro';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
-const all = await getCollection('content');
+const all = await getAllNotes();
 const sourcePatterns = all
   .filter(n => n.data.type === 'source-pattern' && (n.data as any).source === 'nextflow' && n.data.status !== 'archived')
   .sort((a, b) => (a.data as any).title.localeCompare((b.data as any).title));

--- a/site/src/pages/tags/[...tag].astro
+++ b/site/src/pages/tags/[...tag].astro
@@ -1,12 +1,12 @@
 ---
-import { getCollection } from 'astro:content';
+import { getAllNotes } from '../../lib/notes';
 import Base from '../../layouts/Base.astro';
 import { tags as registry } from '../../lib/registries';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 
 export async function getStaticPaths() {
-  const allNotes = await getCollection('content');
+  const allNotes = await getAllNotes();
   const tags = new Set<string>();
   for (const note of allNotes) {
     for (const tag of note.data.tags) tags.add(tag);
@@ -15,16 +15,19 @@ export async function getStaticPaths() {
 }
 
 const { tag } = Astro.props;
-const allNotes = await getCollection('content');
+const allNotes = await getAllNotes();
 
 // Declaring facet + registry gloss, resolved from meta_tags.yml rather than parsed off
 // the tag text — so this stays correct for a bare tag like `meta`.
 const facetLabel = registry.facetLabel(registry.facetOf(tag));
 const gloss = registry.tagDescription(tag);
 
+// Ties broken by id, matching the validator's own sortByRevisedDesc. Without it, notes
+// sharing a revised date fall back to whatever order the loader happened to yield, so the
+// rendered list moves whenever the corpus is walked differently.
 const notes = allNotes
   .filter(n => n.data.tags.includes(tag) && n.data.status !== 'archived')
-  .sort((a, b) => b.data.revised.getTime() - a.data.revised.getTime());
+  .sort((a, b) => b.data.revised.getTime() - a.data.revised.getTime() || a.id.localeCompare(b.id));
 
 const coCounts = new Map<string, number>();
 for (const n of allNotes) {

--- a/site/src/pages/tags/index.astro
+++ b/site/src/pages/tags/index.astro
@@ -1,10 +1,10 @@
 ---
-import { getCollection } from 'astro:content';
+import { getAllNotes } from '../../lib/notes';
 import Base from '../../layouts/Base.astro';
 import { tags as registry } from '../../lib/registries';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
-const allNotes = await getCollection('content');
+const allNotes = await getAllNotes();
 
 const tagCounts = new Map<string, number>();
 for (const note of allNotes) {

--- a/site/src/pages/usage/index.astro
+++ b/site/src/pages/usage/index.astro
@@ -1,5 +1,5 @@
 ---
-import { getCollection } from 'astro:content';
+import { getAllNotes } from '../../lib/notes';
 import Base from '../../layouts/Base.astro';
 import RunPipelines from '../../components/RunPipelines.astro';
 import { listAllCasts, loadAssembly } from '../../lib/casts';
@@ -7,12 +7,12 @@ import { listAllCasts, loadAssembly } from '../../lib/casts';
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const casts = listAllCasts();
 
-const runnablePipelines = (await getCollection('content'))
+const runnablePipelines = (await getAllNotes())
   .filter(n => n.data.type === 'pipeline' && n.data.status !== 'archived')
   .filter(p => loadAssembly(p.id.split('/').pop()!)).length;
 
 // Resolve mold backlinks by name → entry slug.
-const molds = (await getCollection('content')).filter(e => e.data.type === 'mold');
+const molds = (await getAllNotes()).filter(e => e.data.type === 'mold');
 const moldByName = new Map<string, string>();
 for (const m of molds) {
   const name = (m.data as any).name;


### PR DESCRIPTION
> **Posted by Claude (AI assistant) on jmchilton's behalf** — not authored by them personally.

Steps 2 and 3 of converging GWF onto the per-kind collection routing the statistical-genomics-foundry instance already has. Follows #393, which added the `COLLECTIONS` table and proved it partitions the corpus; this makes the site route from it.

Steps 2 and 3 land together because they cannot be separated: splitting `content.config.ts` deletes the `content` collection, and ~20 call sites reference it. Two commits, reviewable independently.

---

## 1. Per-kind schemas (`9c6f3df`)

A per-kind collection needs a per-kind schema, and there was no way to get one — `buildNoteSchema` returns the nine-member union, and `KINDS_BY_NAME` hands back the widened `KindDefinition` because a Map has one value type for every entry.

`DEFINITIONS` is the by-name view with shapes intact; `buildKindSchemas` assembles each kind against the shared context. Both are written out one line per kind rather than derived: a `.map` collapses every kind to the widest common type, which is exactly how the pages would end up with `entry.data: unknown`.

**Probed rather than assumed** — 0 typecheck errors is also what `any` looks like:

```
Property 'no_such_field' does not exist on type '{ revised: Date; type: "mold";
status: "draft" | "reviewed" | ...; ... 14 more ...; references?: unknown[] | undefined; }'
```

Now that #392 has typed `refine`, assembling one kind at a time means `superRefine`'s argument is already exactly the payload `refine` declares, so **no cast is needed on it** — the two changes compose.

## 2. Nine collections, one corpus helper (`77c4e7b`)

`content.config.ts` builds nine collections from `COLLECTIONS`. The directory a note lives in picks its schema; the `type:` literal asserts the note agrees, so location is a **checked** assumption rather than an inference.

`getAllNotes()` is what the ~15 genuinely cross-kind pages ask instead — tags, licenses, dashboard, glossary, the catch-all note route, and the wiki-link/backlink/artifact graphs. This is the direction that stays cheap: assembling the union from per-kind collections is one function, while recovering per-kind precision from a mixed collection would be a narrowing call at every use site.

**Per-kind pages now need no narrowing at all.** `getCollection('molds')[0].data.axis` is typed; `.no_such` is a TS2339.

## Verified by diffing the built site

Of 661 output files, **33 differ: 26 pure reorders and 7 real** — and all 7 are the prompt notes becoming visible.

| page | change |
|---|---|
| `dashboard`, `index` | note count 224 → 226, facets 7 → 8 |
| `licenses/index`, `licenses/galaxy` | `galaxy.LICENSE` 1 → 3 notes |
| `tags/index`, `tags/target/galaxy` | new `prompt/galaxy-internal` facet |
| `molds/author-galaxy-tool-wrapper` | 2 dangling wiki-links resolve; **mold health `error` → `ok`** |

That last one was a *false failure* on the mold health panel, caused entirely by the prompt notes being unreachable. 365 → 368 pages.

| check | result |
|---|---|
| `validate` | **unchanged** — 226 files, 0 errors, 202 warnings |
| `check:kinds` | unchanged, 9 kinds |
| root + site typecheck | 0 errors |
| tests | 158 root · 47 note-schema · all package suites |
| `packages-format` | clean |

## Two ordering hazards found, handled rather than absorbed

**Sorts with no tiebreak.** `dashboard` and `tags/[...tag]` sorted by `revised` alone, so same-date notes fell back to whatever order the loader yielded. Added an id tiebreak matching the validator's own `sortByRevisedDesc`. That accounts for all 26 reorders, which are now intentional rather than incidental.

**One ambiguous slug.** `buildWikiLinkMap` keys by basename and overwrites, and exactly one slug is claimed twice — `cli/foundry/summarize-nextflow.md` and `molds/summarize-nextflow/index.md`. Which one `[[summarize-nextflow]]` resolves to has *always* been decided by walk order. `NOTE_COLLECTIONS` lists the cli collections first so the mold keeps winning, as before.

**This is worth a follow-up.** A corpus that can contain two notes with the same slug, resolved silently by iteration order, is a bug this PR deliberately preserves rather than fixes — changing link targets as a side effect of a routing refactor would be the wrong call. Happy to open an issue.

## One note on the guard

`NOTE_COLLECTIONS` duplicates the package's collection names because its *order* is load-bearing, so it can drift. It's proved against `CollectionName` at compile time. The first attempt **passed vacuously** — `never extends true` is true, so the mismatch branch satisfied the constraint. It now yields `false` on mismatch, and was checked in both directions by deleting a collection and watching the typecheck fail.

## Remaining

- step 4: per-kind list pages onto their own collections, dropping ~29 of the 56 `entry.data as any` casts
- step 5: `walk.ts` routes from `COLLECTIONS` instead of being a second rule

The other ~23 casts live in the generic note-detail page and its body components, which render *any* kind through shared components. Those are cross-kind by construction and want a narrowing helper, independent of this work.
