### PR TITLE
Anchor site paths on the project root, not on module depth

### DIFF
--- a/site/src/lib/casts.ts
+++ b/site/src/lib/casts.ts
@@ -9,7 +9,8 @@
 
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+
+import { REPO_ROOT } from './repo-root';
 
 export type CastTarget = 'claude' | 'web' | 'generic';
 
@@ -93,10 +94,15 @@ export function isHarnessSlug(slug: string): boolean {
   return slug.startsWith('pipeline-');
 }
 
-/** Repo root inferred relative to this file: site/src/lib → ../../.. */
+// This was `path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..')` — three
+// hops counted from this file's own source depth. After `astro build` the module runs from a
+// bundled chunk four levels below the repo root, so those three hops landed on `site/` and every
+// lookup beneath it found nothing. The Usage page rendered `Pipelines 0 / Shared skills 0 /
+// Casts 0` against 54 committed skills, and 54 pages went unbuilt — 47 `/usage/claude/*` plus the
+// 7 `/pipelines/*/harness`. Nothing errored; the lists were simply empty, and the build was green
+// at 316 pages instead of 370. Only the DEFAULT moved; every function below still takes a root.
 function defaultRepoRoot(): string {
-  const here = path.dirname(fileURLToPath(import.meta.url));
-  return path.resolve(here, '..', '..', '..');
+  return REPO_ROOT;
 }
 
 function castDirFor(target: CastTarget, moldSlug: string, repoRoot: string): string {

--- a/site/src/lib/content-files.ts
+++ b/site/src/lib/content-files.ts
@@ -8,15 +8,16 @@
 // index page it links to served the same file correctly from a different `../` count that
 // happened to land.
 //
-// `astro:config/server` gives the project root as Astro computed it, which is the one anchor
-// that does not depend on where a module ended up. It is also why this is a module of its own:
-// that import only resolves inside an Astro build, and the layout rules in `./companions` are
-// worth testing outside one.
+// That anchor now lives in `./repo-root`, because `casts.ts` needed the same one, did not know
+// this module existed, and inferred its own — with the same result one directory over: the Usage
+// page reporting `Casts = 0` against 54 committed skills. `tests/root-anchoring.test.ts` asserts
+// the rule rather than waiting for a third module to learn it.
+//
+// The layout rules stay in `./companions`, which takes a directory rather than finding one and is
+// worth testing outside a build.
 
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
-import { root } from 'astro:config/server';
 import type { NormalizedCompanion } from '@galaxy-foundry/kind-schema';
 import { CONTENT_DIR } from '@galaxy-foundry/note-schema';
 
@@ -27,11 +28,12 @@ import {
   readCompanionIn,
   type NoteKind,
 } from './companions';
+import { REPO_ROOT } from './repo-root';
 
 export { companionOf } from './companions';
 
-/** Absolute path of the corpus root — `root` is the site directory, `content/` its sibling. */
-export const CONTENT_ROOT = fileURLToPath(new URL(`../${CONTENT_DIR}/`, root));
+/** Absolute path of the corpus root — `content/` sits at the repository root. */
+export const CONTENT_ROOT = path.join(REPO_ROOT, CONTENT_DIR);
 
 /** A note's own directory. `id` is the collection-prefixed entry id, e.g. `molds/find-test-data`. */
 export function noteDir(id: string): string {

--- a/site/src/lib/repo-root.ts
+++ b/site/src/lib/repo-root.ts
@@ -1,0 +1,20 @@
+// Where the repository is, for every site module that reads something off disk outside `site/`.
+//
+// `astro:config/server` gives the project directory as Astro computed it, which is the one anchor
+// that does not depend on where a module ended up. Counting `../` from `import.meta.url` does:
+// `astro build` collapses pages, components and lib modules alike into one chunk directory, and a
+// hop count written against a source path is right afterwards only by coincidence. Twice now that
+// coincidence has not held — `MoldHealth.astro` reporting every Mold as missing its `eval.md`, and
+// `casts.ts` reporting `Casts = 0` with 54 of them committed, costing 54 pages the build never
+// mentioned. `tests/root-anchoring.test.ts` asserts the rule so there is no third time.
+//
+// This is a module of its own because the import only resolves inside an Astro build. Anything
+// worth testing outside one should take a directory rather than reach for this — `./companions`
+// is the model.
+
+import { fileURLToPath } from 'node:url';
+
+import { root } from 'astro:config/server';
+
+/** Absolute path of the repository root. `root` is the site directory; the repo is its parent. */
+export const REPO_ROOT = fileURLToPath(new URL('../', root));

--- a/tests/root-anchoring.test.ts
+++ b/tests/root-anchoring.test.ts
@@ -1,0 +1,67 @@
+// A site module may not find the repository root by counting `../` from its own source depth.
+//
+// `astro build` collapses every site module — page, component AND lib alike — into one bundled
+// chunk directory. Measured on astro 7 / vite 8, that directory is:
+//
+//     site/dist/.prerender/chunks/
+//
+// which sits exactly four levels below the repository root. So a `../` count written against a
+// module's source path is correct after the build only when that source happens to be four deep
+// as well. `site/src/pages/molds/` is; `site/src/components/` and `site/src/lib/` are not, and
+// resolve one level short — at `site/` rather than the repo root.
+//
+// That is not a hypothesis. `MoldHealth.astro` (`site/src/components/`, three hops) reported
+// "eval.md not written yet" on all 47 Mold pages while 33 had one, and `content-files.ts` was
+// written to fix it. `casts.ts` (`site/src/lib/`, three hops) then did the same thing to the
+// Usage page: 54 skills on disk, `Casts = 0` rendered, and 54 pages never built — 47
+// `/usage/claude/*` and 7 `/pipelines/*/harness`. Both builds were green, one at 316 pages and
+// one at 370, and nothing compares those numbers to anything.
+//
+// One module was fixed each time. This asserts the RULE instead, because the failure is silent
+// in every direction: no error, no missing file, just an empty list where content should be.
+//
+// The correct anchor is `root` from `astro:config/server` — see `site/src/lib/repo-root.ts`.
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const SITE_SRC = new URL("../site/src/", import.meta.url).pathname;
+const SCANNED_EXTENSIONS = [".ts", ".astro", ".mts", ".js", ".mjs"];
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) return sourceFiles(full);
+    return SCANNED_EXTENSIONS.includes(path.extname(full)) ? [full] : [];
+  });
+}
+
+// Comments are stripped first, so a module is free to DESCRIBE the mistake — `content-files.ts`
+// and this file both do, at length, and neither is a violation.
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+}
+
+// A fixed hop count. `package-version.ts` walks up one `dirname` at a time until it finds what it
+// is looking for, which is depth-tolerant by construction and deliberately not matched here.
+const PARENT_HOP = /(['"`])\.\.[\/'"`]/;
+
+describe("anchoring a site module to the repository root", () => {
+  it("never counts ../ from import.meta.url", () => {
+    const offenders = sourceFiles(SITE_SRC)
+      .filter((file) => {
+        const code = stripComments(readFileSync(file, "utf-8"));
+        return code.includes("import.meta.url") && PARENT_HOP.test(code);
+      })
+      .map((file) => path.relative(path.join(SITE_SRC, "../.."), file));
+
+    expect(
+      offenders,
+      "\nThese resolve against a bundled chunk after `astro build`, not against their own source" +
+        " path. Anchor on `root` from astro:config/server instead — see site/src/lib/repo-root.ts." +
+        `\n\n  ${offenders.join("\n  ")}\n`
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
> **Posted by Claude (AI assistant) on behalf of @jmchilton — not authored by them personally.**

## The bug

`/usage/` shipped this:

| | on the page | on disk |
|---|---|---|
| Pipelines | **0** | 7 |
| Shared skills | **0** | 47 |
| Casts | **0** | 47 |

and 54 pages were never built — 47 `/usage/claude/*` plus the 7 `/pipelines/*/harness`. The build was green at 316 pages. Nothing compares that number to anything, so nothing noticed.

## Why

`casts.ts` found the repo root by counting three `../` from its own source depth:

```ts
const here = path.dirname(fileURLToPath(import.meta.url));
return path.resolve(here, '..', '..', '..');   // site/src/lib → repo root
```

That is right in `astro dev` and wrong in `astro build`. I probed it rather than assuming — a page, a component and a lib module, each printing its own `import.meta.url` into the built HTML:

```
page      → site/dist/.prerender/chunks/zzprobe_cGSsHVyW.mjs
component → site/dist/.prerender/chunks/zzprobe_cGSsHVyW.mjs
lib       → site/dist/.prerender/chunks/zzprobe_cGSsHVyW.mjs
```

Everything collapses into one chunk directory, and that directory is **exactly four levels below the repo root**. So a hop count written against a source path is correct afterwards only when the source is also four deep. `site/src/lib/` is three, and three hops from the chunk land on `site/` — one level short, where no `casts/` exists.

## This is the second time

`MoldHealth.astro` did it from `site/src/components/`, also three hops, and reported every Mold as missing its `eval.md` while 33 had one. `content-files.ts` was written to fix that, and its comment documents the failure well. **But the fix went to the module, not to the rule** — `casts.ts` had no way to know that module existed and inferred its own root, one directory over.

Worth noting what the probe also explains: `statistical-genomics-foundry` has the same idiom on two Mold pages and it *works*, because `site/src/pages/molds/` happens to be four deep too. A coincidence, not a fix. Handled separately.

## The change

- **`site/src/lib/repo-root.ts`** — the one anchor, `root` from `astro:config/server`. Its own module because that import only resolves inside an Astro build.
- **`content-files.ts`** derives `CONTENT_ROOT` from it instead of asking Astro a second time.
- **`casts.ts`** — only the *default* moved; every function still takes a root.
- **`tests/root-anchoring.test.ts`** — fails any `site/src` module that counts `../` from `import.meta.url`.

The guard is the point. Two modules have now learned this the same way, and the failure is silent in every direction: no error, no missing file, just an empty list where content should be.

It is deliberately quiet for two things: `package-version.ts`, which walks up one `dirname` at a time until it finds what it wants and is depth-tolerant by construction; and comments *describing* the mistake, since `content-files.ts` and the test itself both do that at length.

## Red → green

The guard failed on exactly `site/src/lib/casts.ts` before the fix — one offender, no false positives — and passes after.

Behaviourally: **316 → 370 pages**, and `/usage/` now reads 7 / 47 / 47. The 54/47 split reconciles: 7 of the 54 committed skills are `pipeline-*` harnesses, which `isHarnessSlug` deliberately keeps out of the cast inventory and which surface as the 7 Pipelines instead.

## Checks

- 237 tests, 16 files, all passing
- `pnpm typecheck` — 0 errors (69 Astro files)
- `pnpm validate` — 238 files, 0 errors
- `pnpm site:build` — 370 pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)