### PR TITLE
CI: check the generated content notes are current

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -39,6 +39,13 @@ jobs:
       - name: Check the kind manifest is current
         run: npm run check:kinds
 
+      # Dashboard.md and Index.md are generated from content frontmatter, so
+      # editing a note without regenerating leaves them silently wrong. Runs
+      # the same target `make check` does rather than listing the checks a
+      # second time. Same placement rule as validate: needs `dist/`.
+      - name: Check generated content notes are current
+        run: make check-generated
+
       - name: Typecheck root and site
         run: npm run typecheck
 

--- a/content/Dashboard.md
+++ b/content/Dashboard.md
@@ -191,6 +191,7 @@ Generated from `dashboard_sections.json` and content frontmatter. Do not edit by
 
 | Name | Summary | Status | Revised | Rev |
 | --- | --- | --- | --- | --- |
+| [[gxy-sketches-alignment]] | Where the Foundry's per-source summary Molds align with gxy-sketches on field names and source/test-fixture vocabulary, and where they intentionally do not. | draft | 2026-07-24 | 2 |
 | [[open-requirements-ledger]] | Carried unresolved-requirements artifact the source→Galaxy pipeline discharges or explicitly surrenders, autonomously. | draft | 2026-06-16 | 1 |
 | [[component-claude-dynamic-workflows]] | Dynamic workflows natively solve the per-step sub-DAG loop Archon couldn't, with schema-typed step handoffs; cost is in-session-only resume and no mid-run gate. | draft | 2026-06-15 | 1 |
 | [[galaxy-workflow-comments]] | How to annotate a gxformat2 workflow with editor comments: one titled frame per analysis stage, populate contains_steps, color decorative. | draft | 2026-06-12 | 1 |
@@ -232,7 +233,6 @@ Generated from `dashboard_sections.json` and content frontmatter. Do not edit by
 | [[galaxy-collection-semantics]] | Vendored formal spec of Galaxy dataset-collection mapping/reduction semantics, with labeled examples and pinned test references. | draft | 2026-05-05 | 3 |
 | [[galaxy-native-workflow-schema]] | Vendored structural JSON Schema for Galaxy native workflow (.ga) format: vocabulary for the JSON shape Galaxy emits and consumes. | draft | 2026-05-05 | 1 |
 | [[galaxy-xsd]] | Vendored Galaxy tool XML schema for wrapper structure, parameters, outputs, tests, and assertion syntax. | draft | 2026-05-05 | 1 |
-| [[gxy-sketches-alignment]] | Where the Foundry's per-source summary Molds align with gxy-sketches on field names and source/test-fixture vocabulary, and where they intentionally do not. | draft | 2026-05-05 | 1 |
 | [[nextflow-snapshot-to-galaxy-assertions]] | Translates nf-test snapshot assertions into Galaxy workflow test-format assertions, broken out by module-level vs pipeline-level test shape. | draft | 2026-05-05 | 2 |
 | [[iwc-runtime-parameter-shims-survey]] | Focused survey of tiny IWC runtime parameter shims for flags, enums, counts, booleans, and composed text. | draft | 2026-05-04 | 1 |
 | [[component-tool-shed-search]] | Tool Shed's Whoosh repo/tool search and partial GA4GH TRS v2, indexed from hg-walked metadata with no auto-refresh on upload | draft | 2026-05-03 | 2 |


### PR DESCRIPTION
> **Posted by Claude (AI assistant) on jmchilton's behalf** — not authored by them personally.

`content/Dashboard.md` has been stale on `main` since `12e017b` ("Tags: drop the iwc/* family"), which bumped `gxy-sketches-alignment` from rev 1 / `2026-05-05` to rev 2 / `2026-07-24` without regenerating. One row, in the wrong section position with the wrong date.

Nothing noticed because nothing was looking. `make check-generated` already exists and covers exactly this — CI just never ran it, only `check:kinds`.

## The fix

Regenerate `Dashboard.md` (one row moves; `Index.md` was already current), and add the step:

```yaml
- name: Check generated content notes are current
  run: make check-generated
```

Running the **make target** rather than restating `check:dashboard` and `check:index` as two CI steps: `make check` already calls it, so there is one list of what counts as generated content, and a third generated note is one edit rather than two. Placed after the package build for the same reason `validate` is — the `tsx` entrypoint pulls in `@galaxy-foundry/foundry/meta`, whose subpath only resolves once `dist/` exists.

## Verified

Red-to-green, on the real staleness rather than a synthetic one: with the regenerated file stashed, `make check-generated` fails; with it, passes.

`validate` unchanged (226 files, 0 errors, 202 warnings); 158 root tests pass.

## Two neighbours, checked while here

- `make check-assemble-pipelines` — **passes**, also not in CI. Same class of drift check; worth adding if you want it, though it is slower.
- `pnpm check:vendored` — fails locally, but only because it shells into `~/projects/repositories/dannon-galaxy`, which doesn't exist on my machine. It needs local clones of the upstreams, so it can't run in CI as written. Not repo drift, and out of scope here.
