### PR TITLE
Seven bundles shipped a dead path, and CI checked one Mold

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -83,7 +83,7 @@ jobs:
         run: npm run packages-lint
 
       - name: Cast drift check
-        run: npm run cast -- summarize-nextflow --check
+        run: make check-casts
 
       - name: Build site
         run: npm run site:build

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
-.PHONY: validate test typecheck generated check-generated check assemble-pipelines check-assemble-pipelines fixtures fixtures-nextflow fixtures-cwl fixtures-iwc fixtures-skeletons fixtures-verify fixtures-clean sync-planemo sync-planemo-cli sync-planemo-test-report-schema sync-planemo-cli-meta check-planemo-cli
+.PHONY: validate test typecheck generated check-generated check casts check-casts assemble-pipelines check-assemble-pipelines fixtures fixtures-nextflow fixtures-cwl fixtures-iwc fixtures-skeletons fixtures-verify fixtures-clean sync-planemo sync-planemo-cli sync-planemo-test-report-schema sync-planemo-cli-meta check-planemo-cli
 
 FOUNDRY_BUILD := npx tsx packages/build-cli/src/bin/foundry-build.ts
 PIPELINE_SLUGS := $(patsubst content/pipelines/%/index.md,%,$(wildcard content/pipelines/*/index.md))
+MOLD_SLUGS := $(patsubst content/molds/%/index.md,%,$(wildcard content/molds/*/index.md))
 
 validate:
 	npm run validate
@@ -22,13 +23,26 @@ check-generated:
 	npm run check:index
 	npm run check:readme
 
+casts:
+	@for m in $(MOLD_SLUGS); do echo "cast $$m"; $(FOUNDRY_BUILD) cast --root . $$m || exit 1; done
+
+# Every Mold, not a representative one. A verbatim ref's guarantee is
+# src_hash == dst_hash, and a bundle whose source moved on satisfies it against
+# a note that no longer exists — self-consistent and stale. Only re-hashing the
+# source against the record catches that, and only over the whole corpus: seven
+# bundles carried a dead doc path for two weeks while the one Mold CI checked
+# stayed green.
+check-casts:
+	@fail=0; for m in $(MOLD_SLUGS); do $(FOUNDRY_BUILD) cast --root . $$m --check >/dev/null || { echo "drift: $$m"; fail=1; }; done; \
+	if [ $$fail -ne 0 ]; then echo "cast drift — run 'make casts' and commit the result"; exit 1; fi
+
 assemble-pipelines:
 	@for p in $(PIPELINE_SLUGS); do echo "assemble $$p"; $(FOUNDRY_BUILD) assemble-pipeline --root . $$p || exit 1; done
 
 check-assemble-pipelines:
 	@for p in $(PIPELINE_SLUGS); do $(FOUNDRY_BUILD) assemble-pipeline --root . $$p --check || exit 1; done
 
-check: validate check-generated check-assemble-pipelines test
+check: validate check-generated check-casts check-assemble-pipelines test
 
 fixtures:
 	$(MAKE) -C workflow-fixtures all

--- a/casts/claude/skills/changeset-to-galaxy-test-plan/_provenance.json
+++ b/casts/claude/skills/changeset-to-galaxy-test-plan/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/changeset-to-galaxy-test-plan/index.md",
     "revision": 2,
     "content_hash": "1a5f10ecf90158c4fdaf292055ca73dcd6dd39e7253fe417b62020c3c4ec8be9",
-    "commit": "9cd5a742613078781ad8e08918af93285ae29367"
+    "commit": "466d4480b91afa1ea77ae0076fd78f62d727d264"
   },
