### PR TITLE
Name the four values that make the shell this site's

### DIFF
--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -1,13 +1,14 @@
 ---
+import { CONTAINER, REPO_URL, SITE_FULL_NAME } from '../lib/site-identity';
 const year = new Date().getFullYear();
 ---
 <footer class="mt-auto bg-(--color-galaxy-dark) text-(--color-text-on-dark)">
-  <div class="max-w-6xl mx-auto px-4 sm:px-6 py-6 flex flex-wrap items-center justify-between gap-4 text-sm opacity-70">
+  <div class={`${CONTAINER} mx-auto px-4 sm:px-6 py-6 flex flex-wrap items-center justify-between gap-4 text-sm opacity-70`}>
     <div class="flex items-center gap-2">
       <div class="w-1 h-4 bg-(--color-accent) rounded-full"></div>
-      <span>&copy; {year} Galaxy Workflow Foundry</span>
+      <span>&copy; {year} {SITE_FULL_NAME}</span>
     </div>
-    <a href="https://github.com/galaxyproject/foundry" class="text-(--color-text-on-dark) no-underline hover:text-(--color-accent) transition-colors">
+    <a href={REPO_URL} class="text-(--color-text-on-dark) no-underline hover:text-(--color-accent) transition-colors">
       GitHub
     </a>
   </div>

--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -1,5 +1,6 @@
 ---
 import Search from 'astro-pagefind/components/Search.astro';
