### PR TITLE
A palette name says which colour, not whose — and 132 pages the search could not return

### DIFF
--- a/site/src/components/CliCommandBody.astro
+++ b/site/src/components/CliCommandBody.astro
@@ -13,7 +13,7 @@ const reg = cliRegistry[key];
 const cmd = reg?.command;
 ---
 <div class="mb-6 flex flex-wrap gap-2 items-center">
-  <span class="text-xs px-2 py-1 rounded bg-(--color-galaxy-primary) text-white font-mono">cli</span>
+  <span class="text-xs px-2 py-1 rounded bg-(--color-brand) text-white font-mono">cli</span>
   <span class="text-xs px-2 py-1 rounded border border-(--color-border) font-mono">{data.tool} {data.command}</span>
   {reg?.package && (
     <span class="text-xs px-2 py-1 rounded border border-(--color-border) font-mono">
@@ -35,7 +35,7 @@ const cmd = reg?.command;
   <section class="mb-8 p-4 rounded-lg border border-(--color-border) bg-(--color-surface-raised)">
     <h2 class="not-prose text-lg font-semibold mb-2">{cmd.fullName}</h2>
     <p class="not-prose text-sm text-(--color-text-secondary) m-0">{cmd.description}</p>
-    <pre class="not-prose mt-3 p-3 rounded bg-(--color-galaxy-dark) text-(--color-text-on-dark) font-mono text-sm overflow-x-auto"><code>{cmd.synopsis}</code></pre>
+    <pre class="not-prose mt-3 p-3 rounded bg-(--color-brand-dark) text-(--color-text-on-dark) font-mono text-sm overflow-x-auto"><code>{cmd.synopsis}</code></pre>
   </section>
 )}
 

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -2,7 +2,7 @@
 import { CONTAINER, FOOTER_LINKS, REPO_URL, SITE_FULL_NAME } from '../lib/site-identity';
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 ---
-<footer class="mt-auto bg-(--color-galaxy-dark) text-(--color-text-on-dark)">
+<footer class="mt-auto bg-(--color-brand-dark) text-(--color-text-on-dark)">
   <div class={`${CONTAINER} mx-auto px-4 sm:px-6 py-6 flex flex-wrap items-center justify-between gap-4 text-sm opacity-70`}>
     <div class="flex items-center gap-2">
       <div class="w-1 h-4 bg-(--color-accent) rounded-full"></div>

