### PR TITLE
One nav list and a cut point, not two lists

### DIFF
--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -165,7 +165,12 @@ const moreActive = moreLinks.some(link => link.active);
     document.documentElement.dataset.pfTheme = isDark ? 'dark' : 'light';
     updateIcons();
   });
+</script>
 
+{/* Ships only where there is a group to drive. An instance whose destinations all fit on the bar
+    renders no "More", and every line below would bind to nothing on every one of its pages. */}
+{moreLinks.length > 0 && (
+<script is:inline>
   const moreTrigger = document.getElementById('nav-more-trigger');
   const moreWrap = moreTrigger?.closest('.nav-more');
   function closeMore() {
@@ -183,3 +188,4 @@ const moreActive = moreLinks.some(link => link.active);
     if (e.key === 'Escape') closeMore();
   });
 </script>
+)}

--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -1,23 +1,22 @@
 ---
 import Search from 'astro-pagefind/components/Search.astro';
-import { CONTAINER, SITE_NAME } from '../lib/site-identity';
+import { CONTAINER, NAV_LINKS, NAV_VISIBLE, SITE_NAME } from '../lib/site-identity';
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const pathname = Astro.url.pathname.replace(/\/$/, '') || '/';
-const navLinks = [
-  { href: `${base}/story/`, label: 'Story', match: (p: string) => p.startsWith(`${base}/story`) },
-  { href: `${base}/usage/`, label: 'Usage', match: (p: string) => p.startsWith(`${base}/usage`) },
-  { href: `${base}/molds/`, label: 'Molds', match: (p: string) => p.startsWith(`${base}/molds`) },
-  { href: `${base}/patterns/`, label: 'Patterns', match: (p: string) => p.startsWith(`${base}/patterns`) },
-  { href: `${base}/pipelines/`, label: 'Pipelines', match: (p: string) => p.startsWith(`${base}/pipelines`) && !p.includes('/molds') },
-];
-const moreLinks = [
-  { href: `${base}/dashboard/`, label: 'Dashboard', match: (p: string) => p.startsWith(`${base}/dashboard`) },
-  { href: `${base}/index/`, label: 'Index', match: (p: string) => p.startsWith(`${base}/index`) },
-  { href: `${base}/tags/`, label: 'Tags', match: (p: string) => p.startsWith(`${base}/tags`) },
-  { href: `${base}/external/`, label: 'External', match: (p: string) => p.startsWith(`${base}/external`) },
-  { href: `${base}/log/`, label: 'Log', match: (p: string) => p.startsWith(`${base}/log`) },
-];
-const moreActive = moreLinks.some(link => link.match(pathname));
+// One list and a cut point, not two lists. Which destinations exist and which of them fit on the
+// bar are different questions, and only the second one is about this header's width.
+const links = NAV_LINKS.map(link => {
+  const href = `${base}${link.path}`;
+  const section = href.replace(/\/$/, '');
+  return {
+    ...link,
+    href,
+    active: pathname === section || pathname.startsWith(`${section}/`),
+  };
+});
+const barLinks = links.slice(0, NAV_VISIBLE);
+const moreLinks = links.slice(NAV_VISIBLE);
+const moreActive = moreLinks.some(link => link.active);
 ---
 <header class="bg-(--color-galaxy-dark) border-b-4 border-(--color-accent) relative">
   <div class="absolute inset-0 bg-grid-header pointer-events-none"></div>
@@ -27,21 +26,19 @@ const moreActive = moreLinks.some(link => link.match(pathname));
         {SITE_NAME}
       </a>
       <nav class="flex items-center gap-3 text-sm" aria-label="Primary">
