### PR TITLE
Adopt collectionsClaiming; replace comments that named a guard we do not have

### DIFF
--- a/packages/note-schema/src/collections.ts
+++ b/packages/note-schema/src/collections.ts
@@ -20,12 +20,10 @@
 // no caller has to remember to pass the table.
 import {
   collectionOf as routeCollection,
+  collectionsClaiming as routeClaiming,
   kindOf as routeKind,
-  matchesCollection,
   type CollectionRoute,
 } from "@galaxy-foundry/kind-schema/collections";
-
-export { matchesCollection };
 
 /**
  * One collection: a directory, the note files in it, and the kind they all declare.
@@ -88,4 +86,14 @@ export function collectionOf(repoRelPath: string): CollectionName | undefined {
 /** The kind a repo-relative path routes to, or `undefined` if it is not a note. */
 export function kindOf(repoRelPath: string): string | undefined {
   return routeKind(COLLECTIONS, repoRelPath);
+}
+
+/**
+ * EVERY collection claiming a path, not just the first.
+ *
+ * Exists for the routing test that asserts the answer is never longer than one entry — which is
+ * what earns `collectionOf` the right to return the first match and stop.
+ */
+export function collectionsClaiming(repoRelPath: string): CollectionName[] {
+  return routeClaiming(COLLECTIONS, repoRelPath);
 }

--- a/packages/note-schema/src/index.ts
+++ b/packages/note-schema/src/index.ts
@@ -15,8 +15,8 @@ export {
   COLLECTION_NAMES,
   CONTENT_DIR,
   collectionOf,
+  collectionsClaiming,
   kindOf,
-  matchesCollection,
   type CollectionDefinition,
   type CollectionName,
 } from "./collections.js";

--- a/packages/note-schema/src/types/context.ts
+++ b/packages/note-schema/src/types/context.ts
@@ -193,11 +193,12 @@ export type { KindShape };
 /**
  * What a `types/<kind>/schema.ts` exports.
  *
- * `build` returns a plain strict ZodObject rather than the refined schema, for two reasons:
- * zod's `discriminatedUnion` only accepts ZodObject members (a `.superRefine` would wrap it
- * in ZodEffects), and the manifest generator walks `.shape` to derive the required-metadata
- * table. Per-kind cross-field rules go in `refine`, which the assembler dispatches by `type`
- * after the union resolves — so the rule still LIVES in the kind's directory.
+ * The contract itself — why `build` returns a bare strict object, why refinement is a separate
+ * slot, how the union dispatches it — is documented on `KindDefinition` in
+ * @galaxy-foundry/kind-schema, where that machinery now lives. It is deliberately not restated
+ * here: two docstrings for one type is how the wrong one goes stale unnoticed.
+ *
+ * What is worth saying locally is what it means for a kind AUTHOR in this repo.
  *
  * `refine`'s `data` is this kind's INFERRED frontmatter, not `Record<string, unknown>`, and
  * that matters more than it reads: every rule is conditional, so a rule that never fires looks
@@ -216,9 +217,16 @@ export type AnyKindDefinition = LibAnyKindDefinition<KindContext>;
 /**
  * Identity helper a kind directory wraps its definition in.
  *
- * It exists purely to INFER the object shape rather than widen it. Annotating a kind as
- * `: KindDefinition` erases which fields it declares, and that erasure propagates all the way
- * to the Astro site, where `entry.data.tags` degrades to `any`. Inferring keeps each kind's
- * frontmatter type precise for every consumer of the assembled union.
+ * It exists purely to INFER the object shape rather than widen it, and the two ways of losing
+ * that inference fail very differently — worth knowing which one you are looking at.
+ *
+ * Annotating a kind `: KindDefinition` does not erase anything: it fails the package build
+ * outright, one TS2322 at the annotation, because `ZodObject` is invariant in its shape
+ * parameter and a concrete kind is not assignable to the default shape at all. Loud, local,
+ * measured.
+ *
+ * The `any`-shaped erasure is the dangerous one, and it is not visible from here — see
+ * `KINDS` in ./index.ts, where widening the LIST costs nothing anywhere except one type-level
+ * test. Neither failure reaches the Astro site, which this comment used to claim was the guard.
  */
 export const defineKind = kindDefiner<KindContext>();

