### PR TITLE
Adopt @galaxy-foundry/kind-schema for the kind machinery

### DIFF
--- a/packages/note-schema/package.json
+++ b/packages/note-schema/package.json
@@ -38,6 +38,7 @@
   "license": "MIT",
   "dependencies": {
     "@galaxy-foundry/kind-manifest": "^0.2.1",
+    "@galaxy-foundry/kind-schema": "^0.2.0",
     "@galaxy-foundry/license-policy": "^0.1.0",
     "@galaxy-foundry/reference-contract": "^0.1.0",
     "@galaxy-foundry/tag-registry": "^0.1.0",

--- a/packages/note-schema/src/collections.ts
+++ b/packages/note-schema/src/collections.ts
@@ -14,15 +14,26 @@
 // directory holding two kinds. The reverse (two collections, one kind) is equally allowed —
 // it is how a browse route can exist without inventing a kind for it.
 
-/** One collection: a directory, the note files in it, and the kind they all declare. */
-export interface CollectionDefinition {
-  /** Repo-relative directory holding this collection's notes. */
-  base: string;
-  /** Globs relative to `base` selecting note files. Later `!`-prefixed entries exclude. */
-  pattern: readonly string[];
-  /** The `type:` every note in this collection declares. Must be a kind in KINDS. */
-  kind: string;
-}
+// The MATCHING is not ours — it ships in @galaxy-foundry/kind-schema, because the alternative
+// is each instance writing a glob matcher and each getting `**/` subtly wrong in its own way.
+// The TABLE is ours: it names this Foundry's directories. The wrappers below bind the two, so
+// no caller has to remember to pass the table.
+import {
+  collectionOf as routeCollection,
+  kindOf as routeKind,
+  matchesCollection,
+  type CollectionRoute,
+} from "@galaxy-foundry/kind-schema/collections";
+
+export { matchesCollection };
+
+/**
+ * One collection: a directory, the note files in it, and the kind they all declare.
+ *
+ * `base` is repo-relative here — the shared type leaves the frame to the caller, and this is
+ * the frame both consumers can check a real path against without knowing where they ran from.
+ */
+export type CollectionDefinition = CollectionRoute;
 
 /**
  * The one directory every collection lives under, stated once.
@@ -64,29 +75,6 @@ export type CollectionName = keyof typeof COLLECTIONS;
 /** Collection names, for a consumer that needs to iterate every collection. */
 export const COLLECTION_NAMES = Object.keys(COLLECTIONS) as readonly CollectionName[];
 
-// The three glob constructs the table above uses, and nothing more. Astro's loader matches
-// these patterns with picomatch; this matches them for the validator, which has no globber.
-// Two implementations of the same patterns is exactly the drift this module exists to end, so
-// the routing test pins this one against the real corpus — if it and picomatch ever disagreed
-// about a file, the published collection sizes would stop matching the walked file count.
-function globToRegExp(pattern: string): RegExp {
-  let out = "";
-  for (let i = 0; i < pattern.length; i += 1) {
-    const rest = pattern.slice(i);
-    if (rest.startsWith("**/")) {
-      out += "(?:[^/]+/)*"; // zero or more leading path segments
-      i += 2;
-    } else if (pattern[i] === "*") {
-      out += "[^/]*"; // one segment, no separators
-    } else if (".+^${}()|[]\\?".includes(pattern[i]!)) {
-      out += `\\${pattern[i]}`;
-    } else {
-      out += pattern[i];
-    }
-  }
-  return new RegExp(`^${out}$`);
-}
-
 /**
  * The collection a repo-relative path belongs to, or `undefined` if it is not a note.
  *
@@ -94,31 +82,10 @@ function globToRegExp(pattern: string): RegExp {
  * routing test asserts it cannot happen, so the first match is the only match.
  */
 export function collectionOf(repoRelPath: string): CollectionName | undefined {
-  const normalized = repoRelPath.split("\\").join("/");
-  for (const name of COLLECTION_NAMES) {
-    if (matchesCollection(normalized, COLLECTIONS[name])) return name;
-  }
-  return undefined;
-}
-
-/** Whether a repo-relative path is one of this collection's note files. */
-export function matchesCollection(repoRelPath: string, collection: CollectionDefinition): boolean {
-  const prefix = `${collection.base}/`;
-  if (!repoRelPath.startsWith(prefix)) return false;
-  const withinBase = repoRelPath.slice(prefix.length);
-  let matched = false;
-  for (const pattern of collection.pattern) {
-    const negated = pattern.startsWith("!");
-    const re = globToRegExp(negated ? pattern.slice(1) : pattern);
-    if (!re.test(withinBase)) continue;
-    if (negated) return false;
-    matched = true;
-  }
-  return matched;
+  return routeCollection(COLLECTIONS, repoRelPath);
 }
 
 /** The kind a repo-relative path routes to, or `undefined` if it is not a note. */
 export function kindOf(repoRelPath: string): string | undefined {
-  const name = collectionOf(repoRelPath);
-  return name && COLLECTIONS[name].kind;
+  return routeKind(COLLECTIONS, repoRelPath);
 }

--- a/packages/note-schema/src/index.ts
+++ b/packages/note-schema/src/index.ts
@@ -27,6 +27,7 @@ export {
   KINDS_BY_NAME,
   buildKindContext,
   defineKind,
+  type AnyKindDefinition,
   type KindContext,
   type KindDefinition,
   type KindShape,

--- a/packages/note-schema/src/kind-manifest.ts
+++ b/packages/note-schema/src/kind-manifest.ts
@@ -4,8 +4,10 @@
 // The FORMAT, the zod-shape deriver, and the reader all live in
 // @galaxy-foundry/kind-manifest, because they are shared across instances (spec:
 // galaxyproject/foundry-pattern, `content/pattern/standing-up-a-foundry.instructions.txt`).
-// What stays here is the part that is genuinely ours: which kinds exist, and how this
-// instance's registries resolve into the context they are built against.
+// The bridge between the two — turning kind definitions into the deriver's input — is
+// `manifestKinds` in @galaxy-foundry/kind-schema, because both instances had written it
+// identically. What stays here is the part that is genuinely ours: which kinds exist, and how
+// this instance's registries resolve into the context they are built against.
 //
 // `fields` is still DERIVED from the zod shape, never hand-written — that has just moved
 // one repo over, along with the synthetic-shape tests that prove the deriver right.
@@ -15,6 +17,7 @@ import {
   type KindManifest,
   type ManifestSource,
 } from "@galaxy-foundry/kind-manifest";
+import { manifestKinds } from "@galaxy-foundry/kind-schema";
 
 import { buildKindContext } from "./types/context.js";
 import type { BuildKindContextOptions } from "./types/context.js";
@@ -57,20 +60,9 @@ export function buildKindManifest({
   docs = {},
   ...registries
 }: BuildKindManifestOptions): KindManifest {
-  const ctx = buildKindContext(registries);
   return deriveKindManifest({
     instance,
     source: MANIFEST_SOURCE,
-    kinds: KINDS.map((definition) => {
-      const doc = docs[definition.kind];
-      return {
-        kind: definition.kind,
-        title: definition.title,
-        layer: definition.layer,
-        summary: definition.summary,
-        shape: definition.build(ctx).shape,
-        ...(doc === undefined ? {} : { doc }),
-      };
-    }),
+    kinds: manifestKinds(KINDS, buildKindContext(registries), docs),
   });
 }

--- a/packages/note-schema/src/note-schema.ts
+++ b/packages/note-schema/src/note-schema.ts
@@ -2,80 +2,31 @@
 // the validator (`@galaxy-foundry/build-cli`) and the Astro site from the same three
 // registries, so there is no second encoding to drift against.
 //
-// This module is the ASSEMBLER, and only the assembler. Each note kind is defined — and
-// documented, and exemplified — in its own directory under src/types/; see src/types/index.ts
-// for the enumeration and src/types/context.ts for the shared envelope every kind spreads.
+// This module is the ASSEMBLER, and only the assembler — and the assembly itself is no longer
+// ours. `assemble` and `buildKindUnion` ship in @galaxy-foundry/kind-schema, parameterized by
+// the kind context. What stays here is which kinds this Foundry has and how its registries
+// resolve into that context. Each note kind is defined — and documented, and exemplified — in
+// its own directory under src/types/; see src/types/index.ts for the enumeration and
+// src/types/context.ts for the shared envelope every kind spreads.
 //
 // `buildNoteSchema` is a factory rather than a constant because the controlled enums (tags,
 // reference-contract vocab, license ids) live in YAML registries loaded at call time and
 // injected here — which is also what lets a test build the schema against a synthetic registry.
 
-import { z } from "zod";
+import { assemble, buildKindUnion } from "@galaxy-foundry/kind-schema";
 
-import {
-  buildKindContext,
-  type BuildKindContextOptions,
-  type KindContext,
-  type KindDefinition,
-  type KindShape,
-} from "./types/context.js";
-import { DEFINITIONS, KINDS, KINDS_BY_NAME, type BuiltKinds } from "./types/index.js";
+import { buildKindContext, type BuildKindContextOptions } from "./types/context.js";
+import { DEFINITIONS, KINDS } from "./types/index.js";
+
+export type { Assembled } from "@galaxy-foundry/kind-schema";
 
 export type BuildNoteSchemaOptions = BuildKindContextOptions;
 
 export function buildNoteSchema(options: BuildNoteSchemaOptions) {
-  const ctx = buildKindContext(options);
-
-  // zod's discriminatedUnion accepts ZodObject members only, so each kind contributes a plain
-  // strict object here and its cross-field rules run in the dispatch below. The rules still
-  // LIVE in the kind's directory — this only decides when they fire.
-  //
-  // The assertion is the one place a cast is unavoidable: `.map` over a tuple returns an
-  // array, losing the per-element types the site's frontmatter inference depends on. The
-  // mapped type restores exactly what `.map` erased — same order, same length, same elements.
-  type Member = BuiltKinds[number];
-  const members = KINDS.map((k) => k.build(ctx)) as unknown as readonly [Member, ...Member[]];
-
-  return z.discriminatedUnion("type", members).superRefine((d, issues) => {
-    const definition = KINDS_BY_NAME.get((d as { type: string }).type);
-    definition?.refine?.(d as never, issues, ctx);
-  });
+  return buildKindUnion(KINDS, buildKindContext(options));
 }
 
 export type NoteSchema = ReturnType<typeof buildNoteSchema>;
-
-/**
- * One kind's assembled schema: parses that kind's frontmatter, yields that kind's own output.
- *
- * Stated as ONE type rather than left to inference, because inference over the optional
- * `refine` slot yields a UNION of "refined" and "not" — and a union is what turns an ordinary
- * field access on an Astro page into an error, since it would have to hold on both arms.
- */
-export type Assembled<T extends KindShape> = z.ZodType<
-  z.infer<z.ZodObject<T, "strict">>,
-  z.ZodTypeDef,
-  z.input<z.ZodObject<T, "strict">>
->;
-
-/**
- * Assemble one kind into the schema its collection validates with.
- *
- * `build` returns the bare strict object so the manifest generator can walk its `.shape`;
- * `refine` is applied here, to that kind's schema alone, so a cross-field rule sees only its
- * own kind's fields.
- */
-function assemble<T extends KindShape>(
-  definition: KindDefinition<T>,
-  ctx: KindContext,
-): Assembled<T> {
-  const object = definition.build(ctx);
-  const { refine } = definition;
-  // No cast on `d`. Assembling one kind at a time is what makes `superRefine`'s argument
-  // already exactly the payload `refine` declares — which is the whole point of applying the
-  // rule to its own kind's schema rather than after a union resolves.
-  const refined = refine ? object.superRefine((d, issues) => refine(d, issues, ctx)) : object;
-  return refined as Assembled<T>;
-}
 
 /**
  * Every kind's schema, by kind name — what a per-collection Astro loader validates with.

--- a/packages/note-schema/src/types/context.ts
+++ b/packages/note-schema/src/types/context.ts
@@ -8,6 +8,12 @@
 // Kinds receive this rather than importing the registries themselves, so a kind can be tested
 // against a synthetic registry — which is the one thing a kind test always needs.
 
+import {
+  kindDefiner,
+  type AnyKindDefinition as LibAnyKindDefinition,
+  type KindDefinition as LibKindDefinition,
+  type KindShape,
+} from "@galaxy-foundry/kind-schema";
 import { type LicensePolicy, isValidLicenseId } from "@galaxy-foundry/license-policy";
 import { type TagRegistry } from "@galaxy-foundry/tag-registry";
 import { WIKI_LINK_RE } from "@galaxy-foundry/wiki-links";
@@ -174,8 +180,15 @@ export function buildKindContext(options: BuildKindContextOptions): KindContext 
   };
 }
 
-/** Any shape that can be a member of the `type`-discriminated union. */
-export type KindShape = { type: z.ZodTypeAny } & z.ZodRawShape;
+// ---- the kind contract, bound to this instance's context ----
+//
+// `KindDefinition` and `defineKind` are not ours. They ship in @galaxy-foundry/kind-schema,
+// generic over the context a kind draws from, because every Foundry-pattern instance needs the
+// same contract over a different context. What is OURS is `KindContext` above — the field
+// primitives a kind may spread. Binding the parameter once, here, is what keeps the nine kind
+// directories writing `defineKind({...})` with no type parameter in sight.
+
+export type { KindShape };
 
 /**
  * What a `types/<kind>/schema.ts` exports.
@@ -185,40 +198,20 @@ export type KindShape = { type: z.ZodTypeAny } & z.ZodRawShape;
  * in ZodEffects), and the manifest generator walks `.shape` to derive the required-metadata
  * table. Per-kind cross-field rules go in `refine`, which the assembler dispatches by `type`
  * after the union resolves — so the rule still LIVES in the kind's directory.
+ *
+ * `refine`'s `data` is this kind's INFERRED frontmatter, not `Record<string, unknown>`, and
+ * that matters more than it reads: every rule is conditional, so a rule that never fires looks
+ * exactly like a rule with nothing to complain about. Untyped, `d.axis === "source-specifc"`
+ * compiled clean and the mold rule was silently dead. tests/kind-refine.test-d.ts pins it.
  */
-export interface KindDefinition<T extends KindShape = KindShape> {
-  /** The `type:` discriminator value. MUST equal the directory name. */
-  kind: string;
-  /** Display name for the kind catalog. */
-  title: string;
-  /** `substrate` = a kind the Foundry pattern's other instances also declare;
-   *  `instance` = one this domain added. The cross-instance catalog groups by this.
-   *
-   *  Named `layer`, not `origin`, because `origin` is already a frontmatter field on the
-   *  `cli-tool` kind (`npm | pypi`) — one manifest carrying both meanings under one word is a
-   *  trap for anything reading across instances. */
-  layer: "substrate" | "instance";
-  /** One line: what a note of this kind IS. Rendered in the catalog. */
-  summary: string;
-  /** A strict object carrying a `type:` literal — a union member, and the `.shape` the
-   *  manifest generator walks to derive this kind's required-metadata table. */
-  build: (ctx: KindContext) => z.ZodObject<T, "strict">;
-  /**
-   * Cross-field rules over this kind's own fields — the constraints a shape cannot state,
-   * because whether one field is valid depends on another's value (a `source-specific` mold
-   * must name a `source`; a schema note vendoring an external upstream must name a license).
-   *
-   * `data` is this kind's INFERRED frontmatter, not `Record<string, unknown>`. That matters
-   * more than it reads: every rule here is conditional, so a rule that never fires looks
-   * exactly like a rule with nothing to complain about. Untyped, `d.axis === "source-specifc"`
-   * compiled clean and the mold rule was silently dead.
-   */
-  refine?: (
-    data: z.infer<z.ZodObject<T, "strict">>,
-    ctx: z.RefinementCtx,
-    kctx: KindContext,
-  ) => void;
-}
+export type KindDefinition<T extends KindShape = KindShape> = LibKindDefinition<KindContext, T>;
+
+/**
+ * A kind definition with its shape erased — for code that ITERATES the kinds rather than
+ * validating with one. `ZodObject` is invariant in its shape parameter, so the widened
+ * `KindDefinition` above cannot hold a concrete kind at all; this is the iteration type.
+ */
+export type AnyKindDefinition = LibAnyKindDefinition<KindContext>;
 
 /**
  * Identity helper a kind directory wraps its definition in.
@@ -228,6 +221,4 @@ export interface KindDefinition<T extends KindShape = KindShape> {
  * to the Astro site, where `entry.data.tags` degrades to `any`. Inferring keeps each kind's
  * frontmatter type precise for every consumer of the assembled union.
  */
-export function defineKind<T extends KindShape>(definition: KindDefinition<T>): KindDefinition<T> {
-  return definition;
-}
+export const defineKind = kindDefiner<KindContext>();

--- a/packages/note-schema/src/types/index.ts
+++ b/packages/note-schema/src/types/index.ts
@@ -17,7 +17,7 @@ import { kind as research } from "./research/schema.js";
 import { kind as schemaNote } from "./schema/schema.js";
 import { kind as sourcePattern } from "./source-pattern/schema.js";
 
-import { type KindDefinition } from "./context.js";
+import { type AnyKindDefinition } from "./context.js";
 
 // NOT annotated `: readonly KindDefinition[]`. That annotation would widen every element to
 // the default shape and the erasure would propagate to the Astro site, where `entry.data.tags`
@@ -57,19 +57,21 @@ export const DEFINITIONS = {
   prompt,
 } as const;
 
-type BuiltKind<K> = K extends { build: (...args: never[]) => infer R } ? R : never;
-
-/** Each kind's union member, in barrel order, with its shape preserved. */
-export type BuiltKinds = { -readonly [I in keyof typeof KINDS]: BuiltKind<(typeof KINDS)[I]> };
-
-/** Kind definitions by their `type:` discriminator value. */
-export const KINDS_BY_NAME: ReadonlyMap<string, KindDefinition> = new Map(
-  KINDS.map((k) => [k.kind, k as KindDefinition]),
+/**
+ * Kind definitions by their `type:` discriminator value.
+ *
+ * Erased to `AnyKindDefinition`, and it has to be: a Map has one value type for every entry, so
+ * the shapes collapse regardless. Callers who need a kind with its shape intact go through
+ * `DEFINITIONS` above.
+ */
+export const KINDS_BY_NAME: ReadonlyMap<string, AnyKindDefinition> = new Map(
+  KINDS.map((k) => [k.kind, k]),
 );
 
 export {
   buildKindContext,
   defineKind,
+  type AnyKindDefinition,
   type KindContext,
   type KindDefinition,
   type KindShape,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,9 @@ importers:
       '@galaxy-foundry/kind-manifest':
         specifier: ^0.2.1
         version: 0.2.1(zod@3.25.76)
+      '@galaxy-foundry/kind-schema':
+        specifier: ^0.2.0
+        version: 0.2.0(zod@3.25.76)
       '@galaxy-foundry/license-policy':
         specifier: ^0.1.0
         version: 0.1.0
@@ -987,6 +990,12 @@ packages:
 
   '@galaxy-foundry/kind-manifest@0.2.1':
     resolution: {integrity: sha512-a/H/xFryorwsgu0S2kiWlp4rNQvFfaRo2R/BcKPJI+u4u7gzzQuahQk34OS9+BIOG0d0q8ce0i/ElRBvtlA1Gg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      zod: ^3.25.0
+
+  '@galaxy-foundry/kind-schema@0.2.0':
+    resolution: {integrity: sha512-UjLOkR32b7b/fa6pxe6xa12yThDXESlbhSyrZqRA/ZV5bN558CZ6B/QVsUw+ohexWlYQLybw0rjxe61qcOU7Iw==}
     engines: {node: '>=20'}
     peerDependencies:
       zod: ^3.25.0
@@ -4247,6 +4256,11 @@ snapshots:
 
   '@galaxy-foundry/kind-manifest@0.2.1(zod@3.25.76)':
     dependencies:
+      zod: 3.25.76
+
+  '@galaxy-foundry/kind-schema@0.2.0(zod@3.25.76)':
+    dependencies:
+      '@galaxy-foundry/kind-manifest': 0.2.1(zod@3.25.76)
       zod: 3.25.76
 
   '@galaxy-foundry/license-policy@0.1.0':


### PR DESCRIPTION
> Posted by Claude (AI assistant) on behalf of @jmchilton — not authored by them personally.

Consumes [`@galaxy-foundry/kind-schema@0.2.0`](https://www.npmjs.com/package/@galaxy-foundry/kind-schema)
for the kind machinery. **92 insertions, 177 deletions.**

The `KindDefinition` contract, per-kind and union assembly, and the glob matcher behind
`collectionOf` were all written here and written again, line for line, in
`jmchilton/statistical-genomics-foundry` — down to the reasons in the comments. That is what
made them extractable rather than speculative.

| Module | What left |
|---|---|
| `types/context.ts` | `KindShape`, `KindDefinition`, `defineKind` → aliases bound to `KindContext` |
| `note-schema.ts` | local `assemble`/`Assembled` and the `BuiltKinds` union cast → `assemble`/`buildKindUnion` |
| `collections.ts` | `globToRegExp` + `matchesCollection` → `kind-schema/collections`, table bound in two wrappers |
| `kind-manifest.ts` | the kinds→manifest mapping → `manifestKinds` |

What stays is what names content: the nine kinds, the field primitives in `KindContext`, and
the `COLLECTIONS` table.

## Verification

`kinds.generated.json` is **byte-identical** — `check:kinds` passes without regenerating.
160/160 tests, `astro check` 0 errors on 67 files, plus `validate`, `check-generated`,
`check-assemble-pipelines`, `packages-lint` and `packages-format`.

The `astro check` number is a weaker guard than it looks, so it was probed rather than
assumed. Widening `defineKind` to `AnyKindDefinition` produces 8 errors; widening it to the
default shape fails the `note-schema` build outright. Both stay caught.

## Why this pins ^0.2.0 and not ^0.1.0

`astro check` exercises `buildKindSchemas`, never the union — so it could not see that
`NoteSchema`, which this package re-exports, had lost its types on 0.1.0. `z.infer` of it
collapsed to `unknown` with an index signature, and consumers of *our* package would have
inherited that without ever calling kind-schema.

Caught in review, fixed upstream in jmchilton/foundry-lib#20, verified here against the
published 0.2.0 with a `@ts-expect-error` probe: `z.infer<NoteSchema>` rejects a field no kind
declares, as it did before this change. No source change was needed for that — `KINDS` is
already `as const`.

## Follow-ups, deliberately not in this PR

- `tests/collection-routing.test.ts` hand-rolls what the package ships as `collectionsClaiming`;
  adopting it would also retire the `matchesCollection` pass-through re-export.
- The comment at `types/index.ts:22-24` defends tuple precision nothing consumes anymore, and
  names a hazard that is now a compile error rather than a silent widening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011RQWqFtk35YKKqBaLKsiVA