-  "cast_at": "2026-07-30T19:12:11.213Z",
+  "cast_at": "2026-08-02T18:10:24.924Z",
   "refs": [
     {
       "kind": "research",
@@ -66,8 +66,8 @@
       "evidence": "corpus-observed",
       "purpose": "Pick the assertion family and tolerance for each change-set-driven expected output by output type.",
       "trigger": "When turning a change-set behavioral delta into assertion intent and a tolerance.",
-      "src_hash": "2ea0965d34eb40e8631db199270ea8278b01349b7939e8ec0a8a87ad3f6a2c93",
-      "dst_hash": "2ea0965d34eb40e8631db199270ea8278b01349b7939e8ec0a8a87ad3f6a2c93",
+      "src_hash": "81b8feeccd891642572e587a494d1e4d3a1b369a19d92947626230494fd92beb",
+      "dst_hash": "81b8feeccd891642572e587a494d1e4d3a1b369a19d92947626230494fd92beb",
       "source": "deterministic"
     },
     {

--- a/casts/claude/skills/changeset-to-galaxy-test-plan/references/notes/planemo-asserts-idioms.md
+++ b/casts/claude/skills/changeset-to-galaxy-test-plan/references/notes/planemo-asserts-idioms.md
@@ -239,7 +239,7 @@ clustered_anndata:
 - [[galaxy-workflow-testability-design]] — decide which workflow outputs and checkpoints to expose before choosing assertions.
 - [[iwc-test-data-conventions]] — input-side conventions (job inputs, collection shapes, `hashes:`, CVMFS).
 - [[iwc-shortcuts-anti-patterns]] — accepted-vs-smell catalog and corpus prevalence; this note's mirror image.
-- Test-format schema (`@galaxy-tool-util/schema` npm package) — authoritative vocabulary; will be vendored into a Foundry-rendered schema note. See `docs/COMPILATION_PIPELINE.md` for the casting story.
+- Test-format schema (`@galaxy-tool-util/schema` npm package) — authoritative vocabulary; will be vendored into a Foundry-rendered schema note. See `content/meta/casting.md` for the casting story.
 - Planemo test-format spec: [planemo.readthedocs.io/en/latest/test_format.html](https://planemo.readthedocs.io/en/latest/test_format.html).
 - [[galaxy-xsd]] — Galaxy XSD assertion source of truth, vendored from upstream.
 - Tightening of the schema and Pydantic source: [galaxyproject/galaxy#22566](https://github.com/galaxyproject/galaxy/pull/22566).

--- a/casts/claude/skills/cwl-test-to-galaxy-test-plan/_provenance.json
+++ b/casts/claude/skills/cwl-test-to-galaxy-test-plan/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/cwl-test-to-galaxy-test-plan/index.md",
     "revision": 2,
     "content_hash": "b708f94d8cbc0698ed076f62ff6d6194da5ae34c3cdb6443597c433eeca625e3",
-    "commit": "9cd5a742613078781ad8e08918af93285ae29367"
+    "commit": "466d4480b91afa1ea77ae0076fd78f62d727d264"
   },
-  "cast_at": "2026-07-30T19:12:17.767Z",
+  "cast_at": "2026-08-02T18:10:26.473Z",
   "refs": [
     {
       "kind": "research",
@@ -66,8 +66,8 @@
       "evidence": "corpus-observed",
       "purpose": "Describe Galaxy workflow-test assertion intent and tolerances for translated expected outputs.",
       "trigger": "When turning CWL expected outputs into Galaxy test-plan assertions.",
-      "src_hash": "2ea0965d34eb40e8631db199270ea8278b01349b7939e8ec0a8a87ad3f6a2c93",
-      "dst_hash": "2ea0965d34eb40e8631db199270ea8278b01349b7939e8ec0a8a87ad3f6a2c93",
+      "src_hash": "81b8feeccd891642572e587a494d1e4d3a1b369a19d92947626230494fd92beb",
+      "dst_hash": "81b8feeccd891642572e587a494d1e4d3a1b369a19d92947626230494fd92beb",
       "source": "deterministic"
     },
     {

--- a/casts/claude/skills/cwl-test-to-galaxy-test-plan/references/notes/planemo-asserts-idioms.md
+++ b/casts/claude/skills/cwl-test-to-galaxy-test-plan/references/notes/planemo-asserts-idioms.md
@@ -239,7 +239,7 @@ clustered_anndata:
 - [[galaxy-workflow-testability-design]] — decide which workflow outputs and checkpoints to expose before choosing assertions.
 - [[iwc-test-data-conventions]] — input-side conventions (job inputs, collection shapes, `hashes:`, CVMFS).
 - [[iwc-shortcuts-anti-patterns]] — accepted-vs-smell catalog and corpus prevalence; this note's mirror image.
-- Test-format schema (`@galaxy-tool-util/schema` npm package) — authoritative vocabulary; will be vendored into a Foundry-rendered schema note. See `docs/COMPILATION_PIPELINE.md` for the casting story.
+- Test-format schema (`@galaxy-tool-util/schema` npm package) — authoritative vocabulary; will be vendored into a Foundry-rendered schema note. See `content/meta/casting.md` for the casting story.
 - Planemo test-format spec: [planemo.readthedocs.io/en/latest/test_format.html](https://planemo.readthedocs.io/en/latest/test_format.html).
 - [[galaxy-xsd]] — Galaxy XSD assertion source of truth, vendored from upstream.
 - Tightening of the schema and Pydantic source: [galaxyproject/galaxy#22566](https://github.com/galaxyproject/galaxy/pull/22566).

--- a/casts/claude/skills/debug-galaxy-workflow-output/_provenance.json
+++ b/casts/claude/skills/debug-galaxy-workflow-output/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/debug-galaxy-workflow-output/index.md",
     "revision": 5,
     "content_hash": "100b3f985f8e309092bfd05cf544a8286e0a878ee2df3a155dfebe6fcdb286f0",
-    "commit": "9cd5a742613078781ad8e08918af93285ae29367"
+    "commit": "466d4480b91afa1ea77ae0076fd78f62d727d264"
   },
-  "cast_at": "2026-07-30T19:12:20.465Z",
+  "cast_at": "2026-08-02T18:10:27.392Z",
   "refs": [
     {
       "kind": "research",
@@ -118,8 +118,8 @@
       "evidence": "corpus-observed",
       "purpose": "Classify whether a failure is an assertion-choice problem, tolerance problem, or real workflow-output regression.",
       "trigger": "When Planemo reports output assertion failures or generated tests are too strict/too weak.",
-      "src_hash": "2ea0965d34eb40e8631db199270ea8278b01349b7939e8ec0a8a87ad3f6a2c93",
-      "dst_hash": "2ea0965d34eb40e8631db199270ea8278b01349b7939e8ec0a8a87ad3f6a2c93",
+      "src_hash": "81b8feeccd891642572e587a494d1e4d3a1b369a19d92947626230494fd92beb",
+      "dst_hash": "81b8feeccd891642572e587a494d1e4d3a1b369a19d92947626230494fd92beb",
       "source": "deterministic"
     },
     {

--- a/casts/claude/skills/debug-galaxy-workflow-output/references/notes/planemo-asserts-idioms.md
+++ b/casts/claude/skills/debug-galaxy-workflow-output/references/notes/planemo-asserts-idioms.md
@@ -239,7 +239,7 @@ clustered_anndata:
 - [[galaxy-workflow-testability-design]] — decide which workflow outputs and checkpoints to expose before choosing assertions.
 - [[iwc-test-data-conventions]] — input-side conventions (job inputs, collection shapes, `hashes:`, CVMFS).
 - [[iwc-shortcuts-anti-patterns]] — accepted-vs-smell catalog and corpus prevalence; this note's mirror image.
-- Test-format schema (`@galaxy-tool-util/schema` npm package) — authoritative vocabulary; will be vendored into a Foundry-rendered schema note. See `docs/COMPILATION_PIPELINE.md` for the casting story.
+- Test-format schema (`@galaxy-tool-util/schema` npm package) — authoritative vocabulary; will be vendored into a Foundry-rendered schema note. See `content/meta/casting.md` for the casting story.
 - Planemo test-format spec: [planemo.readthedocs.io/en/latest/test_format.html](https://planemo.readthedocs.io/en/latest/test_format.html).
 - [[galaxy-xsd]] — Galaxy XSD assertion source of truth, vendored from upstream.
 - Tightening of the schema and Pydantic source: [galaxyproject/galaxy#22566](https://github.com/galaxyproject/galaxy/pull/22566).

--- a/casts/claude/skills/freeform-summary-to-galaxy-test-plan/_provenance.json
+++ b/casts/claude/skills/freeform-summary-to-galaxy-test-plan/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/freeform-summary-to-galaxy-test-plan/index.md",
     "revision": 2,
     "content_hash": "9c1d56e625a5dd26cb7a82082ac8f4eeb7db287a626bf00e73457c8dd491ad6d",
-    "commit": "9cd5a742613078781ad8e08918af93285ae29367"
+    "commit": "466d4480b91afa1ea77ae0076fd78f62d727d264"
   },
-  "cast_at": "2026-07-30T19:12:27.267Z",
+  "cast_at": "2026-08-02T18:10:28.915Z",
   "refs": [
     {
       "kind": "research",
@@ -66,8 +66,8 @@
       "evidence": "corpus-observed",
       "purpose": "Pick the assertion family and tolerance that fit each synthesized expected output by output type.",
       "trigger": "When turning an expected output into assertion intent and a tolerance.",
-      "src_hash": "2ea0965d34eb40e8631db199270ea8278b01349b7939e8ec0a8a87ad3f6a2c93",
-      "dst_hash": "2ea0965d34eb40e8631db199270ea8278b01349b7939e8ec0a8a87ad3f6a2c93",
+      "src_hash": "81b8feeccd891642572e587a494d1e4d3a1b369a19d92947626230494fd92beb",
+      "dst_hash": "81b8feeccd891642572e587a494d1e4d3a1b369a19d92947626230494fd92beb",
       "source": "deterministic"
     },
     {

--- a/casts/claude/skills/freeform-summary-to-galaxy-test-plan/references/notes/planemo-asserts-idioms.md
+++ b/casts/claude/skills/freeform-summary-to-galaxy-test-plan/references/notes/planemo-asserts-idioms.md
@@ -239,7 +239,7 @@ clustered_anndata:
 - [[galaxy-workflow-testability-design]] — decide which workflow outputs and checkpoints to expose before choosing assertions.
 - [[iwc-test-data-conventions]] — input-side conventions (job inputs, collection shapes, `hashes:`, CVMFS).
 - [[iwc-shortcuts-anti-patterns]] — accepted-vs-smell catalog and corpus prevalence; this note's mirror image.
-- Test-format schema (`@galaxy-tool-util/schema` npm package) — authoritative vocabulary; will be vendored into a Foundry-rendered schema note. See `docs/COMPILATION_PIPELINE.md` for the casting story.
+- Test-format schema (`@galaxy-tool-util/schema` npm package) — authoritative vocabulary; will be vendored into a Foundry-rendered schema note. See `content/meta/casting.md` for the casting story.
 - Planemo test-format spec: [planemo.readthedocs.io/en/latest/test_format.html](https://planemo.readthedocs.io/en/latest/test_format.html).
 - [[galaxy-xsd]] — Galaxy XSD assertion source of truth, vendored from upstream.
 - Tightening of the schema and Pydantic source: [galaxyproject/galaxy#22566](https://github.com/galaxyproject/galaxy/pull/22566).

--- a/casts/claude/skills/implement-galaxy-workflow-test/_provenance.json
+++ b/casts/claude/skills/implement-galaxy-workflow-test/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/implement-galaxy-workflow-test/index.md",
     "revision": 8,
     "content_hash": "966c486ccda2eb1e0f06afa674c5d6b85a7e7bfcc9b1545309e3ef8b1016f931",
-    "commit": "9cd5a742613078781ad8e08918af93285ae29367"
+    "commit": "466d4480b91afa1ea77ae0076fd78f62d727d264"
   },
-  "cast_at": "2026-07-30T19:12:31.376Z",
+  "cast_at": "2026-08-02T18:10:30.430Z",
   "cast_date": "2026-07-20",
   "cast_revision": 1,
   "cast_history": [
@@ -104,8 +104,8 @@
       "evidence": "corpus-observed",
       "purpose": "Choose assertion families, tolerance magnitudes, and the static/Planemo validation loop.",
       "trigger": "When writing or revising output assertions for a Galaxy workflow test file.",
-      "src_hash": "2ea0965d34eb40e8631db199270ea8278b01349b7939e8ec0a8a87ad3f6a2c93",
-      "dst_hash": "2ea0965d34eb40e8631db199270ea8278b01349b7939e8ec0a8a87ad3f6a2c93",
+      "src_hash": "81b8feeccd891642572e587a494d1e4d3a1b369a19d92947626230494fd92beb",
+      "dst_hash": "81b8feeccd891642572e587a494d1e4d3a1b369a19d92947626230494fd92beb",
       "source": "deterministic"
     },
     {

--- a/casts/claude/skills/implement-galaxy-workflow-test/references/notes/planemo-asserts-idioms.md
+++ b/casts/claude/skills/implement-galaxy-workflow-test/references/notes/planemo-asserts-idioms.md
@@ -239,7 +239,7 @@ clustered_anndata:
 - [[galaxy-workflow-testability-design]] — decide which workflow outputs and checkpoints to expose before choosing assertions.
 - [[iwc-test-data-conventions]] — input-side conventions (job inputs, collection shapes, `hashes:`, CVMFS).
 - [[iwc-shortcuts-anti-patterns]] — accepted-vs-smell catalog and corpus prevalence; this note's mirror image.
-- Test-format schema (`@galaxy-tool-util/schema` npm package) — authoritative vocabulary; will be vendored into a Foundry-rendered schema note. See `docs/COMPILATION_PIPELINE.md` for the casting story.
+- Test-format schema (`@galaxy-tool-util/schema` npm package) — authoritative vocabulary; will be vendored into a Foundry-rendered schema note. See `content/meta/casting.md` for the casting story.
 - Planemo test-format spec: [planemo.readthedocs.io/en/latest/test_format.html](https://planemo.readthedocs.io/en/latest/test_format.html).
 - [[galaxy-xsd]] — Galaxy XSD assertion source of truth, vendored from upstream.
 - Tightening of the schema and Pydantic source: [galaxyproject/galaxy#22566](https://github.com/galaxyproject/galaxy/pull/22566).

--- a/casts/claude/skills/nextflow-test-to-galaxy-test-plan/_provenance.json
+++ b/casts/claude/skills/nextflow-test-to-galaxy-test-plan/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/nextflow-test-to-galaxy-test-plan/index.md",
     "revision": 5,
     "content_hash": "4507e5ff7ffaa9751cf80e33c28fec403766dc95197c0813821362711f603732",
-    "commit": "9cd5a742613078781ad8e08918af93285ae29367"
+    "commit": "466d4480b91afa1ea77ae0076fd78f62d727d264"
   },
-  "cast_at": "2026-07-30T19:12:40.257Z",
+  "cast_at": "2026-08-02T18:10:31.956Z",
   "refs": [
     {
       "kind": "research",
@@ -98,8 +98,8 @@
       "evidence": "corpus-observed",
       "purpose": "Describe Galaxy workflow-test assertion intent and tolerances for translated expected outputs.",
       "trigger": "When turning Nextflow expected outputs or snapshots into Galaxy test-plan assertions.",
-      "src_hash": "2ea0965d34eb40e8631db199270ea8278b01349b7939e8ec0a8a87ad3f6a2c93",
-      "dst_hash": "2ea0965d34eb40e8631db199270ea8278b01349b7939e8ec0a8a87ad3f6a2c93",
+      "src_hash": "81b8feeccd891642572e587a494d1e4d3a1b369a19d92947626230494fd92beb",
+      "dst_hash": "81b8feeccd891642572e587a494d1e4d3a1b369a19d92947626230494fd92beb",
       "source": "deterministic"
     },
     {

--- a/casts/claude/skills/nextflow-test-to-galaxy-test-plan/references/notes/planemo-asserts-idioms.md
+++ b/casts/claude/skills/nextflow-test-to-galaxy-test-plan/references/notes/planemo-asserts-idioms.md
@@ -239,7 +239,7 @@ clustered_anndata:
 - [[galaxy-workflow-testability-design]] — decide which workflow outputs and checkpoints to expose before choosing assertions.
 - [[iwc-test-data-conventions]] — input-side conventions (job inputs, collection shapes, `hashes:`, CVMFS).
 - [[iwc-shortcuts-anti-patterns]] — accepted-vs-smell catalog and corpus prevalence; this note's mirror image.
-- Test-format schema (`@galaxy-tool-util/schema` npm package) — authoritative vocabulary; will be vendored into a Foundry-rendered schema note. See `docs/COMPILATION_PIPELINE.md` for the casting story.
+- Test-format schema (`@galaxy-tool-util/schema` npm package) — authoritative vocabulary; will be vendored into a Foundry-rendered schema note. See `content/meta/casting.md` for the casting story.
 - Planemo test-format spec: [planemo.readthedocs.io/en/latest/test_format.html](https://planemo.readthedocs.io/en/latest/test_format.html).
 - [[galaxy-xsd]] — Galaxy XSD assertion source of truth, vendored from upstream.
 - Tightening of the schema and Pydantic source: [galaxyproject/galaxy#22566](https://github.com/galaxyproject/galaxy/pull/22566).

--- a/casts/claude/skills/run-workflow-test/_provenance.json
+++ b/casts/claude/skills/run-workflow-test/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/run-workflow-test/index.md",
     "revision": 6,
     "content_hash": "ddce4858e472c7e4ff1cc74b48be4c18dffe9e732e254bd6e84c41aeab1eae75",
-    "commit": "9cd5a742613078781ad8e08918af93285ae29367"
+    "commit": "466d4480b91afa1ea77ae0076fd78f62d727d264"
   },
-  "cast_at": "2026-07-30T19:12:48.600Z",
+  "cast_at": "2026-08-02T18:10:33.465Z",
   "cast_date": "2026-07-20",
   "cast_revision": 1,
   "cast_history": [
@@ -74,8 +74,8 @@
       "evidence": "corpus-observed",
       "purpose": "Interpret assertion failures and choose the right fast inner-loop command before full reruns.",
       "trigger": "When a workflow test file exists and the task is to run, iterate, or classify its test assertions.",
-      "src_hash": "2ea0965d34eb40e8631db199270ea8278b01349b7939e8ec0a8a87ad3f6a2c93",
-      "dst_hash": "2ea0965d34eb40e8631db199270ea8278b01349b7939e8ec0a8a87ad3f6a2c93",
+      "src_hash": "81b8feeccd891642572e587a494d1e4d3a1b369a19d92947626230494fd92beb",
+      "dst_hash": "81b8feeccd891642572e587a494d1e4d3a1b369a19d92947626230494fd92beb",
       "source": "deterministic"
     },
     {

--- a/casts/claude/skills/run-workflow-test/references/notes/planemo-asserts-idioms.md
+++ b/casts/claude/skills/run-workflow-test/references/notes/planemo-asserts-idioms.md
@@ -239,7 +239,7 @@ clustered_anndata:
 - [[galaxy-workflow-testability-design]] — decide which workflow outputs and checkpoints to expose before choosing assertions.
 - [[iwc-test-data-conventions]] — input-side conventions (job inputs, collection shapes, `hashes:`, CVMFS).
 - [[iwc-shortcuts-anti-patterns]] — accepted-vs-smell catalog and corpus prevalence; this note's mirror image.
-- Test-format schema (`@galaxy-tool-util/schema` npm package) — authoritative vocabulary; will be vendored into a Foundry-rendered schema note. See `docs/COMPILATION_PIPELINE.md` for the casting story.
+- Test-format schema (`@galaxy-tool-util/schema` npm package) — authoritative vocabulary; will be vendored into a Foundry-rendered schema note. See `content/meta/casting.md` for the casting story.
 - Planemo test-format spec: [planemo.readthedocs.io/en/latest/test_format.html](https://planemo.readthedocs.io/en/latest/test_format.html).
 - [[galaxy-xsd]] — Galaxy XSD assertion source of truth, vendored from upstream.
 - Tightening of the schema and Pydantic source: [galaxyproject/galaxy#22566](https://github.com/galaxyproject/galaxy/pull/22566).


### PR DESCRIPTION
> Posted by Claude (AI assistant) on jmchilton's behalf.

Seven shipped bundles carry a reference to a file that does not exist, and CI has been green throughout. This fixes the bytes and closes the hole that hid them.

First of three stacked PRs splitting the cast-convergence work; the two above it are declarative-casting changes and depend on this one only by position. This tranche stands alone and is worth landing on its own — `main` ships the bad bytes today.

## The drift

`planemo-asserts-idioms.md` carries a "see X for the casting story" pointer. When that doc moved, the note was updated and the seven bundles carrying it verbatim were never re-cast, so they still ship the old `docs/COMPILATION_PIPELINE.md` path — a file that no longer exists.

What makes this worth a second look is *why* it survived. For a verbatim ref, `src_hash == dst_hash` is the entire guarantee, and the stale provenance satisfied it: both hashes read `2ea0965d`, self-consistent and wrong. They agree with each other about the note **as it used to be**. Nothing internal to a bundle can detect that — catching it requires re-hashing the source against the record, which is exactly what `cast --check` does.

The fix is a deterministic re-cast. No Mold and no note is edited; only the pointer line changes.

## Why nothing caught it

CI cast-checked `summarize-nextflow` and nothing else, so drift in the other 46 Molds was invisible. One representative Mold is not a sample of a corpus where each bundle carries a different set of references — it is a check on one bundle, and it reported truthfully on that one the whole time.

`make check-casts` now runs `--check` over every Mold and reports *each* drifted one before failing, so the failure message is the work-list rather than the first casualty. It is wired into `make check` beside the pipeline equivalent it mirrors, and CI calls the target instead of naming a Mold — the next Mold added is covered without anyone remembering to add it.

## Verification

- `make check` green at this commit: **236 tests / 15 files**, `casts/` clean after.
- Merges into current `main` with no conflict.
- The gate was falsified before being kept: reverting the parent commit makes `make check-casts` fail and name all seven bundles.