--- a/site/src/components/FoundryStory.astro
+++ b/site/src/components/FoundryStory.astro
@@ -57,7 +57,7 @@ const imageSrc = `${base}/images/casting-molds-story.png`;
   }
   .story-copy h3 {
     margin: 0.65rem 0 0.7rem;
-    color: var(--color-galaxy-dark);
+    color: var(--color-brand-dark);
     font-size: clamp(1.35rem, 2.4vw, 2rem);
     line-height: 1.08;
     letter-spacing: -0.015em;
@@ -84,7 +84,7 @@ const imageSrc = `${base}/images/casting-molds-story.png`;
     align-items: center;
     gap: 0.4rem;
     padding: 0.52rem 0.9rem;
-    background: var(--color-galaxy-dark);
+    background: var(--color-brand-dark);
     color: var(--color-text-on-dark);
     border-radius: 0.35rem;
     text-decoration: none;
@@ -92,7 +92,7 @@ const imageSrc = `${base}/images/casting-molds-story.png`;
     transition: background 0.15s ease, transform 0.15s ease;
   }
   .story-primary:hover {
-    background: var(--color-galaxy-primary);
+    background: var(--color-brand);
     transform: translateX(2px);
   }
   .story-secondary {

--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -18,7 +18,7 @@ const barLinks = links.slice(0, NAV_VISIBLE);
 const moreLinks = links.slice(NAV_VISIBLE);
 const moreActive = moreLinks.some(link => link.active);
 ---
-<header class="bg-(--color-galaxy-dark) border-b-4 border-(--color-accent) relative">
+<header class="bg-(--color-brand-dark) border-b-4 border-(--color-accent) relative">
   <div class="absolute inset-0 bg-grid-header pointer-events-none"></div>
   <div class={`relative ${CONTAINER} mx-auto px-4 sm:px-6 py-4 flex flex-wrap items-center justify-between gap-2`}>
     <div class="flex items-center gap-4">
@@ -60,7 +60,7 @@ const moreActive = moreLinks.some(link => link.active);
             id="nav-more-menu"
             role="menu"
             aria-labelledby="nav-more-trigger"
-            class="nav-more-menu absolute left-0 top-full mt-2 min-w-40 rounded-md border border-(--color-accent) bg-(--color-galaxy-dark) shadow-lg py-1 z-50"
+            class="nav-more-menu absolute left-0 top-full mt-2 min-w-40 rounded-md border border-(--color-accent) bg-(--color-brand-dark) shadow-lg py-1 z-50"
           >
             {moreLinks.map(link => (
               <a

--- a/site/src/components/MoldBody.astro
+++ b/site/src/components/MoldBody.astro
@@ -104,8 +104,8 @@ function producersOf(id: string): { moldId: string; description: string }[] {
     overflow-wrap: anywhere;
   }
   .mold-strip-cell-axis {
-    background: color-mix(in srgb, var(--color-galaxy-primary) 8%, transparent);
-    box-shadow: inset 3px 0 0 var(--color-galaxy-primary);
+    background: color-mix(in srgb, var(--color-brand) 8%, transparent);
+    box-shadow: inset 3px 0 0 var(--color-brand);
   }
   .mold-strip-cell-axis dd {
     color: var(--color-link);
@@ -271,7 +271,7 @@ function producersOf(id: string): { moldId: string; description: string }[] {
     letter-spacing: 0.12em;
     padding: 0.1rem 0.45rem;
     border-radius: 0.2rem;
-    background: color-mix(in srgb, var(--color-galaxy-grey) 18%, transparent);
+    background: color-mix(in srgb, var(--color-neutral) 18%, transparent);
     color: var(--color-text-secondary);
   }
   .artifact-filename {

--- a/site/src/components/PatternBody.astro
+++ b/site/src/components/PatternBody.astro
@@ -81,10 +81,10 @@ const relatedPatterns = (data.related_patterns ?? [])
   .pattern-map-panel {
     margin: 0 0 1.25rem;
     padding: 1rem;
-    border: 1px solid color-mix(in srgb, var(--color-galaxy-primary) 22%, var(--color-border-subtle));
+    border: 1px solid color-mix(in srgb, var(--color-brand) 22%, var(--color-border-subtle));
     border-radius: 0.75rem;
     background:
-      linear-gradient(135deg, color-mix(in srgb, var(--color-galaxy-primary) 8%, transparent), transparent 45%),
+      linear-gradient(135deg, color-mix(in srgb, var(--color-brand) 8%, transparent), transparent 45%),
       var(--color-surface-raised);
   }
   .pattern-map-panel-top {
@@ -200,7 +200,7 @@ const relatedPatterns = (data.related_patterns ?? [])
   .confidence {
     border-radius: 999px;
     padding: 0.18rem 0.5rem;
-    background: color-mix(in srgb, var(--color-galaxy-primary) 12%, transparent);
+    background: color-mix(in srgb, var(--color-brand) 12%, transparent);
     color: var(--color-text-secondary);
     font-family: var(--font-mono);
     font-size: 0.68rem;

--- a/site/src/components/PatternSpotlight.astro
+++ b/site/src/components/PatternSpotlight.astro
@@ -100,10 +100,10 @@ function shortTitle(title: string): string {
     gap: 0.55rem;
     min-height: 12rem;
     padding: 1.05rem;
-    border: 1px solid color-mix(in srgb, var(--color-galaxy-primary) 22%, var(--color-border-subtle));
+    border: 1px solid color-mix(in srgb, var(--color-brand) 22%, var(--color-border-subtle));
     border-radius: 0.65rem;
     background:
-      linear-gradient(135deg, color-mix(in srgb, var(--color-galaxy-primary) 12%, transparent), transparent 42%),
+      linear-gradient(135deg, color-mix(in srgb, var(--color-brand) 12%, transparent), transparent 42%),
       var(--color-surface-raised);
     color: inherit;
     transition: border-color 0.18s ease, transform 0.18s ease, box-shadow 0.18s ease;

--- a/site/src/components/PhaseGraph.astro
+++ b/site/src/components/PhaseGraph.astro
@@ -178,7 +178,7 @@ function isWikiLink(s: string): boolean {
     border-radius: 0.15rem;
     transform: rotate(45deg);
     background: var(--color-surface);
-    border: 2px solid var(--color-galaxy-grey);
+    border: 2px solid var(--color-neutral);
   }
   .stop-loop.stop-branch .stop-marker {
     background: var(--color-accent);
@@ -244,12 +244,12 @@ function isWikiLink(s: string): boolean {
   }
   .stop-tag-loop {
     background: var(--color-accent);
-    color: var(--color-galaxy-dark);
+    color: var(--color-brand-dark);
   }
   .stop-tag-fallthrough {
-    background: color-mix(in srgb, var(--color-galaxy-grey) 18%, transparent);
+    background: color-mix(in srgb, var(--color-neutral) 18%, transparent);
     color: var(--color-text-secondary);
-    border: 1px solid color-mix(in srgb, var(--color-galaxy-grey) 40%, transparent);
+    border: 1px solid color-mix(in srgb, var(--color-neutral) 40%, transparent);
   }
 
   /* Branch inner paths */
@@ -258,7 +258,7 @@ function isWikiLink(s: string): boolean {
     list-style: none;
     margin: 0.4rem 0 0.2rem;
     padding: 0 0 0 0.85rem;
-    border-left: 1px dashed color-mix(in srgb, var(--color-galaxy-grey) 50%, transparent);
+    border-left: 1px dashed color-mix(in srgb, var(--color-neutral) 50%, transparent);
     display: flex;
     flex-direction: column;
     gap: 0.25rem;
@@ -276,7 +276,7 @@ function isWikiLink(s: string): boolean {
     top: 0.65em;
     width: 0.7rem;
     height: 1px;
-    background: color-mix(in srgb, var(--color-galaxy-grey) 50%, transparent);
+    background: color-mix(in srgb, var(--color-neutral) 50%, transparent);
   }
   .branch-leaf-text {
     font-style: italic;

--- a/site/src/components/ReferenceContract.astro
+++ b/site/src/components/ReferenceContract.astro
@@ -96,11 +96,11 @@ function pillInfo(group: keyof typeof contract, key: string, extraClass = '') {
     border-radius: 1rem;
     background:
       linear-gradient(180deg,
-        color-mix(in srgb, var(--color-galaxy-primary) 4%, transparent),
+        color-mix(in srgb, var(--color-brand) 4%, transparent),
         transparent 40%),
       var(--color-surface-raised);
     padding: 1.25rem 1.25rem 1.1rem;
-    box-shadow: 0 1px 0 color-mix(in srgb, var(--color-galaxy-primary) 6%, transparent);
+    box-shadow: 0 1px 0 color-mix(in srgb, var(--color-brand) 6%, transparent);
   }
   .reference-contract-head {
     margin-bottom: 1.1rem;
@@ -166,19 +166,19 @@ function pillInfo(group: keyof typeof contract, key: string, extraClass = '') {
     bottom: 0.7rem;
     width: 3px;
     border-radius: 0 2px 2px 0;
-    background: var(--color-galaxy-primary);
+    background: var(--color-brand);
     opacity: 0.55;
   }
-  .reference-kind-research::before { background: var(--color-galaxy-primary); }
+  .reference-kind-research::before { background: var(--color-brand); }
   .reference-kind-schema::before   { background: var(--color-accent); }
   .reference-kind-pattern::before  { background: var(--color-link); }
-  .reference-kind-mold::before     { background: var(--color-galaxy-gold-dark); }
+  .reference-kind-mold::before     { background: var(--color-accent-dark); }
   .reference-card:hover {
     border-color: color-mix(in srgb, var(--color-accent) 50%, var(--color-border));
     transform: translateY(-1px);
     box-shadow:
-      0 1px 2px color-mix(in srgb, var(--color-galaxy-dark) 6%, transparent),
-      0 6px 14px color-mix(in srgb, var(--color-galaxy-dark) 7%, transparent);
+      0 1px 2px color-mix(in srgb, var(--color-brand-dark) 6%, transparent),
+      0 6px 14px color-mix(in srgb, var(--color-brand-dark) 7%, transparent);
   }
   .reference-card-top {
     display: flex;

--- a/site/src/components/RunPipelines.astro
+++ b/site/src/components/RunPipelines.astro
@@ -139,7 +139,7 @@ Codex:  $pipeline-{p.slug}</code></pre>
     border-radius: 0.7rem;
   }
   .run-card:hover {
-    border-color: var(--color-galaxy-primary);
+    border-color: var(--color-brand);
   }
   .run-card-head {
     display: flex;

--- a/site/src/components/SchemaBody.astro
+++ b/site/src/components/SchemaBody.astro
@@ -99,7 +99,7 @@ const rootDescription = root?.description as string | undefined;
 const rootTitle = root?.title as string | undefined;
 ---
 <div class="mb-6 flex flex-wrap gap-2 items-center">
-  <span class="text-xs px-2 py-1 rounded bg-(--color-galaxy-primary) text-white font-mono">schema</span>
+  <span class="text-xs px-2 py-1 rounded bg-(--color-brand) text-white font-mono">schema</span>
   <span class="text-xs px-2 py-1 rounded border border-(--color-border) font-mono">{data.name}</span>
   {data.package && (
     <span class="text-xs px-2 py-1 rounded border border-(--color-border) font-mono">

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -6,8 +6,18 @@ import { CONTAINER, SITE_DESCRIPTION, SITE_NAME } from '../lib/site-identity';
 interface Props {
   title: string;
   description?: string;
+  /**
+   * Whether this page's main content goes in the search index. Defaults to yes.
+   *
+   * Pagefind's rule is all-or-nothing and runs backwards from what the attribute looks like: mark
+   * no page and every page is indexed from its `<body>`, mark ONE and every unmarked page leaves
+   * the index entirely. So the default has to be yes — opt-in would leave each new route one
+   * forgotten prop away from being unfindable, with nothing on the page to see. Asserted against
+   * the built index in `tests/search-index.test.ts`.
+   */
+  searchable?: boolean;
 }
-const { title, description = SITE_DESCRIPTION } = Astro.props;
+const { title, description = SITE_DESCRIPTION, searchable = true } = Astro.props;
 const fullTitle = `${title} - ${SITE_NAME}`;
 ---
 <!doctype html>
@@ -32,7 +42,11 @@ const fullTitle = `${title} - ${SITE_NAME}`;
 <body class="min-h-dvh flex flex-col bg-(--color-surface) text-(--color-text-primary)">
   <a href="#main" class="skip-link">Skip to content</a>
   <Header />
-  <main id="main" class={`flex-1 bg-grid ${CONTAINER} w-full mx-auto px-4 sm:px-6 py-6 leading-relaxed`}>
+  <main
+    id="main"
+    class={`flex-1 bg-grid ${CONTAINER} w-full mx-auto px-4 sm:px-6 py-6 leading-relaxed`}
+    data-pagefind-body={searchable ? true : undefined}
+  >
     <slot />
   </main>
   <Footer />

--- a/site/src/pages/[...slug].astro
+++ b/site/src/pages/[...slug].astro
@@ -77,7 +77,7 @@ const showMeta = data.type !== 'pipeline';
 const metaMode: 'full' | 'related-only' = data.type === 'mold' ? 'related-only' : 'full';
 ---
 <Base title={pageTitle}>
-  <div data-pagefind-body>
+  <div>
     <NoteHeader entry={entry} pageTitle={pageTitle} typeLabel={typeLabel} eyebrow={eyebrow} showActions={showActions} />
     {showMeta && <NoteMeta entry={entry} linkMap={linkMap} mode={metaMode} />}
     {data.license && <LicenseBox entry={entry} />}

--- a/site/src/pages/design/index.astro
+++ b/site/src/pages/design/index.astro
@@ -58,7 +58,7 @@ const groups = await Promise.all(
   }
   .design-hero h1 {
     margin: 0 0 1rem;
-    color: var(--color-galaxy-dark);
+    color: var(--color-brand-dark);
     font-size: clamp(2rem, 4vw, 3.5rem);
     line-height: 1.04;
     letter-spacing: -0.025em;

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -22,7 +22,7 @@ const navCards = [
     <span class="eyebrow mb-4">Galaxy Workflow Foundry</span>
     <h1
       id="hero-heading"
-      class="hero-title text-balance text-(--color-galaxy-dark) dark:text-(--color-text-primary)"
+      class="hero-title text-balance text-(--color-brand-dark) dark:text-(--color-text-primary)"
     >
       Build Galaxy workflows<br />
       <span class="hero-title-accent">from anything.</span>
@@ -111,7 +111,7 @@ const navCards = [
     align-items: center;
     gap: 0.4rem;
     padding: 0.55rem 1rem;
-    background: var(--color-galaxy-dark);
+    background: var(--color-brand-dark);
     color: var(--color-text-on-dark);
     border-radius: 0.375rem;
     text-decoration: none;
@@ -119,7 +119,7 @@ const navCards = [
     transition: transform 0.15s ease, background 0.15s ease;
   }
   .hero-cta:hover {
-    background: var(--color-galaxy-primary);
+    background: var(--color-brand);
     transform: translateX(2px);
   }
   .hero-cta:active {

--- a/site/src/pages/molds/index.astro
+++ b/site/src/pages/molds/index.astro
@@ -116,7 +116,7 @@ function healthFor(m: typeof molds[number]): 'ok' | 'warn' | 'error' {
     display: inline-block;
     padding: 0.18rem 0.55rem;
     border-radius: 0.3rem;
-    background: var(--color-galaxy-primary);
+    background: var(--color-brand);
     color: white;
     font-size: 0.72rem;
     letter-spacing: 0.04em;

--- a/site/src/pages/patterns/index.astro
+++ b/site/src/pages/patterns/index.astro
@@ -181,7 +181,7 @@ function formatDate(d: Date): string {
   }
   .patterns-stats dd {
     margin: 0;
-    color: var(--color-galaxy-primary);
+    color: var(--color-brand);
     font-size: 1.65rem;
     font-weight: 700;
     line-height: 1;

--- a/site/src/pages/source-patterns/nextflow/index.astro
+++ b/site/src/pages/source-patterns/nextflow/index.astro
@@ -113,9 +113,9 @@ function formatKind(kind: string): string {
     transition: border-color 0.18s ease, transform 0.18s ease, box-shadow 0.18s ease;
   }
   .source-pattern-card-map {
-    border-color: color-mix(in srgb, var(--color-galaxy-primary) 24%, var(--color-border-subtle));
+    border-color: color-mix(in srgb, var(--color-brand) 24%, var(--color-border-subtle));
     background:
-      linear-gradient(135deg, color-mix(in srgb, var(--color-galaxy-primary) 8%, transparent), transparent 48%),
+      linear-gradient(135deg, color-mix(in srgb, var(--color-brand) 8%, transparent), transparent 48%),
       var(--color-surface-raised);
   }
   .source-pattern-card:hover {

--- a/site/src/pages/story/index.astro
+++ b/site/src/pages/story/index.astro
@@ -283,7 +283,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
   }
   .story-hero h1 {
     margin: 0 0 1.1rem;
-    color: var(--color-galaxy-dark);
+    color: var(--color-brand-dark);
     font-size: clamp(2.25rem, 5.2vw, 4.25rem);
     font-weight: 700;
     line-height: 1.0;

--- a/site/src/pages/usage/claude/[skill].astro
+++ b/site/src/pages/usage/claude/[skill].astro
@@ -413,7 +413,7 @@ codex plugin add foundry-skills@galaxy-workflow-foundry</code></pre>
       background: var(--color-accent);
       opacity: 0.7;
     }
-    .contract-card.consume::before { background: var(--color-galaxy-primary); }
+    .contract-card.consume::before { background: var(--color-brand); }
     .validation-card::before { background: var(--color-badge-reviewed-text); }
     .contract-card h4,
     .validation-head h3 {
@@ -518,11 +518,11 @@ codex plugin add foundry-skills@galaxy-workflow-foundry</code></pre>
       inset: 0 auto 0 0;
       width: 3px;
       border-radius: 0.85rem 0 0 0.85rem;
-      background: var(--color-galaxy-primary);
+      background: var(--color-brand);
       opacity: 0.65;
     }
     .ref-kind-schema::before { background: var(--color-accent); }
-    .ref-kind-research::before { background: var(--color-galaxy-primary); }
+    .ref-kind-research::before { background: var(--color-brand); }
     .ref-card-head {
       display: flex;
       align-items: flex-start;

--- a/site/src/pages/usage/index.astro
+++ b/site/src/pages/usage/index.astro
@@ -130,7 +130,7 @@ cp -r foundry/casts/claude/skills/&lt;name&gt; ~/.agents/skills/&lt;name&gt;  # 
             const moldId = moldByName.get(c.moldSlug);
             const skillHref = target === 'claude' ? `${base}/usage/claude/${c.moldSlug}/` : null;
             return (
-              <li class="p-4 rounded-lg border border-(--color-border) hover:border-(--color-galaxy-primary) transition-colors">
+              <li class="p-4 rounded-lg border border-(--color-border) hover:border-(--color-brand) transition-colors">
                 <div class="flex items-baseline justify-between gap-2 mb-1">
                   {skillHref
                     ? <a href={skillHref} class="font-mono font-semibold text-(--color-link) hover:underline">{c.moldSlug}</a>

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -6,11 +6,17 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 @theme {
-  /* Galaxy brand */
-  --color-galaxy-primary: #25537b;
-  --color-galaxy-dark: #2c3143;
-  --color-galaxy-gold-dark: #d0bd2a;
-  --color-galaxy-grey: #58585a;
+  /* The brand, which is Galaxy's. These NAMES say which colour, not whose — a shared component
+     asking for a branded property name charges every instance that is not that brand with
+     declaring someone else's identity to get a card rendered. Whose brand this is lives in
+     SITE_IDENTITY, where it is a value rather than a property name nothing can override. */
+  --color-brand: #25537b;
+  --color-brand-dark: #2c3143;
+
+  /* Neutral structure: graph stations, chip backgrounds. Equal to --color-text-secondary today,
+     and kept apart from it because a repeated value is not a mapping — a graph's borders are not
+     downstream of a decision about body copy. */
+  --color-neutral: #58585a;
 
   /* Surfaces */
   --color-surface: #ffffff;
@@ -33,6 +39,7 @@
 
   /* Accent — slightly desaturated from pure #ffd700 for less screaming gold */
   --color-accent: #e8c547;
+  --color-accent-dark: #d0bd2a;
 
   /* The rail of the subway-style phase graph; a lighter blue in dark. */
   --color-rail: #25537b;
@@ -89,8 +96,8 @@
    The dark rule below is NOT the same shape: white at 3% is its own decision, not a token. */
 .bg-grid {
   background-image:
-    linear-gradient(to right, color-mix(in srgb, var(--color-galaxy-primary) 6%, transparent) 1px, transparent 1px),
-    linear-gradient(to bottom, color-mix(in srgb, var(--color-galaxy-primary) 6%, transparent) 1px, transparent 1px);
+    linear-gradient(to right, color-mix(in srgb, var(--color-brand) 6%, transparent) 1px, transparent 1px),
+    linear-gradient(to bottom, color-mix(in srgb, var(--color-brand) 6%, transparent) 1px, transparent 1px);
   background-size: 24px 24px;
 }
 .dark .bg-grid {
@@ -121,7 +128,7 @@
 }
 a:hover .tag {
   background-color: var(--color-accent);
-  color: var(--color-galaxy-dark);
+  color: var(--color-brand-dark);
 }
 
 .dangling {
@@ -143,7 +150,7 @@ a:hover .tag {
   top: -3rem;
   z-index: 100;
   padding: 0.5rem 0.75rem;
-  background: var(--color-galaxy-dark);
+  background: var(--color-brand-dark);
   color: var(--color-text-on-dark);
   border-radius: 0.25rem;
   text-decoration: none;
@@ -173,7 +180,7 @@ a:hover .tag {
 }
 .data-table th {
   @apply text-left px-3 py-2 font-semibold border-b text-white;
-  background-color: var(--color-galaxy-primary);
+  background-color: var(--color-brand);
   border-color: var(--color-border-subtle);
 }
 .data-table td {
@@ -205,7 +212,7 @@ a:hover .tag {
   text-decoration-color: var(--color-link-hover);
 }
 .prose :where(h1, h2, h3, h4, h5, h6):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-  color: var(--color-galaxy-dark);
+  color: var(--color-brand-dark);
 }
 .dark .prose :where(h1, h2, h3, h4, h5, h6):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
   color: var(--color-text-primary);
@@ -238,11 +245,11 @@ a:hover .tag {
   content: none;
 }
 .prose :where(pre):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-  background-color: var(--color-galaxy-dark);
+  background-color: var(--color-brand-dark);
   border-radius: 0.5rem;
 }
 .prose :where(th):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-  background-color: var(--color-galaxy-primary);
+  background-color: var(--color-brand);
   color: white;
   padding: 0.5rem 0.75rem;
 }
@@ -330,7 +337,7 @@ a:hover .tag {
 }
 .page-stats dd {
   margin: 0;
-  color: var(--color-galaxy-primary);
+  color: var(--color-brand);
   font-size: 1.65rem;
   font-weight: 700;
   line-height: 1;
@@ -370,12 +377,12 @@ a:hover .tag {
 }
 
 .tinted-shadow {
-  box-shadow: 0 1px 2px color-mix(in srgb, var(--color-galaxy-primary) 8%, transparent),
-              0 8px 24px -12px color-mix(in srgb, var(--color-galaxy-primary) 18%, transparent);
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--color-brand) 8%, transparent),
+              0 8px 24px -12px color-mix(in srgb, var(--color-brand) 18%, transparent);
 }
 .tinted-shadow-hover:hover {
-  box-shadow: 0 2px 4px color-mix(in srgb, var(--color-galaxy-primary) 12%, transparent),
-              0 16px 32px -10px color-mix(in srgb, var(--color-galaxy-primary) 28%, transparent);
+  box-shadow: 0 2px 4px color-mix(in srgb, var(--color-brand) 12%, transparent),
+              0 16px 32px -10px color-mix(in srgb, var(--color-brand) 28%, transparent);
 }
 
 /* --- Shared card grid (patterns, molds, …) --- */
@@ -403,9 +410,9 @@ a:hover .tag {
   transform: translateY(-2px);
 }
 .card-feature {
-  border-color: color-mix(in srgb, var(--color-galaxy-primary) 22%, var(--color-border-subtle));
+  border-color: color-mix(in srgb, var(--color-brand) 22%, var(--color-border-subtle));
   background:
-    linear-gradient(135deg, color-mix(in srgb, var(--color-galaxy-primary) 9%, transparent), transparent 46%),
+    linear-gradient(135deg, color-mix(in srgb, var(--color-brand) 9%, transparent), transparent 46%),
     var(--color-surface-raised);
   border-radius: 0.75rem;
 }
@@ -509,7 +516,7 @@ a:hover .tag {
   font-family: var(--font-mono);
   font-size: 0.85rem;
   margin-bottom: 0.5rem;
-  color: var(--color-galaxy-primary);
+  color: var(--color-brand);
 }
 .dark .admonition-title {
   color: var(--color-link);

--- a/tests/built-shell.test.ts
+++ b/tests/built-shell.test.ts
@@ -332,3 +332,56 @@ describe("the container width", () => {
     expect(new Set(widthsIn(home, "<footer", "</footer>"))).toEqual(new Set([mainWidth]));
   });
 });
+
+/**
+ * Pages the search box will never return, on purpose.
+ *
+ * Empty is a claim, not a stub: every route on this site is worth finding. The list exists because
+ * an absence has to be a DECISION — without one, "deliberately out of the index" and "nobody
+ * thought about this route" are the same observation, which is how 132 of them accumulated.
+ */
+const UNSEARCHABLE: string[] = [];
+
+describe("what the search box can find", () => {
+  // The contract nothing checked, and the one place where reading the source tells you nothing.
+  //
+  // Pagefind's rule is all-or-nothing and runs BACKWARDS from what the attribute looks like. Mark
+  // no page with `data-pagefind-body` and every page is indexed from its `<body>`. Mark ONE and
+  // every unmarked page leaves the index entirely. So an annotation that reads as "index this
+  // page" means "index only pages like this one", and putting it on a single route is strictly
+  // worse for the rest of the site than never adding it.
+  //
+  // Which is exactly what had happened here. One route carried it, and the index held 242 of these
+  // 374 pages — missing every artifact page, every tag page, the glossary, the dashboard and 48
+  // generated skill pages. The routes a reader is likeliest to arrive at by searching.
+  //
+  // Nothing reported it, and this is the part worth remembering: the build log prints
+  // "Pagefind indexed 374 pages" in BOTH states, because it counts pages processed rather than
+  // pages indexed. There is no warning, no diff and no page that looks wrong. The only symptom is
+  // a search answering "no results" for words plainly on the page.
+  //
+  // So this asserts on the emitted INDEX rather than on the markup. A source-level check would
+  // confirm the attribute is written; only the index confirms a reader can find the page.
+  const indexedPageCount = (): number => {
+    const entry = JSON.parse(read(path.join(DIST, "pagefind/pagefind-entry.json"))) as {
+      languages: Record<string, { page_count: number }>;
+    };
+    return Object.values(entry.languages).reduce((total, lang) => total + lang.page_count, 0);
+  };
+
+  it("holds every page the build emitted, less the ones declared unsearchable", () => {
+    expect(indexedPageCount()).toBe(pages.length - UNSEARCHABLE.length);
+  });
+
+  it("marks the main column rather than falling back to the whole body", () => {
+    // `<body>` is Pagefind's default when nothing is marked, and it pulls the nav and footer into
+    // every result's excerpt. Narrower is better, but narrower is also what makes the all-or-
+    // nothing rule apply at all — so having marked anything, every page has to be marked.
+    const unmarked = pages.filter((file) => !read(file).includes("data-pagefind-body"));
+    expect(unmarked.map(rel).sort(), "\nemitted but unfindable").toEqual(UNSEARCHABLE);
+  });
+
+  it("puts the attribute on <main>, so chrome stays out of the excerpt", () => {
+    expect(home).toMatch(/<main[^>]*\sdata-pagefind-body/);
+  });
+});


### PR DESCRIPTION
> Posted by Claude (AI assistant) on jmchilton's behalf — they did not write this text.

Four palette tokens carried Galaxy's name into every rule that used them — **64 references across
20 files**. Based on `main`, **depends on nothing**: no package upgrade, no shell change, no
coordination with #439.

```
--color-galaxy-primary   ->  --color-brand
--color-galaxy-dark      ->  --color-brand-dark
--color-galaxy-gold-dark ->  --color-accent-dark   (regrouped beside --color-accent)
--color-galaxy-grey      ->  --color-neutral
```

## Why this is worth doing in Galaxy's own foundry

It reads as harmless here, and it is — right up until a component carrying these names is worth
sharing. Then every instance that is not Galaxy has to declare Galaxy's identity to get a card
rendered, and it is a cost charged for nothing: the value was never in the name. This is the same
move [foundry-lib#46](https://github.com/jmchilton/foundry-lib/pull/46) made for the shell's
`--color-chrome`, and the one statgen made in
[#151](https://github.com/jmchilton/statistical-genomics-foundry/pull/151) — GWF is the last of the
three still naming a brand in a property.

Whose brand this is stays in `SITE_IDENTITY`, where it is a value an instance supplies rather than
a property name nothing can override.

## What deliberately did not change

No value moves and no use site moves. `--color-neutral` stays apart from `--color-text-secondary`
though both are `#58585a`: a phase graph's station borders are not downstream of a decision about
body copy. Same rule that kept `--color-link` off the brand token in #444 — a repeated value is not
a mapping.

`--color-accent-dark` moved to sit beside `--color-accent` in the `@theme` block, which is the only
reason the emitted stylesheet is not byte-identical.

## Verification of the rename

The rename is provably a no-op on the rendered site. Built `main` and this branch, then compared
all 374 pages with the four renamed tokens normalised on both sides — the names appear in the
markup, since Tailwind arbitrary-value utilities like `bg-(--color-brand-dark)` *are* class names:

```
0 of 374 pages differ
```

And the stylesheet, parsed into declarations rather than diffed as minified text:

```
main declarations   : 140
debrand declarations: 140
only in main   : []
only in debrand: []
```

Same 140 declarations, 351 bytes smaller from shorter names, `--color-accent-dark` in a new
position. 272 tests, `astro check` 0-0-0, 374 pages.

The palette check added in #444 — every declared `@theme` token must reach `:root` — still passes,
which is what rules out a rename that dropped a use site and left a dead token behind.

---

# Second chunk: 132 pages the search box could never return

Independent of the rename, and the more urgent of the two — this one is visible to readers.

One route carried `data-pagefind-body`. Pagefind's rule is all-or-nothing and runs **backwards**
from what that looks like:

| build | pages indexed |
|---|---|
| `[...slug].astro` marks itself (i.e. `main` today) | **242** |
| nothing marked at all | **374** |

Marking one route **de-indexed 132 pages**. The annotation that reads as "index this page" means
"index only pages like this one", so adding it to a single route was strictly worse for the rest of
the site than never adding it.

**What was missing:** all 35 artifact pages, all 23 tag routes, all 48 generated skill pages, 8
pipeline pages, 7 licence pages, plus the glossary, dashboard, index, log, external, story, design
and every section landing page. The routes a reader is likeliest to arrive at by searching rather
than by following a link.

## Why nobody noticed

The build log prints `Pagefind indexed 374 pages` in **both** states, because it counts pages
processed rather than pages indexed. No warning, no diff, no page that looks wrong. The only symptom
is a search answering "no results" for words plainly on the site — which reads as a Pagefind quirk
rather than as a fault anyone owns.

## The fix

`Base.astro` marks `<main>` for every page, with a `searchable` prop to opt out. Defaulted true:
opt-in would leave each new route one forgotten prop away from being unfindable. Marking `<main>`
rather than letting Pagefind fall back to `<body>` also keeps the nav and footer out of every
result's excerpt.

**The assertion reads the emitted index, not the markup.** A source-level check confirms the
attribute was written; only the index confirms a reader can find the page. It lives in
`built-shell.test.ts` beside the existing `ensureBuilt()`/`builtPages()` harness rather than in a
new file.

Written red against the state on `main`, and it reports the defect with the numbers:

```
AssertionError: expected 242 to be 374
emitted but unfindable: expected [ …(132) ] to deeply equal []
```

`UNSEARCHABLE` is empty, and that is a claim rather than a stub. An absence has to be a decision —
without a list, "deliberately out of the index" and "nobody thought about this route" are the same
observation, which is how 132 accumulated.

## What this unblocks

[foundry-lib#54](https://github.com/jmchilton/foundry-lib/pull/54) moves `ReferenceContract.astro`
into site-kit, and its `REFERENCE_TOKENS` names `--color-brand`. The rename has to land first, and
is worth landing on its own regardless.

That PR also ships the search contract as a package concern — `SiteShell` marks `<main>` by default,
and `searchIndexGaps` is the source-level counterpart to the index assertion added here. This branch
does not wait for it: the 132 pages are unfindable today.

## Verification

275 tests, `astro check` 0-0-0, 374 pages built, **374 indexed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
