### PR TITLE
Collapse the seven copies of the write-or-check decision

### DIFF
--- a/packages/build-cli/src/commands/assemble-pipeline.ts
+++ b/packages/build-cli/src/commands/assemble-pipeline.ts
@@ -9,13 +9,13 @@
 // Usage:
 //   foundry-build assemble-pipeline <slug> [harness-name] [--check] [--root <dir>]
 
-import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import path from "node:path";
 import process from "node:process";
 
 import { readMarkdown } from "../lib/frontmatter.js";
 import { parsePhases, phaseMoldPaths, type ParsedPhase } from "../lib/pipeline-phases.js";
+import { reconcileText } from "../lib/reconcile.js";
 import {
   aggregateRequiredTools,
   moldCliRefs,
@@ -106,14 +106,6 @@ function firstSentence(s: string): string {
   const idx = s.indexOf(". ");
   const head = idx >= 0 ? s.slice(0, idx) : s.replace(/\.\s*$/, "");
   return head.trim();
-}
-
-function sha256OfBuffer(buf: Buffer | string): string {
-  return createHash("sha256").update(buf).digest("hex");
-}
-
-function sha256(filePath: string): string {
-  return createHash("sha256").update(readFileSync(filePath)).digest("hex");
 }
 
 // ---- assembly model ----
@@ -429,26 +421,6 @@ function renderAssembly(
   return lines.join("\n");
 }
 
-// ---- reconcile ----
-
-function reconcile(
-  filePath: string,
-  expected: string,
-  check: boolean,
-  label: string,
-): { drift?: string } {
-  const exists = existsSync(filePath);
-  const currentHash = exists ? sha256(filePath) : null;
-  if (currentHash === sha256OfBuffer(expected)) return {};
-  if (!check) {
-    mkdirSync(path.dirname(filePath), { recursive: true });
-    writeFileSync(filePath, expected);
-  }
-  return {
-    drift: exists ? `${label} content differs from deterministic render` : `${label} missing`,
-  };
-}
-
 // ---- main ----
 
 export async function runAssemblePipelineCommand(argv = process.argv.slice(2)): Promise<void> {
@@ -513,20 +485,18 @@ export async function runAssemblePipelineCommand(argv = process.argv.slice(2)): 
 
   const bundleRoot = path.join(repoRoot, "casts", "claude", "skills", harnessName);
   const drift: Array<{ file: string; reason: string }> = [];
-  const skillResult = reconcile(
-    path.join(bundleRoot, "SKILL.md"),
-    result.skill,
-    args.check,
-    "SKILL.md",
-  );
-  if (skillResult.drift) drift.push({ file: "SKILL.md", reason: skillResult.drift });
-  const assemblyResult = reconcile(
-    path.join(bundleRoot, "_assembly.json"),
-    assemblyText,
-    args.check,
-    "_assembly.json",
-  );
-  if (assemblyResult.drift) drift.push({ file: "_assembly.json", reason: assemblyResult.drift });
+  for (const [label, expected] of [
+    ["SKILL.md", result.skill],
+    ["_assembly.json", assemblyText],
+  ] as const) {
+    const outcome = reconcileText({
+      path: path.join(bundleRoot, label),
+      expected,
+      label,
+      check: args.check,
+    });
+    if (outcome.reason) drift.push({ file: label, reason: outcome.reason });
+  }
 
   for (const d of drift) console.error(`drift: ${d.file} — ${d.reason}`);
 

--- a/packages/build-cli/src/commands/cast-mold.ts
+++ b/packages/build-cli/src/commands/cast-mold.ts
@@ -9,7 +9,6 @@
 //   foundry-build cast <mold-name> [--target=claude] [--check] [--note="..."]
 
 import { execSync } from "node:child_process";
-import { createHash } from "node:crypto";
 import {
   copyFileSync,
   existsSync,
@@ -34,6 +33,14 @@ import {
 } from "@galaxy-foundry/license-policy";
 
 import { readMarkdown } from "../lib/frontmatter.js";
+import {
+  driftOf,
+  reconcile,
+  reconcileText,
+  sha256File,
+  sha256Text,
+  type Drift,
+} from "../lib/reconcile.js";
 import {
   aggregateRequiredTools,
   requiredToolRows,
@@ -382,14 +389,6 @@ function expandCompanions(
 }
 
 // ---- file ops ----
-
-function sha256(filePath: string): string {
-  return createHash("sha256").update(readFileSync(filePath)).digest("hex");
-}
-
-function sha256OfBuffer(buf: Buffer | string): string {
-  return createHash("sha256").update(buf).digest("hex");
-}
 
 function gitHead(repoRoot: string): string | null {
   try {
@@ -827,6 +826,17 @@ function readExistingProvenance(provenancePath: string): LegacyProvenanceCarryOv
 
 // ---- cast assembly ----
 
+/**
+ * What provenance records for a ref's destination.
+ *
+ * A `--check` run writes nothing, so a drifted ref keeps the hash that was actually on disk —
+ * the record reports what the check FOUND, not what it wanted. Every other path has just put
+ * the expected bytes there, or found them already there, so the expected hash is the truth.
+ */
+function recordedHash(drift: Drift, check: boolean): string | null {
+  return drift.reason && check ? drift.currentHash : drift.expectedHash;
+}
+
 async function castOneRef(
   resolved: ResolvedRef,
   repoRoot: string,
@@ -869,25 +879,20 @@ async function castOneRef(
         error: `failed to import ${resolved.package_source.spec}: ${(e as Error).message}`,
       };
     }
-    const expectedHash = sha256OfBuffer(json);
-    const dstExists = existsSync(dstAbs);
-    const dstHash = dstExists ? sha256(dstAbs) : null;
-    let drift: string | undefined;
-    if (dstHash !== expectedHash) {
-      drift = dstExists ? "package schema content drifted" : "package schema missing";
-      if (!check) {
-        mkdirSync(path.dirname(dstAbs), { recursive: true });
-        writeFileSync(dstAbs, json);
-      }
-    }
+    const drift = reconcileText({
+      path: dstAbs,
+      expected: json,
+      label: "package schema",
+      check,
+    });
     return {
       entry: {
         ...skeleton(resolved),
-        src_hash: expectedHash,
-        dst_hash: drift && check ? dstHash : expectedHash,
+        src_hash: drift.expectedHash,
+        dst_hash: recordedHash(drift, check),
         source: "deterministic",
       },
-      drift,
+      drift: drift.reason,
     };
   }
 
@@ -898,24 +903,26 @@ async function castOneRef(
       error: `ref source missing: ${resolved.src}`,
     };
   }
-  const srcHash = sha256(srcAbs);
+  const srcHash = sha256File(srcAbs);
 
   if (resolved.mode === "verbatim") {
-    const dstExists = existsSync(dstAbs);
-    const dstHash = dstExists ? sha256(dstAbs) : null;
-    let drift: string | undefined;
-    if (dstHash !== srcHash) {
-      drift = dstExists ? "dst hash differs from src" : "dst missing";
-      if (!check) copyVerbatim(srcAbs, dstAbs);
-    }
+    // The one ref that is a COPY rather than a render: compared against the source's own hash,
+    // and written with `copyFileSync`, so the expected bytes are never a string in hand.
+    const drift = reconcile({
+      path: dstAbs,
+      expectedHash: srcHash,
+      label: "dst",
+      check,
+      write: () => copyVerbatim(srcAbs, dstAbs),
+    });
     return {
       entry: {
         ...skeleton(resolved),
         src_hash: srcHash,
-        dst_hash: drift && check ? dstHash : srcHash,
+        dst_hash: recordedHash(drift, check),
         source: "deterministic",
       },
-      drift,
+      drift: drift.reason,
     };
   }
 
@@ -923,25 +930,15 @@ async function castOneRef(
     const parsed = readMarkdown(srcAbs);
     const sidecar = await buildCliSidecar(srcAbs, resolved.src, parsed.meta);
     const text = JSON.stringify(sidecar, null, 2) + "\n";
-    const expectedHash = sha256OfBuffer(text);
-    const dstExists = existsSync(dstAbs);
-    const dstHash = dstExists ? sha256(dstAbs) : null;
-    let drift: string | undefined;
-    if (dstHash !== expectedHash) {
-      drift = dstExists ? "sidecar content differs" : "sidecar missing";
-      if (!check) {
-        mkdirSync(path.dirname(dstAbs), { recursive: true });
-        writeFileSync(dstAbs, text);
-      }
-    }
+    const drift = reconcileText({ path: dstAbs, expected: text, label: "sidecar", check });
     return {
       entry: {
         ...skeleton(resolved),
         src_hash: srcHash,
-        dst_hash: drift && check ? dstHash : expectedHash,
+        dst_hash: recordedHash(drift, check),
         source: "deterministic",
       },
-      drift,
+      drift: drift.reason,
     };
   }
 
@@ -956,7 +953,7 @@ async function castOneRef(
     ) {
       // Source hasn't drifted; carry forward prior LLM output entry.
       const dstExists = existsSync(dstAbs);
-      const dstHash = dstExists ? sha256(dstAbs) : null;
+      const dstHash = dstExists ? sha256File(dstAbs) : null;
       const drift =
         dstHash === priorEntry.dst_hash
           ? undefined
@@ -1040,7 +1037,7 @@ function applyLicensePolicy(entries: ProvenanceRefEntry[], repoRoot: string): st
     if (e.license_file) {
       const abs = path.join(repoRoot, e.license_file);
       if (existsSync(abs)) {
-        e.license_file_hash = sha256(abs);
+        e.license_file_hash = sha256File(abs);
       } else {
         errors.push(`${e.src}: license_file missing: ${e.license_file}`);
       }
@@ -1243,22 +1240,6 @@ function renderSkillMarkdown(args: {
   return lines.join("\n");
 }
 
-function reconcileSkillMarkdown(
-  bundleRoot: string,
-  expected: string,
-  check: boolean,
-): { drift?: string } {
-  const skillPath = path.join(bundleRoot, "SKILL.md");
-  const expectedHash = sha256OfBuffer(expected);
-  const exists = existsSync(skillPath);
-  const currentHash = exists ? sha256(skillPath) : null;
-  if (currentHash === expectedHash) return {};
-  if (!check) writeFileSync(skillPath, expected);
-  return {
-    drift: exists ? "SKILL.md content differs from deterministic render" : "SKILL.md missing",
-  };
-}
-
 // ---- main ----
 
 export async function runCastMoldCommand(argv = process.argv.slice(2)): Promise<void> {
@@ -1279,7 +1260,7 @@ export async function runCastMoldCommand(argv = process.argv.slice(2)): Promise<
     console.error(`${moldRel}: type is not 'mold' (got ${String(moldParsed.meta.type)})`);
     process.exit(2);
   }
-  const moldHash = sha256(moldAbs);
+  const moldHash = sha256File(moldAbs);
 
   // Claude target lives under a `skills/` subdir so casts/claude/ doubles as a
   // Claude Code plugin root (.claude-plugin/plugin.json + skills/<name>/SKILL.md).
@@ -1317,13 +1298,13 @@ export async function runCastMoldCommand(argv = process.argv.slice(2)): Promise<
   );
 
   const refEntries: ProvenanceRefEntry[] = [];
-  const drift: Array<{ src: string; reason: string }> = [];
+  const drift: Array<{ file: string; reason: string }> = [];
 
   for (const r of resolved) {
     const result = await castOneRef(r, repoRoot, bundleRoot, carry.prior_refs, args.check);
     refEntries.push(result.entry);
     if (result.error) errors.push(result.error);
-    if (result.drift) drift.push({ src: r.src, reason: result.drift });
+    if (result.drift) drift.push({ file: r.src, reason: result.drift });
   }
 
   // License → redistribution-policy enforcement + license_file hashing.
@@ -1341,30 +1322,36 @@ export async function runCastMoldCommand(argv = process.argv.slice(2)): Promise<
     metaByPath,
     requiredTools,
   });
-  const skillResult = reconcileSkillMarkdown(bundleRoot, skillText, args.check);
-  if (skillResult.drift) drift.push({ src: "SKILL.md", reason: skillResult.drift });
+  const skillDrift = reconcileText({
+    path: path.join(bundleRoot, "SKILL.md"),
+    expected: skillText,
+    label: "SKILL.md",
+    check: args.check,
+  });
+  if (skillDrift.reason) drift.push({ file: "SKILL.md", reason: skillDrift.reason });
 
   // Emit/reconcile _required_tools.json manifest at bundle root.
   const requiredToolsPath = path.join(bundleRoot, "_required_tools.json");
   if (requiredTools.length === 0) {
+    // Reconciling to ABSENT — the one desired state `reconcile` cannot express, since there is
+    // no expected content to hash. A mold that stops requiring tools must not leave the old
+    // manifest behind claiming it still does.
     if (existsSync(requiredToolsPath)) {
       if (args.check) {
-        drift.push({ src: "_required_tools.json", reason: "stale manifest (no tools required)" });
+        drift.push({ file: "_required_tools.json", reason: "stale manifest (no tools required)" });
       } else {
         unlinkSync(requiredToolsPath);
       }
     }
   } else {
-    const manifestText = JSON.stringify(requiredTools, null, 2) + "\n";
-    const expectedHash = sha256OfBuffer(manifestText);
-    const exists = existsSync(requiredToolsPath);
-    const currentHash = exists ? sha256(requiredToolsPath) : null;
-    if (currentHash !== expectedHash) {
-      drift.push({
-        src: "_required_tools.json",
-        reason: exists ? "manifest content drifted" : "manifest missing",
-      });
-      if (!args.check) writeFileSync(requiredToolsPath, manifestText);
+    const manifestDrift = reconcileText({
+      path: requiredToolsPath,
+      expected: JSON.stringify(requiredTools, null, 2) + "\n",
+      label: "_required_tools.json",
+      check: args.check,
+    });
+    if (manifestDrift.reason) {
+      drift.push({ file: "_required_tools.json", reason: manifestDrift.reason });
     }
   }
 
@@ -1372,14 +1359,11 @@ export async function runCastMoldCommand(argv = process.argv.slice(2)): Promise<
   const verifyText = JSON.stringify(verify, null, 2) + "\n";
   const verifyPath = path.join(bundleRoot, "_verify.json");
   if (args.check) {
-    const existingVerifyHash = existsSync(verifyPath) ? sha256(verifyPath) : null;
-    const expectedVerifyHash = sha256OfBuffer(verifyText);
-    if (existingVerifyHash !== expectedVerifyHash) {
-      drift.push({
-        src: "_verify.json",
-        reason: existingVerifyHash ? "verify manifest content drifted" : "verify manifest missing",
-      });
-    }
+    // Compared but never written here: the write happens with the provenance record below,
+    // behind an error gate that can abort the cast. Reconciling it early would put the file on
+    // disk for a cast that then refused to finish.
+    const verifyDrift = driftOf(verifyPath, sha256Text(verifyText), "_verify.json");
+    if (verifyDrift.reason) drift.push({ file: "_verify.json", reason: verifyDrift.reason });
   }
 
   // runs/*/summary.json validation — find a schema ref for this mold and validate any committed runs.
@@ -1395,7 +1379,7 @@ export async function runCastMoldCommand(argv = process.argv.slice(2)): Promise<
 
   // Report.
   for (const e of errors) console.error(`error: ${e}`);
-  for (const d of drift) console.error(`drift: ${d.src} — ${d.reason}`);
+  for (const d of drift) console.error(`drift: ${d.file} — ${d.reason}`);
 
   if (args.check) {
     if (errors.length || drift.length) {

--- a/packages/build-cli/src/commands/validate-artifact.ts
+++ b/packages/build-cli/src/commands/validate-artifact.ts
@@ -3,10 +3,11 @@
 // stderr are captured as diagnostic evidence without requiring a JSON shape.
 
 import { spawnSync } from "node:child_process";
-import { createHash } from "node:crypto";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import process from "node:process";
+
+import { sha256File, sha256Text } from "../lib/reconcile.js";
 import type { VerifyManifest, VerifyManifestEntry } from "./cast-mold.js";
 
 interface Args {
@@ -59,14 +60,6 @@ function parseArgs(argv: string[]): Args {
     provenancePath,
     root,
   };
-}
-
-function sha256Text(text: string): string {
-  return createHash("sha256").update(text).digest("hex");
-}
-
-function sha256File(filePath: string): string {
-  return createHash("sha256").update(readFileSync(filePath)).digest("hex");
 }
 
 function loadVerifyEntry(verifyPath: string, artifactId: string): VerifyManifestEntry {

--- a/packages/build-cli/src/lib/reconcile.ts
+++ b/packages/build-cli/src/lib/reconcile.ts
@@ -1,0 +1,111 @@
+// One answer to "does this file on disk match what we would write?", for every command that
+// renders a deterministic artifact and offers a `--check` gate over it.
+//
+// The decision is four lines and it was written seven times: twice in assemble-pipeline, five
+// times in cast-mold. Each copy independently got the same three things right — hash rather
+// than string compare, distinguish MISSING from DRIFTED, and never write under `--check` — and
+// worded the result differently, so the same fault reported as "content drifted", "content
+// differs", "dst hash differs from src", or "content differs from deterministic render"
+// depending on which artifact happened to be stale.
+//
+// Two things stay out of here on purpose:
+//
+//   - `writeOrCheck` in content-notes.ts, which is the OTHER dialect: one artifact, exits the
+//     process on drift. The commands here reconcile many artifacts and report them together,
+//     so they need drift as a VALUE rather than as an exit. Both are real; neither subsumes
+//     the other, and collapsing them would mean giving one of the two callers a worse error.
+//
+//   - What to DO about drift. Whether stale means exit 1, and what else gets rolled into the
+//     verdict, belongs to the command — cast-mold also fails on pending LLM refs, which is not
+//     a file comparison at all.
+
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+export function sha256Text(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}
+
+export function sha256File(filePath: string): string {
+  return createHash("sha256").update(readFileSync(filePath)).digest("hex");
+}
+
+export interface Drift {
+  /** Why the file is out of sync, or undefined when it already matches. */
+  reason?: string;
+  /**
+   * The hash on disk BEFORE reconciling — null when the file was absent.
+   *
+   * Returned rather than discarded because provenance records what a `--check` run actually
+   * found, not what it wanted to find: a drifted entry keeps the stale hash so the record says
+   * which bytes were on disk when the check failed.
+   */
+  currentHash: string | null;
+  /** The hash the file is supposed to have — carried back so a caller that renders the content
+   *  does not hash it a second time to record it. */
+  expectedHash: string;
+}
+
+/**
+ * Compare without touching the file.
+ *
+ * The read-only half, for an artifact whose write happens elsewhere in the command and under
+ * different conditions than "not checking" — `_verify.json` is written with the provenance
+ * record, after an error gate that can abort the whole cast.
+ */
+export function driftOf(filePath: string, expectedHash: string, label: string): Drift {
+  const exists = existsSync(filePath);
+  const currentHash = exists ? sha256File(filePath) : null;
+  if (currentHash === expectedHash) return { currentHash, expectedHash };
+  return {
+    reason: exists ? `${label} content drifted` : `${label} missing`,
+    currentHash,
+    expectedHash,
+  };
+}
+
+export interface ReconcileOptions {
+  path: string;
+  expectedHash: string;
+  label: string;
+  check: boolean;
+  /**
+   * How to produce the file. A callback rather than the content itself because not every
+   * artifact is a string we hold — a verbatim ref is a file COPY, compared against the source's
+   * hash and written with `copyFileSync`. Only the write differs; the decision above it does not.
+   */
+  write: () => void;
+}
+
+/** Compare, and bring the file into line unless this is a check run. */
+export function reconcile(options: ReconcileOptions): Drift {
+  const drift = driftOf(options.path, options.expectedHash, options.label);
+  if (drift.reason && !options.check) options.write();
+  return drift;
+}
+
+/**
+ * The common case: the expected content is a string already in hand.
+ *
+ * Creates the parent directory, because a first cast writes into a bundle that does not exist
+ * yet — and does so only on the write path, so `--check` on a never-cast mold leaves no
+ * directory behind to make the next check pass for the wrong reason.
+ */
+export function reconcileText(options: {
+  path: string;
+  expected: string;
+  label: string;
+  check: boolean;
+}): Drift {
+  return reconcile({
+    path: options.path,
+    expectedHash: sha256Text(options.expected),
+    label: options.label,
+    check: options.check,
+    write: () => {
+      mkdirSync(path.dirname(options.path), { recursive: true });
+      writeFileSync(options.path, options.expected);
+    },
+  });
+}

--- a/packages/build-cli/test/reconcile.test.ts
+++ b/packages/build-cli/test/reconcile.test.ts
@@ -1,0 +1,151 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { driftOf, reconcile, reconcileText, sha256Text } from "../src/lib/reconcile.js";
+
+let work: string;
+
+beforeEach(() => {
+  work = mkdtempSync(path.join(tmpdir(), "foundry-reconcile-"));
+});
+
+afterEach(() => {
+  rmSync(work, { recursive: true, force: true });
+});
+
+const file = (name: string) => path.join(work, name);
+
+describe("driftOf", () => {
+  it("reports nothing when the bytes already match", () => {
+    const p = file("a.json");
+    writeFileSync(p, "same\n");
+    expect(driftOf(p, sha256Text("same\n"), "a.json")).toEqual({
+      currentHash: sha256Text("same\n"),
+      expectedHash: sha256Text("same\n"),
+    });
+  });
+
+  // MISSING and DRIFTED are separate verdicts, not one "stale": a first cast reports the
+  // artifact absent, and a hand-edited one reports it changed. Collapsing them would tell an
+  // author to look for an edit they never made.
+  it("distinguishes a missing file from a drifted one", () => {
+    const p = file("a.json");
+    expect(driftOf(p, sha256Text("x"), "a.json").reason).toBe("a.json missing");
+    writeFileSync(p, "hand-edited\n");
+    expect(driftOf(p, sha256Text("x"), "a.json").reason).toBe("a.json content drifted");
+  });
+
+  // Provenance needs both halves: what the check FOUND, and what it should have found.
+  it("hands back the hash that was on disk alongside the one that was wanted", () => {
+    const p = file("a.json");
+    writeFileSync(p, "stale\n");
+    const drift = driftOf(p, sha256Text("fresh\n"), "a.json");
+    expect(drift.currentHash).toBe(sha256Text("stale\n"));
+    expect(drift.expectedHash).toBe(sha256Text("fresh\n"));
+  });
+
+  it("never writes", () => {
+    const p = file("a.json");
+    driftOf(p, sha256Text("x"), "a.json");
+    expect(existsSync(p)).toBe(false);
+  });
+});
+
+describe("reconcile", () => {
+  it("runs the write callback when the file has drifted", () => {
+    const p = file("a.json");
+    writeFileSync(p, "old\n");
+    let wrote = 0;
+    const drift = reconcile({
+      path: p,
+      expectedHash: sha256Text("new\n"),
+      label: "a.json",
+      check: false,
+      write: () => {
+        wrote++;
+        writeFileSync(p, "new\n");
+      },
+    });
+    expect(drift.reason).toBe("a.json content drifted");
+    expect(wrote).toBe(1);
+    expect(readFileSync(p, "utf8")).toBe("new\n");
+  });
+
+  it("does not run the write callback when the file already matches", () => {
+    const p = file("a.json");
+    writeFileSync(p, "same\n");
+    let wrote = 0;
+    const drift = reconcile({
+      path: p,
+      expectedHash: sha256Text("same\n"),
+      label: "a.json",
+      check: false,
+      write: () => wrote++,
+    });
+    expect(drift.reason).toBeUndefined();
+    expect(wrote).toBe(0);
+  });
+
+  // The property the whole `--check` gate rests on. A check run that repaired what it found
+  // would pass on its second invocation and report a clean tree that was never clean.
+  it("reports drift without writing under --check", () => {
+    const p = file("a.json");
+    writeFileSync(p, "old\n");
+    let wrote = 0;
+    const drift = reconcile({
+      path: p,
+      expectedHash: sha256Text("new\n"),
+      label: "a.json",
+      check: true,
+      write: () => wrote++,
+    });
+    expect(drift.reason).toBe("a.json content drifted");
+    expect(wrote).toBe(0);
+    expect(readFileSync(p, "utf8")).toBe("old\n");
+  });
+
+  // A verbatim ref is a file copy compared against the SOURCE's hash — the caller supplies both
+  // the hash and the write, and neither is a string this module ever holds.
+  it("compares against a hash the caller supplies rather than content it renders", () => {
+    const src = file("src.bin");
+    const dst = file("dst.bin");
+    writeFileSync(src, "payload\n");
+    const drift = reconcile({
+      path: dst,
+      expectedHash: sha256Text("payload\n"),
+      label: "dst",
+      check: false,
+      write: () => writeFileSync(dst, readFileSync(src)),
+    });
+    expect(drift.reason).toBe("dst missing");
+    expect(readFileSync(dst, "utf8")).toBe("payload\n");
+  });
+});
+
+describe("reconcileText", () => {
+  it("creates the parent directory a first cast has not made yet", () => {
+    const p = path.join(work, "casts", "claude", "skills", "x", "SKILL.md");
+    const drift = reconcileText({ path: p, expected: "# X\n", label: "SKILL.md", check: false });
+    expect(drift.reason).toBe("SKILL.md missing");
+    expect(readFileSync(p, "utf8")).toBe("# X\n");
+    // Hashed once, on the way through — a caller recording provenance does not hash it again.
+    expect(drift.expectedHash).toBe(sha256Text("# X\n"));
+  });
+
+  // `--check` on a never-cast mold must leave no bundle directory behind: an empty directory
+  // would make the NEXT check report the file missing from a tree the check itself created.
+  it("creates nothing under --check", () => {
+    const dir = path.join(work, "casts", "claude", "skills", "x");
+    const drift = reconcileText({
+      path: path.join(dir, "SKILL.md"),
+      expected: "# X\n",
+      label: "SKILL.md",
+      check: true,
+    });
+    expect(drift.reason).toBe("SKILL.md missing");
+    expect(existsSync(dir)).toBe(false);
+  });
+});


### PR DESCRIPTION
> Posted by Claude (AI assistant) on behalf of @jmchilton — they did not write this text.

Groundwork for extracting a generated-artifact package shared with `statistical-genomics-foundry`. Nothing is extracted here; this makes `build-cli` stop disagreeing with itself first, so the eventual package has one signature to publish rather than a coin flip between seven.

## What was there

`build-cli` asked "does this file match what we would write?" in **seven** places:

| Site | |
|---|---|
| `assemble-pipeline.ts:434` | `reconcile(path, expected, check, label)` |
| `assemble-pipeline.ts` ×2 call sites | SKILL.md, _assembly.json |
| `cast-mold.ts:1246` | `reconcileSkillMarkdown` — the same function with `label` fixed to `"SKILL.md"` |
| `cast-mold.ts:872` | package-schema ref, inlined |
| `cast-mold.ts:904` | verbatim ref, inlined |
| `cast-mold.ts:926` | sidecar ref, inlined |
| `cast-mold.ts:1358` | `_required_tools.json`, inlined |
| `cast-mold.ts:1373` | `_verify.json`, inlined |

Every copy independently got the same three things right — hash rather than string compare, MISSING distinct from DRIFTED, never write under `--check` — and worded the verdict differently. The same fault reported as `content drifted`, `content differs`, `dst hash differs from src`, or `content differs from deterministic render` depending on which artifact happened to be stale.

The `sha256`/`sha256OfBuffer` helpers were also copy-pasted three times (`assemble-pipeline`, `cast-mold`, `validate-artifact`), byte-identical bodies under two different naming schemes.

## What's here

`lib/reconcile.ts`: `driftOf` compares, `reconcile` writes unless checking, `reconcileText` is the string case. `Drift` carries `currentHash` and `expectedHash` because provenance records **what a `--check` run found**, not what it wanted — a drifted entry keeps the stale hash.

The `write` callback is why one function covers all seven: a verbatim ref is a `copyFileSync` against the source's own hash, so the expected bytes are never a string in hand. Only the write differs; the decision above it does not.

## Left alone on purpose

- **`writeOrCheck` in `content-notes.ts`** — the *other* dialect: one artifact, exits the process on drift. The commands here reconcile many artifacts and report them together, so they need drift as a value. Neither subsumes the other. `build-cli` now has exactly two implementations, one per real dialect, which is the point.
- **`_required_tools.json`'s delete branch** — reconciling to ABSENT has no expected content to hash. Stays inline, commented.
- **`_verify.json`** uses `driftOf` (compare only) rather than `reconcile`: its write happens with the provenance record, behind an error gate that can abort the cast. Reconciling it early would put the file on disk for a cast that then refused to finish.

## Behavior

Verified by re-casting `summarize-nextflow` in **write** mode, not just `--check`: every ref hash and every artifact byte-identical, only `commit` and `cast_at` moved (both inherently non-deterministic). `make check-assemble-pipelines` clean across all three pipelines.

Two intentional deltas:

1. **Drift wording is uniform now** — `<label> content drifted` / `<label> missing`, replacing cast-mold's five bespoke strings. No test asserts the wording; the tests assert the *filename*, which the label carries.
2. **`src` → `file`** on cast-mold's drift accumulator. It keyed on `src` while assemble-pipeline keyed on `file` for the same concept, both printed by the same format string — and cast-mold's own values were already inconsistent (a source path for refs, a destination filename for SKILL.md). Same output, one name.

## Tests

10 new unit tests for `lib/reconcile.ts`, proven non-vacuous by breaking the `--check` guard (2 fail) . They pin the properties the gate rests on: a check run that repaired what it found would pass on its second invocation and report a tree that was never clean; `--check` on a never-cast mold must leave no directory behind, or the *next* check reports a file missing from a tree the check itself created.

Green: build-cli 19, root 160, `validate`, `check:kinds`, `make check-generated`, `make check-assemble-pipelines`, `cast --check`, `typecheck` (root + site, 0 errors), `smoke:packages`, lint, format.

One pre-existing failure unrelated to this change: `summarize-nextflow` `resolves bacass profile test data expressions` times out at 120s. Confirmed identical on unmodified `main`.
