### PR TITLE
The footer's links are data, and its year was a clock

### DIFF
--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -1,15 +1,22 @@
 ---
-import { CONTAINER, REPO_URL, SITE_FULL_NAME } from '../lib/site-identity';
-const year = new Date().getFullYear();
+import { CONTAINER, FOOTER_LINKS, REPO_URL, SITE_FULL_NAME } from '../lib/site-identity';
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 ---
 <footer class="mt-auto bg-(--color-galaxy-dark) text-(--color-text-on-dark)">
   <div class={`${CONTAINER} mx-auto px-4 sm:px-6 py-6 flex flex-wrap items-center justify-between gap-4 text-sm opacity-70`}>
     <div class="flex items-center gap-2">
       <div class="w-1 h-4 bg-(--color-accent) rounded-full"></div>
-      <span>&copy; {year} {SITE_FULL_NAME}</span>
+      {/* No year. `new Date().getFullYear()` runs at BUILD time, so the notice reported whenever
+          the site was last deployed rather than anything about the work — and it put a clock in
+          the output, which the rendered-output diffing this shell is verified by cannot tell from
+          a real change. One instance carried it and the other never did; neither had decided to. */}
+      <span>&copy; {SITE_FULL_NAME}</span>
     </div>
-    <a href={REPO_URL} class="text-(--color-text-on-dark) no-underline hover:text-(--color-accent) transition-colors">
-      GitHub
-    </a>
+    <div class="flex items-center gap-4">
+      {FOOTER_LINKS.map(link => (
+        <a href={`${base}${link.path}`} class="text-(--color-text-on-dark) no-underline hover:text-(--color-accent) transition-colors">{link.label}</a>
+      ))}
+      <a href={REPO_URL} class="text-(--color-text-on-dark) no-underline hover:text-(--color-accent) transition-colors">GitHub</a>
+    </div>
   </div>
 </footer>

--- a/site/src/lib/site-identity.ts
+++ b/site/src/lib/site-identity.ts
@@ -28,11 +28,16 @@ export const SITE_DESCRIPTION =
 export const REPO_URL = "https://github.com/galaxyproject/foundry";
 
 /**
- * The primary navigation, in order.
+ * A destination in the shell's chrome.
  *
  * `path` is site-absolute and carries no base — `BASE_URL` is applied where the link is rendered.
- * That keeps this a plain list: no closures, nothing an environment variable has to resolve, so it
- * can be serialized, read from a file, or handed to a shared header as a prop.
+ * That keeps these plain lists: no closures, nothing an environment variable has to resolve, so
+ * they can be serialized, read from a file, or handed to a shared component as props.
+ */
+export type ShellLink = { path: string; label: string };
+
+/**
+ * The primary navigation, in order.
  *
  * Active state is DERIVED from `path`: a link is active on its own page and on everything under
  * it. Every entry used to carry that rule as its own `match` closure, and fifteen of the sixteen
@@ -41,7 +46,7 @@ export const REPO_URL = "https://github.com/galaxyproject/foundry";
  * dates to the first commit of the repo and matches none of the 374 pages the build emits. It is
  * gone rather than ported, because a shared header cannot take an exception it cannot express.
  */
