### PR TITLE
Fix architecture links and landing copy

### DIFF
--- a/content/meta/architecture.md
+++ b/content/meta/architecture.md
@@ -8,11 +8,11 @@ tags:
 status: reviewed
 created: 2026-04-30
 revised: 2026-08-02
-revision: 45
+revision: 46
 summary: "A short map of the Foundry's major parts, boundaries, and focused architecture records."
 ---
 
-The Galaxy Workflow Foundry is a knowledge base with two compilation paths: one renders authored knowledge for people, and the other casts selected knowledge into portable artifacts for agents. This page is the map of that system. It stays deliberately short; each architectural concern has an owning record linked below.
+The Galaxy Workflow Foundry is a knowledge base with two compilation paths: one renders authored knowledge for people, and the other casts selected knowledge into portable artifacts for agents. This page is the map of that system.
 
 ## System map
 
@@ -33,14 +33,6 @@ authored Foundry source
 
 The source of truth is the authored material under `content/` plus the registries and schema implementations that define its contracts. The site and casts are projections of that source, not alternative authoring surfaces.
 
-## Major boundaries
-
-- **Knowledge versus implementation.** Molds, Patterns, Pipelines, CLI references, schemas, and research notes are Foundry knowledge. TypeScript packages and the Astro application validate, transform, and render that knowledge. [[content-model]] owns the first side; [[code-architecture]] owns the second.
-- **Authored versus generated.** Authors edit source notes, registries, package schemas, and code. They regenerate dashboards, indexes, kind manifests, cast bundles, and assembled pipeline skills. [[build-and-validation]] owns those flows and their drift gates.
-- **Foundry versus external systems.** IWC and source-pipeline fixtures provide evidence; gxwf and Planemo perform design-time or runtime work. They are referenced or invoked, not absorbed into the content model. [[corpus]] owns the corpus boundary.
-- **Foundry versus harness.** The Foundry describes journeys as Pipelines and can assemble a lightweight test-drive harness. Stateful production orchestration remains a consumer concern. [[harness-pipelines]] owns that boundary.
-- **Logical ownership versus physical placement.** A file's directory follows its role and lifecycle. [[repository-layout]] is the authority on where authored, generated, vendored, and temporary material belongs.
-
 ## Focused architecture records
 
 - [[code-architecture]] — packages, applications, dependency direction, entry points, and implementation contracts.
@@ -50,14 +42,21 @@ The source of truth is the authored material under `content/` plus the registrie
 
 These records explain how the system is implemented. The Foundry's domain design remains in the records that own it: [[guiding-principles]], [[molds]], [[mold-spec]], [[casting]], [[eval-philosophy]], [[corpus]], and [[harness-pipelines]]. The glossary remains authoritative when terminology differs.
 
+## Major boundaries
+
+- **Knowledge versus implementation.** The [[content-model]] describes Molds, Patterns, Pipelines, CLI references, schemas, research notes, and how they relate. The [[code-architecture]] explains how TypeScript packages and the Astro application validate, transform, and render that knowledge.
+- **Authored versus generated.** Authors edit source notes, registries, package schemas, and code. They regenerate dashboards, indexes, kind manifests, cast bundles, and assembled pipeline skills. [[build-and-validation]] owns those flows and their drift gates.
+- **Foundry versus external systems.** IWC and source-pipeline fixtures provide evidence; gxwf and Planemo perform design-time or runtime work. They are referenced or invoked, not absorbed into the content model. [[corpus]] owns the corpus boundary.
+- **Foundry versus harness.** As described in [[harness-pipelines]], the Foundry represents journeys as Pipelines and can assemble a lightweight test-drive harness, while stateful production orchestration remains a consumer concern.
+- **Logical ownership versus physical placement.** A file's directory follows its role and lifecycle. [[repository-layout]] is the authority on where authored, generated, vendored, and temporary material belongs.
+
 ## Architectural invariants
 
-1. `content/` is the knowledge source; casts and the site are derived views.
-2. Frontmatter has one zod authority shared by validation and rendering.
-3. Tags, reference kinds, and note kinds are declared vocabularies rather than path or prefix guesses.
-4. Wiki-link parsing and resolution use one shared implementation.
-5. Generated artifacts have deterministic regeneration or an explicit provenance record.
-6. Runtime-specific packaging belongs to casting; Molds remain durable, target-neutral source.
-7. External corpora are cited or materialized as fixtures, never silently copied into the knowledge base.
+- `content/` is the knowledge source; casts and the site are derived views.
+- Frontmatter has one zod authority shared by validation and rendering.
+- Tags, reference kinds, and note kinds are declared vocabularies.
+- Generated artifacts have deterministic regeneration or an explicit provenance record.
+- Runtime-specific packaging belongs to casting; Molds remain durable, target-neutral source.
+- External corpora are cited or materialized as fixtures, never silently copied into the knowledge base.
 
 An architectural change should update the focused record that owns the changed contract. Update this map only when a top-level component, boundary, or reading route changes.

--- a/site/src/components/StopGapBanner.astro
+++ b/site/src/components/StopGapBanner.astro
@@ -1,19 +1,20 @@
 ---
 // Shared stop-gap framing for the pipeline-harness surfaces (run-a-pipeline
 // page, per-pipeline Run panel, harness sub-route). Single source for the
-// "these are deliberate in-repo stop-gaps" honesty wired to ARCHITECTURE §15.
+// "these are deliberate in-repo stop-gaps" honesty wired to the harness design record.
 interface Props {
   compact?: boolean;
 }
 const { compact = false } = Astro.props;
-const archHref = 'https://github.com/galaxyproject/foundry/blob/main/content/meta/architecture.md#15-tracked-follow-up';
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+const harnessHref = `${base}/meta/harness-pipelines/`;
 ---
 <aside class:list={['stop-gap', compact && 'stop-gap-compact']} aria-label="Stop-gap notice">
   <span class="badge badge-draft">stop-gap</span>
   <p>
     Pipeline harnesses are a deliberate in-repo <strong>stop-gap</strong>, not the production
     harness surface. How a pipeline becomes an executable harness is open research
-    (<a href={archHref} rel="noreferrer">ARCHITECTURE §15</a>). Today each harness is a trivial
+    (<a href={harnessHref}>Harness Pipelines</a>). Today each harness is a trivial
     linear skill that runs its phase casts in order; expect <strong>manual checkpoints</strong>
     where a phase isn't yet cast. If a run teaches you something, change the Mold and recast —
     don't hand-edit the harness skill.


### PR DESCRIPTION
## What changed

- replace the Usage pipeline banner's stale GitHub architecture anchor with a base-aware in-site link to the Harness Pipelines record
- move Focused architecture records above Major boundaries
- make the knowledge/implementation and Foundry/harness boundary copy more natural
- simplify Architectural invariants into bullets and remove the requested wording and invariant

## Why

The Usage banner still referenced a section in the former monolithic architecture document. That document has been decomposed, leaving the GitHub anchor stale and sending readers outside the site. The architecture landing copy also needed to reflect the new focused-record structure more directly.

## Impact

Readers remain within the Foundry site and land on the current harness architecture record. The architecture map is easier to scan and uses less formal ownership language.

## Validation

- `npm run validate` — passes with 0 errors (existing advisory warnings remain)
- `npm run site:typecheck` — passes with 0 diagnostics
- commit pre-commit hooks — pass
- `npm run site:build` — compilation succeeds, but route prerendering is blocked by an unrelated dependency error: `neotraverse` does not export `forEach`
