### PR TITLE
Route the validator's walk through COLLECTIONS

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -203,15 +203,14 @@ Layered validation (`validateData` orchestrates):
    Failures error. Pipeline membership is not required of a Mold — standalone and indirectly-invoked Molds are first-class, so no coverage warning is emitted.
 9. **Artifact graph and layout checks** — producer/consumer artifact IDs, producer-owned `output_artifacts[].schema` links, schema vendoring metadata, schema `validator_bin` package bins, Mold source layout, CLI command docs, pattern evidence, body wiki links, and Mold stub bodies.
 
-`findMdFiles` skip rules:
+`findMdFiles` does not decide which files are notes. It walks `content/` and routes what it finds through `COLLECTIONS`:
 
 ```ts
-const SKIP_DIRS = new Set([".obsidian", "casts"]);
-const SKIP_FILES = new Set(["Dashboard.md", "Index.md", "log.md", "glossary.md"]);
-const DIR_NOTE_TYPES = new Set(["molds", "pipelines"]);
+if (entry.startsWith(".")) continue;                        // .obsidian and friends
+if (!collectionOf(`${CONTENT_DIR}/${rel}`)) continue;       // the table decides
 ```
 
-Hidden directories skipped. Casts directory (`casts/`) is **always skipped** — it's generated content, validated by casting tooling separately.
+Everything the old skip rules named falls out of the table rather than being restated: `Dashboard.md` / `Index.md` / `log.md` sit at the content root and `glossary.md` in `content/meta/`, and no collection's base reaches either; `molds` and `pipelines` glob `**/index.md`, which is directory-note semantics stated as a pattern; `casts/` is outside `content/` entirely. Dotfiles are the one exclusion left in code, because `.obsidian/` holds markdown that is editor state and no glob would tell it apart from a note.
 
 **One shared module, no drift.** Because everything is TS, anything both the validator and the Astro site depend on lives in **one shared module** imported by both. The wiki-link slug + resolver now lives one level further out, in `@galaxy-foundry/wiki-links`, shared across Foundry instances; `packages/build-cli/src/lib/wiki-links.ts` and `site/src/lib/wiki-links.ts` are thin adapters over it that add this instance's map and return shapes. The **frontmatter schema and reference contract** likewise live in `@galaxy-foundry/note-schema` — `buildNoteSchema` and the registry loaders — which both the validator and `site/src/content.config.ts` build from. No parallel implementations, no drift risk.
 
@@ -333,14 +332,13 @@ content/pipelines/nextflow-to-galaxy/
 
 `docs/` holds long-form Foundry-meta design narrative; the validator's directory-note rule applies to Mold and Pipeline.
 
-Validator distinction:
+Directory-note semantics are a glob in the shared table, not a rule of their own:
 ```ts
-const DIR_NOTE_TYPES = new Set(["molds", "pipelines"]);
-if (parts.some(p => DIR_NOTE_TYPES.has(p)) && path.basename !== "index.md") continue;
+molds:     { base: "content/molds",     pattern: ["**/index.md"], kind: "mold" },
+pipelines: { base: "content/pipelines", pattern: ["**/index.md"], kind: "pipeline" },
 ```
 
-Astro content collection:
-- `content` — typed, explicit globs for `cli/**/*.md`, `molds/**/index.md`, `patterns/**/*.md`, `source-patterns/**/*.md`, `pipelines/**/index.md`, `research/**/*.md`, and `schemas/**/*.md`, with generated dashboard/index/log/glossary files excluded.
+Astro content collections: one per entry in `COLLECTIONS`, each loading its own base and glob and parsing against its own kind's schema. The validator's walk routes from the same table, so what the site publishes and what the validator checks are the same set by construction — see §6.
 
 Routes:
 - `[...slug].astro` renders content notes, including Mold `index.md` directory notes, through type-specific body components.
@@ -527,12 +525,12 @@ foundry/
 │       ├── schema.ts                     # load + tag-enum injection
 │       ├── frontmatter.ts                # gray-matter wrapper + date normalization
 │       ├── wiki-links.ts                 # adapter over @galaxy-foundry/wiki-links
-│       └── walk.ts                       # findMdFiles + skip rules
+│       └── walk.ts                       # findMdFiles; routes through COLLECTIONS
 ├── tests/
 │   └── validate.test.ts                  # Vitest
 ├── site/                                 # Astro renderer
 │   ├── src/