-export const NAV_LINKS = [
+export const NAV_LINKS: ShellLink[] = [
   { path: "/story/", label: "Story" },
   { path: "/usage/", label: "Usage" },
   { path: "/molds/", label: "Molds" },
@@ -66,6 +71,17 @@ export const NAV_LINKS = [
  * Raise it while the bar has slack; lower it the moment a label wraps to a second row.
  */
 export const NAV_VISIBLE = 5;
+
+/**
+ * Destinations the footer offers beside the repository, which it always links.
+ *
+ * Empty here, and one entry in the sibling. That is the whole of what the two footers disagreed
+ * about once the copyright line went: an instance whose corpus has an obvious front door names it
+ * twice, and this one does not have one.
+ *
+ * The list renders in order, before the repository link.
+ */
+export const FOOTER_LINKS: ShellLink[] = [];
 
 /**
  * The measure of the reading column, as a Tailwind class.

--- a/tests/built-shell.test.ts
+++ b/tests/built-shell.test.ts
@@ -31,7 +31,7 @@ import path from "node:path";
 
 import { beforeAll, describe, expect, it } from "vitest";
 
-import { NAV_LINKS } from "../site/src/lib/site-identity";
+import { FOOTER_LINKS, NAV_LINKS, REPO_URL } from "../site/src/lib/site-identity";
 
 const REPO_ROOT = new URL("../", import.meta.url).pathname;
 const SITE = path.join(REPO_ROOT, "site");
@@ -165,6 +165,21 @@ describe("the stylesheet the shell depends on", () => {
   });
 });
 
+const region = (html: string, open: string, close: string): string =>
+  html.slice(html.indexOf(open), html.indexOf(close) + close.length);
+const hrefsIn = (nav: string): string[] =>
+  [...nav.matchAll(/<a\s[^>]*href="([^"]+)"/g)].flatMap((m) => (m[1] ? [m[1]] : []));
+const activeIn = (nav: string): string[] =>
+  [...nav.matchAll(/<a\s[^>]*href="([^"]+)"[^>]*aria-current="page"/g)].flatMap((m) =>
+    m[1] ? [m[1]] : [],
+  );
+/** The wordmark is the first link in the header, and it points at the site root. */
+const baseFrom = (html: string): string =>
+  (/<a\s[^>]*href="([^"]+)"/.exec(region(html, "<header", "</header>"))?.[1] ?? "/").replace(
+    /\/$/,
+    "",
+  );
+
 describe("the navigation", () => {
   // `NAV_LINKS` is data: a path and a label, nothing callable. Which link is active is DERIVED
   // from the path rather than declared per entry, and one derivation now stands in for ten
@@ -173,21 +188,6 @@ describe("the navigation", () => {
   // Both halves fail quietly. A destination that points at no route renders as a perfectly good
   // link to a 404, and a section that never lights up looks like a page the reader navigated to
   // some other way. Neither shows up in a build log.
-  const region = (html: string, open: string, close: string): string =>
-    html.slice(html.indexOf(open), html.indexOf(close) + close.length);
-  const hrefsIn = (nav: string): string[] =>
-    [...nav.matchAll(/<a\s[^>]*href="([^"]+)"/g)].flatMap((m) => (m[1] ? [m[1]] : []));
-  const activeIn = (nav: string): string[] =>
-    [...nav.matchAll(/<a\s[^>]*href="([^"]+)"[^>]*aria-current="page"/g)].flatMap((m) =>
-      m[1] ? [m[1]] : [],
-    );
-  /** The wordmark is the first link in the header, and it points at the site root. */
-  const baseFrom = (html: string): string =>
-    (/<a\s[^>]*href="([^"]+)"/.exec(region(html, "<header", "</header>"))?.[1] ?? "/").replace(
-      /\/$/,
-      "",
-    );
-
   it("emits links under the base the site is configured to deploy at", () => {
     // The assertion that found the `BASE_URL` leak above, stated directly so the next one names
     // itself instead of surfacing as "no section is ever marked active". The pages are served
@@ -240,6 +240,36 @@ describe("the navigation", () => {
         .filter((seen) => seen.marked.length !== 1 || seen.marked[0] !== href);
     });
     expect(wrong, "\npages whose header does not mark exactly their own section").toEqual([]);
+  });
+});
+
+describe("the footer", () => {
+  it("links to the repository and to every extra destination it declares", () => {
+    const links = hrefsIn(region(home, "<footer", "</footer>"));
+    const declared = FOOTER_LINKS.map((link) => `${baseFrom(home)}${link.path}`);
+
+    expect(links, "\nthe repository link is missing from the footer").toContain(REPO_URL);
+    expect(
+      declared.filter((href) => !links.includes(href)),
+      "\ndeclared but not rendered",
+    ).toEqual([]);
+    expect(
+      FOOTER_LINKS.filter((link) => !existsSync(path.join(DIST, link.path, "index.html"))).map(
+        (link) => link.path,
+      ),
+      "\nfooter destinations with no built index",
+    ).toEqual([]);
+  });
+
+  it("puts no clock in the output", () => {
+    // The copyright line used to read `© ${new Date().getFullYear()}`, which runs at BUILD time:
+    // the page reported when it was last deployed, and the same commit rendered differently on
+    // either side of a new year. Every check this shell has is a diff against built output, and a
+    // build that is not reproducible from its source makes those diffs unreadable.
+    const stamped = pages.filter((file) =>
+      /\b(19|20)\d{2}\b/.test(region(read(file), "<footer", "</footer>")),
+    );
+    expect(stamped.map(rel), "\npages whose footer carries a year").toEqual([]);
   });
 });
 


### PR DESCRIPTION
> Posted by Claude (AI assistant) on jmchilton's behalf.

`Footer.astro` was the last shell file that differed between this repo and the sibling. After this, **`Base.astro`, `Header.astro` and `Footer.astro` are all byte-identical across the two instances** — the entire reading shell is one file living in three places, and everything that makes each site itself lives in `site-identity.ts`.

## The links

The footers disagreed about one thing: the sibling offers a link to its corpus front door beside the GitHub link, and this one has no single equivalent. That becomes `FOOTER_LINKS` — the same `ShellLink` shape the nav uses, rendered in order before the repository link, which both instances always carry. Empty here, one entry there.

## The year

Deleted, and this is the part worth a second opinion.

`new Date().getFullYear()` runs at **build time**. The notice reported when the site was last deployed, not anything about the work: a site not rebuilt in 2027 claims © 2026, and a rebuild of unchanged content claims the new year. It also put a clock in the output — the same commit renders differently across a new year, which every check on this shell has to read through, since they are all diffs against built HTML. The `©` mark stays; the sibling gains it in the companion PR.

Provenance, since that decided the direction: this footer was born with the year in `fc49964 Initial project structure` (2026-04-30); the sibling's was copied from it on 2026-06-26 without one, and `git log -S getFullYear` finds nothing there ever. Neither repo touched it again. Another crib artifact, like the container width and the searchbox before it.

## Assertions

Two new, in `tests/built-shell.test.ts`, each falsified before being kept:

| break | what fails |
| --- | --- |
| restore `{new Date().getFullYear()}` | puts no clock in the output |
| delete the repository link | links to the repository and to every extra destination |
| stop rendering `FOOTER_LINKS` *(falsified in the sibling — the list is empty here, so that clause is vacuous in this repo)* | links to the repository and to every extra destination |
| point a declared link at a route that does not exist | same |

The `region`/`hrefsIn`/`baseFrom` helpers move to module scope so the footer block reuses them.

## Verification

Rendered diff against a pre-change build, all 374 pages: every footer changes in exactly two ways — `© 2026 Galaxy Workflow Foundry` → `© Galaxy Workflow Foundry`, and the GitHub link gains the flex wrapper that holds the (empty) link list. Nothing else on any page.

251 tests pass, root `tsc --noEmit` and `astro check` both clean.
