### PR TITLE
Write the four missing Gotchas, and stop claiming silence

### DIFF
--- a/content/Dashboard.md
+++ b/content/Dashboard.md
@@ -141,11 +141,15 @@ Generated from `dashboard_sections.json` and content frontmatter. Do not edit by
 
 | Name | Summary | Status | Revised | Rev |
 | --- | --- | --- | --- | --- |
-| [[validate-summary-galaxy-workflow]] | AJV gate for summarize-galaxy-workflow JSON documents. | draft | 2026-07-01 | 1 |
+| [[validate-galaxy-tool-discovery]] | AJV gate for discover-shed-tool recommendation documents. | draft | 2026-08-04 | 2 |
+| [[validate-galaxy-tool-summary]] | AJV gate for galaxy-tool-cache summarize manifests, including the nested parsed_tool subtree. | draft | 2026-08-04 | 2 |
+| [[validate-galaxy-workflow-test-plan]] | AJV gate for Galaxy workflow test-plan YAML documents. | draft | 2026-08-04 | 2 |
+| [[validate-summary-cwl]] | AJV gate for summarize-cwl JSON documents. | draft | 2026-08-04 | 2 |
+| [[validate-summary-galaxy-workflow]] | AJV gate for summarize-galaxy-workflow JSON documents. | draft | 2026-08-04 | 2 |
+| [[validate-summary-nextflow]] | AJV gate for summarize-nextflow JSON documents. | draft | 2026-08-04 | 2 |
 | [[add]] | Fetch a tool from the Tool Shed (shed-path or bare/stock id) and cache its ParsedTool locally for later summarize/schema. | draft | 2026-06-18 | 2 |
 | [[list]] | Enumerate the tools in a cache directory with their resolved versions; the surface for confirming which stock/shed pin got cached. | draft | 2026-06-18 | 1 |
 | [[summarize]] | Emit a deterministic galaxy-tool-summary manifest (cache provenance + embedded ParsedTool + generated input JSON Schemas) for a cached tool. | draft | 2026-06-18 | 2 |
-| [[validate-galaxy-workflow-test-plan]] | AJV gate for Galaxy workflow test-plan YAML documents. | draft | 2026-06-16 | 1 |
 | [[draft-extract]] | Extract the concrete subset of a draft workflow: trim drafty steps, strip `_plan_*`, promote class when fully resolved. | draft | 2026-05-27 | 1 |
 | [[draft-next-step]] | Pick the next drafty step a harness should work on, or report no remaining work; deterministic topological + alphabetical tiebreak. | draft | 2026-05-27 | 1 |
 | [[draft-validate]] | Validate a `class: GalaxyWorkflowDraft` workflow against draft-contract rules; with --concrete, also validate the extracted concrete subset. | draft | 2026-05-27 | 1 |
@@ -156,10 +160,6 @@ Generated from `dashboard_sections.json` and content frontmatter. Do not edit by
 | [[planemo-workflow_test_init]] | Initialize a Galaxy workflow test description for supplied workflow. | draft | 2026-05-11 | 1 |
 | [[planemo-workflow_test_on_invocation]] | Run defined tests against existing workflow invocation. | draft | 2026-05-11 | 1 |
 | [[summarize-nextflow]] | Statically introspect a Nextflow / nf-core pipeline tree and emit a validated JSON summary. | draft | 2026-05-11 | 1 |
-| [[validate-galaxy-tool-discovery]] | AJV gate for discover-shed-tool recommendation documents. | draft | 2026-05-11 | 1 |
-| [[validate-galaxy-tool-summary]] | AJV gate for galaxy-tool-cache summarize manifests, including the nested parsed_tool subtree. | draft | 2026-05-11 | 1 |
-| [[validate-summary-cwl]] | AJV gate for summarize-cwl JSON documents. | draft | 2026-05-11 | 1 |
-| [[validate-summary-nextflow]] | AJV gate for summarize-nextflow JSON documents. | draft | 2026-05-11 | 1 |
 | [[validate-tests-format]] | AJV gate for Galaxy workflow tests YAML, with optional workflow cross-check. | draft | 2026-05-11 | 1 |
 | [[convert]] | Convert a Galaxy workflow between native (.ga) and format2 (.gxwf.yml) representations. | draft | 2026-05-06 | 2 |
 | [[tool-revisions]] | Resolve a Tool Shed tool to changeset revisions for reproducible workflow pinning. Final step in discover-and-pin. | draft | 2026-05-06 | 2 |

--- a/content/cli/foundry/validate-galaxy-tool-discovery.md
+++ b/content/cli/foundry/validate-galaxy-tool-discovery.md
@@ -8,8 +8,8 @@ tags:
   - cli/foundry
 status: draft
 created: 2026-05-11
