### PR TITLE
Six palette tokens nothing had ever asked for

### DIFF
--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -9,7 +9,6 @@
   /* Galaxy brand */
   --color-galaxy-primary: #25537b;
   --color-galaxy-dark: #2c3143;
-  --color-galaxy-gold: #ffd700;
   --color-galaxy-gold-dark: #d0bd2a;
   --color-galaxy-grey: #58585a;
 
@@ -17,8 +16,6 @@
   --color-surface: #ffffff;
   --color-surface-raised: #f6f8fa;
   --color-surface-hover: #edf4fa;
-  --color-surface-dark: #2c3143;
-  --color-surface-dark-medium: #3c435c;
 
   /* Text */
   --color-text-primary: #2c3143;
@@ -36,11 +33,9 @@
 
   /* Accent — slightly desaturated from pure #ffd700 for less screaming gold */
   --color-accent: #e8c547;
-  --color-accent-hover: #f2d55a;
 
-  /* Rail / station colors for the subway-style phase graph; flip in dark. */
+  /* The rail of the subway-style phase graph; a lighter blue in dark. */
   --color-rail: #25537b;
-  --color-rail-on: #e8c547;
 
   /* Badges */
   --color-badge-draft-bg: #fff3cd;
@@ -54,9 +49,8 @@
   --color-badge-archived-bg: #d6d8db;
   --color-badge-archived-text: #383d41;
 
-  /* Tags */
+  /* Tags. The chip's hover is the accent, not a lighter shade of its own background. */
   --color-tag-bg: #edf4fa;
-  --color-tag-bg-hover: #cde0f0;
 
   /* Fonts */
   --font-sans: 'Atkinson Hyperlegible', ui-sans-serif, system-ui, -apple-system, sans-serif;
@@ -74,9 +68,7 @@
   --color-text-secondary: #b6bfca;
   --color-text-muted: #8b94a0;
   --color-rail: #6fa5d4;
-  --color-rail-on: #e8c547;
   --color-link: #6fa5d4;
-  --color-link-hover: #ffd700;
   --color-badge-draft-bg: #3d2e00;
   --color-badge-draft-text: #f0c000;
   --color-badge-reviewed-bg: #0f2d16;
@@ -88,15 +80,17 @@
   --color-badge-archived-bg: #21262d;
   --color-badge-archived-text: #8b949e;
   --color-tag-bg: #21262d;
-  --color-tag-bg-hover: #30363d;
 }
 
 /* --- Grid background --- */
 
+/* The tint is the brand at 6%, so it says so. A colour spelled out as `rgba(37, 83, 123, …)` is
+   invisible to every search for the token it duplicates, including the one that renames it.
+   The dark rule below is NOT the same shape: white at 3% is its own decision, not a token. */
 .bg-grid {
   background-image:
-    linear-gradient(to right, rgba(37, 83, 123, 0.06) 1px, transparent 1px),
-    linear-gradient(to bottom, rgba(37, 83, 123, 0.06) 1px, transparent 1px);
+    linear-gradient(to right, color-mix(in srgb, var(--color-galaxy-primary) 6%, transparent) 1px, transparent 1px),
+    linear-gradient(to bottom, color-mix(in srgb, var(--color-galaxy-primary) 6%, transparent) 1px, transparent 1px);
   background-size: 24px 24px;
 }
 .dark .bg-grid {

--- a/tests/built-shell.test.ts
+++ b/tests/built-shell.test.ts
@@ -148,12 +148,16 @@ describe("the document skeleton", () => {
   });
 });
 