+import { CONTAINER, SITE_NAME } from '../lib/site-identity';
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const pathname = Astro.url.pathname.replace(/\/$/, '') || '/';
 const navLinks = [
@@ -20,10 +21,10 @@ const moreActive = moreLinks.some(link => link.match(pathname));
 ---
 <header class="bg-(--color-galaxy-dark) border-b-4 border-(--color-accent) relative">
   <div class="absolute inset-0 bg-grid-header pointer-events-none"></div>
-  <div class="relative max-w-6xl mx-auto px-4 sm:px-6 py-4 flex flex-wrap items-center justify-between gap-2">
+  <div class={`relative ${CONTAINER} mx-auto px-4 sm:px-6 py-4 flex flex-wrap items-center justify-between gap-2`}>
     <div class="flex items-center gap-4">
       <a href={`${base}/`} class="text-xl font-bold text-(--color-text-on-dark) no-underline hover:text-(--color-accent) transition-colors">
-        Foundry
+        {SITE_NAME}
       </a>
       <nav class="flex items-center gap-3 text-sm" aria-label="Primary">
         {navLinks.map(link => {

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -2,16 +2,13 @@
 import '../styles/global.css';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
+import { CONTAINER, SITE_DESCRIPTION, SITE_NAME } from '../lib/site-identity';
 interface Props {
   title: string;
-  pageTitle?: string;
   description?: string;
 }
-const {
-  title,
-  description = 'Galaxy Workflow Foundry — knowledge base + casting pipeline for Galaxy workflows.',
-} = Astro.props;
-const fullTitle = `${title} - Foundry`;
+const { title, description = SITE_DESCRIPTION } = Astro.props;
+const fullTitle = `${title} - ${SITE_NAME}`;
 ---
 <!doctype html>
 <html lang="en">
@@ -35,7 +32,7 @@ const fullTitle = `${title} - Foundry`;
 <body class="min-h-dvh flex flex-col bg-(--color-surface) text-(--color-text-primary)">
   <a href="#main" class="skip-link">Skip to content</a>
   <Header />
-  <main id="main" class="flex-1 bg-grid max-w-6xl w-full mx-auto px-4 sm:px-6 py-6 leading-relaxed">
+  <main id="main" class={`flex-1 bg-grid ${CONTAINER} w-full mx-auto px-4 sm:px-6 py-6 leading-relaxed`}>
     <slot />
   </main>
   <Footer />

--- a/site/src/lib/site-identity.ts
+++ b/site/src/lib/site-identity.ts
@@ -26,9 +26,26 @@ export const REPO_URL = 'https://github.com/galaxyproject/foundry';
 /**
  * The measure of the reading column, as a Tailwind class.
  *
- * Written out in full because Tailwind finds utilities by scanning source text: assembled from
- * pieces (`max-w-${size}`) it would find nothing and emit no rule, and the page would build clean
- * and render full-bleed. Base, Header and Footer had a copy of this each, free to disagree —
- * `tests/built-shell.test.ts` now asserts the three agree, which is what makes this safe to move.
+ * NOT this site's to choose, unlike everything above it — both instances now carry the same value.
+ * The sibling used to sit one step narrower, and that difference was never decided: its shell was copied
+ * from this one two months later, and the width changed in the same edit as the name and the
+ * description. Neither repo touched it again.
+ *
+ * Nor does either corpus defend a value. The prose measure is set by narrowing locally on the
+ * pages that want it — the sibling does that a dozen times, this instance once — so this is only
+ * the outer bound for tables and grids, of which this instance has 117 pages' worth.
+ *
+ * It lives here because it has to live somewhere until the shell is shared, and it is the first
+ * thing that should LEAVE this file when it is: a shared component can hold one measure and take
+ * no prop for it.
+ *
+ * Two notes on spelling, one mechanism behind both: Tailwind finds utilities by scanning source
+ * TEXT, comments included. So the value is written out in full rather than assembled — from
+ * pieces (`max-w-${size}`) it would find nothing, emit no rule, and the page would build clean and
+ * render full-bleed. And the widths above are described rather than named, because this file
+ * briefly shipped a rule for a width nothing used, on the strength of a comment mentioning it.
+ *
+ * Base, Header and Footer each carried a copy of this, free to disagree —
+ * `tests/built-shell.test.ts` asserts the three agree.
  */
 export const CONTAINER = 'max-w-6xl';

--- a/site/src/lib/site-identity.ts
+++ b/site/src/lib/site-identity.ts
@@ -1,0 +1,34 @@
+// What makes this site THIS site, in one place.
+//
+// The shell — Base, Header, Footer — is within a handful of lines of the sibling instance's, and
+// every one of those lines is a value rather than a decision: the name in the wordmark, the name
+// in the footer, the description, the width of the column. Naming them here is worth doing on its
+// own terms, and it is also what would have to happen first if the shell were ever to be shared:
+// what remains after this is markup, and markup is the part that could move.
+//
+// The two names are not redundant. The wordmark and the <title> suffix want the short one, and
+// the footer wants the full one — this instance is "Foundry" in its own header and "Galaxy
+// Workflow Foundry" at the bottom of the page. The sibling happens to use one string for both,
+// which is a fact about its name and not about the shape of this file.
+
+/** Short name: the header wordmark and the `<title>` suffix. */
+export const SITE_NAME = 'Foundry';
+
+/** Full name: the footer, and the first words of the description. */
+export const SITE_FULL_NAME = 'Galaxy Workflow Foundry';
+
+/** Default `<meta name="description">`, and the og/twitter pair built from it. */
+export const SITE_DESCRIPTION =
+  'Galaxy Workflow Foundry — knowledge base + casting pipeline for Galaxy workflows.';
+
+export const REPO_URL = 'https://github.com/galaxyproject/foundry';
+
+/**
+ * The measure of the reading column, as a Tailwind class.
+ *
+ * Written out in full because Tailwind finds utilities by scanning source text: assembled from
+ * pieces (`max-w-${size}`) it would find nothing and emit no rule, and the page would build clean
+ * and render full-bleed. Base, Header and Footer had a copy of this each, free to disagree —
+ * `tests/built-shell.test.ts` now asserts the three agree, which is what makes this safe to move.
+ */
+export const CONTAINER = 'max-w-6xl';


### PR DESCRIPTION
> **Posted by Claude (AI assistant) on behalf of @jmchilton — not authored by them personally.**

Step 2 of de-risking the shared-shell work: converge the components **in place**, so that if they are ever extracted it is a move rather than a merge. Step 1 was [#427](https://github.com/galaxyproject/foundry/pull/427), which is what makes this safe to attempt.

`Base`, `Header` and `Footer` carried the site's name, its description and the width of its reading column inline. All three are values rather than decisions — and the width was written out **three times**, with nothing checking the three agreed until #427.

```ts
export const SITE_NAME = 'Foundry';                      // wordmark, <title> suffix
export const SITE_FULL_NAME = 'Galaxy Workflow Foundry'; // footer
export const SITE_DESCRIPTION = '…';
export const REPO_URL = '…';
export const CONTAINER = 'max-w-6xl';
```

Two names because there genuinely are two: this site is "Foundry" in its own header and "Galaxy Workflow Foundry" at the bottom of the page. The sibling uses one string for both, which is a fact about its name and not about the shape of the file.

`CONTAINER` is spelled out in full rather than assembled from pieces. Tailwind finds utilities by scanning source text, so `` `max-w-${size}` `` would find nothing, emit no rule, and the page would build clean and render full-bleed — the same silent-success shape as everything else in this area.

## Verified as a refactor, not asserted as one

Built `dist/` before and after and compared **all 374 pages**. The only difference on any of them:

```
- …transition-colors">\nFoundry\n</a>
+ …transition-colors"> Foundry </a>
```

The wordmark's own surrounding whitespace, which is how Astro renders an expression where a text node used to be. Both forms carry whitespace and HTML collapses them identically.

**Every class attribute is byte-identical.** That took template literals rather than `class:list` — `class:list` appends, so it moved `max-w-6xl` to the end of all three attributes. Functionally irrelevant to Tailwind, but it made the diff say "374 pages changed" when nothing had, which is exactly the noise that hides a real change.

## The point

The sibling instance's `Base.astro` is now **byte-identical** to this one ([its half is here](https://github.com/jmchilton/statistical-genomics-foundry/pull/141)). Whether or not the shell is ever shared, the two files no longer differ by anything a reader has to think about.

`Footer.astro` is deliberately *not* identical yet — this one has a copyright year, that one a Books link. Those are the footer's links, and they want the same data treatment the nav does. That is the next step, not this one.

## Checks

245 tests, 17 files. `pnpm typecheck` — 0 errors. 374 pages.

Note: the `packages` job is red on `main` for an unrelated reason — [#428](https://github.com/galaxyproject/foundry/pull/428) fixes it and is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)