-revised: 2026-05-11
-revision: 1
+revised: 2026-08-04
+revision: 2
 summary: "AJV gate for discover-shed-tool recommendation documents."
 related_notes:
   - "[[galaxy-tool-discovery]]"
@@ -21,10 +21,15 @@ Validate a tool-discovery recommendation against the [[galaxy-tool-discovery]] s
 
 ## Output
 
-Silent on success (exit `0`). Schema failure: stderr diagnostics, exit `3`. Input errors exit `1`.
+Prints `<path>: valid` to stdout on success (exit `0`). Schema failure: stderr diagnostics, exit `3`. Input errors exit `1`.
 
 ## Examples
 
 ```bash
 foundry validate-galaxy-tool-discovery recommendation.json
 ```
+
+## Gotchas
+
+- **A miss is a valid document.** `status: miss` with `candidate: null` satisfies the schema, so exit `0` means the recommendation is well-formed — not that a wrapper was found. Branch on `status` (`hit` / `weak` / `miss`); an exit-code check routes every miss down the discover path as if it had succeeded.
+- `weak` is the status that needs a human or a confirmation step. The schema requires a candidate for both `hit` and `weak` and cannot tell them apart for you.

--- a/content/cli/foundry/validate-galaxy-tool-summary.md
+++ b/content/cli/foundry/validate-galaxy-tool-summary.md
@@ -8,8 +8,8 @@ tags:
   - cli/foundry
 status: draft
 created: 2026-05-11
-revised: 2026-05-11
-revision: 1
+revised: 2026-08-04
+revision: 2
 summary: "AJV gate for galaxy-tool-cache summarize manifests, including the nested parsed_tool subtree."
 related_notes:
   - "[[galaxy-tool-summary]]"
