### PR TITLE
Resolve related_* links on every kind, and make a dangling link block

### DIFF
--- a/casts/claude/skills/cwl-summary-to-galaxy-data-flow/_provenance.json
+++ b/casts/claude/skills/cwl-summary-to-galaxy-data-flow/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/cwl-summary-to-galaxy-data-flow/index.md",
     "revision": 2,
     "content_hash": "d9ffbf76c60adbe4884615d70aa0de6b5a7fdc1c4385931ed01344ed3bc480f3",
-    "commit": "a56c6127966e59c75cf67d1d41ca03c8b4cf45dd"
+    "commit": "aede1aeab8ceb890192c9606a6e967a36fcf2224"
   },
-  "cast_at": "2026-08-02T22:04:23.402Z",
+  "cast_at": "2026-08-03T23:37:48.205Z",
   "refs": [
     {
       "kind": "pattern",
@@ -51,8 +51,8 @@
       "evidence": "corpus-observed",
       "purpose": "Ground genomic-interval operation choices in curated, corpus-observed Galaxy interval recipes.",
       "trigger": "When the workflow operates on genomic intervals (BED/GFF/VCF coordinate features) and data-flow translation needs overlap, merge, coverage, windowing, masking, or set-algebra steps.",
-      "src_hash": "4566e84f1f4182729f45d11401c1eaf844ae81a19351035c60ee76e50537c173",
-      "dst_hash": "4566e84f1f4182729f45d11401c1eaf844ae81a19351035c60ee76e50537c173",
+      "src_hash": "2f6e228baab452d7bd51fbd27fc4f584cb9387d496261cb264695824901d23bf",
+      "dst_hash": "2f6e228baab452d7bd51fbd27fc4f584cb9387d496261cb264695824901d23bf",
       "source": "deterministic"
     },
     {

--- a/casts/claude/skills/cwl-summary-to-galaxy-data-flow/references/patterns/galaxy-interval-patterns.md
+++ b/casts/claude/skills/cwl-summary-to-galaxy-data-flow/references/patterns/galaxy-interval-patterns.md
@@ -13,8 +13,8 @@ tags:
   - topic/interval-transform
 status: draft
 created: 2026-06-10
-revised: 2026-06-10
-revision: 1
+revised: 2026-08-03
+revision: 2
 summary: "Use this MOC to choose corpus-grounded Galaxy genomic interval operations and recipes on coordinate features."
 related_notes:
   - "[[iwc-interval-operations-survey]]"
@@ -33,7 +33,7 @@ related_molds:
   - "[[cwl-summary-to-galaxy-data-flow]]"
   - "[[nextflow-summary-to-galaxy-template]]"
   - "[[cwl-summary-to-galaxy-template]]"
-  - "[[paper-summary-to-galaxy-template]]"
+  - "[[freeform-summary-to-galaxy-template]]"
   - "[[compare-against-iwc-exemplar]]"
 ---
 

--- a/casts/claude/skills/cwl-summary-to-galaxy-template/_provenance.json
+++ b/casts/claude/skills/cwl-summary-to-galaxy-template/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/cwl-summary-to-galaxy-template/index.md",
     "revision": 4,
     "content_hash": "6b50dfd2d7faf9306f9e69e9adf0163c41d9c5739b470e2cf1ae5e5c46f18d69",
-    "commit": "a56c6127966e59c75cf67d1d41ca03c8b4cf45dd"
+    "commit": "aede1aeab8ceb890192c9606a6e967a36fcf2224"
   },
-  "cast_at": "2026-08-02T22:04:26.955Z",
+  "cast_at": "2026-08-03T23:37:50.551Z",
   "refs": [
     {
       "kind": "cli-command",
@@ -67,8 +67,8 @@
       "evidence": "corpus-observed",
       "purpose": "Use corpus-grounded genomic-interval pattern guidance for unresolved skeleton steps.",
       "trigger": "When adding TODO steps for interval overlap, merge, coverage, windowing, masking, or set-algebra on coordinate features.",
-      "src_hash": "4566e84f1f4182729f45d11401c1eaf844ae81a19351035c60ee76e50537c173",
-      "dst_hash": "4566e84f1f4182729f45d11401c1eaf844ae81a19351035c60ee76e50537c173",
+      "src_hash": "2f6e228baab452d7bd51fbd27fc4f584cb9387d496261cb264695824901d23bf",
+      "dst_hash": "2f6e228baab452d7bd51fbd27fc4f584cb9387d496261cb264695824901d23bf",
       "source": "deterministic"
     },
     {

--- a/casts/claude/skills/cwl-summary-to-galaxy-template/references/patterns/galaxy-interval-patterns.md
+++ b/casts/claude/skills/cwl-summary-to-galaxy-template/references/patterns/galaxy-interval-patterns.md
@@ -13,8 +13,8 @@ tags:
   - topic/interval-transform
 status: draft
 created: 2026-06-10
-revised: 2026-06-10
-revision: 1
+revised: 2026-08-03
+revision: 2
 summary: "Use this MOC to choose corpus-grounded Galaxy genomic interval operations and recipes on coordinate features."
 related_notes:
   - "[[iwc-interval-operations-survey]]"
@@ -33,7 +33,7 @@ related_molds:
   - "[[cwl-summary-to-galaxy-data-flow]]"
   - "[[nextflow-summary-to-galaxy-template]]"
   - "[[cwl-summary-to-galaxy-template]]"
-  - "[[paper-summary-to-galaxy-template]]"
+  - "[[freeform-summary-to-galaxy-template]]"
   - "[[compare-against-iwc-exemplar]]"
 ---
 

--- a/casts/claude/skills/freeform-summary-to-galaxy-data-flow/_provenance.json
+++ b/casts/claude/skills/freeform-summary-to-galaxy-data-flow/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/freeform-summary-to-galaxy-data-flow/index.md",
     "revision": 2,
     "content_hash": "f64e964f842d70005c254bda1498dc619ce5af19a750f2a1dc85838c0023125c",
-    "commit": "a56c6127966e59c75cf67d1d41ca03c8b4cf45dd"
+    "commit": "aede1aeab8ceb890192c9606a6e967a36fcf2224"
   },
-  "cast_at": "2026-08-02T22:04:36.997Z",
+  "cast_at": "2026-08-03T23:37:51.887Z",
   "refs": [
     {
       "kind": "pattern",
@@ -51,8 +51,8 @@
       "evidence": "corpus-observed",
       "purpose": "Ground genomic-interval operation choices in curated, corpus-observed Galaxy interval recipes.",
       "trigger": "When the workflow operates on genomic intervals (BED/GFF/VCF coordinate features) and data-flow translation needs overlap, merge, coverage, windowing, masking, or set-algebra steps.",
-      "src_hash": "4566e84f1f4182729f45d11401c1eaf844ae81a19351035c60ee76e50537c173",
-      "dst_hash": "4566e84f1f4182729f45d11401c1eaf844ae81a19351035c60ee76e50537c173",
+      "src_hash": "2f6e228baab452d7bd51fbd27fc4f584cb9387d496261cb264695824901d23bf",
+      "dst_hash": "2f6e228baab452d7bd51fbd27fc4f584cb9387d496261cb264695824901d23bf",
       "source": "deterministic"
     },
     {

--- a/casts/claude/skills/freeform-summary-to-galaxy-data-flow/references/patterns/galaxy-interval-patterns.md
+++ b/casts/claude/skills/freeform-summary-to-galaxy-data-flow/references/patterns/galaxy-interval-patterns.md
@@ -13,8 +13,8 @@ tags:
   - topic/interval-transform
 status: draft
 created: 2026-06-10
-revised: 2026-06-10
-revision: 1
+revised: 2026-08-03
+revision: 2
 summary: "Use this MOC to choose corpus-grounded Galaxy genomic interval operations and recipes on coordinate features."
 related_notes:
   - "[[iwc-interval-operations-survey]]"
@@ -33,7 +33,7 @@ related_molds:
   - "[[cwl-summary-to-galaxy-data-flow]]"
   - "[[nextflow-summary-to-galaxy-template]]"
   - "[[cwl-summary-to-galaxy-template]]"
-  - "[[paper-summary-to-galaxy-template]]"
+  - "[[freeform-summary-to-galaxy-template]]"
   - "[[compare-against-iwc-exemplar]]"
 ---
 

--- a/casts/claude/skills/freeform-summary-to-galaxy-template/_provenance.json
+++ b/casts/claude/skills/freeform-summary-to-galaxy-template/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/freeform-summary-to-galaxy-template/index.md",
     "revision": 5,
     "content_hash": "ef30eb8dfeee86c3f938b849bb3bbb95720027dab1189829919b8d4b55b4b816",
-    "commit": "a56c6127966e59c75cf67d1d41ca03c8b4cf45dd"
+    "commit": "aede1aeab8ceb890192c9606a6e967a36fcf2224"
   },
-  "cast_at": "2026-08-02T22:04:39.728Z",
+  "cast_at": "2026-08-03T23:37:54.185Z",
   "refs": [
     {
       "kind": "cli-command",
@@ -67,8 +67,8 @@
       "evidence": "corpus-observed",
       "purpose": "Use corpus-grounded genomic-interval pattern guidance for unresolved skeleton steps.",
       "trigger": "When adding TODO steps for interval overlap, merge, coverage, windowing, masking, or set-algebra on coordinate features.",
-      "src_hash": "4566e84f1f4182729f45d11401c1eaf844ae81a19351035c60ee76e50537c173",
-      "dst_hash": "4566e84f1f4182729f45d11401c1eaf844ae81a19351035c60ee76e50537c173",
+      "src_hash": "2f6e228baab452d7bd51fbd27fc4f584cb9387d496261cb264695824901d23bf",
+      "dst_hash": "2f6e228baab452d7bd51fbd27fc4f584cb9387d496261cb264695824901d23bf",
       "source": "deterministic"
     },
     {

--- a/casts/claude/skills/freeform-summary-to-galaxy-template/references/patterns/galaxy-interval-patterns.md
+++ b/casts/claude/skills/freeform-summary-to-galaxy-template/references/patterns/galaxy-interval-patterns.md
@@ -13,8 +13,8 @@ tags:
   - topic/interval-transform
 status: draft
 created: 2026-06-10
-revised: 2026-06-10
-revision: 1
+revised: 2026-08-03
+revision: 2
 summary: "Use this MOC to choose corpus-grounded Galaxy genomic interval operations and recipes on coordinate features."
 related_notes:
   - "[[iwc-interval-operations-survey]]"
@@ -33,7 +33,7 @@ related_molds:
   - "[[cwl-summary-to-galaxy-data-flow]]"
   - "[[nextflow-summary-to-galaxy-template]]"
   - "[[cwl-summary-to-galaxy-template]]"
-  - "[[paper-summary-to-galaxy-template]]"
+  - "[[freeform-summary-to-galaxy-template]]"
   - "[[compare-against-iwc-exemplar]]"
 ---
 

--- a/casts/claude/skills/nextflow-summary-to-galaxy-data-flow/_provenance.json
+++ b/casts/claude/skills/nextflow-summary-to-galaxy-data-flow/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/nextflow-summary-to-galaxy-data-flow/index.md",
     "revision": 5,
     "content_hash": "ab1fde58ac26d8d204e39eca5032fe304ad01c5128eb82b5f06bd2321426b174",
-    "commit": "a56c6127966e59c75cf67d1d41ca03c8b4cf45dd"
+    "commit": "aede1aeab8ceb890192c9606a6e967a36fcf2224"
   },
-  "cast_at": "2026-08-02T22:04:52.122Z",
+  "cast_at": "2026-08-03T23:37:55.552Z",
   "cast_date": "2026-05-07",
   "cast_revision": 3,
   "cast_history": [
@@ -70,8 +70,8 @@
       "evidence": "corpus-observed",
       "purpose": "Ground genomic-interval operation choices in curated, corpus-observed Galaxy interval recipes.",
       "trigger": "When the workflow operates on genomic intervals (BED/GFF/VCF coordinate features) and data-flow translation needs overlap, merge, coverage, windowing, masking, or set-algebra steps.",
-      "src_hash": "4566e84f1f4182729f45d11401c1eaf844ae81a19351035c60ee76e50537c173",
-      "dst_hash": "4566e84f1f4182729f45d11401c1eaf844ae81a19351035c60ee76e50537c173",
+      "src_hash": "2f6e228baab452d7bd51fbd27fc4f584cb9387d496261cb264695824901d23bf",
+      "dst_hash": "2f6e228baab452d7bd51fbd27fc4f584cb9387d496261cb264695824901d23bf",
       "source": "deterministic"
     },
     {

--- a/casts/claude/skills/nextflow-summary-to-galaxy-data-flow/references/patterns/galaxy-interval-patterns.md
+++ b/casts/claude/skills/nextflow-summary-to-galaxy-data-flow/references/patterns/galaxy-interval-patterns.md
@@ -13,8 +13,8 @@ tags:
   - topic/interval-transform
 status: draft
 created: 2026-06-10
-revised: 2026-06-10
-revision: 1
+revised: 2026-08-03
+revision: 2
 summary: "Use this MOC to choose corpus-grounded Galaxy genomic interval operations and recipes on coordinate features."
 related_notes:
   - "[[iwc-interval-operations-survey]]"
@@ -33,7 +33,7 @@ related_molds:
   - "[[cwl-summary-to-galaxy-data-flow]]"
   - "[[nextflow-summary-to-galaxy-template]]"
   - "[[cwl-summary-to-galaxy-template]]"
-  - "[[paper-summary-to-galaxy-template]]"
+  - "[[freeform-summary-to-galaxy-template]]"
   - "[[compare-against-iwc-exemplar]]"
 ---
 

--- a/casts/claude/skills/nextflow-summary-to-galaxy-template/_provenance.json
+++ b/casts/claude/skills/nextflow-summary-to-galaxy-template/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/nextflow-summary-to-galaxy-template/index.md",
     "revision": 8,
     "content_hash": "23676d3bdc6a728949f757ae221a7e40153666e7028f671ea8ab52fe5b9f2686",
-    "commit": "a56c6127966e59c75cf67d1d41ca03c8b4cf45dd"
+    "commit": "aede1aeab8ceb890192c9606a6e967a36fcf2224"
   },
-  "cast_at": "2026-08-02T22:04:55.546Z",
+  "cast_at": "2026-08-03T23:37:57.886Z",
   "cast_date": "2026-05-07",
   "cast_revision": 3,
   "cast_history": [
@@ -86,8 +86,8 @@
       "evidence": "corpus-observed",
       "purpose": "Use corpus-grounded genomic-interval pattern guidance for unresolved skeleton steps.",
       "trigger": "When adding TODO steps for interval overlap, merge, coverage, windowing, masking, or set-algebra on coordinate features.",
-      "src_hash": "4566e84f1f4182729f45d11401c1eaf844ae81a19351035c60ee76e50537c173",
-      "dst_hash": "4566e84f1f4182729f45d11401c1eaf844ae81a19351035c60ee76e50537c173",
+      "src_hash": "2f6e228baab452d7bd51fbd27fc4f584cb9387d496261cb264695824901d23bf",
+      "dst_hash": "2f6e228baab452d7bd51fbd27fc4f584cb9387d496261cb264695824901d23bf",
       "source": "deterministic"
     },
     {

--- a/casts/claude/skills/nextflow-summary-to-galaxy-template/references/patterns/galaxy-interval-patterns.md
+++ b/casts/claude/skills/nextflow-summary-to-galaxy-template/references/patterns/galaxy-interval-patterns.md
@@ -13,8 +13,8 @@ tags:
   - topic/interval-transform
 status: draft
 created: 2026-06-10
-revised: 2026-06-10
-revision: 1
+revised: 2026-08-03
+revision: 2
 summary: "Use this MOC to choose corpus-grounded Galaxy genomic interval operations and recipes on coordinate features."
 related_notes:
   - "[[iwc-interval-operations-survey]]"
@@ -33,7 +33,7 @@ related_molds:
   - "[[cwl-summary-to-galaxy-data-flow]]"
   - "[[nextflow-summary-to-galaxy-template]]"
   - "[[cwl-summary-to-galaxy-template]]"
-  - "[[paper-summary-to-galaxy-template]]"
+  - "[[freeform-summary-to-galaxy-template]]"
   - "[[compare-against-iwc-exemplar]]"
 ---
 

--- a/casts/claude/skills/nextflow-test-to-galaxy-test-plan/_provenance.json
+++ b/casts/claude/skills/nextflow-test-to-galaxy-test-plan/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/nextflow-test-to-galaxy-test-plan/index.md",
     "revision": 5,
     "content_hash": "4507e5ff7ffaa9751cf80e33c28fec403766dc95197c0813821362711f603732",
-    "commit": "a56c6127966e59c75cf67d1d41ca03c8b4cf45dd"
+    "commit": "aede1aeab8ceb890192c9606a6e967a36fcf2224"
   },
-  "cast_at": "2026-08-02T22:04:58.195Z",
+  "cast_at": "2026-08-03T23:38:00.340Z",
   "refs": [
     {
       "kind": "research",
@@ -22,8 +22,8 @@
       "purpose": "Interpret nf-test profiles, snapshot assertions, and Nextflow fixture conventions before translating them.",
       "trigger": "When converting nf_tests, snapshot fixtures, test profiles, or source test-data references into a Galaxy workflow test plan.",
       "verification": "Translate nf-core/bacass nf-test snapshots into a Galaxy test plan and confirm this note improves profile/snapshot extraction.",
-      "src_hash": "807c26846c6ea331b12c129e8caa438eacf5ea113b9dde51e2e3027c9878ad58",
-      "dst_hash": "807c26846c6ea331b12c129e8caa438eacf5ea113b9dde51e2e3027c9878ad58",
+      "src_hash": "b3f6dd5de325f8b9d85cc597b928df70b9f842eb2d1d2652aa68bde8e2c325c7",
+      "dst_hash": "b3f6dd5de325f8b9d85cc597b928df70b9f842eb2d1d2652aa68bde8e2c325c7",
       "source": "deterministic"
     },
     {

--- a/casts/claude/skills/nextflow-test-to-galaxy-test-plan/references/notes/component-nextflow-testing.md
+++ b/casts/claude/skills/nextflow-test-to-galaxy-test-plan/references/notes/component-nextflow-testing.md
@@ -5,9 +5,9 @@ tags:
 component: "Nextflow Testing and Test Fixtures"
 status: draft
 created: 2026-05-01
-revised: 2026-05-05
-revision: 2
-summary: "nf-test patterns mapped to Galaxy planemo asserts and CWL test equivalents — backs nextflow-test-to-target-tests Mold and summarize-nextflow §7."
+revised: 2026-08-03
+revision: 3
+summary: "nf-test patterns mapped to Galaxy planemo asserts and CWL test equivalents — backs the nextflow test-plan Molds and summarize-nextflow §7."
 companions:
   - "component-nextflow-testing.yml"
 sources:
@@ -22,7 +22,8 @@ sources:
   - "https://nf-co.re/docs/contributing/pipelines#test-data"
 related_molds:
   - "[[summarize-nextflow]]"
-  - "[[nextflow-test-to-target-tests]]"
+  - "[[nextflow-test-to-galaxy-test-plan]]"
+  - "[[nextflow-test-to-cwl-test-plan]]"
   - "[[implement-galaxy-workflow-test]]"
 related_notes:
   - "[[planemo-asserts-idioms]]"
@@ -33,10 +34,11 @@ related_notes:
 
 # Nextflow Testing and Test Fixtures
 
-Operational grounding for two Molds:
+Operational grounding for three Molds:
 
 - [[summarize-nextflow]] §7 — extract `nf_tests[]` and `test_fixtures` from a real nf-core or DSL2 pipeline.
-- [[nextflow-test-to-target-tests]] — translate nf-test fixtures + assertions into Galaxy / CWL equivalents.
+- [[nextflow-test-to-galaxy-test-plan]] — translate nf-test fixtures + assertions into Galaxy equivalents.
+- [[nextflow-test-to-cwl-test-plan]] — the same translation, toward CWL.
 
 The summarize side is mostly *enumeration*: walk `tests/*.nf.test`, extract structured fields per the Mold §7 spec. The translation side is *mapping*: each nf-test assertion pattern has a (sometimes lossy) Galaxy or CWL equivalent.
 

--- a/casts/claude/skills/nextflow-to-test-data/_provenance.json
+++ b/casts/claude/skills/nextflow-to-test-data/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/nextflow-to-test-data/index.md",
     "revision": 2,
     "content_hash": "5569467ca2b1bb6bdaec69f4d6a9482b111b4433d5a70f1bf19c29a8d511f3ca",
-    "commit": "a56c6127966e59c75cf67d1d41ca03c8b4cf45dd"
+    "commit": "aede1aeab8ceb890192c9606a6e967a36fcf2224"
   },
-  "cast_at": "2026-08-02T22:04:59.139Z",
+  "cast_at": "2026-08-03T23:38:01.703Z",
   "refs": [
     {
       "kind": "research",
@@ -22,8 +22,8 @@
       "purpose": "Interpret nf-test profiles and fixture conventions before mapping declared fixtures onto Galaxy inputs.",
       "trigger": "When reading `test_fixtures` / `nf_tests` to decide which profile's fixtures best cover the workflow inputs.",
       "verification": "Map nf-core/bacass declared fixtures onto its Galaxy interface and confirm this note improves profile/fixture selection.",
-      "src_hash": "807c26846c6ea331b12c129e8caa438eacf5ea113b9dde51e2e3027c9878ad58",
-      "dst_hash": "807c26846c6ea331b12c129e8caa438eacf5ea113b9dde51e2e3027c9878ad58",
+      "src_hash": "b3f6dd5de325f8b9d85cc597b928df70b9f842eb2d1d2652aa68bde8e2c325c7",
+      "dst_hash": "b3f6dd5de325f8b9d85cc597b928df70b9f842eb2d1d2652aa68bde8e2c325c7",
       "source": "deterministic"
     },
     {

--- a/casts/claude/skills/nextflow-to-test-data/references/notes/component-nextflow-testing.md
+++ b/casts/claude/skills/nextflow-to-test-data/references/notes/component-nextflow-testing.md
@@ -5,9 +5,9 @@ tags:
 component: "Nextflow Testing and Test Fixtures"
 status: draft
 created: 2026-05-01
-revised: 2026-05-05
-revision: 2
-summary: "nf-test patterns mapped to Galaxy planemo asserts and CWL test equivalents — backs nextflow-test-to-target-tests Mold and summarize-nextflow §7."
+revised: 2026-08-03
+revision: 3
+summary: "nf-test patterns mapped to Galaxy planemo asserts and CWL test equivalents — backs the nextflow test-plan Molds and summarize-nextflow §7."
 companions:
   - "component-nextflow-testing.yml"
 sources:
@@ -22,7 +22,8 @@ sources:
   - "https://nf-co.re/docs/contributing/pipelines#test-data"
 related_molds:
   - "[[summarize-nextflow]]"
-  - "[[nextflow-test-to-target-tests]]"
+  - "[[nextflow-test-to-galaxy-test-plan]]"
+  - "[[nextflow-test-to-cwl-test-plan]]"
   - "[[implement-galaxy-workflow-test]]"
 related_notes:
   - "[[planemo-asserts-idioms]]"
@@ -33,10 +34,11 @@ related_notes:
 
 # Nextflow Testing and Test Fixtures
 
-Operational grounding for two Molds:
+Operational grounding for three Molds:
 
 - [[summarize-nextflow]] §7 — extract `nf_tests[]` and `test_fixtures` from a real nf-core or DSL2 pipeline.
-- [[nextflow-test-to-target-tests]] — translate nf-test fixtures + assertions into Galaxy / CWL equivalents.
+- [[nextflow-test-to-galaxy-test-plan]] — translate nf-test fixtures + assertions into Galaxy equivalents.
+- [[nextflow-test-to-cwl-test-plan]] — the same translation, toward CWL.
 
 The summarize side is mostly *enumeration*: walk `tests/*.nf.test`, extract structured fields per the Mold §7 spec. The translation side is *mapping*: each nf-test assertion pattern has a (sometimes lossy) Galaxy or CWL equivalent.
 

--- a/casts/claude/skills/summarize-nextflow/_provenance.json
+++ b/casts/claude/skills/summarize-nextflow/_provenance.json
@@ -6,11 +6,11 @@
     "path": "content/molds/summarize-nextflow/index.md",
     "revision": 14,
     "content_hash": "cb1d13ddba33496cc62070c3adde6a3e4159053db8ee304fbe5a803e810f849e",
-    "commit": "a56c6127966e59c75cf67d1d41ca03c8b4cf45dd"
+    "commit": "aede1aeab8ceb890192c9606a6e967a36fcf2224"
   },
   "cast_method": "hand-cast",
   "cast_agent": "claude (manual transcription, no LLM cast prompt)",
-  "cast_at": "2026-08-02T22:05:10.080Z",
+  "cast_at": "2026-08-03T23:38:03.201Z",
   "cast_date": "2026-05-08",
   "cast_revision": 11,
   "cast_history": [
@@ -144,8 +144,8 @@
       "purpose": "Extract nf-test files, snapshot fixtures, test profiles, and Nextflow test-data conventions.",
       "trigger": "When filling test_fixtures or nf_tests sections of the summary.",
       "verification": "Run the generated summarize-nextflow skill against nf-core/bacass and confirm this reference improves nf_tests and snapshot fixture extraction.",
-      "src_hash": "807c26846c6ea331b12c129e8caa438eacf5ea113b9dde51e2e3027c9878ad58",
-      "dst_hash": "807c26846c6ea331b12c129e8caa438eacf5ea113b9dde51e2e3027c9878ad58",
+      "src_hash": "b3f6dd5de325f8b9d85cc597b928df70b9f842eb2d1d2652aa68bde8e2c325c7",
+      "dst_hash": "b3f6dd5de325f8b9d85cc597b928df70b9f842eb2d1d2652aa68bde8e2c325c7",
       "source": "deterministic"
     },
     {

--- a/casts/claude/skills/summarize-nextflow/references/notes/component-nextflow-testing.md
+++ b/casts/claude/skills/summarize-nextflow/references/notes/component-nextflow-testing.md
@@ -5,9 +5,9 @@ tags:
 component: "Nextflow Testing and Test Fixtures"
 status: draft
 created: 2026-05-01
-revised: 2026-05-05
-revision: 2
-summary: "nf-test patterns mapped to Galaxy planemo asserts and CWL test equivalents — backs nextflow-test-to-target-tests Mold and summarize-nextflow §7."
+revised: 2026-08-03
+revision: 3
+summary: "nf-test patterns mapped to Galaxy planemo asserts and CWL test equivalents — backs the nextflow test-plan Molds and summarize-nextflow §7."
 companions:
   - "component-nextflow-testing.yml"
 sources:
@@ -22,7 +22,8 @@ sources:
   - "https://nf-co.re/docs/contributing/pipelines#test-data"
 related_molds:
   - "[[summarize-nextflow]]"
-  - "[[nextflow-test-to-target-tests]]"
+  - "[[nextflow-test-to-galaxy-test-plan]]"
+  - "[[nextflow-test-to-cwl-test-plan]]"
   - "[[implement-galaxy-workflow-test]]"
 related_notes:
   - "[[planemo-asserts-idioms]]"
@@ -33,10 +34,11 @@ related_notes:
 
 # Nextflow Testing and Test Fixtures
 
-Operational grounding for two Molds:
+Operational grounding for three Molds:
 
 - [[summarize-nextflow]] §7 — extract `nf_tests[]` and `test_fixtures` from a real nf-core or DSL2 pipeline.
-- [[nextflow-test-to-target-tests]] — translate nf-test fixtures + assertions into Galaxy / CWL equivalents.
+- [[nextflow-test-to-galaxy-test-plan]] — translate nf-test fixtures + assertions into Galaxy equivalents.
+- [[nextflow-test-to-cwl-test-plan]] — the same translation, toward CWL.
 
 The summarize side is mostly *enumeration*: walk `tests/*.nf.test`, extract structured fields per the Mold §7 spec. The translation side is *mapping*: each nf-test assertion pattern has a (sometimes lossy) Galaxy or CWL equivalent.
 

--- a/content/Dashboard.md
+++ b/content/Dashboard.md
@@ -70,8 +70,8 @@ Generated from `dashboard_sections.json` and content frontmatter. Do not edit by
 
 | Name | Summary | Status | Revised | Rev |
 | --- | --- | --- | --- | --- |
-| [[galaxy-interval-patterns]] | Use this MOC to choose corpus-grounded Galaxy genomic interval operations and recipes on coordinate features. | draft | 2026-06-10 | 1 |
-| [[galaxy-sequence-patterns]] | Use this MOC to choose corpus-grounded Galaxy operations on sequence records (FASTA) — interconvert, reformat, merge, length, extract/mask by region. | draft | 2026-06-10 | 1 |
+| [[galaxy-interval-patterns]] | Use this MOC to choose corpus-grounded Galaxy genomic interval operations and recipes on coordinate features. | draft | 2026-08-03 | 2 |
+| [[galaxy-sequence-patterns]] | Use this MOC to choose corpus-grounded Galaxy operations on sequence records (FASTA) — interconvert, reformat, merge, length, extract/mask by region. | draft | 2026-08-03 | 2 |
 | [[interval-consensus-by-multi-intersect]] | Find features reproducible across replicates: multi-intersect per-replicate sets, threshold by replicate count, then intersect back against the merged call. | draft | 2026-06-10 | 1 |
 | [[interval-coverage]] | Two coverage modes: genome-wide depth as a bedgraph (genomecoveragebed) and reads counted in given regions (coveragebed). Same family, different question. | draft | 2026-06-10 | 1 |
 | [[interval-mask-by-set-algebra]] | Compute regions from regions: concatenate candidate intervals, merge into non-overlapping spans, then subtract the set to keep. The gops_* set-algebra recipe. | draft | 2026-06-10 | 1 |
@@ -172,11 +172,11 @@ Generated from `dashboard_sections.json` and content frontmatter. Do not edit by
 
 | Name | Summary | Status | Revised | Rev |
 | --- | --- | --- | --- | --- |
+| [[galaxy-workflow-draft]] | JSON Schema for `class: GalaxyWorkflowDraft` — gxformat2 with `TODO_*` sentinels and `_plan_*` planning fields per draft step. | draft | 2026-08-03 | 2 |
 | [[cast-provenance]] | _provenance.json contract beside every cast: Mold revision, per-ref src/dst hashes, license lineage, artifact handoff. Schema v4 — deterministic casts only. | draft | 2026-08-02 | 2 |
 | [[planemo-test-report]] | JSON Schema for the report emitted by `planemo test --test_output_json` (and friends), vendored from upstream planemo. | draft | 2026-07-20 | 3 |
 | [[summary-galaxy-workflow]] | JSON Schema for the structured summary emitted by the summarize-galaxy-workflow Mold. | draft | 2026-07-01 | 1 |
 | [[galaxy-workflow-test-plan]] | JSON Schema for the intermediate Galaxy workflow test-plan handoff produced by the test-plan Molds and consumed by implement-galaxy-workflow-test. | draft | 2026-06-16 | 1 |
-| [[galaxy-workflow-draft]] | JSON Schema for `class: GalaxyWorkflowDraft` — gxformat2 with `TODO_*` sentinels and `_plan_*` planning fields per draft step. | draft | 2026-05-27 | 1 |
 | [[summary-cwl]] | JSON Schema for the structured summary emitted by the summarize-cwl Mold. | draft | 2026-05-10 | 1 |
 | [[summary-nextflow]] | JSON Schema for the structured summary emitted by the summarize-nextflow Mold. | draft | 2026-05-06 | 10 |
 | [[galaxy-tool-summary]] | JSON Schema for the deterministic per-tool manifest emitted by `galaxy-tool-cache summarize`. | draft | 2026-05-05 | 1 |
@@ -191,6 +191,7 @@ Generated from `dashboard_sections.json` and content frontmatter. Do not edit by
 
 | Name | Summary | Status | Revised | Rev |
 | --- | --- | --- | --- | --- |
+| [[component-nextflow-testing]] | nf-test patterns mapped to Galaxy planemo asserts and CWL test equivalents — backs the nextflow test-plan Molds and summarize-nextflow §7. | draft | 2026-08-03 | 3 |
 | [[gxy-sketches-alignment]] | Where the Foundry's per-source summary Molds align with gxy-sketches on field names and source/test-fixture vocabulary, and where they intentionally do not. | draft | 2026-07-24 | 2 |
 | [[open-requirements-ledger]] | Carried unresolved-requirements artifact the source→Galaxy pipeline discharges or explicitly surrenders, autonomously. | draft | 2026-06-16 | 1 |
 | [[component-claude-dynamic-workflows]] | Dynamic workflows natively solve the per-step sub-DAG loop Archon couldn't, with schema-typed step handoffs; cost is in-session-only resume and no mid-run gate. | draft | 2026-06-15 | 1 |
@@ -228,7 +229,6 @@ Generated from `dashboard_sections.json` and content frontmatter. Do not edit by
 | [[nf-schema-samplesheet-galaxy-gaps]] | nf-schema validation mapped to Galaxy column_definitions: what survives, degrades, or is lost; Galaxy work items + cast loss-recording vocabulary. | draft | 2026-05-06 | 1 |
 | [[component-nextflow-channel-operators]] | Structured digest of Nextflow channel operators (47 entries) with cardinality and shape semantics; backs summarize-nextflow §6 edge reconciliation. | draft | 2026-05-05 | 1 |
 | [[component-nextflow-containers-and-envs]] | Container URL grammar (depot, BioContainers, mulled-v2, Wave, ORAS) and conda directive resolution rules backing summarize-nextflow §5. | draft | 2026-05-05 | 3 |
-| [[component-nextflow-testing]] | nf-test patterns mapped to Galaxy planemo asserts and CWL test equivalents — backs nextflow-test-to-target-tests Mold and summarize-nextflow §7. | draft | 2026-05-05 | 2 |
 | [[component-nf-core-module-conventions]] | RFC 2119 conventions enforced by nf-core/tools module lint, with lint-check pointers. Backs summarize-nextflow + author-galaxy-tool-wrapper. | draft | 2026-05-05 | 1 |
 | [[galaxy-collection-semantics]] | Vendored formal spec of Galaxy dataset-collection mapping/reduction semantics, with labeled examples and pinned test references. | draft | 2026-05-05 | 3 |
 | [[galaxy-native-workflow-schema]] | Vendored structural JSON Schema for Galaxy native workflow (.ga) format: vocabulary for the JSON shape Galaxy emits and consumes. | draft | 2026-05-05 | 1 |

--- a/content/Index.md
+++ b/content/Index.md
@@ -184,7 +184,7 @@ Generated from content frontmatter. Do not edit by hand.
 - [[component-nextflow-containers-and-envs]] — Container URL grammar (depot, BioContainers, mulled-v2, Wave, ORAS) and conda directive resolution rules backing summarize-nextflow §5.
 - [[component-nextflow-inspect]] — White paper on Nextflow's native introspection subcommands — `nextflow inspect`, `nextflow config`, and adjacent tooling. Survey, not decision.
 - [[component-nextflow-pipeline-anatomy]] — Stub. DSL2 layout, channel idioms, operator-chain reading rules. Grows from cast contact with rnaseq/sarek/ad-hoc — see issue #17.
-- [[component-nextflow-testing]] — nf-test patterns mapped to Galaxy planemo asserts and CWL test equivalents — backs nextflow-test-to-target-tests Mold and summarize-nextflow §7.
+- [[component-nextflow-testing]] — nf-test patterns mapped to Galaxy planemo asserts and CWL test equivalents — backs the nextflow test-plan Molds and summarize-nextflow §7.
 - [[component-nf-core-module-conventions]] — RFC 2119 conventions enforced by nf-core/tools module lint, with lint-check pointers. Backs summarize-nextflow + author-galaxy-tool-wrapper.
 - [[component-nf-core-tools]] — White paper on nf-core/tools — conventions, CLI surface, schema universe, container resolution. Survey, not decision.
 - [[component-tool-shed-search]] — Tool Shed's Whoosh repo/tool search and partial GA4GH TRS v2, indexed from hg-walked metadata with no auto-refresh on upload

--- a/content/meta/build-and-validation.md
+++ b/content/meta/build-and-validation.md
@@ -7,8 +7,8 @@ tags:
   - meta
 status: reviewed
 created: 2026-08-02
-revised: 2026-08-02
-revision: 1
+revised: 2026-08-03
+revision: 2
 summary: "How authored Foundry source is checked, generated, cast, assembled, rendered, and kept current."
 ---
 
@@ -38,7 +38,7 @@ Authors change source notes, registries, schema implementations, or code. Genera
 2. parse frontmatter and validate the note against its kind's strict zod schema;
 3. check dates, paths, note shapes, and companion contracts;
 4. load tag and reference registries and enforce membership and coherence;
-5. build the shared wiki-link map and resolve frontmatter and body links;
+5. build the shared wiki-link map and resolve frontmatter and body links; an unresolved link is an error wherever it is written, and `related_patterns` and `related_molds` resolve on every kind that declares them rather than on Molds alone;
 6. run kind-specific checks for Molds, Patterns, Pipelines, schemas, CLI notes, prompts, research notes, and artifacts;
 7. run cross-note checks such as bidirectional relationships, typed-reference compatibility, pipeline phase resolution, and artifact producer/consumer ordering;
 8. run `validateUnroutedContent`, which errors on markdown under `content/` that no collection claims, no directory note owns, and `NOT_NOTES` does not declare.

--- a/content/patterns/galaxy-interval-patterns.md
+++ b/content/patterns/galaxy-interval-patterns.md
@@ -13,8 +13,8 @@ tags:
   - topic/interval-transform
 status: draft
 created: 2026-06-10
-revised: 2026-06-10
-revision: 1
+revised: 2026-08-03
+revision: 2
 summary: "Use this MOC to choose corpus-grounded Galaxy genomic interval operations and recipes on coordinate features."
 related_notes:
   - "[[iwc-interval-operations-survey]]"
@@ -33,7 +33,7 @@ related_molds:
   - "[[cwl-summary-to-galaxy-data-flow]]"
   - "[[nextflow-summary-to-galaxy-template]]"
   - "[[cwl-summary-to-galaxy-template]]"
-  - "[[paper-summary-to-galaxy-template]]"
+  - "[[freeform-summary-to-galaxy-template]]"
   - "[[compare-against-iwc-exemplar]]"
 ---
 

--- a/content/patterns/galaxy-sequence-patterns.md
+++ b/content/patterns/galaxy-sequence-patterns.md
@@ -13,8 +13,8 @@ tags:
   - topic/sequence-transform
 status: draft
 created: 2026-06-10
-revised: 2026-06-10
-revision: 1
+revised: 2026-08-03
+revision: 2
 summary: "Use this MOC to choose corpus-grounded Galaxy operations on sequence records (FASTA) — interconvert, reformat, merge, length, extract/mask by region."
 related_notes:
   - "[[iwc-sequence-operations-survey]]"
@@ -31,7 +31,7 @@ related_molds:
   - "[[cwl-summary-to-galaxy-data-flow]]"
   - "[[nextflow-summary-to-galaxy-template]]"
   - "[[cwl-summary-to-galaxy-template]]"
-  - "[[paper-summary-to-galaxy-template]]"
+  - "[[freeform-summary-to-galaxy-template]]"
   - "[[compare-against-iwc-exemplar]]"
 ---
 

--- a/content/research/component-nextflow-testing/index.md
+++ b/content/research/component-nextflow-testing/index.md
@@ -5,9 +5,9 @@ tags:
 component: "Nextflow Testing and Test Fixtures"
 status: draft
 created: 2026-05-01
-revised: 2026-05-05
-revision: 2
-summary: "nf-test patterns mapped to Galaxy planemo asserts and CWL test equivalents — backs nextflow-test-to-target-tests Mold and summarize-nextflow §7."
+revised: 2026-08-03
+revision: 3
+summary: "nf-test patterns mapped to Galaxy planemo asserts and CWL test equivalents — backs the nextflow test-plan Molds and summarize-nextflow §7."
 companions:
   - "component-nextflow-testing.yml"
 sources:
@@ -22,7 +22,8 @@ sources:
   - "https://nf-co.re/docs/contributing/pipelines#test-data"
 related_molds:
   - "[[summarize-nextflow]]"
-  - "[[nextflow-test-to-target-tests]]"
+  - "[[nextflow-test-to-galaxy-test-plan]]"
+  - "[[nextflow-test-to-cwl-test-plan]]"
   - "[[implement-galaxy-workflow-test]]"
 related_notes:
   - "[[planemo-asserts-idioms]]"
@@ -33,10 +34,11 @@ related_notes:
 
 # Nextflow Testing and Test Fixtures
 
-Operational grounding for two Molds:
+Operational grounding for three Molds:
 
 - [[summarize-nextflow]] §7 — extract `nf_tests[]` and `test_fixtures` from a real nf-core or DSL2 pipeline.
-- [[nextflow-test-to-target-tests]] — translate nf-test fixtures + assertions into Galaxy / CWL equivalents.
+- [[nextflow-test-to-galaxy-test-plan]] — translate nf-test fixtures + assertions into Galaxy equivalents.
+- [[nextflow-test-to-cwl-test-plan]] — the same translation, toward CWL.
 
 The summarize side is mostly *enumeration*: walk `tests/*.nf.test`, extract structured fields per the Mold §7 spec. The translation side is *mapping*: each nf-test assertion pattern has a (sometimes lossy) Galaxy or CWL equivalent.
 

--- a/content/schemas/galaxy-workflow-draft.md
+++ b/content/schemas/galaxy-workflow-draft.md
@@ -11,8 +11,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-05-27
-revised: 2026-05-27
-revision: 1
+revised: 2026-08-03
+revision: 2
 related_notes:
   - "[[galaxy-workflow-draft-format]]"
   - "[[galaxy-data-flow-draft-contract]]"
@@ -23,7 +23,7 @@ related_notes:
 related_molds:
   - "[[nextflow-summary-to-galaxy-template]]"
   - "[[cwl-summary-to-galaxy-template]]"
-  - "[[paper-summary-to-galaxy-template]]"
+  - "[[freeform-summary-to-galaxy-template]]"
   - "[[implement-galaxy-tool-step]]"
 summary: "JSON Schema for `class: GalaxyWorkflowDraft` — gxformat2 with `TODO_*` sentinels and `_plan_*` planning fields per draft step."
 ---

--- a/packages/build-cli/src/commands/validate.ts
+++ b/packages/build-cli/src/commands/validate.ts
@@ -196,15 +196,17 @@ function validateBidirectionalRelatedNotes(
 }
 
 /**
- * For Mold typed-references, ensure wiki-link refs resolve to a note of the
- * expected type. (Schema-/example-/prompt-path checks deferred until those
- * kinds appear — matches `INITIAL_ARCHITECTURE.md` §6 sketch.)
+ * `related_patterns` and `related_molds` resolve, and resolve to the kind the field names.
+ *
+ * Every kind that declares these fields is checked, not only Molds. Gating on `type === "mold"`
+ * silently exempted the pattern, research and schema notes that carry the same fields, and a
+ * deleted Mold left dangling references in all three — the field a note uses decides what is
+ * checked, not the kind of note using it.
  */
-function validateMoldRefs(
+function validateRelatedFields(
   files: FileMeta[],
   slugMap: Map<string, string>,
   metaByPath: Map<string, Frontmatter>,
-  contentRoot: string,
 ): CrossFileFinding[] {
   const findings: CrossFileFinding[] = [];
   const checks: Array<{ field: string; expected: string }> = [
@@ -212,7 +214,6 @@ function validateMoldRefs(
     { field: "related_molds", expected: "mold" },
   ];
   for (const f of files) {
-    if (f.meta.type !== "mold") continue;
     for (const c of checks) {
       const v = f.meta[c.field];
       if (!Array.isArray(v)) continue;
@@ -236,6 +237,25 @@ function validateMoldRefs(
         }
       }
     }
+  }
+  return findings;
+}
+
+/**
+ * Mold typed-references resolve to a note of the kind the reference declares.
+ *
+ * Mold-only, and legitimately so: `references` is a Mold field. (Schema-/example-/prompt-path
+ * checks deferred until those kinds appear — matches `INITIAL_ARCHITECTURE.md` §6 sketch.)
+ */
+function validateMoldRefs(
+  files: FileMeta[],
+  slugMap: Map<string, string>,
+  metaByPath: Map<string, Frontmatter>,
+  contentRoot: string,
+): CrossFileFinding[] {
+  const findings: CrossFileFinding[] = [];
+  for (const f of files) {
+    if (f.meta.type !== "mold") continue;
     const typedRefs = f.meta.references;
     if (Array.isArray(typedRefs)) {
       typedRefs.forEach((ref, i) => {
@@ -996,6 +1016,14 @@ const BODY_WIKI_LINK_RE = /\[\[([^\]\n]+)\]\]/g;
 const FENCED_CODE_RE = /```[\s\S]*?```/g;
 const INLINE_CODE_RE = /(`+)[\s\S]+?\1/g;
 
+/**
+ * Body wiki links resolve.
+ *
+ * An error, matching the frontmatter link fields. As a warning this reported a dangling link
+ * beside 228 advisory ones and blocked nothing, which is the same as not reporting it — and
+ * `content/meta/content-model.md` says an unresolved link fails validation, which was not true
+ * of the body until it was an error.
+ */
 function validateBodyWikiLinks(
   files: FileMeta[],
   slugMap: Map<string, string>,
@@ -1017,7 +1045,7 @@ function validateBodyWikiLinks(
       if (!resolveWikiLink(wl, slugMap)) {
         findings.push({
           path: f.path,
-          severity: "warning",
+          severity: "error",
           message: `body wiki-link ${wl} did not resolve`,
         });
       }
@@ -1450,6 +1478,7 @@ export function validateDirectory(opts: ValidateOptions): {
 
   const crossFindings: CrossFileFinding[] = [];
   crossFindings.push(...validateBidirectionalRelatedNotes(validFiles, slugMap));
+  crossFindings.push(...validateRelatedFields(validFiles, slugMap, metaByPath));
   crossFindings.push(...validateMoldRefs(validFiles, slugMap, metaByPath, opts.directory));
   crossFindings.push(...validateSourcePatternRefs(validFiles, slugMap, metaByPath));
   crossFindings.push(...validatePipelinePhases(validFiles, slugMap, metaByPath));

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -1470,7 +1470,36 @@ describe("validateDirectory (cross-file)", () => {
     expect(r.warnings).toBeGreaterThanOrEqual(1);
   });
 
-  it("warns on body wiki-links that do not resolve", () => {
+  // The check used to run only on notes of type `mold`, so the same dangling `related_molds`
+  // entry was an error on a Mold and silent on every other kind that declares the field.
+  it("errors on related_molds that do not resolve, on a note that is not a mold", () => {
+    writeFm(path.join(dir, "patterns/pattern-r.md"), {
+      ...patternRequired({ title: "Pattern R" }),
+      related_molds: ["[[ghost-mold]]"],
+    });
+
+    const r = validateDirectory({
+      directory: dir,
+      tagsPath: TAGS_PATH,
+    });
+    expect(r.errors).toBeGreaterThanOrEqual(1);
+  });
+
+  it("errors when related_molds resolves to a note that is not a mold", () => {
+    writeFm(path.join(dir, "patterns/pattern-s.md"), {
+      ...patternRequired({ title: "Pattern S" }),
+      related_molds: ["[[pattern-t]]"],
+    });
+    writeFm(path.join(dir, "patterns/pattern-t.md"), patternRequired({ title: "Pattern T" }));
+
+    const r = validateDirectory({
+      directory: dir,
+      tagsPath: TAGS_PATH,
+    });
+    expect(r.errors).toBeGreaterThanOrEqual(1);
+  });
+
+  it("errors on body wiki-links that do not resolve", () => {
     mkdirSync(path.dirname(path.join(dir, "patterns/pattern-x.md")), { recursive: true });
     writeFileSync(
       path.join(dir, "patterns/pattern-x.md"),
@@ -1483,8 +1512,7 @@ describe("validateDirectory (cross-file)", () => {
       directory: dir,
       tagsPath: TAGS_PATH,
     });
-    expect(r.errors).toBe(0);
-    expect(r.warnings).toBeGreaterThanOrEqual(1);
+    expect(r.errors).toBeGreaterThanOrEqual(1);
   });
 
   it("ignores body wiki-links inside fenced or inline code", () => {


### PR DESCRIPTION
> Posted by Claude (AI assistant) on behalf of @jmchilton — not authored by them personally.

Audit of GWF's wiki-link checking, prompted by [jmchilton/statistical-genomics-foundry#149](https://github.com/jmchilton/statistical-genomics-foundry/pull/149), which added the equivalent check there and immediately found a live rendering bug. Two of the three things I went looking for were real.

## What was broken

**`related_patterns` and `related_molds` were checked on Molds and on nothing else.** `validateMoldRefs` opened with `if (f.meta.type !== "mold") continue;` — but pattern, research and schema notes declare the same fields. The same dangling entry was an error on a Mold and silent everywhere else.

**Body wiki-links were `severity: "warning"`.** One dangling link sat among 228 advisory warnings and blocked nothing. `content/meta/content-model.md` says an unresolved link "fails validation" — which was not true of the body.

Together they hid **5 dangling links**, all from two Mold renames that git itself recorded as renames (`R063`, `R069`):

| dead target | successor | left behind in |
|---|---|---|
| `paper-summary-to-galaxy-template` | `freeform-summary-to-galaxy-template` | 2 patterns + 1 schema note |
| `nextflow-test-to-target-tests` | `nextflow-test-to-galaxy-test-plan` (+ `-cwl-test-plan`) | 1 research note, frontmatter **and** body |

The research note's frontmatter entry and its body bullet named the same dead Mold. Only the body one was reported, and only as a warning.

## The fix

`validateRelatedFields` runs over every note — the field a note uses decides what is checked, not the kind of note using it. Typed `references` stays Mold-only, which is correct: it *is* a Mold field. Body links become errors, matching the frontmatter fields.

`component-nextflow-testing` backs both nextflow test plans (its summary names Galaxy asserts *and* CWL equivalents), so it now cites both — which makes its "Operational grounding for two Molds" lead-in three.

`build-and-validation.md` gains the coverage and severity in step 5, since promoting a gate changes what it proves.

## Tests

**`related_molds` had no test at all** — which is how the mold-only gate survived. Added two (unresolved target; resolves-to-wrong-kind), both verified failing with the gate restored before keeping them. The existing body-link test asserted `errors === 0` and is updated to assert the error.

## What I checked and found *not* broken

I expected the three wiki-link maps to disagree, and they don't:

- `site/src/lib/wiki-links.ts` keys on a **raw** basename while lookup slugifies — which looked like statgen's bug. It isn't: Astro's ids are already slugified upstream, so the routes (`/research/cwl-v12-schemas/`, `/cli/planemo/planemo-workflowtestinit/`) match what the resolver produces. Verified against the built site.
- The validator's `buildSlugMap` lacks the Mold `name` alias the site map has. Latent only — every Mold's `name` currently equals its directory, so no link exercises the difference. Worth knowing, not worth changing on zero evidence.

## Gates

`make check` exits 0 — 242 files, 0 errors, 228 warnings (all pre-existing companion advisories); 268 tests pass; `astro check` clean.

Dashboard and Index regenerated. Casts re-run only for the **nine** bundles whose vendored references actually changed — `make casts` rewrites all ~60 `_provenance.json` with a fresh timestamp, which is churn, not signal.

## Not in this PR

The warning count itself. 228 advisory warnings is enough that a real one is hard to see — the same failure mode this PR fixes for links, one level up. Worth a separate look at whether those companion advisories should be errors, exemptions, or retired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