+/** Every stylesheet the build emitted, concatenated. The shell's styles are split across several. */
+const emittedCss = (): string =>
+  readdirSync(path.join(DIST, "_astro"))
+    .filter((entry) => entry.endsWith(".css"))
+    .map((entry) => read(path.join(DIST, "_astro", entry)))
+    .join("\n");
+
 describe("the stylesheet the shell depends on", () => {
   it("emits a utility that only the layout names", () => {
-    const css = readdirSync(path.join(DIST, "_astro"))
-      .filter((entry) => entry.endsWith(".css"))
-      .map((entry) => read(path.join(DIST, "_astro", entry)))
-      .join("\n");
+    const css = emittedCss();
 
     expect(css).not.toHaveLength(0);
     expect(
@@ -162,6 +166,43 @@ describe("the stylesheet the shell depends on", () => {
         ` emitted stylesheet. Tailwind did not scan the file that declares it — see the header` +
         ` comment. The pages will render unstyled, and nothing else reports this.`,
     ).toBe(true);
+  });
+});
+
+// Here rather than in a file of its own because it asserts on the same built `dist/`, and a second
+// suite that spawns its own `astro build` would double the slowest thing in this repo's test run.
+describe("the palette this stylesheet declares", () => {
+  // Tailwind 4 emits an `@theme` token ONLY where it finds a reference, so a token nothing uses
+  // reaches no stylesheet and costs no bytes. Which is exactly why they accumulate: six had, and
+  // the one that mattered was `--color-surface-dark`, a semantic name holding #2c3143 — the colour
+  // the header bar has always used — under the surfaces heading, well away from the brand token
+  // that was actually doing the work. A dead token is not waste, it is a wrong answer waiting for
+  // a reader in a hurry.
+  //
+  // `:root` is the load-bearing part, and it is what found two of the six. A token redeclared under
+  // `.dark` emits from THAT rule whichever way, because a class is not tree-shaken — so a search of
+  // the whole stylesheet reports it alive while the light value is referenced by nothing.
+  // `--color-rail-on` and `--color-tag-bg-hover` were both exactly that: present in the file, absent
+  // from `:root`, used nowhere.
+  it("declares no token that reaches no stylesheet", () => {
+    const source = read(path.join(SITE, "src/styles/global.css"));
+    const block = source.slice(source.indexOf("@theme"), source.indexOf("\n}", source.indexOf("@theme")));
+    const declared = [...block.matchAll(/^\s*(--[\w-]+):/gm)].map((m) => m[1]!);
+
+    const css = emittedCss();
+    const root = (css.match(/:root[^{]*\{[^}]*\}/g) ?? []).join("");
+    const dead = declared.filter((token) => !root.includes(`${token}:`));
+
+    expect(declared.length, "\nno tokens parsed out of @theme — has the block moved?").toBeGreaterThan(20);
+    expect(
+      dead,
+      "\nthese are declared in `@theme` and referenced by nothing, so Tailwind emitted no" +
+        " declaration for them. Delete them, or use them. A token carrying a value that is also" +
+        " some other token's is the worst kind: it reads as the right name for a colour that is" +
+        " actually spelled elsewhere.\n\n  " +
+        dead.join("\n  ") +
+        "\n",
+    ).toEqual([]);
   });
 });
 


### PR DESCRIPTION
> Posted by Claude (AI assistant) on jmchilton's behalf — they did not write this text.

Stylesheet cleanup, measured. Based on `main` and **depends on nothing** — no package upgrade, no shell change, no coordination with #439.

## Six dead tokens

Tailwind 4 emits an `@theme` token only where it finds a reference, so a token nothing uses reaches no stylesheet and costs no bytes. That is exactly why they accumulate: nothing renders wrong, nothing gets bigger.

| token | value | why it was dead |
|---|---|---|
| `--color-galaxy-gold` | `#ffd700` | the raw brand gold; the value survives as `--color-link-hover` |
| `--color-surface-dark` | `#2c3143` | **the colour the header bar has always used**, under a semantic name, filed with the surfaces well away from the brand token doing the work |
| `--color-surface-dark-medium` | `#3c435c` | referenced nowhere at all |
| `--color-accent-hover` | `#f2d55a` | the accent has no hover state |
| `--color-rail-on` | `#e8c547` | the phase graph draws its rail and never lit a station |
| `--color-tag-bg-hover` | `#cde0f0` | the chip's hover is the accent, not a lighter shade of its own background |

`--color-surface-dark` is the one that mattered, and not for the bytes. It is the *right name* for a colour spelled somewhere else, sitting exactly where a reader in a hurry would find it and use it. That is a wrong answer waiting, not waste.

The `.dark` block loses `--color-rail-on` and `--color-tag-bg-hover` with them, plus `--color-link-hover`, which restated the light value verbatim. A no-op override is a claim that dark mode decided something here.

## One inlined literal

`.bg-grid` drew its tint as `rgba(37, 83, 123, 0.06)` — `--color-galaxy-primary` written out in decimal, under a name no search for the token finds. Now `color-mix`, the form this stylesheet already uses in seven other places; lightningcss emits the resolved `#25537b0f` beside it, so the tint is unchanged.

The dark rule keeps its literal deliberately. `rgba(255, 255, 255, 0.03)` matches `--color-surface` (`#ffffff`), and collapsing it would invent a mapping nobody made: white-at-3% in dark mode is its own decision, not "the surface colour."

## The check reads `:root`, not the file

This is what found **two of the six**. A token redeclared under `.dark` emits from *that* rule whichever way, because a class is not tree-shaken — so a whole-stylesheet search reports it alive while the light value is referenced by nothing. `--color-rail-on` and `--color-tag-bg-hover` were both exactly that, and both are what a naive check would still be missing.

Written red: against the stylesheet as it stands on `main`, the new assertion reports all six and nothing else.

## Verification

271 tests, `astro check` 0-0-0, 374 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
