### PR TITLE
Adopt loadKindDocs from @galaxy-foundry/kind-schema

### DIFF
--- a/packages/build-cli/package.json
+++ b/packages/build-cli/package.json
@@ -38,6 +38,7 @@
   "license": "MIT",
   "dependencies": {
     "@galaxy-foundry/foundry": "workspace:*",
+    "@galaxy-foundry/kind-schema": "^0.3.0",
     "@galaxy-foundry/license-policy": "^0.1.0",
     "@galaxy-foundry/note-schema": "workspace:*",
     "@galaxy-foundry/planemo-cli-meta": "workspace:*",

--- a/packages/build-cli/src/commands/generate-kind-manifest.ts
+++ b/packages/build-cli/src/commands/generate-kind-manifest.ts
@@ -10,10 +10,10 @@
 // foundry-pattern site renders both instances' manifests side by side as a kind catalog, and
 // it must be able to read them from a checkout without installing either instance's toolchain.
 
-import { readFileSync } from "node:fs";
 import path from "node:path";
 import process from "node:process";
 
+import { loadKindDocs } from "@galaxy-foundry/kind-schema/docs";
 import { bundledPolicy } from "@galaxy-foundry/license-policy";
 import { KINDS, buildKindManifest, loadReferenceContract } from "@galaxy-foundry/note-schema";
 import { loadTagRegistry } from "@galaxy-foundry/tag-registry";
@@ -25,24 +25,20 @@ const OUTPUT = `${TYPES_DIR}/kinds.generated.json`;
 const INSTANCE = "galaxy-workflow-foundry";
 
 /**
- * kind name -> kind.md body.
+ * Read each kind's `kind.md`, or say which one is missing and stop.
  *
- * Driven by the barrel rather than a directory listing: `KINDS` is the one enumeration, so a
- * kind with no `kind.md` fails naming itself, and an unrelated directory under types/ is not
- * mistaken for a kind.
+ * The READING is not ours — it ships in @galaxy-foundry/kind-schema, because the other instance
+ * wrote the same loader beside the same manifest call. What stays here is the decision to exit:
+ * the package throws, deliberately, so a library never takes a command's exit for it. Reported
+ * as one line rather than rethrown, because the bin's catch-all prints a stack.
  */
 function loadDocs(typesDir: string): Record<string, string> {
-  const docs: Record<string, string> = {};
-  for (const definition of KINDS) {
-    const file = path.join(typesDir, definition.kind, "kind.md");
-    try {
-      docs[definition.kind] = readFileSync(file, "utf8").trim();
-    } catch {
-      process.stderr.write(`${definition.kind}: cannot read ${file}\n`);
-      process.exit(1);
-    }
+  try {
+    return loadKindDocs(KINDS, typesDir);
+  } catch (e) {
+    process.stderr.write(`${(e as Error).message}\n`);
+    process.exit(1);
   }
-  return docs;
 }
 
 export function runGenerateKindManifestCommand(argv = process.argv.slice(2)): void {

--- a/packages/note-schema/package.json
+++ b/packages/note-schema/package.json
@@ -38,7 +38,7 @@
   "license": "MIT",
   "dependencies": {
     "@galaxy-foundry/kind-manifest": "^0.2.1",
-    "@galaxy-foundry/kind-schema": "^0.2.0",
+    "@galaxy-foundry/kind-schema": "^0.3.0",
     "@galaxy-foundry/license-policy": "^0.1.0",
     "@galaxy-foundry/reference-contract": "^0.1.0",
     "@galaxy-foundry/tag-registry": "^0.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       '@galaxy-foundry/foundry':
         specifier: workspace:*
         version: link:../foundry
+      '@galaxy-foundry/kind-schema':
+        specifier: ^0.3.0
+        version: 0.3.0(zod@3.25.76)
       '@galaxy-foundry/license-policy':
         specifier: ^0.1.0
         version: 0.1.0
@@ -174,8 +177,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1(zod@3.25.76)
       '@galaxy-foundry/kind-schema':
-        specifier: ^0.2.0
-        version: 0.2.0(zod@3.25.76)
+        specifier: ^0.3.0
+        version: 0.3.0(zod@3.25.76)
       '@galaxy-foundry/license-policy':
         specifier: ^0.1.0
         version: 0.1.0
@@ -994,8 +997,8 @@ packages:
     peerDependencies:
       zod: ^3.25.0
 
-  '@galaxy-foundry/kind-schema@0.2.0':
-    resolution: {integrity: sha512-UjLOkR32b7b/fa6pxe6xa12yThDXESlbhSyrZqRA/ZV5bN558CZ6B/QVsUw+ohexWlYQLybw0rjxe61qcOU7Iw==}
+  '@galaxy-foundry/kind-schema@0.3.0':
+    resolution: {integrity: sha512-D25FnCCy4h7fNZCSzseMPQwU9+7jhYlbrv1Yf/lzeOytmLPoaufZGSZ0/L9y0DYZGCne/y/eVg23WEH1LereLg==}
     engines: {node: '>=20'}
     peerDependencies:
       zod: ^3.25.0
@@ -4258,7 +4261,7 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
-  '@galaxy-foundry/kind-schema@0.2.0(zod@3.25.76)':
+  '@galaxy-foundry/kind-schema@0.3.0(zod@3.25.76)':
     dependencies:
       '@galaxy-foundry/kind-manifest': 0.2.1(zod@3.25.76)
       zod: 3.25.76


### PR DESCRIPTION
> Posted by Claude (AI assistant) on behalf of @jmchilton — they did not write this text.

Consumer half of [foundry-lib#22](https://github.com/jmchilton/foundry-lib/pull/22). Deletes our copy of the `kind.md` loader; the other instance wrote the same function beside the same `manifestKinds` call, with a byte-identical docstring, so the reading ships in `@galaxy-foundry/kind-schema@0.3.0`.

## What stays here

The **exit**. The package throws rather than calling `process.exit`, deliberately — whether a missing `kind.md` is fatal is this command's call, not the library's. So `loadDocs` survives as a four-line wrapper that catches and reports.

It reports one line rather than rethrowing, because the bin's catch-all is `console.error(e)`, which would print a stack where a filename used to be.

Verified rather than assumed — with `mold/kind.md` moved aside:

```
$ npm run kinds
mold: cannot read packages/note-schema/src/types/mold/kind.md
$ echo $?
1
```

Identical message, identical exit code.

## The manifest does not move

`check:kinds` passes **without regenerating**, so `kinds.generated.json` is byte-identical. That's the real signal here: the loader swap changed nothing a consumer can see.

## Two version bumps, one of them not obvious

`build-cli` gains `@galaxy-foundry/kind-schema` as a direct dependency — it imports the `/docs` subpath itself now, rather than reaching through `note-schema`.

`note-schema` also moves `^0.2.0` → `^0.3.0`, which needs explaining because it doesn't use anything new. Its range already *allowed* 0.3.0, but the lockfile had pinned 0.2.0, so adding build-cli's dependency resolved **two copies** of kind-schema into the workspace:

```
build-cli:    0.3.0
note-schema:  0.2.0
```

Benign today — kind-schema exports pure functions and types, with no classes and no `instanceof` to fail across copies. But this is the same shape as the dual-zod problem that broke the tarball smoke test in foundry-lib#20, and one copy is worth the tighter floor. After the bump both resolve to 0.3.0.

## Verification

Full CI sequence locally, all green: `packages-typecheck`, `packages-build`, `validate`, `check:kinds`, `make check-generated`, `typecheck` (root + site, 0 errors), root tests 160, build-cli tests 19, `smoke:packages`, `packages-format`, `packages-lint`, `cast --check`, `make check-assemble-pipelines`, `site:build` (368 pages).