-        {navLinks.map(link => {
-          const active = link.match(pathname);
-          return (
-            <a
-              href={link.href}
-              aria-current={active ? 'page' : undefined}
-              class:list={[
-                'text-(--color-text-on-dark) no-underline hover:text-(--color-accent) transition-colors opacity-80 hover:opacity-100',
-                active && 'nav-link-active',
-              ]}
-            >
-              {link.label}
-            </a>
-          );
-        })}
+        {barLinks.map(link => (
+          <a
+            href={link.href}
+            aria-current={link.active ? 'page' : undefined}
+            class:list={[
+              'text-(--color-text-on-dark) no-underline hover:text-(--color-accent) transition-colors opacity-80 hover:opacity-100',
+              link.active && 'nav-link-active',
+            ]}
+          >
+            {link.label}
+          </a>
+        ))}
+        {moreLinks.length > 0 && (
         <div class="nav-more relative">
           <button
             type="button"
@@ -65,38 +62,36 @@ const moreActive = moreLinks.some(link => link.match(pathname));
             aria-labelledby="nav-more-trigger"
             class="nav-more-menu absolute left-0 top-full mt-2 min-w-40 rounded-md border border-(--color-accent) bg-(--color-galaxy-dark) shadow-lg py-1 z-50"
           >
-            {moreLinks.map(link => {
-              const active = link.match(pathname);
-              return (
-                <a
-                  href={link.href}
-                  role="menuitem"
-                  aria-current={active ? 'page' : undefined}
-                  class:list={[
-                    'block px-4 py-1.5 text-sm text-(--color-text-on-dark) no-underline hover:text-(--color-accent) hover:bg-white/5 transition-colors opacity-80 hover:opacity-100',
-                    active && 'nav-link-active',
-                  ]}
-                >
-                  {link.label}
-                </a>
-              );
-            })}
+            {moreLinks.map(link => (
+              <a
+                href={link.href}
+                role="menuitem"
+                aria-current={link.active ? 'page' : undefined}
+                class:list={[
+                  'block px-4 py-1.5 text-sm text-(--color-text-on-dark) no-underline hover:text-(--color-accent) hover:bg-white/5 transition-colors opacity-80 hover:opacity-100',
+                  link.active && 'nav-link-active',
+                ]}
+              >
+                {link.label}
+              </a>
+            ))}
           </div>
         </div>
+        )}
       </nav>
     </div>
     <div class="flex items-center gap-2">
       <Search className="pagefind-ui" searchboxOptions={{ 'show-sub-results': true }} />
-    <button id="theme-toggle" type="button"
-      class="p-1.5 rounded text-(--color-text-on-dark) opacity-70 hover:opacity-100 hover:text-(--color-accent) transition-all duration-200 cursor-pointer active:scale-95"
-      aria-label="Toggle dark mode">
-      <svg id="icon-sun" class="w-5 h-5 hidden" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-        <circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/>
-      </svg>
-      <svg id="icon-moon" class="w-5 h-5 hidden" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
-      </svg>
-    </button>
+      <button id="theme-toggle" type="button"
+        class="p-1.5 rounded text-(--color-text-on-dark) opacity-70 hover:opacity-100 hover:text-(--color-accent) transition-all duration-200 cursor-pointer active:scale-95"
+        aria-label="Toggle dark mode">
+        <svg id="icon-sun" class="w-5 h-5 hidden" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+          <circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/>
+        </svg>
+        <svg id="icon-moon" class="w-5 h-5 hidden" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+        </svg>
+      </button>
     </div>
   </div>
 </header>
@@ -119,8 +114,11 @@ const moreActive = moreLinks.some(link => link.match(pathname));
     --pf-searchbox-dropdown-max-height: 70vh;
     --pf-dropdown-z-index: 50;
   }
