### PR TITLE
Read per-kind pages from their own collection

### DIFF
--- a/site/src/components/PatternSpotlight.astro
+++ b/site/src/components/PatternSpotlight.astro
@@ -1,21 +1,20 @@
 ---
-import { getAllNotes } from '../lib/notes';
+import { getCollection } from 'astro:content';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
-const all = await getAllNotes();
-const patterns = all
-  .filter(n => n.data.type === 'pattern' && n.data.status !== 'archived')
+const patterns = (await getCollection('patterns'))
+  .filter(n => n.data.status !== 'archived')
   .sort((a, b) => {
     const revised = b.data.revised.getTime() - a.data.revised.getTime();
     if (revised !== 0) return revised;
-    return (a.data as any).title.localeCompare((b.data as any).title);
+    return a.data.title.localeCompare(b.data.title);
   });
 
 const maps = patterns
-  .filter(p => (p.data as any).pattern_kind === 'moc')
-  .sort((a, b) => (a.data as any).title.localeCompare((b.data as any).title));
+  .filter(p => p.data.pattern_kind === 'moc')
+  .sort((a, b) => a.data.title.localeCompare(b.data.title));
 const recentImplementationPatterns = patterns
-  .filter(p => ['operation', 'recipe'].includes((p.data as any).pattern_kind))
+  .filter(p => ['operation', 'recipe'].includes(p.data.pattern_kind))
   .slice(0, 4);
 
 function shortTitle(title: string): string {
@@ -33,7 +32,7 @@ function shortTitle(title: string): string {
     {maps.length > 0 && (
       <div class="map-spotlight-grid">
         {maps.map((pattern) => {
-          const data = pattern.data as any;
+          const data = pattern.data;
           return (
             <a href={`${base}/${pattern.id}/`} class="map-spotlight-card no-underline tinted-shadow tinted-shadow-hover">
               <span class="spotlight-index font-mono">MAP</span>
@@ -51,7 +50,7 @@ function shortTitle(title: string): string {
 
     <div class="spotlight-grid">
       {recentImplementationPatterns.map((pattern, index) => {
-        const data = pattern.data as any;
+        const data = pattern.data;
         return (
           <a href={`${base}/${pattern.id}/`} class="spotlight-card no-underline tinted-shadow tinted-shadow-hover">
             <span class="spotlight-index font-mono">{String(index + 1).padStart(2, '0')}</span>

--- a/site/src/components/PipelineMatrix.astro
+++ b/site/src/components/PipelineMatrix.astro
@@ -1,9 +1,8 @@
 ---
-import { getAllNotes } from '../lib/notes';
+import { getCollection } from 'astro:content';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
-const all = await getAllNotes();
-const pipelines = all.filter(n => n.data.type === 'pipeline' && n.data.status !== 'archived');
+const pipelines = (await getCollection('pipelines')).filter(n => n.data.status !== 'archived');
 
 const SOURCES = ['paper', 'cwl', 'nextflow'] as const;
 const TARGETS = ['galaxy', 'cwl'] as const;
@@ -20,13 +19,13 @@ const grid = new Map<string, Cell>();
 for (const src of SOURCES) for (const tgt of TARGETS) grid.set(`${src}|${tgt}`, null);
 
 for (const p of pipelines) {
-  const tags: string[] = (p.data as any).tags ?? [];
+  const tags = p.data.tags;
   const src = tags.find(t => t.startsWith('source/'))?.split('/')[1];
   const tgt = tags.find(t => t.startsWith('target/'))?.split('/')[1];
   if (!src || !tgt) continue;
   const key = `${src}|${tgt}`;
   if (!grid.has(key)) continue;
-  const d = p.data as any;
+  const d = p.data;
   grid.set(key, {
     slug: p.id,
     title: d.title,

--- a/site/src/components/RunPipelines.astro
+++ b/site/src/components/RunPipelines.astro
@@ -3,7 +3,7 @@
 // runnable harness-card grid. Mounted on /usage/ (variant="full") above the
 // Mold casts, and on /pipelines/ (variant="text") below the catalog table.
 // Single source for the run story — edit here, both surfaces follow.
-import { getAllNotes } from '../lib/notes';
+import { getCollection } from 'astro:content';
 import StopGapBanner from './StopGapBanner.astro';
 import { loadAssembly, assemblyStats } from '../lib/casts';
 
@@ -13,15 +13,15 @@ interface Props {
 const { variant = 'full' } = Astro.props;
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 
-const pipelines = (await getAllNotes())
-  .filter(n => n.data.type === 'pipeline' && n.data.status !== 'archived')
+const pipelines = (await getCollection('pipelines'))
+  .filter(n => n.data.status !== 'archived')
   .map(p => {
     const slug = p.id.split('/').pop()!;
     const assembly = loadAssembly(slug);
     return {
       slug,
-      title: (p.data as any).title as string,
-      summary: (p.data as any).summary as string | undefined,
+      title: p.data.title,
+      summary: p.data.summary,
       assembly,
       stats: assembly ? assemblyStats(assembly) : null,
     };

--- a/site/src/pages/molds/index.astro
+++ b/site/src/pages/molds/index.astro
@@ -1,24 +1,23 @@
 ---
-import { getAllNotes } from '../../lib/notes';
+import { getCollection } from 'astro:content';
 import { existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import Base from '../../layouts/Base.astro';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
-const all = await getAllNotes();
-const molds = all.filter(n => n.data.type === 'mold' && n.data.status !== 'archived');
+const molds = (await getCollection('molds')).filter(n => n.data.status !== 'archived');
 const evalCount = molds.filter(m => hasEval(m.id)).length;
 
 // Group by axis.
 const AXES = ['source-specific', 'target-specific', 'tool-specific', 'generic'] as const;
 const byAxis = new Map<string, typeof molds>();
 for (const m of molds) {
-  const ax = (m.data as any).axis;
+  const ax = m.data.axis;
   const list = byAxis.get(ax) ?? [];
   list.push(m);
   byAxis.set(ax, list);
 }
-for (const [, list] of byAxis) list.sort((a, b) => (a.data as any).name.localeCompare((b.data as any).name));
+for (const [, list] of byAxis) list.sort((a, b) => a.data.name.localeCompare(b.data.name));
 
 function hasEval(id: string): boolean {
   const evalPath = fileURLToPath(new URL(`../../../../content/${id}/eval.md`, import.meta.url));
@@ -26,7 +25,7 @@ function hasEval(id: string): boolean {
 }
 
 function healthFor(m: typeof molds[number]): 'ok' | 'warn' | 'error' {
-  const d = m.data as any;
+  const d = m.data;
   if (d.axis === 'source-specific' && !d.source) return 'error';
   if (d.axis === 'target-specific' && !d.target) return 'error';
   if (d.axis === 'tool-specific' && !d.tool) return 'error';
@@ -77,7 +76,7 @@ function healthFor(m: typeof molds[number]): 'ok' | 'warn' | 'error' {
         </div>
         <div class="card-grid">
           {list.map(m => {
-            const d = m.data as any;
+            const d = m.data;
             const spec = d.source ?? d.target ?? d.tool ?? null;
             const health = healthFor(m);
             const evalPresent = hasEval(m.id);

--- a/site/src/pages/patterns/index.astro
+++ b/site/src/pages/patterns/index.astro
@@ -1,21 +1,23 @@
 ---
-import { getAllNotes } from '../../lib/notes';
+import { getCollection } from 'astro:content';
 import Base from '../../layouts/Base.astro';
 
+// The patterns collection, not the whole corpus filtered down to it: `entry.data` is a
+// pattern's own frontmatter here, so `title` and `pattern_kind` are typed fields rather than
+// casts.
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
-const all = await getAllNotes();
-const patterns = all
-  .filter(n => n.data.type === 'pattern' && n.data.status !== 'archived')
-  .sort((a, b) => (a.data as any).title.localeCompare((b.data as any).title));
+const patterns = (await getCollection('patterns'))
+  .filter(n => n.data.status !== 'archived')
+  .sort((a, b) => a.data.title.localeCompare(b.data.title));
 
-const maps = patterns.filter(p => (p.data as any).pattern_kind === 'moc');
-const implementationPatterns = patterns.filter(p => ['operation', 'recipe'].includes((p.data as any).pattern_kind));
-const topicTags = [...new Set(patterns.flatMap(p => (p.data.tags as string[]).filter(t => t.startsWith('topic/'))))]
+const maps = patterns.filter(p => p.data.pattern_kind === 'moc');
+const implementationPatterns = patterns.filter(p => ['operation', 'recipe'].includes(p.data.pattern_kind));
+const topicTags = [...new Set(patterns.flatMap(p => p.data.tags.filter(t => t.startsWith('topic/'))))]
   .sort((a, b) => a.localeCompare(b));
 
 const groups = new Map<string, typeof implementationPatterns>();
 for (const pattern of implementationPatterns) {
-  const title = (pattern.data as any).title as string;
+  const title = pattern.data.title;
   const group = title.includes(':') ? title.split(':')[0] : 'General';
   const list = groups.get(group) ?? [];
   list.push(pattern);
@@ -61,9 +63,9 @@ function formatDate(d: Date): string {
       </div>
       <div class="card-grid card-grid-wide">
         {maps.map(pattern => {
-          const data = pattern.data as any;
+          const data = pattern.data;
           const linkedCount = data.related_patterns?.length ?? 0;
-          const subjectTags = (data.tags as string[]).filter(t => t !== 'pattern');
+          const subjectTags = data.tags.filter(t => t !== 'pattern');
           return (
             <article class="card card-feature tinted-shadow tinted-shadow-hover">
               <div class="card-top">
@@ -102,8 +104,8 @@ function formatDate(d: Date): string {
       </div>
       <div class="card-grid">
         {list.map(pattern => {
-          const data = pattern.data as any;
-          const subjectTags = (data.tags as string[]).filter(t => t !== 'pattern');
+          const data = pattern.data;
+          const subjectTags = data.tags.filter(t => t !== 'pattern');
           return (
             <article class="card tinted-shadow tinted-shadow-hover">
               <div class="card-top">

--- a/site/src/pages/pipelines/index.astro
+++ b/site/src/pages/pipelines/index.astro
@@ -1,14 +1,13 @@
 ---
-import { getAllNotes } from '../../lib/notes';
+import { getCollection } from 'astro:content';
 import Base from '../../layouts/Base.astro';
 import RunPipelines from '../../components/RunPipelines.astro';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
-const all = await getAllNotes();
-const pipelines = all
-  .filter(n => n.data.type === 'pipeline' && n.data.status !== 'archived')
-  .sort((a, b) => (a.data as any).title.localeCompare((b.data as any).title));
-const totalPhases = pipelines.reduce((sum, p) => sum + phaseCount((p.data as any).phases), 0);
+const pipelines = (await getCollection('pipelines'))
+  .filter(n => n.data.status !== 'archived')
+  .sort((a, b) => a.data.title.localeCompare(b.data.title));
+const totalPhases = pipelines.reduce((sum, p) => sum + phaseCount(p.data.phases), 0);
 
 function phaseCount(phases: unknown): number {
   return Array.isArray(phases) ? phases.length : 0;
@@ -47,7 +46,7 @@ function phaseCount(phases: unknown): number {
     <thead><tr><th>Pipeline</th><th>Summary</th><th>Phases</th><th>Status</th></tr></thead>
     <tbody>
       {pipelines.map(p => {
-        const d = p.data as any;
+        const d = p.data;
         return (
           <tr>
             <td><a href={`${base}/${p.id}/`}>{d.title}</a></td>

--- a/site/src/pages/source-patterns/nextflow/index.astro
+++ b/site/src/pages/source-patterns/nextflow/index.astro
@@ -1,15 +1,14 @@
 ---
-import { getAllNotes } from '../../../lib/notes';
+import { getCollection } from 'astro:content';
 import Base from '../../../layouts/Base.astro';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
-const all = await getAllNotes();
-const sourcePatterns = all
-  .filter(n => n.data.type === 'source-pattern' && (n.data as any).source === 'nextflow' && n.data.status !== 'archived')
-  .sort((a, b) => (a.data as any).title.localeCompare((b.data as any).title));
+const sourcePatterns = (await getCollection('source-patterns'))
+  .filter(n => n.data.source === 'nextflow' && n.data.status !== 'archived')
+  .sort((a, b) => a.data.title.localeCompare(b.data.title));
 
-const maps = sourcePatterns.filter(p => (p.data as any).source_pattern_kind === 'moc');
-const leaves = sourcePatterns.filter(p => (p.data as any).source_pattern_kind !== 'moc');
+const maps = sourcePatterns.filter(p => p.data.source_pattern_kind === 'moc');
+const leaves = sourcePatterns.filter(p => p.data.source_pattern_kind !== 'moc');
 
 function formatKind(kind: string): string {
   return kind.replace(/-/g, ' ');
@@ -46,7 +45,7 @@ function formatKind(kind: string): string {
       </div>
       <div class="source-pattern-grid source-pattern-grid-maps">
         {maps.map(pattern => {
-          const data = pattern.data as any;
+          const data = pattern.data;
           return (
             <article class="source-pattern-card source-pattern-card-map tinted-shadow tinted-shadow-hover">
               <div class="source-pattern-card-top">
@@ -72,7 +71,7 @@ function formatKind(kind: string): string {
     ) : (
       <div class="source-pattern-grid">
         {leaves.map(pattern => {
-          const data = pattern.data as any;
+          const data = pattern.data;
           const implementedBy = data.implemented_by_patterns?.length ?? 0;
           return (
             <article class="source-pattern-card tinted-shadow tinted-shadow-hover">


### PR DESCRIPTION
> **Posted by Claude (AI assistant) on jmchilton's behalf** — not authored by them personally.

Step 4 of the per-kind collection convergence. #394 has landed, so this is now a single commit on top of `main`.

Nine pages and components asked for the whole corpus and filtered it down to a single kind, then cast `entry.data` at every field access, because the union does not know which kind survived the filter. Asking the kind's own collection makes both the filter and the casts unnecessary.

```diff
-const all = await getAllNotes();
-const patterns = all
-  .filter(n => n.data.type === 'pattern' && n.data.status !== 'archived')
-  .sort((a, b) => (a.data as any).title.localeCompare((b.data as any).title));
+const patterns = (await getCollection('patterns'))
+  .filter(n => n.data.status !== 'archived')
+  .sort((a, b) => a.data.title.localeCompare(b.data.title));
```

| file | casts |
|---|---|
| `pages/patterns/index.astro` | 6 → 0 |
| `pages/source-patterns/nextflow/index.astro` | 6 → 0 |
| `components/PatternSpotlight.astro` | 6 → 0 |
| `pages/molds/index.astro` | 4 → 0 |
| `pages/pipelines/index.astro` | 3 → 0 |
| `components/PipelineMatrix.astro` | 2 → 0 |
| `components/RunPipelines.astro` | 2 → 0 |

**56 → 27** `entry.data as any` across the site.

## Provably a refactor

The built site is **byte-for-byte identical** to the one #394 produces: 0 of 661 output files changed, same file set, 368 pages. Nothing about what is rendered moved — only how the pages ask for it.

| check | result |
|---|---|
| built site vs #394 | **0 files differ** of 661 |
| `validate` | unchanged — 226 files, 0 errors, 202 warnings |
| root + site typecheck | 0 errors |
| tests | 158 root, all package suites |
| `packages-format` | clean |

## What the remaining 27 casts are

They are cross-kind *by construction*, not leftovers:

- the catch-all `[...slug].astro` note route, which renders every kind
- the body components it dispatches to — `MoldBody`, `PatternBody`, `SchemaBody`, `ResearchBody`, `CliCommandBody`, `NoteMeta`, `LicenseBox`, `IncomingRefs`, `MoldHealth`, `PatternHealth`
- corpus-wide pages: `dashboard`, `index`, `tags`, `licenses`, `usage`, `raw`, `artifacts`

These receive "some note" and want a **narrowing helper** (`isKind(entry, 'mold')`), not a collection. They would look the same under either architecture — a generic note-detail page is cross-kind whether the corpus lives in one collection or nine. Worth doing, but it is its own change and not part of this convergence.

## Remaining in the series

- step 5: `walk.ts` routes from `COLLECTIONS` instead of `DIR_NOTE_TYPES`/`SKIP_FILES` being a second rule

Also opened #395 for the ambiguous `[[summarize-nextflow]]` slug found during #394 — 46 links across 34 notes with no defined target.