@@ -22,10 +22,15 @@ Validate a Galaxy tool-cache summarize manifest against the [[galaxy-tool-summar
 
 ## Output
 
-Silent on success (exit `0`). Schema failure: stderr diagnostics, exit `3`. Input errors exit `1`.
+Prints `<path>: valid` to stdout on success (exit `0`). Schema failure: stderr diagnostics, exit `3`. Input errors exit `1`.
 
 ## Examples
 
 ```bash
 foundry validate-galaxy-tool-summary manifest.json
 ```
+
+## Gotchas
+
+- **Half the contract is upstream.** The canonical schema ships `$defs.ParsedTool` as a placeholder; the command replaces it with `parsedToolSchema` from `@galaxy-tool-util/schema` before AJV compiles. Diagnostics under `/parsed_tool/…` come from a contract this repo does not own, and an upstream release can change what this command accepts with no commit here.
+- Only the merged schema is validated, so there is no flag to check the manifest envelope without the `parsed_tool` subtree. A manifest that is fine at the top level still fails as a whole if its embedded tool drifts from upstream.

--- a/content/cli/foundry/validate-galaxy-workflow-test-plan.md
+++ b/content/cli/foundry/validate-galaxy-workflow-test-plan.md
@@ -8,8 +8,8 @@ tags:
   - cli/foundry
 status: draft
 created: 2026-06-16
-revised: 2026-06-16
-revision: 1
+revised: 2026-08-04
+revision: 2
 summary: "AJV gate for Galaxy workflow test-plan YAML documents."
 related_notes:
   - "[[galaxy-workflow-test-plan]]"
@@ -21,7 +21,7 @@ Validate a Galaxy workflow test-plan document against the [[galaxy-workflow-test
 
 ## Output
 
-Silent on success (exit `0`). On schema failure, prints AJV diagnostics to stderr and exits `3`. Input errors (missing file, malformed YAML) exit `1`.
+Prints `<path>: valid` to stdout on success (exit `0`). On schema failure, prints AJV diagnostics to stderr and exits `3`. Input errors (missing file, malformed YAML) exit `1`.
 
 ## Examples
 

--- a/content/cli/foundry/validate-summary-cwl.md
+++ b/content/cli/foundry/validate-summary-cwl.md
@@ -8,8 +8,8 @@ tags:
   - cli/foundry
 status: draft
 created: 2026-05-11
-revised: 2026-05-11
-revision: 1
+revised: 2026-08-04
+revision: 2
 summary: "AJV gate for summarize-cwl JSON documents."
 related_notes:
   - "[[summary-cwl]]"
@@ -21,10 +21,15 @@ Validate a JSON document against the [[summary-cwl]] schema bundled with `@galax
 
 ## Output
 
-Silent on success (exit `0`). On schema failure, prints AJV diagnostics to stderr and exits `3`. Input errors exit `1`.
+Prints `<path>: valid` to stdout on success (exit `0`). On schema failure, prints AJV diagnostics to stderr and exits `3`. Input errors exit `1`.
 
 ## Examples
 
 ```bash
 foundry validate-summary-cwl summary.json
 ```
+
+## Gotchas
+
+- **There is no producer path to prefer.** Its sibling [[foundry validate-summary-nextflow]] documents that `foundry summarize-nextflow` validates by default and should be used instead; no such shortcut exists here, because nothing in `foundry` emits a summary-cwl document. Every producer is hand-written or third-party, and this gate is the only check any of them gets.
+- The schema root sets `additionalProperties: false`, so a producer that adds a field it considers harmless fails outright rather than warning. Extend the schema first.

--- a/content/cli/foundry/validate-summary-galaxy-workflow.md
+++ b/content/cli/foundry/validate-summary-galaxy-workflow.md
@@ -8,8 +8,8 @@ tags:
   - cli/foundry
 status: draft
 created: 2026-07-01
-revised: 2026-07-01
-revision: 1
+revised: 2026-08-04
+revision: 2
 summary: "AJV gate for summarize-galaxy-workflow JSON documents."
 related_notes:
   - "[[summary-galaxy-workflow]]"
@@ -21,10 +21,15 @@ Validate a JSON document against the [[summary-galaxy-workflow]] schema bundled 
 
 ## Output
 
-Silent on success (exit `0`). On schema failure, prints AJV diagnostics to stderr and exits `3`. Input errors exit `1`.
+Prints `<path>: valid` to stdout on success (exit `0`). On schema failure, prints AJV diagnostics to stderr and exits `3`. Input errors exit `1`.
 
 ## Examples
 
 ```bash
 foundry validate-summary-galaxy-workflow summary-galaxy-workflow.json
 ```
+
+## Gotchas
+
+- **Shape is all this checks, and the producer is an LLM.** [[summarize-galaxy-workflow]] writes these documents, so a summary can name steps the workflow does not have, or miss ones it does, and still pass. Exit `0` means safe to parse, never faithful to the workflow.
+- The gate cannot substitute for [[gxwf validate]]. That runs against the workflow; this runs against a description of it, and the two disagree exactly when the summary is wrong — the case worth catching.

--- a/content/cli/foundry/validate-summary-nextflow.md
+++ b/content/cli/foundry/validate-summary-nextflow.md
@@ -8,8 +8,8 @@ tags:
   - cli/foundry
 status: draft
 created: 2026-05-11
-revised: 2026-05-11
-revision: 1
+revised: 2026-08-04
+revision: 2
 summary: "AJV gate for summarize-nextflow JSON documents."
 related_notes:
   - "[[summary-nextflow]]"
@@ -21,7 +21,7 @@ Validate a JSON document against the [[summary-nextflow]] schema bundled with `@
 
 ## Output
 
-Silent on success (exit `0`). On schema failure, prints AJV diagnostics to stderr and exits `3`. Input errors (missing file, malformed JSON) exit `1`.
+Prints `<path>: valid` to stdout on success (exit `0`). On schema failure, prints AJV diagnostics to stderr and exits `3`. Input errors (missing file, malformed JSON) exit `1`.
 
 ## Examples
 

--- a/packages/foundry/test/run-json-validator.test.ts
+++ b/packages/foundry/test/run-json-validator.test.ts
@@ -1,0 +1,89 @@
+// Pins the runner's observable surface — stdout, stderr, exit code — because that surface is
+// what every `foundry validate-*` page under content/cli/foundry/ documents. All six claimed
+// silence on success while the runner has always printed `<path>: valid`; nothing caught it.
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runJsonValidator } from "../src/lib/run-json-validator.js";
+import { galaxyToolSummaryValidator } from "../src/index.js";
+
+const MINIMAL = fileURLToPath(
+  new URL("./fixtures/galaxy-tool-summary/minimal.json", import.meta.url),
+);
+
+class Exited extends Error {
+  constructor(readonly code: number) {
+    super(`exit ${code}`);
+  }
+}
+
+const run = (target: string): { code: number; out: string; err: string } => {
+  const realExit = process.exit;
+  const realOut = process.stdout.write;
+  const realErr = process.stderr.write;
+  let out = "";
+  let err = "";
+  let code = -1;
+  process.exit = ((c?: number) => {
+    code = c ?? 0;
+    throw new Exited(code);
+  }) as typeof process.exit;
+  process.stdout.write = ((chunk: unknown) => {
+    out += String(chunk);
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: unknown) => {
+    err += String(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    runJsonValidator(target, galaxyToolSummaryValidator);
+  } catch (e) {
+    if (!(e instanceof Exited)) throw e;
+  } finally {
+    process.exit = realExit;
+    process.stdout.write = realOut;
+    process.stderr.write = realErr;
+  }
+  return { code, out, err };
+};
+
+describe("runJsonValidator", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "foundry-runner-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("announces the valid document on stdout and exits 0", () => {
+    const r = run(MINIMAL);
+    expect(r.code).toBe(0);
+    expect(r.out).toBe(`${MINIMAL}: valid\n`);
+    expect(r.err).toBe("");
+  });
+
+  it("writes diagnostics and a count to stderr, exits 3", () => {
+    const target = path.join(dir, "wrong.json");
+    writeFileSync(target, JSON.stringify({ not: "a manifest" }));
+    const r = run(target);
+    expect(r.code).toBe(3);
+    expect(r.out).toBe("");
+    expect(r.err).toMatch(/^\s{2}\S.*\(\w+\)$/m);
+    expect(r.err).toMatch(new RegExp(`: \\d+ error\\(s\\)\n$`));
+  });
+
+  it("exits 1 on a file it cannot read", () => {
+    const r = run(path.join(dir, "absent.json"));
+    expect(r.code).toBe(1);
+    expect(r.out).toBe("");
+    expect(r.err).toMatch(/^error reading /);
+  });
+});


### PR DESCRIPTION
> Posted by Claude (AI assistant) on jmchilton's behalf — they did not write this text.

The four `foundry validate-*` pages missing `## Gotchas` were the last non-authoring chunk of the warning backlog. Writing them turned up a second thing.

## The four sections

Three of the four **already contained their gotcha**, sitting in the intro paragraph under no heading:

- **`validate-summary-cwl`** — *"the cwl summarizer itself is not yet shipped as a foundry subcommand."* Its sibling `validate-summary-nextflow` files exactly this fact under `## Gotchas`, with the opposite value: use `foundry summarize-nextflow`, validation is on by default. Same fact, one filed and one not.
- **`validate-summary-galaxy-workflow`** — *"run by an LLM Mold rather than shipped as a foundry subcommand."*
- **`validate-galaxy-tool-summary`** — *"the nested `parsed_tool` subtree is validated against `[[parsed-tool]]` in the same pass."*

The fourth, `validate-galaxy-tool-discovery`, had nothing pre-written, so I read the schema and ran the command:

```json
{"status":"miss","candidate":null,"alternates":[],"rationale":"…","warnings":[]}
```
```
miss.json: valid   (exit 0)
```

A miss is a **valid document**. `DiscoveryRecommendation` requires `candidate` and permits `null` for `status: miss`, so exit `0` means the recommendation is well-formed, not that a wrapper was found. A harness branching on the exit code routes every miss down the success path. That is the gotcha worth the tokens, and it is invisible from `--help`.

The `validate-galaxy-tool-summary` one is worth calling out too: the canonical schema ships `$defs.ParsedTool` as a placeholder and the command swaps in `parsedToolSchema` from `@galaxy-tool-util/schema` before AJV compiles. Diagnostics under `/parsed_tool/…` come from a contract this repo does not own — an upstream release changes what the command accepts with no commit here.

## The thing writing them turned up

Every one of these pages says **"Silent on success (exit `0`)"**. All six of them. It is not true and never has been — both `runJsonValidator` and `runYamlValidator` print `<path>: valid` to stdout:

```
$ foundry validate-galaxy-tool-summary test/fixtures/galaxy-tool-summary/minimal.json
test/fixtures/galaxy-tool-summary/minimal.json: valid
```

Corrected on all six, including `validate-summary-nextflow` and `validate-galaxy-workflow-test-plan`, which needed nothing else. Leaving two knowingly-false pages behind to keep the diff tidy seemed worse than the two extra lines.

## Why it went unnoticed

`packages/foundry`'s tests all exercise the validators as pure functions. Nothing had ever asserted the runner's observable surface — which is the surface these pages document. `test/run-json-validator.test.ts` now pins stdout, stderr and exit code for the valid / invalid / unreadable cases; deleting the success line turns the first test red, which is how I checked it.

`meta-parity.test.ts` already exists for precisely this reason — *"drift means the site's per-subcommand pages will misrepresent the CLI; fail loudly."* It guards the flags. Nothing guarded the output.

## Verification

`make check` exit 0. 270 root tests, 46 in `packages/foundry` (was 43), lint and format clean.

Warnings: **53 → 49**, and the `## Gotchas` class is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