-  /* The input sits at the right edge of a narrow header, so the dropdown is widened and
-     right-anchored rather than tracking the input's 16rem width. */
+  /* The input sits at the right edge of the header, so the dropdown is widened and right-anchored
+     rather than tracking the input's width. The two instances shipped different input widths from
+     the pagefind 2 migration until now — that migration was done twice on the same day and the
+     value drifted between the copies — and this comment called the header "narrow", which stopped
+     being true of either of them once the container widths converged. */
   .pagefind-ui .pf-searchbox-dropdown {
     right: 0;
     left: auto;

--- a/site/src/lib/site-identity.ts
+++ b/site/src/lib/site-identity.ts
@@ -2,9 +2,13 @@
 //
 // The shell — Base, Header, Footer — is within a handful of lines of the sibling instance's, and
 // every one of those lines is a value rather than a decision: the name in the wordmark, the name
-// in the footer, the description, the width of the column. Naming them here is worth doing on its
-// own terms, and it is also what would have to happen first if the shell were ever to be shared:
-// what remains after this is markup, and markup is the part that could move.
+// in the footer, the description, the width of the column, where the nav goes. Naming them here is
+// worth doing on its own terms, and it is also what would have to happen first if the shell were
+// ever to be shared: what remains after this is markup, and markup is the part that could move.
+//
+// Base.astro and Header.astro are now byte-identical to the sibling's. That is the measure of how
+// much of the shell was ever this site's: two files, and the difference between them was entirely
+// the values below.
 //
 // The two names are not redundant. The wordmark and the <title> suffix want the short one, and
 // the footer wants the full one — this instance is "Foundry" in its own header and "Galaxy
@@ -12,16 +16,56 @@
 // which is a fact about its name and not about the shape of this file.
 
 /** Short name: the header wordmark and the `<title>` suffix. */
-export const SITE_NAME = 'Foundry';
+export const SITE_NAME = "Foundry";
 
 /** Full name: the footer, and the first words of the description. */
-export const SITE_FULL_NAME = 'Galaxy Workflow Foundry';
+export const SITE_FULL_NAME = "Galaxy Workflow Foundry";
 
 /** Default `<meta name="description">`, and the og/twitter pair built from it. */
 export const SITE_DESCRIPTION =
-  'Galaxy Workflow Foundry — knowledge base + casting pipeline for Galaxy workflows.';
+  "Galaxy Workflow Foundry — knowledge base + casting pipeline for Galaxy workflows.";
 
-export const REPO_URL = 'https://github.com/galaxyproject/foundry';
+export const REPO_URL = "https://github.com/galaxyproject/foundry";
+
+/**
+ * The primary navigation, in order.
+ *
+ * `path` is site-absolute and carries no base — `BASE_URL` is applied where the link is rendered.
+ * That keeps this a plain list: no closures, nothing an environment variable has to resolve, so it
+ * can be serialized, read from a file, or handed to a shared header as a prop.
+ *
+ * Active state is DERIVED from `path`: a link is active on its own page and on everything under
+ * it. Every entry used to carry that rule as its own `match` closure, and fifteen of the sixteen
+ * across the two instances were the same single line. The sixteenth — Pipelines, here — also
+ * excluded any path containing `/molds`, and that pair of routes has never existed: the clause
+ * dates to the first commit of the repo and matches none of the 374 pages the build emits. It is
+ * gone rather than ported, because a shared header cannot take an exception it cannot express.
+ */
+export const NAV_LINKS = [
+  { path: "/story/", label: "Story" },
+  { path: "/usage/", label: "Usage" },
+  { path: "/molds/", label: "Molds" },
+  { path: "/patterns/", label: "Patterns" },
+  { path: "/pipelines/", label: "Pipelines" },
+  { path: "/dashboard/", label: "Dashboard" },
+  { path: "/index/", label: "Index" },
+  { path: "/tags/", label: "Tags" },
+  { path: "/external/", label: "External" },
+  { path: "/log/", label: "Log" },
+];
+
+/**
+ * How many of them stay on the bar. Everything after goes under "More".
+ *
+ * A count, not a claim about which sections matter — it is set by what fits, and what fits differs
+ * between the two instances because the wordmark does. Measured against the built page at the
+ * 1152px bound: this wordmark is 75px, and five links plus the search box leave 399px of slack.
+ * The sibling's wordmark is 279px — 204px more, about four links' worth — so it carries all six of
+ * its destinations on the bar and its "More" group never renders.
+ *
+ * Raise it while the bar has slack; lower it the moment a label wraps to a second row.
+ */
+export const NAV_VISIBLE = 5;
 
 /**
  * The measure of the reading column, as a Tailwind class.
@@ -48,4 +92,4 @@ export const REPO_URL = 'https://github.com/galaxyproject/foundry';
  * Base, Header and Footer each carried a copy of this, free to disagree —
  * `tests/built-shell.test.ts` asserts the three agree.
  */
-export const CONTAINER = 'max-w-6xl';
+export const CONTAINER = "max-w-6xl";

--- a/tests/built-shell.test.ts
+++ b/tests/built-shell.test.ts
@@ -176,9 +176,11 @@ describe("the navigation", () => {
   const region = (html: string, open: string, close: string): string =>
     html.slice(html.indexOf(open), html.indexOf(close) + close.length);
   const hrefsIn = (nav: string): string[] =>
-    [...nav.matchAll(/<a\s[^>]*href="([^"]+)"/g)].map((m) => m[1]);
+    [...nav.matchAll(/<a\s[^>]*href="([^"]+)"/g)].flatMap((m) => (m[1] ? [m[1]] : []));
   const activeIn = (nav: string): string[] =>
-    [...nav.matchAll(/<a\s[^>]*href="([^"]+)"[^>]*aria-current="page"/g)].map((m) => m[1]);
+    [...nav.matchAll(/<a\s[^>]*href="([^"]+)"[^>]*aria-current="page"/g)].flatMap((m) =>
+      m[1] ? [m[1]] : [],
+    );
   /** The wordmark is the first link in the header, and it points at the site root. */
   const baseFrom = (html: string): string =>
     (/<a\s[^>]*href="([^"]+)"/.exec(region(html, "<header", "</header>"))?.[1] ?? "/").replace(
@@ -230,7 +232,7 @@ describe("the navigation", () => {
       // The section index and the last page under it. The rule is "this page or anything beneath
       // it", and the second sample is the half a plain equality check would get wrong.
       return [under[0], under[under.length - 1]]
-        .filter(Boolean)
+        .filter((file): file is string => Boolean(file))
         .map((file) => ({
           page: rel(file),
           marked: activeIn(region(read(file), "<nav", "</nav>")),

--- a/tests/built-shell.test.ts
+++ b/tests/built-shell.test.ts
@@ -31,6 +31,8 @@ import path from "node:path";
 
 import { beforeAll, describe, expect, it } from "vitest";
 
+import { NAV_LINKS } from "../site/src/lib/site-identity";
+
 const REPO_ROOT = new URL("../", import.meta.url).pathname;
 const SITE = path.join(REPO_ROOT, "site");
 const DIST = path.join(SITE, "dist");
@@ -47,6 +49,20 @@ function newestMtime(dir: string): number {
 }
 
 /**
+ * The environment for the child build, with vitest's own removed.
+ *
+ * Vitest mirrors `import.meta.env` into `process.env` — `MODE`, `DEV`, `PROD`, `SSR`, and
+ * `BASE_URL=/`. A child `astro build` inherits all five, and takes `BASE_URL` over the `base` in
+ * `astro.config.mjs`: every link on every page comes out root-relative, and this suite asserts
+ * against a site that is not the one being shipped. It built cleanly, all 374 pages, for as long
+ * as this file has existed. Nothing noticed until an assertion read an href.
+ */
+function buildEnv(): NodeJS.ProcessEnv {
+  const { BASE_URL, MODE, DEV, PROD, SSR, ...rest } = process.env;
+  return rest;
+}
+
+/**
  * Build only when `dist/` is missing or older than the sources.
  *
  * Asserting against a stale `dist/` is worse than not asserting: it reports on a site nobody is
@@ -55,10 +71,9 @@ function newestMtime(dir: string): number {
 function ensureBuilt(): void {
   const landmark = path.join(DIST, "index.html");
   const fresh =
-    existsSync(landmark) &&
-    statSync(landmark).mtimeMs > newestMtime(path.join(SITE, "src"));
+    existsSync(landmark) && statSync(landmark).mtimeMs > newestMtime(path.join(SITE, "src"));
   if (fresh) return;
-  execFileSync("pnpm", ["run", "build"], { cwd: SITE, stdio: "inherit" });
+  execFileSync("pnpm", ["run", "build"], { cwd: SITE, stdio: "inherit", env: buildEnv() });
 }
 
 function builtPages(dir: string = DIST): string[] {
@@ -145,8 +160,84 @@ describe("the stylesheet the shell depends on", () => {
       css.includes(LAYOUT_ONLY_UTILITY),
       `\n\`${LAYOUT_ONLY_UTILITY}\` is referenced by the built markup but has no rule in any` +
         ` emitted stylesheet. Tailwind did not scan the file that declares it — see the header` +
-        ` comment. The pages will render unstyled, and nothing else reports this.`
+        ` comment. The pages will render unstyled, and nothing else reports this.`,
     ).toBe(true);
+  });
+});
+
+describe("the navigation", () => {
+  // `NAV_LINKS` is data: a path and a label, nothing callable. Which link is active is DERIVED
+  // from the path rather than declared per entry, and one derivation now stands in for ten
+  // hand-written matchers — so the derivation is what gets asserted, against built pages.
+  //
+  // Both halves fail quietly. A destination that points at no route renders as a perfectly good
+  // link to a 404, and a section that never lights up looks like a page the reader navigated to
+  // some other way. Neither shows up in a build log.
+  const region = (html: string, open: string, close: string): string =>
+    html.slice(html.indexOf(open), html.indexOf(close) + close.length);
+  const hrefsIn = (nav: string): string[] =>
+    [...nav.matchAll(/<a\s[^>]*href="([^"]+)"/g)].map((m) => m[1]);
+  const activeIn = (nav: string): string[] =>
+    [...nav.matchAll(/<a\s[^>]*href="([^"]+)"[^>]*aria-current="page"/g)].map((m) => m[1]);
+  /** The wordmark is the first link in the header, and it points at the site root. */
+  const baseFrom = (html: string): string =>
+    (/<a\s[^>]*href="([^"]+)"/.exec(region(html, "<header", "</header>"))?.[1] ?? "/").replace(
+      /\/$/,
+      "",
+    );
+
+  it("emits links under the base the site is configured to deploy at", () => {
+    // The assertion that found the `BASE_URL` leak above, stated directly so the next one names
+    // itself instead of surfacing as "no section is ever marked active". The pages are served
+    // from a subpath; a build that forgets it produces links that all 404 on the deployed site
+    // and all resolve locally.
+    const configured = /\bbase\s*[:=]\s*["']([^"']+)["']/.exec(
+      read(path.join(SITE, "astro.config.mjs")),
+    )?.[1];
+
+    expect(configured, "\nno base in astro.config.mjs — has the config moved?").toBeTruthy();
+    expect(baseFrom(home)).toBe(configured);
+  });
+
+  it("points every destination at a section the build emitted", () => {
+    const missing = NAV_LINKS.filter(
+      (link) => !existsSync(path.join(DIST, link.path, "index.html")),
+    );
+    expect(
+      missing.map((link) => link.path),
+      "\nnav destinations with no built index",
+    ).toEqual([]);
+  });
+
+  it("renders every destination it declares, on the bar or under More", () => {
+    // The bar is a slice of the list, so a wrong cut point drops links off the end of the header
+    // rather than erroring. Count and membership both, since a duplicate would satisfy the count.
+    const rendered = new Set(hrefsIn(region(home, "<nav", "</nav>")));
+    const declared = NAV_LINKS.map((link) => `${baseFrom(home)}${link.path}`);
+
+    expect(
+      declared.filter((href) => !rendered.has(href)),
+      "\ndeclared but not rendered",
+    ).toEqual([]);
+    expect(rendered.size).toBe(NAV_LINKS.length);
+  });
+
+  it("marks the section the reader is in, and marks no other", () => {
+    const base = baseFrom(home);
+    const wrong = NAV_LINKS.flatMap((link) => {
+      const href = `${base}${link.path}`;
+      const under = pages.filter((file) => rel(file).startsWith(link.path.slice(1)));
+      // The section index and the last page under it. The rule is "this page or anything beneath
+      // it", and the second sample is the half a plain equality check would get wrong.
+      return [under[0], under[under.length - 1]]
+        .filter(Boolean)
+        .map((file) => ({
+          page: rel(file),
+          marked: activeIn(region(read(file), "<nav", "</nav>")),
+        }))
+        .filter((seen) => seen.marked.length !== 1 || seen.marked[0] !== href);
+    });
+    expect(wrong, "\npages whose header does not mark exactly their own section").toEqual([]);
   });
 });
 


### PR DESCRIPTION
> Posted by Claude (AI assistant) on jmchilton's behalf.

The nav was two hardcoded lists whose entries each carried a `match` closure. It is now one list of `{path, label}` plus a count of how many fit on the bar, and the active rule is derived.

## Why this shape

Fifteen of the sixteen `match` closures across this repo and the sibling were the same line — `p.startsWith(href-without-its-slash)`. The sixteenth, on Pipelines, also excluded any path containing `/molds`. That route pair has never existed: the clause dates to `fc49964 Initial project structure` and matches none of the 374 pages the build emits. It is deleted rather than ported.

Deriving the rule is what makes `NAV_LINKS` **data** — no closures, nothing an environment variable has to resolve. A `match` per entry cannot be passed to a shared component or read from a file; a path can. `Header.astro` is byte-identical to the sibling's after this, as `Base.astro` already was.

Where the bar cuts is a count, and it is measured rather than chosen. At the 1152px bound this wordmark is 75px and five links plus the search box leave 399px of slack. The sibling's wordmark is 279px — about four links' worth — which is why it carries all six of its destinations flat and its More group renders nothing.

The More menu's script now ships only where there is a group to drive it. Same file in both repos; the sibling emits no group, so it emits no script.

## The bug this turned up

**The harness has been building the site at the wrong base since it landed in #427.** Vitest mirrors `import.meta.env` into `process.env`, including `BASE_URL=/`. The child `astro build` inherits it and prefers it over the `base` in `astro.config.mjs`, so every link on every page came out root-relative — `/story/` instead of `/foundry/story/`. Routing still used the configured base, so nothing matched anything.

It built clean, all 374 pages, every time. No previous assertion read an href, so nothing caught it. `ensureBuilt` now strips the five mirrored variables, and there is a named assertion for it so the next occurrence says so directly instead of surfacing as "no section is ever marked active".

## Assertions

Four new, in `tests/built-shell.test.ts`. Each was falsified before being kept:

| break | what fails |
| --- | --- |
| `slice(NAV_VISIBLE + 1)` — drop a link off the end | renders every destination (+1 more) |
| `active: pathname === section` — exact match only | marks the section the reader is in |
| let vitest's `BASE_URL` through | emits links under the configured base (+ marks the section) |

## Verification

- **All 374 headers byte-identical to a pre-change build** after whitespace normalisation. The derivation reproduces the ten hand-written matchers exactly; the only rendered change is the More script moving into its own tag.
- 249 tests pass, `astro check` 0 errors.