--- a/packages/note-schema/src/types/index.ts
+++ b/packages/note-schema/src/types/index.ts
@@ -19,9 +19,16 @@ import { kind as sourcePattern } from "./source-pattern/schema.js";
 
 import { type AnyKindDefinition } from "./context.js";
 
-// NOT annotated `: readonly KindDefinition[]`. That annotation would widen every element to
-// the default shape and the erasure would propagate to the Astro site, where `entry.data.tags`
-// degrades to `any`. Left inferred, this is a tuple of precisely-typed kinds.
+// `as const`, and NOT annotated. The tuple is load-bearing: `buildKindUnion` is generic over the
+// kind LIST and recovers each member's output type from it. Annotate this
+// `readonly AnyKindDefinition[]` and `.map` erasure reaches the return type, so
+// `z.infer<NoteSchema>` — which this package re-exports — degrades to `unknown` for consumers
+// who never touched a kind.
+//
+// Nothing you would think to run reports that. Measured: the widening costs 0 `tsc` errors
+// across the packages and 0 in `astro check`, because the erasure arrives as `any`, and an `any`
+// satisfies every field access rather than failing one. tests/note-union.test-d.ts is the only
+// thing that catches it, which is why it exists.
 export const KINDS = [
   mold,
   pattern,

--- a/tests/collection-routing.test.ts
+++ b/tests/collection-routing.test.ts
@@ -7,8 +7,8 @@ import {
   COLLECTION_NAMES,
   CONTENT_DIR,
   collectionOf,
+  collectionsClaiming,
   KINDS,
-  matchesCollection,
 } from "@galaxy-foundry/note-schema";
 import { readMarkdown } from "../packages/build-cli/src/lib/frontmatter.js";
 import { findMdFiles } from "../packages/build-cli/src/lib/walk.js";
@@ -158,10 +158,7 @@ describe("collection routing (path table vs corpus)", () => {
   // they share a base and are kept disjoint only by the `!*/index.md` exclusion.
   it("claims each note for exactly one collection", () => {
     const overlapping = corpus
-      .map((n) => ({
-        rel: n.rel,
-        names: COLLECTION_NAMES.filter((c) => matchesCollection(n.rel, COLLECTIONS[c])),
-      }))
+      .map((n) => ({ rel: n.rel, names: collectionsClaiming(n.rel) }))
       .filter((r) => r.names.length > 1)
       .map((r) => `${r.rel}: ${r.names.join(", ")}`);
     expect(overlapping, `\nclaimed by several collections:\n  ${overlapping.join("\n  ")}`).toEqual(

--- a/tests/note-union.test-d.ts
+++ b/tests/note-union.test-d.ts
@@ -1,0 +1,39 @@
+// The assembled union keeps its members' shapes, asserted where that fact lives: the typecheck.
+//
+// This is the guard the comments around `KINDS` used to claim the Astro site was. It is not:
+// widening `KINDS` to `readonly AnyKindDefinition[]` was measured at 0 `tsc` errors in the
+// packages AND 0 in `astro check`, because the erasure lands as `any` and an `any` satisfies
+// every field access rather than failing one. The site cannot report a type it is handed.
+//
+// What it costs, unguarded, is not local. `NoteSchema` is re-exported from this package's public
+// API, so an erased union hands `z.infer<NoteSchema>` of `unknown` to consumers who never
+// touched the kinds — which is exactly the regression that shipped once and was caught by a
+// hand-run probe rather than by CI.
+//
+// Checked by `tsc --noEmit` at the repo root (`npm run typecheck`, which CI runs), because the
+// root tsconfig includes tests/. vitest does not collect this file — its include is
+// `tests/**/*.test.ts`, and `.test-d.ts` does not match.
+
+import type { z } from "zod";
+
+import type { NoteSchema } from "@galaxy-foundry/note-schema";
+
+type Note = z.infer<NoteSchema>;
+
+declare const note: Note;
+
+/** The discriminator survives: narrowing by `type` is what every consumer does first. */
+export const discriminator: Note["type"] = note.type;
+
+/** An arm's own field survives, reachable only after narrowing to that arm. */
+export const axis = note.type === "mold" ? note.axis : undefined;
+
+// @ts-expect-error — a field NO kind declares must not compile. If this stops erroring, the
+// union has erased to `unknown` with an index signature and every field access below it is
+// silently meaningless, including the two above.
+export const bogus = note.definitely_not_a_field;
+
+// @ts-expect-error — `axis` belongs to the mold arm alone, so reading it off an unnarrowed note
+// must fail. This is what separates "the union kept its arms" from "the union collapsed into
+// one wide record that happens to contain every field".
+export const unnarrowedAxis = note.axis;


### PR DESCRIPTION
> Posted by Claude (AI assistant) on behalf of @jmchilton — they did not write this text.

The two deferred items from #399. The second turned out to be more than a comment fix.

## collectionsClaiming

The routing test hand-rolled `COLLECTION_NAMES.filter((c) => matchesCollection(n.rel, COLLECTIONS[c]))`, which is exactly what `kind-schema` ships as `collectionsClaiming` — and which its own docstring says exists *"to write that test with"*.

Adopting it retires the `matchesCollection` pass-through re-export: it had exactly one consumer, that line. `collections.ts` gains a table-bound wrapper instead, matching how `collectionOf`/`kindOf` already read.

Non-vacuity checked by dropping the `!*/index.md` exclusion so the two `content/cli` collections overlap — the test still fails.

## The comments claimed a guard that does not exist

Three comments said widening a kind's shape *"propagates to the Astro site, where `entry.data.tags` degrades to `any`"*. I measured both halves before rewriting. Both are wrong:

| Widening | Actual result |
|---|---|
| a kind `: KindDefinition` | **Package build fails**, 1 × TS2322 at the annotation. `ZodObject` is invariant in its shape parameter, so a concrete kind is not assignable to the default shape at all. It never reaches the site. |
| `KINDS: readonly AnyKindDefinition[]` | **0 `tsc` errors** across the packages, **0** in `astro check`. |

The second is the dangerous one, and the reason the site cannot catch it is the same reason the comment invoked it: the erasure arrives as `any`, and an `any` satisfies every field access rather than failing one. Naming the site as the guard was backwards — it is the one place that provably cannot report this.

What it costs is not local. `NoteSchema` is re-exported from the package's public API, so an erased union hands `z.infer<NoteSchema>` of `unknown` to consumers who never touched a kind. **That regression already shipped once**, during the kind-schema adoption, and was caught by a hand-run probe rather than by CI.

## So the guard now exists

`tests/note-union.test-d.ts` — sibling of the existing `kind-refine.test-d.ts`, same mechanism, no new infrastructure: the root tsconfig already includes `tests/`, and vitest does not collect `.test-d.ts`.

It pins three things: the discriminator survives, an arm's own field is reachable after narrowing, and — the two `@ts-expect-error`s — a field no kind declares must not compile, and `axis` must *not* be readable off an unnarrowed note. That last one is what separates "the union kept its arms" from "the union collapsed into one wide record containing every field".

Red-to-green, measured:

```
KINDS widened, before this PR:  packages 0 errors, astro check 0 errors
KINDS widened, after:           npm run typecheck → 2 errors   ← CI runs this
```

## Also

`context.ts`'s `KindDefinition` docstring stopped restating the contract that moved into the package — why `build` returns a bare object, how the union dispatches refinement. It now defers to the package's own docstring and keeps only what a kind author in *this* repo needs. Two docstrings for one type is how the wrong one goes stale unnoticed, which is what this PR is cleaning up.

## Verification

`packages-build`, `packages-typecheck`, `typecheck` (root + site, 0/0/0), tests 160, `validate`, `check:kinds`, `make check-generated`, `packages-lint`, `packages-format`, `smoke:packages`, `cast --check`, `make check-assemble-pipelines`, `site:build` (368 pages). All green.
