### PR TITLE
Print each finding under the file it is about

### DIFF
--- a/packages/build-cli/src/commands/validate.ts
+++ b/packages/build-cli/src/commands/validate.ts
@@ -1386,11 +1386,13 @@ export function validateDirectory(opts: ValidateOptions): {
   let warningCount = 0;
   let filesChecked = 0;
   const validFiles: FileMeta[] = [];
-  const printedHeaders = new Set<string>();
+  let lastHeader: string | undefined;
 
+  // Reprint on every change of file, not once per file: a file's findings arrive in more than one
+  // block, and a header printed only the first time files the later ones under its neighbour.
   const printHeader = (filePath: string): void => {
-    if (printedHeaders.has(filePath)) return;
-    printedHeaders.add(filePath);
+    if (lastHeader === filePath) return;
+    lastHeader = filePath;
     process.stdout.write(`\n${filePath}:\n`);
   };
 
@@ -1457,14 +1459,23 @@ export function validateDirectory(opts: ValidateOptions): {
   crossFindings.push(...validateBodyWikiLinks(validFiles, slugMap));
   crossFindings.push(...validateMoldStubBody(validFiles));
 
+  // Grouped, so each file reads as one block rather than once per cross-file pass that found it.
+  const findingsByPath = new Map<string, CrossFileFinding[]>();
   for (const f of crossFindings) {
-    printHeader(f.path);
-    if (f.severity === "error") {
-      process.stdout.write(`  ERROR  ${f.message}\n`);
-      errorCount++;
-    } else {
-      process.stdout.write(`  WARN   ${f.message}\n`);
-      warningCount++;
+    const group = findingsByPath.get(f.path);
+    if (group) group.push(f);
+    else findingsByPath.set(f.path, [f]);
+  }
+  for (const [filePath, group] of findingsByPath) {
+    printHeader(filePath);
+    for (const f of group) {
+      if (f.severity === "error") {
+        process.stdout.write(`  ERROR  ${f.message}\n`);
+        errorCount++;
+      } else {
+        process.stdout.write(`  WARN   ${f.message}\n`);
+        warningCount++;
+      }
     }
   }
 

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -2082,8 +2082,16 @@ describe("validateDirectory (cross-file)", () => {
         name: "consumer",
         axis: "generic",
         input_artifacts: [
-          { id: "brief-a", role: "brief", description: "Interface brief when running the A pipeline." },
-          { id: "brief-b", role: "brief", description: "Interface brief when running the B pipeline." },
+          {
+            id: "brief-a",
+            role: "brief",
+            description: "Interface brief when running the A pipeline.",
+          },
+          {
+            id: "brief-b",
+            role: "brief",
+            description: "Interface brief when running the B pipeline.",
+          },
         ],
       }),
     });
@@ -2123,5 +2131,68 @@ describe("validateDirectory (cross-file)", () => {
     expect(captureValidate()).toMatch(
       /phases\[0\]: no prior phase produces any input_artifact for role 'brief' \(brief-a, brief-b\)/,
     );
+  });
+
+  const findingsByHeader = (captured: string): Map<string, string[]> => {
+    const blocks = new Map<string, string[]>();
+    let current = "";
+    for (const line of captured.split("\n")) {
+      const header = /^(\S.*):$/.exec(line);
+      if (header?.[1] !== undefined) {
+        current = header[1];
+        if (!blocks.has(current)) blocks.set(current, []);
+        continue;
+      }
+      const finding = /^ {2}(?:ERROR|WARN) {2,}(.*)$/.exec(line);
+      if (finding?.[1] !== undefined) blocks.get(current)?.push(finding[1]);
+    }
+    return blocks;
+  };
+
+  it("files a finding under its own path when its checks are not adjacent", () => {
+    writeFm(path.join(dir, "molds/producer-x/index.md"), {
+      ...baseRequired({
+        type: "mold",
+        tags: ["target/galaxy"],
+        name: "producer-x",
+        axis: "generic",
+        output_artifacts: [
+          {
+            id: "summary-x",
+            kind: "json",
+            default_filename: "summary-x.json",
+            description: "Structured summary the consumer reads.",
+          },
+        ],
+      }),
+    });
+    writeFm(path.join(dir, "molds/consumer-x/index.md"), {
+      ...baseRequired({
+        type: "mold",
+        tags: ["target/galaxy"],
+        name: "consumer-x",
+        axis: "generic",
+        input_artifacts: [
+          { id: "summary-x", description: "Structured summary produced upstream." },
+        ],
+      }),
+    });
+    // Warns from the artifact pass and again from the companion pass, with both Molds between.
+    writeFm(path.join(dir, "pipelines/zeta/index.md"), {
+      ...baseRequired({
+        type: "pipeline",
+        tags: ["target/galaxy"],
+        title: "Zeta",
+        phases: [{ mold: "[[consumer-x]]" }],
+      }),
+    });
+
+    const blocks = findingsByHeader(captureValidate());
+    expect(blocks.get(path.join(dir, "pipelines/zeta/index.md"))).toEqual([
+      "phases[0]: input_artifact 'summary-x' has no prior phase producing it in this pipeline",
+      expect.stringContaining("should have eval.md"),
+      expect.stringContaining("should have scenarios.md"),
+    ]);
+    expect(blocks.get(path.join(dir, "molds/producer-x/index.md"))).toHaveLength(2);
   });
 });


### PR DESCRIPTION
> Posted by Claude (AI assistant) on jmchilton's behalf — they did not write this text.

Found while triaging the remaining warnings: the report was telling me which files needed work, and for two of them it was naming the wrong file.

`printHeader` prints a path **once ever** — `printedHeaders` is a `Set`. But `crossFindings` is built by appending ~18 independent passes and is never grouped by path, so a file whose findings land in two non-adjacent blocks gets its later findings printed under whatever header came last.

What the report said:

```
content/pipelines/interview-to-galaxy/index.md:
  WARN   pipeline: should have eval.md
  WARN   pipeline: should have eval.md      ← paper-to-cwl's
  WARN   pipeline: should have scenarios.md ← paper-to-cwl's
```

`interview-to-galaxy/` **has** `scenarios.md`. `paper-to-cwl/` has only `index.md`, and printed its header early for two artifact-binding warnings — so its companion warnings, emitted by a later pass, arrived orphaned and landed on its neighbour. `changeset-to-galaxy-test-plan` was the same shape.

Verified at the emit site before touching anything: the checks are correct. One warning for `interview-to-galaxy`, two for `paper-to-cwl`. Only the display was wrong.

## Why this was worth stopping for

Four of 53 warnings, so the arithmetic barely moves — the counts were always right. That is the problem. A wrong count announces itself; a warning filed under the wrong name reads as a correct report, and the backlog it describes is the current work. I had started reading `interview-to-galaxy` to write the scenarios file it already has.

## The fix

Group cross findings by path before printing, and let the header reprint on a **change** of file rather than dedupe forever. Both halves are load-bearing: grouping alone still loses a file that warned during the per-file frontmatter pass and again in a cross pass, because that first header is far above and would suppress the second.

Written red — against `main` the new test gets one line where it expects three, exactly the block that went missing.

## Verification

`make check` exit 0. 271 tests, `npm run typecheck` 0-0-0. Warnings stay 53; `interview-to-galaxy` now shows the one it owns and `paper-to-cwl` carries its four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
