### PR TITLE
Drop the backlink reciprocity rule

### DIFF
--- a/content/meta/build-and-validation.md
+++ b/content/meta/build-and-validation.md
@@ -8,7 +8,7 @@ tags:
 status: reviewed
 created: 2026-08-02
 revised: 2026-08-03
-revision: 2
+revision: 3
 summary: "How authored Foundry source is checked, generated, cast, assembled, rendered, and kept current."
 ---
 
@@ -38,9 +38,9 @@ Authors change source notes, registries, schema implementations, or code. Genera
 2. parse frontmatter and validate the note against its kind's strict zod schema;
 3. check dates, paths, note shapes, and companion contracts;
 4. load tag and reference registries and enforce membership and coherence;
-5. build the shared wiki-link map and resolve frontmatter and body links; an unresolved link is an error wherever it is written, and `related_patterns` and `related_molds` resolve on every kind that declares them rather than on Molds alone;
+5. build the shared wiki-link map and resolve frontmatter and body links; an unresolved link is an error wherever it is written, on every kind that declares the field;
 6. run kind-specific checks for Molds, Patterns, Pipelines, schemas, CLI notes, prompts, research notes, and artifacts;
-7. run cross-note checks such as bidirectional relationships, typed-reference compatibility, pipeline phase resolution, and artifact producer/consumer ordering;
+7. run cross-note checks such as typed-reference compatibility, pipeline phase resolution, and artifact producer/consumer ordering;
 8. run `validateUnroutedContent`, which errors on markdown under `content/` that no collection claims, no directory note owns, and `NOT_NOTES` does not declare.
 
 Step 8 is what closes the walk. Steps 1–7 check the files the routing table found; step 8 checks that the table found everything there was to find. [[content-model]] owns the three-way accounting it enforces.

--- a/content/meta/content-model.md
+++ b/content/meta/content-model.md
@@ -7,8 +7,8 @@ tags:
   - meta
 status: reviewed
 created: 2026-08-02
-revised: 2026-08-02
-revision: 2
+revised: 2026-08-03
+revision: 3
 summary: "How Foundry notes, kinds, metadata, tags, links, references, and companions represent knowledge."
 ---
 
@@ -53,6 +53,8 @@ The registry has two corpus-level drift rules: a note may not use an undeclared 
 Body prose and selected frontmatter fields use Obsidian-style `[[Target]]` links. The validator and renderer share one parser and resolver. Resolution is exact after normalization — there is no prefix fallback, so an unresolved link fails validation or renders visibly unresolved rather than landing on an arbitrary near-match. Code spans are excluded because a backticked `[[Target]]` names the syntax rather than creating a link.
 
 That exclusion cuts both ways, and the second edge is the sharp one: `validateBodyWikiLinks` strips code spans *before* it scans, so a backticked link is not merely unrendered — it is unchecked. It can name a note that never existed and neither the site nor the validator will say so. Wrap a wiki link in backticks only when the literal token is the subject: a template slot, a frontmatter field shape, or a shell construct like `[[:space:]]` that is not a wiki link at all.
+
+Links are one-directional and backlinks are derived. The site computes incoming references from the same link fields, so a relationship shows on both notes while being written once. A note is never asked to list what points at it.
 
 ## Typed references
 

--- a/packages/build-cli/src/commands/validate.ts
+++ b/packages/build-cli/src/commands/validate.ts
@@ -161,48 +161,7 @@ function buildSlugMap(files: FileMeta[]): Map<string, string> {
   return m;
 }
 