-│   │   ├── content.config.ts             # Astro content collection schema
+│   │   ├── content.config.ts             # one Astro collection per COLLECTIONS entry
 │   │   ├── lib/
 │   │   │   ├── wiki-links.ts             # link map + backlinks over the shared resolver
 │   │   │   ├── remark-wiki-links.ts

--- a/packages/build-cli/src/lib/walk.ts
+++ b/packages/build-cli/src/lib/walk.ts
@@ -1,20 +1,28 @@
 // File discovery for the validator and generators.
-// See INITIAL_ARCHITECTURE.md §6 for skip rules.
+//
+// Which files are notes is decided by ONE table: COLLECTIONS in @galaxy-foundry/note-schema.
+// This module used to answer that question a second time — SKIP_FILES named the generated
+// files at the content root, DIR_NOTE_TYPES re-stated "molds and pipelines are directory
+// notes", and between them they approximated the site's globs closely enough to look
+// deliberate. They were never held to it: the two rules disagreed about `content/prompts/**`
+// for as long as it existed.
+//
+// This module now traverses and routes. It does not decide.
 
 import { readdirSync, statSync } from "node:fs";
 import path from "node:path";
-
-export const SKIP_DIRS = new Set([".obsidian", "casts"]);
-export const SKIP_FILES = new Set(["Dashboard.md", "Index.md", "log.md", "glossary.md"]);
-/** Note types that use directory-note semantics: only `<type>/<slug>/index.md` is validated. */
-export const DIR_NOTE_TYPES = new Set(["molds", "pipelines"]);
+import { CONTENT_DIR, collectionOf } from "@galaxy-foundry/note-schema";
 
 /**
- * Walk a directory and yield .md file paths that should be validated.
- * Skips hidden dirs, SKIP_DIRS, SKIP_FILES, and non-`index.md` files inside DIR_NOTE_TYPES dirs.
+ * Walk a content root and yield the files COLLECTIONS claims as notes, in sorted depth-first
+ * order.
+ *
+ * `contentRoot` is the content directory itself — absolute or relative, and under any name a
+ * checkout gives it. What it is called on disk does not route anything: paths are matched as
+ * `CONTENT_DIR`-relative, because that is the form COLLECTIONS states its bases in.
  */