-function validateBidirectionalRelatedNotes(
-  files: FileMeta[],
-  slugMap: Map<string, string>,
-): CrossFileFinding[] {
-  const forward = new Map<string, Set<string>>();
-  for (const f of files) {
-    const targets = new Set<string>();
-    const rns = f.meta.related_notes;
-    if (Array.isArray(rns)) {
-      for (const wl of rns) {
-        const tp = resolveWikiLink(wl, slugMap);
-        if (tp && tp !== f.path) targets.add(tp);
-      }
-    }
-    forward.set(f.path, targets);
-  }
-  const slugByPath = new Map<string, string>();
-  for (const f of files) slugByPath.set(f.path, f.slug);
-  const findings: CrossFileFinding[] = [];
-  for (const [a, targets] of forward) {
-    for (const b of targets) {
-      const back = forward.get(b);
-      if (!back || back.has(a)) continue;
-      const aSlug = slugByPath.get(a) ?? a;
-      findings.push({
-        path: b,
-        severity: "warning",
-        message: `related_notes: missing backlink to [[${aSlug}]] (declared in ${a})`,
-      });
-    }
-  }
-  return findings;
-}
-
-/**
- * `related_patterns` and `related_molds` resolve, and resolve to the kind the field names.
- *
- * Every kind that declares these fields is checked, not only Molds. Gating on `type === "mold"`
- * silently exempted the pattern, research and schema notes that carry the same fields, and a
- * deleted Mold left dangling references in all three — the field a note uses decides what is
- * checked, not the kind of note using it.
- */
+/** `related_patterns` and `related_molds` resolve to a note of the kind the field names. */
 function validateRelatedFields(
   files: FileMeta[],
   slugMap: Map<string, string>,
@@ -241,12 +200,7 @@ function validateRelatedFields(
   return findings;
 }
 
-/**
- * Mold typed-references resolve to a note of the kind the reference declares.
- *
- * Mold-only, and legitimately so: `references` is a Mold field. (Schema-/example-/prompt-path
- * checks deferred until those kinds appear — matches `INITIAL_ARCHITECTURE.md` §6 sketch.)
- */
+/** Mold typed-references resolve to a note of the kind the reference declares. */
 function validateMoldRefs(
   files: FileMeta[],
   slugMap: Map<string, string>,
@@ -1016,14 +970,7 @@ const BODY_WIKI_LINK_RE = /\[\[([^\]\n]+)\]\]/g;
 const FENCED_CODE_RE = /```[\s\S]*?```/g;
 const INLINE_CODE_RE = /(`+)[\s\S]+?\1/g;
 
-/**
- * Body wiki links resolve.
- *
- * An error, matching the frontmatter link fields. As a warning this reported a dangling link
- * beside 228 advisory ones and blocked nothing, which is the same as not reporting it — and
- * `content/meta/content-model.md` says an unresolved link fails validation, which was not true
- * of the body until it was an error.
- */
+/** Body wiki links resolve, outside fenced and inline code. */
 function validateBodyWikiLinks(
   files: FileMeta[],
   slugMap: Map<string, string>,
@@ -1477,7 +1424,6 @@ export function validateDirectory(opts: ValidateOptions): {
   for (const f of validFiles) metaByPath.set(f.path, f.meta);
 
   const crossFindings: CrossFileFinding[] = [];
-  crossFindings.push(...validateBidirectionalRelatedNotes(validFiles, slugMap));
   crossFindings.push(...validateRelatedFields(validFiles, slugMap, metaByPath));
   crossFindings.push(...validateMoldRefs(validFiles, slugMap, metaByPath, opts.directory));
   crossFindings.push(...validateSourcePatternRefs(validFiles, slugMap, metaByPath));

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -1470,8 +1470,6 @@ describe("validateDirectory (cross-file)", () => {
     expect(r.warnings).toBeGreaterThanOrEqual(1);
   });
 
-  // The check used to run only on notes of type `mold`, so the same dangling `related_molds`
-  // entry was an error on a Mold and silent on every other kind that declares the field.
   it("errors on related_molds that do not resolve, on a note that is not a mold", () => {
     writeFm(path.join(dir, "patterns/pattern-r.md"), {
       ...patternRequired({ title: "Pattern R" }),


### PR DESCRIPTION
> Posted by Claude (AI assistant) on behalf of @jmchilton — not authored by them personally.

Deletes `validateBidirectionalRelatedNotes`. Links are one-directional; backlinks are derived.

`buildBacklinkMap` already computes incoming references from `parent_pattern`, `related_notes`, `related_patterns`, `related_molds`, `phases` and `output_artifact_schema`, and `IncomingRefs.astro` renders them on every note page. If A lists B, B's page shows A. The check asked authors to hand-maintain exactly that.

Three things made it worth deleting rather than satisfying:

- **It covered one of the six fields** that feed the same panel — `related_notes` alone.
- **It complained to the wrong note.** The finding was pushed onto the *target*, so a note accrued warnings in proportion to how often it was cited. `iwc-sequence-operations-survey` was told 8 times to cite back the 8 notes referencing it. A survey citing its sources is right; the sources citing the survey back is noise — which is why there were 136 of them.
- **Nothing justified it.** No design record stated the rule, no test covered it, and it dates to the initial commit — predating the backlink renderer that made it redundant. statgen never adopted it.

**Warnings: 228 → 92.** What that unburies is the point — pipeline artifact-ordering gaps, `evidence=hypothesis` schema refs, cli-commands missing `## Gotchas`, and the eval/scenarios companion backlog were all sitting underneath.

`content-model.md` states the rule positively so it can't be reinvented; `build-and-validation.md` drops it from the layer list.

Also trims the commentary I added in #441 down to one line per function — it narrated history rather than intent, which AGENTS.md asks against ("one short line max").

Companion PR in the pattern repo: galaxyproject/foundry-pattern#36 — its Astro-stack instructions listed backlinks among the rules belonging in the validator, which reads as a reciprocity check to write.

## Gates

`make check` exits 0 — 242 files, 0 errors, 92 warnings, 268 tests.

Note: `tests/built-shell.test.ts > offers a skip link…` has a 5s timeout and reads all 374 built pages, so it times out under load inside `make check` and passes in ~400ms alone. Pre-existing and unrelated; worth a longer timeout in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)