-export function* findMdFiles(root: string): Generator<string> {
-  yield* walk(root, root);
+export function* findMdFiles(contentRoot: string): Generator<string> {
+  yield* walk(contentRoot, contentRoot);
 }
 
 function* walk(dir: string, root: string): Generator<string> {
@@ -25,20 +33,23 @@ function* walk(dir: string, root: string): Generator<string> {
     return;
   }
   for (const entry of entries) {
-    if (entry.startsWith(".") || SKIP_DIRS.has(entry)) continue;
+    // Dotfiles are the one exclusion the table cannot express: `.obsidian/` holds markdown
+    // that is editor state rather than content, and no glob would tell it apart from a note.
+    if (entry.startsWith(".")) continue;
     const full = path.join(dir, entry);
-    const st = statSync(full);
-    if (st.isDirectory()) {
+    if (statSync(full).isDirectory()) {
       yield* walk(full, root);
       continue;
     }
-    if (!entry.endsWith(".md")) continue;
-    if (SKIP_FILES.has(entry)) continue;
-    const rel = path.relative(root, full);
-    const parts = rel.split(path.sep);
-    if (parts.some((p) => DIR_NOTE_TYPES.has(p)) && entry !== "index.md") continue;
+    // Routing subsumes the extension check — every pattern in the table ends in `.md`.
+    if (!collectionOf(routablePath(root, full))) continue;
     yield full;
   }
+}
+
+/** A walked path in the repo-relative form COLLECTIONS matches against. */
+function routablePath(root: string, full: string): string {
+  return `${CONTENT_DIR}/${path.relative(root, full).split(path.sep).join("/")}`;
 }
 
 /** Slug used for wiki-link resolution: `index.md` → parent dir name; otherwise basename without extension. */

--- a/packages/note-schema/src/collections.ts
+++ b/packages/note-schema/src/collections.ts
@@ -1,9 +1,9 @@
 // Where each kind's notes LIVE — the one path→kind routing table.
 //
-// Two things currently decide which files are notes, and they are written twice: the Astro
+// Two things used to decide which files are notes, and they were written twice: the Astro
 // loader's glob in site/src/content.config.ts, and `walk.ts`'s SKIP_FILES / DIR_NOTE_TYPES in
-// the validator. Nothing makes them agree, and they do not: `content/prompts/**` is walked by
-// the validator and globbed by neither, so two notes are checked and never published.
+// the validator. Nothing made them agree, and they did not: `content/prompts/**` was walked by
+// the validator and globbed by neither, so two notes were checked and never published.
 //
 // This is that table, stated once. A collection maps a directory (plus the glob selecting note
 // files within it) to the ONE kind every note there declares. Both consumers route from here,
@@ -23,6 +23,16 @@ export interface CollectionDefinition {
   /** The `type:` every note in this collection declares. Must be a kind in KINDS. */
   kind: string;
 }
+
+/**
+ * The one directory every collection lives under, stated once.
+ *
+ * `base` is written repo-relative because that is the form both consumers can check a real
+ * path against without knowing where they were invoked from. Consumers that walk the content
+ * tree directly are handed that directory under whatever name it has on disk, so they need
+ * this to route what they find. The routing test pins it against the table.
+ */
+export const CONTENT_DIR = "content";
 
 /**
  * Every collection this Foundry publishes and validates.

--- a/packages/note-schema/src/index.ts
+++ b/packages/note-schema/src/index.ts
@@ -13,6 +13,7 @@ export {
 export {
   COLLECTIONS,
   COLLECTION_NAMES,
+  CONTENT_DIR,
   collectionOf,
   kindOf,
   matchesCollection,

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -1,6 +1,11 @@
 import { defineCollection } from 'astro:content';
 import { glob } from 'astro/loaders';
-import { COLLECTIONS, buildKindSchemas, type CollectionName } from '@galaxy-foundry/note-schema';
+import {
+  COLLECTIONS,
+  CONTENT_DIR,
+  buildKindSchemas,
+  type CollectionName,
+} from '@galaxy-foundry/note-schema';
 import { licensePolicy, referenceContract, tags } from './lib/registries';
 
 // One collection per kind, routed by path. The directory a note lives in picks the schema it
@@ -30,7 +35,7 @@ function slugifyPath(entry: string): string {
 // collection's base reaches them.
 function load(name: CollectionName) {
   const { base, pattern } = COLLECTIONS[name];
-  const prefix = base.replace(/^content\//, '');
+  const prefix = base.slice(`${CONTENT_DIR}/`.length);
   return glob({
     pattern: [...pattern],
     base: `../${base}`,

--- a/tests/collection-routing.test.ts
+++ b/tests/collection-routing.test.ts
@@ -1,9 +1,11 @@
+import { readdirSync, statSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   COLLECTIONS,
   COLLECTION_NAMES,
+  CONTENT_DIR,
   collectionOf,
   KINDS,
   matchesCollection,
@@ -19,23 +21,54 @@ import { findMdFiles } from "../packages/build-cli/src/lib/walk.js";
 // into per-kind collections. Nothing here is domain-specific; it is the check any Foundry
 // wants once location decides which schema a note is parsed against.
 //
-// Three distinct failures this catches:
+// Four distinct failures this catches:
 //   1. a kind with no collection — unauthorable, its schema can never run;
-//   2. a note file no collection claims — walked by the validator, published by nothing;
-//   3. a note whose declared `type:` is not the kind its location routes to.
+//   2. a note file no collection claims — committed, validated by nothing, published by nothing;
+//   3. a note whose declared `type:` is not the kind its location routes to;
+//   4. a walk that does not yield what the table claims.
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, "..");
 
-/** Every walked note, as (repo-relative path, declared type). */
+/** Every markdown file under `content/`, repo-relative, whether or not it is a note. */
+const everyMarkdownFile = (() => {
+  const found: string[] = [];
+  const visit = (dir: string): void => {
+    for (const entry of readdirSync(dir).sort()) {
+      if (entry.startsWith(".")) continue;
+      const full = path.join(dir, entry);
+      if (statSync(full).isDirectory()) {
+        visit(full);
+        continue;
+      }
+      if (entry.endsWith(".md")) found.push(path.relative(repoRoot, full).split(path.sep).join("/"));
+    }
+  };
+  visit(path.join(repoRoot, CONTENT_DIR));
+  return found;
+})();
+
+/** Every file the validator's walk yields, repo-relative and in walk order. */
+const corpusFiles = [...findMdFiles(path.join(repoRoot, CONTENT_DIR))].map((file) =>
+  path.relative(repoRoot, file).split(path.sep).join("/"),
+);
+
+/**
+ * Every markdown file under `content/` that declares a `type:`, as (path, declared type).
+ *
+ * Deliberately NOT sourced from the walk. The walk now routes from COLLECTIONS, so anything
+ * derived from it agrees with the table by construction — the orphan check below would pass on
+ * a corpus it was silently blind to. Frontmatter is the one statement of "this is a note" that
+ * the table does not get a vote in, so it is what the table is held against.
+ */
 const corpus = (() => {
   const notes: { rel: string; type: string }[] = [];
-  for (const file of findMdFiles(path.join(repoRoot, "content"))) {
-    const { hasFrontmatter, meta } = readMarkdown(file);
+  for (const rel of everyMarkdownFile) {
+    const { hasFrontmatter, meta } = readMarkdown(path.join(repoRoot, rel));
     if (!hasFrontmatter) continue;
     const type = meta?.type;
     if (typeof type !== "string") continue;
-    notes.push({ rel: path.relative(repoRoot, file).split(path.sep).join("/"), type });
+    notes.push({ rel, type });
   }
   return notes;
 })();
@@ -56,6 +89,35 @@ describe("collection routing (path table vs corpus)", () => {
     expect(unroutable, `\nkinds with no collection: ${unroutable.join(", ")}`).toEqual([]);
   });
 
+  // `CONTENT_DIR` is what lets a consumer holding the content directory under some other name
+  // route a path it finds there. It is only true because every `base` starts with it, and
+  // nothing in the table's own types says so.
+  it("puts every collection under the content dir", () => {
+    const outside = COLLECTION_NAMES.filter(
+      (n) => !COLLECTIONS[n].base.startsWith(`${CONTENT_DIR}/`),
+    );
+    expect(outside, `\ncollections outside ${CONTENT_DIR}/: ${outside.join(", ")}`).toEqual([]);
+  });
+
+  // The validator's walk and the site's globs are ONE rule now, so this is what holds the walk
+  // to it: it enumerates the content tree independently and asserts the walk yields exactly the
+  // files the table claims, no frontmatter filter involved.
+  //
+  // Both directions matter and fail differently. A file the table claims but the walk misses is
+  // published unvalidated; a file the walk yields but the table disclaims is validated as a note
+  // the site will never render — which is precisely the `content/prompts/**` bug this table was
+  // written to end, in the era when the walk decided for itself.
+  it("walks exactly the files the table claims", () => {
+    const walked = corpusFiles;
+    const claimed = everyMarkdownFile.filter((rel) => collectionOf(rel));
+    const missed = claimed.filter((rel) => !walked.includes(rel));
+    const extra = walked.filter((rel) => !claimed.includes(rel));
+    expect(
+      { missed, extra },
+      `\nclaimed but not walked:\n  ${missed.join("\n  ")}\nwalked but not claimed:\n  ${extra.join("\n  ")}`,
+    ).toEqual({ missed: [], extra: [] });
+  });
+
   // Every collection's `kind` must be a kind that exists — the other direction of the same
   // rule, which a typo in the table would otherwise satisfy silently.
   it("routes every collection to a kind that exists", () => {
@@ -64,12 +126,15 @@ describe("collection routing (path table vs corpus)", () => {
     expect(bogus, `\ncollections naming no kind: ${bogus.join(", ")}`).toEqual([]);
   });
 
-  // A note the validator checks but no collection claims is checked and never published.
-  // This is the drift that existed while the Astro glob and `walk.ts` were two separate
-  // rules, and the reason this table exists.
-  it("claims every note the validator walks", () => {
+  // A file that declares a `type:` has announced itself as a note. If no collection claims it,
+  // it is authored, committed, and invisible to everything — neither validated nor published.
+  // `content/prompts/**` sat in exactly that state, and this is the check that would have said
+  // so on the day it was added.
+  it("claims every note in the content tree", () => {
     const orphans = corpus.filter((n) => !collectionOf(n.rel)).map((n) => n.rel);
-    expect(orphans, `\nwalked but in no collection:\n  ${orphans.join("\n  ")}`).toEqual([]);
+    expect(orphans, `\ndeclares a type but is in no collection:\n  ${orphans.join("\n  ")}`).toEqual(
+      [],
+    );
   });
 
   // Location picks the schema; the `type:` literal in that schema asserts the note agrees.


### PR DESCRIPTION
> **Posted by Claude (AI assistant) on jmchilton's behalf** — not authored by them personally.

Step 5, the last of the convergence onto per-kind path routing. #393 added the `COLLECTIONS` table, #394 made the site route from it, #396 moved the per-kind pages onto their own collections. This retires the second rule.

`walk.ts` was still answering "which files are notes?" on its own:

```ts
const SKIP_DIRS = new Set([".obsidian", "casts"]);
const SKIP_FILES = new Set(["Dashboard.md", "Index.md", "log.md", "glossary.md"]);
const DIR_NOTE_TYPES = new Set(["molds", "pipelines"]);
```

Three sets that between them approximated the site's globs closely enough to look deliberate. Nothing held them to it, and they had already drifted — that is the `content/prompts/**` bug #393 documented and #394 fixed on the site side, which lived here for as long as the directory existed.

It now traverses and routes:

```ts
if (entry.startsWith(".")) continue;
if (!collectionOf(routablePath(root, full))) continue;
```

Everything the skip sets named falls out of the table instead of being restated. `Dashboard.md` / `Index.md` / `log.md` sit at the content root and `glossary.md` in `content/meta/` — no collection's base reaches either. Directory-note semantics for molds and pipelines *are* `pattern: ["**/index.md"]`. `casts/` is outside `content/` and was never reachable from a walk rooted there, so that entry had been dead for some time.

Dotfiles are the one skip left in code, and deliberately: `.obsidian/` holds markdown that is editor state, and no glob would tell it apart from a note.

`CONTENT_DIR` is new — the directory every `base` sits under, stated once. It is what lets a caller holding the content directory under some other name (an absolute path, a checkout elsewhere) route a path it finds there against a table written repo-relative. The routing test pins it, since nothing in the table's types says every base starts with it.

## Verified

**Byte-identical walk output, order included.** 226 files, same sequence. Order matters here and is not incidental: the validator's `buildSlugMap` is last-wins, so the walk sequence is what decides `[[summarize-nextflow]]` (#395). Preserving it keeps that resolution exactly where it was.

**The built site is unchanged apart from the page I edited.** Of 735 non-pagefind output files, one differs: `design/architecture/`, which renders `docs/ARCHITECTURE.md`. The pagefind chunks rehash because that page's text changed.

| check | result |
|---|---|
| `validate` | **unchanged** — 226 files, 0 errors, 202 warnings |
| `check:index`, `check:kinds` | pass |
| root + site typecheck | 0 errors |
| tests | 160 root (158 + 2 new) · 47 note-schema · all package suites |
| `packages-format`, `packages-lint` | clean |

## The test had to change, or it would have gone quiet

The orphan check — "a note file no collection claims" — sourced its corpus from `findMdFiles`. Now that the walk routes from the table, anything derived from it agrees with the table *by construction*: dropping `prompts` from `COLLECTIONS` would drop those files from the walk too, and the test would pass on a corpus it had gone blind to. Exactly the bug it exists to catch, undetectable.

It now enumerates `content/` independently and keys on frontmatter: **every markdown file declaring a `type:` must be claimed by a collection.** Frontmatter is the one statement of "this is a note" the table gets no vote in, so it is what the table is held against. 95 of the 321 markdown files under `content/` are unclaimed (mold `eval.md` / `scenarios.md` siblings, the generated root files, the glossary) and none of them declare a type.

Proved by breaking it: deleting the `prompts` row fails the check with the two prompt notes named.

New alongside it, `walks exactly the files the table claims`, both directions. A file claimed but not walked is published unvalidated; a file walked but not claimed is validated as a note nothing renders. Proved non-vacuous in both directions — re-adding a skip the table doesn't have fails on `missed`, dropping the routing check fails on `extra`.

## Unrelated, found while running the checks

`pnpm check:dashboard` fails on `main` and has for a while: `content/Dashboard.md` has a stale row for `gxy-sketches-alignment` (`2026-05-05` rev 1, now `2026-07-24` rev 2). One line, regenerates cleanly. CI only runs `check:kinds`, so nothing caught it. Left alone here — happy to fix separately, and worth deciding whether `check:dashboard` and `check:index` belong in CI.

Related: #393, #394, #396. Open: #395 (ambiguous slug).
