### PR TITLE
cli-command: source_url for the document a page summarizes

### DIFF
--- a/.changeset/cli-command-source-url.md
+++ b/.changeset/cli-command-source-url.md
@@ -1,0 +1,20 @@
+---
+"@galaxy-foundry/note-schema": minor
+---
+
+`cli-command` names the document a page summarizes `source_url`, constrained to a URL, and owes
+one exactly where the page really is a summary of something else.
+
+The field is the sibling Foundry's name and constraint for the same idea, so one spelling now
+means one thing across both instances rather than three fields sharing a stem and disagreeing.
+It is distinct from the `schema` kind's `upstream`, which stays: there the field records where a
+**vendored** artifact came from, and a cross-field rule keys off whether it points outside this
+repository. Summarizing an external command is not vendoring it.
+
+The accompanying validator rule replaces a blanket "must declare upstream" with the condition
+that actually holds. A command this repository implements has no second place for a reader to
+check, and eight pages pointed at one `program.ts` in this very tree; those now carry no
+`source_url` and are rejected if they grow one. Every other cli-command page must declare one.
+The split keys off `foundryCliMeta` — the same program metadata the corpus check already
+imports — rather than a name pattern, so a command added to our own CLI is classified by the
+thing that knows.

--- a/casts/claude/skills/advance-galaxy-draft-step/_provenance.json
+++ b/casts/claude/skills/advance-galaxy-draft-step/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/advance-galaxy-draft-step/index.md",
     "revision": 3,
     "content_hash": "f2852f94cb0101011ecfa991f09d551a8537bb3da02117a17e34ecba6e81c2a6",
-    "commit": "a56c6127966e59c75cf67d1d41ca03c8b4cf45dd"
+    "commit": "b9590579bec9fec7caeb35f2274c3a9639d665d6"
   },
-  "cast_at": "2026-08-02T22:04:15.280Z",
+  "cast_at": "2026-08-05T22:23:44.947Z",
   "refs": [
     {
       "kind": "cli-command",
@@ -22,7 +22,7 @@
       "purpose": "At loop endstate, extract the concrete gxformat2 workflow from the fully-concretized draft — drop drafty steps, strip `_plan_*` fields, promote `class` to `GalaxyWorkflow` — and write it as the runnable `galaxy-workflow.gxwf.yml`.",
       "trigger": "When [[draft-next-step]] reports `draft: false` (no remaining drafty steps).",
       "verification": "Cast the skill, run the loop to endstate on an IWC-derived draft, confirm draft-extract emits a `class: GalaxyWorkflow` file that passes terminal `gxwf validate` with no `_plan_*` fields or drafty steps.",
-      "src_hash": "8d2615dc95f50821690bfdab598ebb6f905c6debb1505909fa26e12c2aac2680",
+      "src_hash": "f8e9350c96ce005ed5e38deefff6c993824c951784f17f79f7e60d1ad664d8d7",
       "dst_hash": "c59fbafbe6cf53cd7bcdd867d73b69d078c949c0dfa83abdc084f309793a60aa",
       "source": "deterministic"
     },
@@ -38,7 +38,7 @@
       "purpose": "Deterministically pick the next drafty step (or report no remaining work). The orchestrator owns the loop oracle so the harness reduces to `while draft: invoke skill`.",
       "trigger": "At the start of every iteration, before any per-step work.",
       "verification": "Cast the skill, run on a multi-step IWC-derived draft, confirm the orchestrator picks one step per call and exits when draft: false.",
-      "src_hash": "c859994b7557ae90e54440849889d811325ad4d5e7b3b90a7b875b0fb2fca569",
+      "src_hash": "d4fe7945945a57846fe8b168e7bacba04f739de1d86bc613ae6f0e5879ac2f55",
       "dst_hash": "8638645f5974d8072dc3c63e522b7ab25d562f8d6217ea93b61f0a29f371d6f7",
       "source": "deterministic"
     },
@@ -54,7 +54,7 @@
       "purpose": "Validate the mutated draft against draft-contract rules and, with --concrete, also gate the extracted concrete subset (including the step just implemented) against full gxformat2.",
       "trigger": "After implementing or modifying the chosen step in the draft.",
       "verification": "Cast the skill, exercise on an IWC-derived draft, confirm both draft-contract diagnostics and concrete-projection diagnostics route back to the step the iteration touched.",
-      "src_hash": "784ee3d6d8ac183370be6ec0d0fb7fb60baa8a0d9d4b4d55affc1217016db716",
+      "src_hash": "37cded427fbccf49ff19a6fe8b03f9e90857afe556e5db0e51a01402fbf33f1e",
       "dst_hash": "afa59b0815308a340780247df0548909518564d58352a0c695ceca37a07eee5b",
       "source": "deterministic"
     },

--- a/casts/claude/skills/apply-galaxy-workflow-changeset/_provenance.json
+++ b/casts/claude/skills/apply-galaxy-workflow-changeset/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/apply-galaxy-workflow-changeset/index.md",
     "revision": 2,
     "content_hash": "ad5df3bb1de89c558f5fa3cf34b0379131407180da0878eaf601caec48d6711c",
-    "commit": "a56c6127966e59c75cf67d1d41ca03c8b4cf45dd"
+    "commit": "b9590579bec9fec7caeb35f2274c3a9639d665d6"
   },
-  "cast_at": "2026-08-02T22:04:16.954Z",
+  "cast_at": "2026-08-05T22:23:46.438Z",
   "refs": [
     {
       "kind": "cli-command",
@@ -22,7 +22,7 @@
       "purpose": "Validate the emitted draft against draft-contract rules (sentinel form, topology, _plan_* placement) before handing off to the per-step loop.",
       "trigger": "After writing the modified draft workflow file.",
       "verification": "Cast the skill, run on a representative workflow + change-set, confirm draft-validate diagnostics route back.",
-      "src_hash": "784ee3d6d8ac183370be6ec0d0fb7fb60baa8a0d9d4b4d55affc1217016db716",
+      "src_hash": "37cded427fbccf49ff19a6fe8b03f9e90857afe556e5db0e51a01402fbf33f1e",
       "dst_hash": "afa59b0815308a340780247df0548909518564d58352a0c695ceca37a07eee5b",
       "source": "deterministic"
     },

--- a/casts/claude/skills/compare-against-iwc-exemplar/_provenance.json
+++ b/casts/claude/skills/compare-against-iwc-exemplar/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/compare-against-iwc-exemplar/index.md",
     "revision": 9,
     "content_hash": "fadd8c9c2f723fff2e1d30340dbafe61406a81c2b6f26c319f39d09aa5f90add",
-    "commit": "e4ee3dd7e0b3af9886ea6009b961b0c5ecb2f349"
+    "commit": "b9590579bec9fec7caeb35f2274c3a9639d665d6"
   },
-  "cast_at": "2026-08-05T14:55:30.454Z",
+  "cast_at": "2026-08-05T22:23:50.054Z",
   "cast_date": "2026-05-07",
   "cast_revision": 3,
   "cast_history": [
@@ -40,7 +40,7 @@
       "evidence": "corpus-observed",
       "purpose": "Normalize fetched IWC workflows into a consistent representation for structural comparison, and surface the nearest exemplar forward as a cleaned gxformat2 view (sibling file plus inline excerpt) for the downstream template Mold.",
       "trigger": "After fetching a candidate IWC workflow file and before structural comparison; and again on the nearest exemplar after ranking to emit the iwc-exemplar-gxformat2 view.",
-      "src_hash": "9945cc274f2b5ad1a77ea6b6d0c9d68f4163991b9d451ed9eeff2bd10c87349c",
+      "src_hash": "1bb19d20b4a39b1708d8f5346a0294616cdb9df83ba5255c4a90d97030d13b83",
       "dst_hash": "1cdf49f10f77039af6efc5b82fe79720bb18e50d1f57d653670697f7262c7640",
       "source": "deterministic"
     },

--- a/casts/claude/skills/convert-nfcore-module-to-galaxy-tool/_provenance.json
+++ b/casts/claude/skills/convert-nfcore-module-to-galaxy-tool/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/convert-nfcore-module-to-galaxy-tool/index.md",
     "revision": 4,
     "content_hash": "0f8a5fb3ffc3434b6daec33aa7317e217de81b2c2655da5325154e7ab209e117",
-    "commit": "a56c6127966e59c75cf67d1d41ca03c8b4cf45dd"
+    "commit": "b9590579bec9fec7caeb35f2274c3a9639d665d6"
   },
-  "cast_at": "2026-08-02T22:04:21.679Z",
+  "cast_at": "2026-08-05T22:23:51.186Z",
   "cast_date": "2026-07-20",
   "cast_revision": 2,
   "cast_history": [
@@ -36,7 +36,7 @@
       "purpose": "Reference for `planemo lint` flags and output classification; first gate in the convergence loop.",
       "trigger": "Step 10.1 — after every <command>/<inputs>/<outputs> emission.",
       "verification": "Cast and confirm the cast skill consults the manpage's exit-code and error-shape sections, not free-text guesses.",
-      "src_hash": "d09982fcb1cbb6f5a92a3be6b32753ab2791dee3c55b19caf27072451ce3ad08",
+      "src_hash": "2db8204a138ffca690abcafae9648cfb3875e1a179d7049fb4c11666dd6a7d7a",
       "dst_hash": "862d714fa6eb7d9233173948162ff880262e2c867394f1157d073a4ce8d81523",
       "source": "deterministic"
     },
@@ -52,7 +52,7 @@
       "purpose": "Reference for `planemo test --test_output_json` invocation, exit codes, and the JSON report path.",
       "trigger": "Step 10.2 — after lint clears.",
       "verification": "Cast and confirm the cast skill always runs with --test_output_json and reads from the JSON, not stdout.",
-      "src_hash": "531ebf6f4f96777eae381bcb3e197980f42ba37967bdd71715d3541472d75d69",
+      "src_hash": "6a499521af2cc5ada3661ae40bed9313b0ab82dd49d9365b40ffb10a3182e742",
       "dst_hash": "f4698abd6b129048befaa3e335010d99c2748a3a4a5334b90584ce5b9ee913e6",
       "source": "deterministic"
     },

--- a/casts/claude/skills/cwl-summary-to-galaxy-template/_provenance.json
+++ b/casts/claude/skills/cwl-summary-to-galaxy-template/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/cwl-summary-to-galaxy-template/index.md",
     "revision": 4,
     "content_hash": "6b50dfd2d7faf9306f9e69e9adf0163c41d9c5739b470e2cf1ae5e5c46f18d69",
-    "commit": "aede1aeab8ceb890192c9606a6e967a36fcf2224"
+    "commit": "b9590579bec9fec7caeb35f2274c3a9639d665d6"
   },
-  "cast_at": "2026-08-03T23:37:50.551Z",
+  "cast_at": "2026-08-05T22:23:56.978Z",
   "refs": [
     {
       "kind": "cli-command",
@@ -22,7 +22,7 @@
       "purpose": "Validate the emitted draft against draft-contract rules (sentinel form, topology, _plan_* placement) before handing off.",
       "trigger": "After writing or modifying the draft workflow file.",
       "verification": "Cast the skill, run on a representative CWL workflow, confirm draft-validate diagnostics route back.",
-      "src_hash": "784ee3d6d8ac183370be6ec0d0fb7fb60baa8a0d9d4b4d55affc1217016db716",
+      "src_hash": "37cded427fbccf49ff19a6fe8b03f9e90857afe556e5db0e51a01402fbf33f1e",
       "dst_hash": "afa59b0815308a340780247df0548909518564d58352a0c695ceca37a07eee5b",
       "source": "deterministic"
     },

--- a/casts/claude/skills/discover-shed-tool/_provenance.json
+++ b/casts/claude/skills/discover-shed-tool/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/discover-shed-tool/index.md",
     "revision": 5,
     "content_hash": "05c99cbac2ec6a4d130b06204c15d0e76cf4fd0e00cdc8164dd606dac72809e2",
-    "commit": "a56c6127966e59c75cf67d1d41ca03c8b4cf45dd"
+    "commit": "b9590579bec9fec7caeb35f2274c3a9639d665d6"
   },
-  "cast_at": "2026-08-02T22:04:33.965Z",
+  "cast_at": "2026-08-05T22:24:03.362Z",
   "cast_date": "2026-05-07",
   "cast_revision": 5,
   "cast_history": [
@@ -50,7 +50,7 @@
       "evidence": "corpus-observed",
       "purpose": "Resolve a Tool Shed tool version to an installable changeset revision.",
       "trigger": "After selecting a candidate version that needs a reproducible changeset pin.",
-      "src_hash": "7b99cdd73d680079ed605225bb768a87ec4309216af89a6562bf1b554d9cc88f",
+      "src_hash": "82061af5970f0fd0335ac3901f6fc33426e192880c6859ab993e55de52bcfd5d",
       "dst_hash": "db0b13f2b92593c9cd3bf5a80276a31e537c07caff76786167ebe9f7feac5938",
       "source": "deterministic"
     },
@@ -65,7 +65,7 @@
       "evidence": "corpus-observed",
       "purpose": "Search the Tool Shed for candidate wrappers matching a step's tool need.",
       "trigger": "When resolving a workflow step to an installable Galaxy tool wrapper.",
-      "src_hash": "c5500094c6cfbfdea28986ed0f2a305d04c5b8b7ad45c56b389dc07f8185da24",
+      "src_hash": "cdf8be42eee7134c7cbd7a0a7891f36b0752f8d8d32251fc79664576257fd3dc",
       "dst_hash": "72f5f7cc0cd5ed40038af89e6041c7916d65c51ba1c7bc7b2c46ba64c51d9359",
       "source": "deterministic"
     },
@@ -80,7 +80,7 @@
       "evidence": "corpus-observed",
       "purpose": "List available Tool Shed versions for a selected candidate.",
       "trigger": "After a Tool Shed search candidate is selected and before pinning a version.",
-      "src_hash": "221bedccf7edf49c5b88198b3a35a64a316ffa5b67bda8fd448f752283b6208c",
+      "src_hash": "d11b5ee6d85c3f880cbbdc41bea41f293bbea8dc0671bb409fd81a35a666ee3a",
       "dst_hash": "90f35a407af778a1a1c714f79ceb8dc3559523964175e734b565eed8b9aeb6a5",
       "source": "deterministic"
     },

--- a/casts/claude/skills/freeform-summary-to-galaxy-template/_provenance.json
+++ b/casts/claude/skills/freeform-summary-to-galaxy-template/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/freeform-summary-to-galaxy-template/index.md",
     "revision": 5,
     "content_hash": "ef30eb8dfeee86c3f938b849bb3bbb95720027dab1189829919b8d4b55b4b816",
-    "commit": "aede1aeab8ceb890192c9606a6e967a36fcf2224"
+    "commit": "b9590579bec9fec7caeb35f2274c3a9639d665d6"
   },
-  "cast_at": "2026-08-03T23:37:54.185Z",
+  "cast_at": "2026-08-05T22:24:08.376Z",
   "refs": [
     {
       "kind": "cli-command",
@@ -22,7 +22,7 @@
       "purpose": "Validate the emitted draft against draft-contract rules (sentinel form, topology, _plan_* placement) before handing off.",
       "trigger": "After writing or modifying the draft workflow file.",
       "verification": "Cast the skill, run on a representative paper-derived summary, confirm draft-validate diagnostics route back.",
-      "src_hash": "784ee3d6d8ac183370be6ec0d0fb7fb60baa8a0d9d4b4d55affc1217016db716",
+      "src_hash": "37cded427fbccf49ff19a6fe8b03f9e90857afe556e5db0e51a01402fbf33f1e",
       "dst_hash": "afa59b0815308a340780247df0548909518564d58352a0c695ceca37a07eee5b",
       "source": "deterministic"
     },

--- a/casts/claude/skills/implement-galaxy-tool-step/_provenance.json
+++ b/casts/claude/skills/implement-galaxy-tool-step/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/implement-galaxy-tool-step/index.md",
     "revision": 8,
     "content_hash": "45f5bb50f0fa56ee1e25b323b67f7c4eda64ef9b376b80a2fdc37f20e6a23e1c",
-    "commit": "a56c6127966e59c75cf67d1d41ca03c8b4cf45dd"
+    "commit": "b9590579bec9fec7caeb35f2274c3a9639d665d6"
   },
-  "cast_at": "2026-08-02T22:04:44.968Z",
+  "cast_at": "2026-08-05T22:29:23.592Z",
   "refs": [
     {
       "kind": "cli-command",
@@ -22,7 +22,7 @@
       "purpose": "Validate the mutated draft against draft-contract rules; with --concrete, also gate the extracted concrete subset (including the step just implemented) against full gxformat2.",
       "trigger": "After implementing or modifying a concrete tool step in the draft.",
       "verification": "Cast the skill, exercise on an IWC-derived draft with one drafty step, confirm both surfaces validate and diagnostics route back to the implemented step.",
-      "src_hash": "784ee3d6d8ac183370be6ec0d0fb7fb60baa8a0d9d4b4d55affc1217016db716",
+      "src_hash": "37cded427fbccf49ff19a6fe8b03f9e90857afe556e5db0e51a01402fbf33f1e",
       "dst_hash": "afa59b0815308a340780247df0548909518564d58352a0c695ceca37a07eee5b",
       "source": "deterministic"
     },

--- a/casts/claude/skills/implement-galaxy-workflow-test/_provenance.json
+++ b/casts/claude/skills/implement-galaxy-workflow-test/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/implement-galaxy-workflow-test/index.md",
     "revision": 8,
     "content_hash": "966c486ccda2eb1e0f06afa674c5d6b85a7e7bfcc9b1545309e3ef8b1016f931",
-    "commit": "a56c6127966e59c75cf67d1d41ca03c8b4cf45dd"
+    "commit": "b9590579bec9fec7caeb35f2274c3a9639d665d6"
   },
-  "cast_at": "2026-08-02T22:04:46.585Z",
+  "cast_at": "2026-08-05T22:29:28.474Z",
   "cast_date": "2026-07-20",
   "cast_revision": 1,
   "cast_history": [
@@ -30,7 +30,7 @@
       "evidence": "corpus-observed",
       "purpose": "Run the cheap static workflow-test validation and workflow-label cross-check before Planemo execution.",
       "trigger": "After authoring or editing a Galaxy workflow test file and before Planemo invocation.",
-      "src_hash": "dc500585d94e675d1809707dc8585c4da8f6d8f3ac977c9027bb66d9480820ab",
+      "src_hash": "7157ef7750ead142086e0597d52d2ef6ef072e8ec2939f2ac6965bdccf04849d",
       "dst_hash": "973184698733ffb86bb5a15781902846afec311047f5684f779f8ad023e5d24c",
       "source": "deterministic"
     },

--- a/casts/claude/skills/nextflow-summary-to-galaxy-template/_provenance.json
+++ b/casts/claude/skills/nextflow-summary-to-galaxy-template/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/nextflow-summary-to-galaxy-template/index.md",
     "revision": 8,
     "content_hash": "23676d3bdc6a728949f757ae221a7e40153666e7028f671ea8ab52fe5b9f2686",
-    "commit": "aede1aeab8ceb890192c9606a6e967a36fcf2224"
+    "commit": "b9590579bec9fec7caeb35f2274c3a9639d665d6"
   },
-  "cast_at": "2026-08-03T23:37:57.886Z",
+  "cast_at": "2026-08-05T22:29:37.296Z",
   "cast_date": "2026-05-07",
   "cast_revision": 3,
   "cast_history": [
@@ -41,7 +41,7 @@
       "purpose": "Validate the emitted draft against draft-contract rules (sentinel form, topology, _plan_* placement) before handing off.",
       "trigger": "After writing or modifying the draft workflow file.",
       "verification": "Cast the skill, run on a representative Nextflow pipeline, confirm draft-validate diagnostics route back.",
-      "src_hash": "784ee3d6d8ac183370be6ec0d0fb7fb60baa8a0d9d4b4d55affc1217016db716",
+      "src_hash": "37cded427fbccf49ff19a6fe8b03f9e90857afe556e5db0e51a01402fbf33f1e",
       "dst_hash": "afa59b0815308a340780247df0548909518564d58352a0c695ceca37a07eee5b",
       "source": "deterministic"
     },

--- a/casts/claude/skills/run-workflow-test/_provenance.json
+++ b/casts/claude/skills/run-workflow-test/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/run-workflow-test/index.md",
     "revision": 6,
     "content_hash": "ddce4858e472c7e4ff1cc74b48be4c18dffe9e732e254bd6e84c41aeab1eae75",
-    "commit": "a56c6127966e59c75cf67d1d41ca03c8b4cf45dd"
+    "commit": "b9590579bec9fec7caeb35f2274c3a9639d665d6"
   },
-  "cast_at": "2026-08-02T22:05:03.236Z",
+  "cast_at": "2026-08-05T22:29:44.630Z",
   "cast_date": "2026-07-20",
   "cast_revision": 1,
   "cast_history": [
@@ -30,7 +30,7 @@
       "evidence": "corpus-observed",
       "purpose": "Run static schema and workflow-label checks before expensive workflow execution.",
       "trigger": "Before invoking Planemo when a Galaxy workflow test file is present.",
-      "src_hash": "dc500585d94e675d1809707dc8585c4da8f6d8f3ac977c9027bb66d9480820ab",
+      "src_hash": "7157ef7750ead142086e0597d52d2ef6ef072e8ec2939f2ac6965bdccf04849d",
       "dst_hash": "973184698733ffb86bb5a15781902846afec311047f5684f779f8ad023e5d24c",
       "source": "deterministic"
     },

--- a/casts/claude/skills/summarize-galaxy-tool/_provenance.json
+++ b/casts/claude/skills/summarize-galaxy-tool/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/summarize-galaxy-tool/index.md",
     "revision": 8,
     "content_hash": "a53a303bff1d7ace3b44fb12af329b12695bfcd165933634b8fb6484c0c306f7",
-    "commit": "a56c6127966e59c75cf67d1d41ca03c8b4cf45dd"
+    "commit": "b9590579bec9fec7caeb35f2274c3a9639d665d6"
   },
-  "cast_at": "2026-08-02T22:05:07.494Z",
+  "cast_at": "2026-08-05T22:29:48.826Z",
   "refs": [
     {
       "kind": "cli-command",
@@ -22,7 +22,7 @@
       "purpose": "Cache-population precondition: `summarize` reads an already-cached pin and fails if missing, so `add` fetches the pin into the cache first. Stock/built-in bare ids resolve against the shed but need an explicit `--tool-version`.",
       "trigger": "When the requested pin is not yet present in the configured cache directory.",
       "verification": "Cast the skill, `add` a fresh pin then `summarize` it, confirm the cache miss is resolved before the manifest is emitted.",
-      "src_hash": "0090da3c49e1c39b81453a998db8faa7979b20f89443231c8e372ce5384324a5",
+      "src_hash": "6cb4b61fbdd1aa49a5052abb24020c43bdf57e0360643a65e55b23b42155f561",
       "dst_hash": "85e3bb884171beb69631186ca6f0f7552e6c6d0721383ab6653e7a32c84a1b71",
       "source": "deterministic"
     },
@@ -38,7 +38,7 @@
       "purpose": "Discover the concrete cached version of a stock/built-in bare id before `add`/`summarize`, since the shed's TRS version-list endpoint can't auto-resolve it; never hand-guess a stock version.",
       "trigger": "When the pin is a bare/stock id (no owner/repo) and its concrete version isn't already known.",
       "verification": "Cast the skill, populate a cache with a stock tool, run `list --json`, confirm the reported version feeds `add`/`summarize` for that bare id.",
-      "src_hash": "7b867a3b9293bd1425b6e0b7a49632c60551db6afcf0bdec1b335f36ff6b00b6",
+      "src_hash": "e352306726b54752ad63ac68b2a468d49eb22cebd7b367344ee6b10c8e790434",
       "dst_hash": "92d336667531c34180db6f75b9fdf87261923c1e85567dce3b21a6d87d9543bd",
       "source": "deterministic"
     },
@@ -54,7 +54,7 @@
       "purpose": "Emit the deterministic [[galaxy-tool-summary]] manifest for the cached pin; this Mold runs the command rather than hand-authoring the manifest.",
       "trigger": "Once the pin is confirmed present in the cache.",
       "verification": "Cast the skill, run `summarize` on a cached pin (e.g. staramr_search), confirm the emitted manifest validates against [[galaxy-tool-summary]].",
-      "src_hash": "5e8ac7fe768f902d311196fcecdc33c1c0bc0de176d52447639e99a679e6c1c6",
+      "src_hash": "96099b98e52244ac882066511a8ffa87c1fbbd6fb1c7acc98de3cca822f98277",
       "dst_hash": "b51364ad4d415f6047e3cf3d3052dea1598cd2197595be66697c9777918b2de7",
       "source": "deterministic"
     },

--- a/casts/claude/skills/summarize-galaxy-workflow/_provenance.json
+++ b/casts/claude/skills/summarize-galaxy-workflow/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/summarize-galaxy-workflow/index.md",
     "revision": 2,
     "content_hash": "23b770bbbd5409a37a7a0ea457a10b2cfba21f36a6e7e892125735035ac36078",
-    "commit": "a56c6127966e59c75cf67d1d41ca03c8b4cf45dd"
+    "commit": "b9590579bec9fec7caeb35f2274c3a9639d665d6"
   },
-  "cast_at": "2026-08-02T22:05:09.135Z",
+  "cast_at": "2026-08-05T22:29:50.354Z",
   "refs": [
     {
       "kind": "cli-command",
@@ -22,7 +22,7 @@
       "purpose": "Convert a legacy `.ga` workflow to gxformat2 before summarizing, and record the conversion under documents.converted_path.",
       "trigger": "When the supplied workflow is native `.ga` rather than gxformat2.",
       "verification": "Cast the skill, run on one `.ga` and one gxformat2 fixture; confirm the `.ga` case populates documents.converted_path and both summaries validate.",
-      "src_hash": "9945cc274f2b5ad1a77ea6b6d0c9d68f4163991b9d451ed9eeff2bd10c87349c",
+      "src_hash": "1bb19d20b4a39b1708d8f5346a0294616cdb9df83ba5255c4a90d97030d13b83",
       "dst_hash": "1cdf49f10f77039af6efc5b82fe79720bb18e50d1f57d653670697f7262c7640",
       "source": "deterministic"
     },
@@ -38,7 +38,7 @@
       "purpose": "Validate the gxformat2 workflow before extraction and record diagnostics under documents.validation.",
       "trigger": "Before extracting structure from the workflow document.",
       "verification": "Cast the skill, run on one valid and one malformed workflow; the malformed one surfaces gxwf validate diagnostics in the summary.",
-      "src_hash": "7f5b7f131c79ecdca31d890502b71940cae8319cd35c20041e3c285bc2ae9ac9",
+      "src_hash": "1bf4b4c50e9987f63e65ad36f6deefe6e399fe009280d4bee8533d6c451acf1e",
       "dst_hash": "ff10c49819b0f7af13f247ea03e4dd24ba2e5144da3beaa6b1ab96698c7e03b7",
       "source": "deterministic"
     },

--- a/casts/claude/skills/validate-galaxy-workflow/_provenance.json
+++ b/casts/claude/skills/validate-galaxy-workflow/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/validate-galaxy-workflow/index.md",
     "revision": 4,
     "content_hash": "02f24bacec6166da30493ac9b6a56e5e2ce1fda6b12ec3ad82001ad053512478",
-    "commit": "a56c6127966e59c75cf67d1d41ca03c8b4cf45dd"
+    "commit": "b9590579bec9fec7caeb35f2274c3a9639d665d6"
   },
-  "cast_at": "2026-08-02T22:05:13.887Z",
+  "cast_at": "2026-08-05T22:29:54.948Z",
   "refs": [
     {
       "kind": "cli-command",
@@ -22,7 +22,7 @@
       "purpose": "Validate the assembled gxformat2 workflow before runtime testing.",
       "trigger": "After all Galaxy steps and workflow tests have been assembled.",
       "verification": "Run the cast skill on a complete IWC-derived workflow and confirm terminal validation findings are separated from runtime test failures.",
-      "src_hash": "7f5b7f131c79ecdca31d890502b71940cae8319cd35c20041e3c285bc2ae9ac9",
+      "src_hash": "1bf4b4c50e9987f63e65ad36f6deefe6e399fe009280d4bee8533d6c451acf1e",
       "dst_hash": "ff10c49819b0f7af13f247ea03e4dd24ba2e5144da3beaa6b1ab96698c7e03b7",
       "source": "deterministic"
     },

--- a/content/cli/foundry/summarize-nextflow.md
+++ b/content/cli/foundry/summarize-nextflow.md
@@ -3,7 +3,6 @@ type: cli-command
 tool: foundry
 command: summarize-nextflow
 package: "@galaxy-foundry/foundry"
-upstream: "https://github.com/galaxyproject/foundry/blob/main/packages/foundry/src/program.ts"
 tags:
   - cli/foundry
 status: draft

--- a/content/cli/foundry/validate-galaxy-tool-discovery.md
+++ b/content/cli/foundry/validate-galaxy-tool-discovery.md
@@ -3,7 +3,6 @@ type: cli-command
 tool: foundry
 command: validate-galaxy-tool-discovery
 package: "@galaxy-foundry/foundry"
-upstream: "https://github.com/galaxyproject/foundry/blob/main/packages/foundry/src/program.ts"
 tags:
   - cli/foundry
 status: draft

--- a/content/cli/foundry/validate-galaxy-tool-summary.md
+++ b/content/cli/foundry/validate-galaxy-tool-summary.md
@@ -3,7 +3,6 @@ type: cli-command
 tool: foundry
 command: validate-galaxy-tool-summary
 package: "@galaxy-foundry/foundry"
-upstream: "https://github.com/galaxyproject/foundry/blob/main/packages/foundry/src/program.ts"
 tags:
   - cli/foundry
 status: draft

--- a/content/cli/foundry/validate-galaxy-workflow-test-plan.md
+++ b/content/cli/foundry/validate-galaxy-workflow-test-plan.md
@@ -3,7 +3,6 @@ type: cli-command
 tool: foundry
 command: validate-galaxy-workflow-test-plan
 package: "@galaxy-foundry/foundry"
-upstream: "https://github.com/galaxyproject/foundry/blob/main/packages/foundry/src/program.ts"
 tags:
   - cli/foundry
 status: draft

--- a/content/cli/foundry/validate-summary-cwl.md
+++ b/content/cli/foundry/validate-summary-cwl.md
@@ -3,7 +3,6 @@ type: cli-command
 tool: foundry
 command: validate-summary-cwl
 package: "@galaxy-foundry/foundry"
-upstream: "https://github.com/galaxyproject/foundry/blob/main/packages/foundry/src/program.ts"
 tags:
   - cli/foundry
 status: draft

--- a/content/cli/foundry/validate-summary-galaxy-workflow.md
+++ b/content/cli/foundry/validate-summary-galaxy-workflow.md
@@ -3,7 +3,6 @@ type: cli-command
 tool: foundry
 command: validate-summary-galaxy-workflow
 package: "@galaxy-foundry/foundry"
-upstream: "https://github.com/galaxyproject/foundry/blob/main/packages/foundry/src/program.ts"
 tags:
   - cli/foundry
 status: draft

--- a/content/cli/foundry/validate-summary-nextflow.md
+++ b/content/cli/foundry/validate-summary-nextflow.md
@@ -3,7 +3,6 @@ type: cli-command
 tool: foundry
 command: validate-summary-nextflow
 package: "@galaxy-foundry/foundry"
-upstream: "https://github.com/galaxyproject/foundry/blob/main/packages/foundry/src/program.ts"
 tags:
   - cli/foundry
 status: draft

--- a/content/cli/foundry/validate-tests-format.md
+++ b/content/cli/foundry/validate-tests-format.md
@@ -3,7 +3,6 @@ type: cli-command
 tool: foundry
 command: validate-tests-format
 package: "@galaxy-foundry/foundry"
-upstream: "https://github.com/galaxyproject/foundry/blob/main/packages/foundry/src/program.ts"
 tags:
   - cli/foundry
 status: draft

--- a/content/cli/galaxy-tool-cache/add.md
+++ b/content/cli/galaxy-tool-cache/add.md
@@ -3,7 +3,7 @@ type: cli-command
 tool: galaxy-tool-cache
 command: add
 package: "@galaxy-tool-util/cli"
-upstream: "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/galaxy-tool-cache.json"
+source_url: "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/galaxy-tool-cache.json"
 tags:
   - cli/galaxy-tool-cache
 status: draft

--- a/content/cli/galaxy-tool-cache/list.md
+++ b/content/cli/galaxy-tool-cache/list.md
@@ -3,7 +3,7 @@ type: cli-command
 tool: galaxy-tool-cache
 command: list
 package: "@galaxy-tool-util/cli"
-upstream: "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/galaxy-tool-cache.json"
+source_url: "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/galaxy-tool-cache.json"
 tags:
   - cli/galaxy-tool-cache
 status: draft

--- a/content/cli/galaxy-tool-cache/summarize.md
+++ b/content/cli/galaxy-tool-cache/summarize.md
@@ -3,7 +3,7 @@ type: cli-command
 tool: galaxy-tool-cache
 command: summarize
 package: "@galaxy-tool-util/cli"
-upstream: "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/galaxy-tool-cache.json"
+source_url: "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/galaxy-tool-cache.json"
 tags:
   - cli/galaxy-tool-cache
 status: draft

--- a/content/cli/gxwf/convert.md
+++ b/content/cli/gxwf/convert.md
@@ -3,7 +3,7 @@ type: cli-command
 tool: gxwf
 command: convert
 package: "@galaxy-tool-util/cli"
-upstream: "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/gxwf.json"
+source_url: "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/gxwf.json"
 tags:
   - cli/gxwf
 status: draft

--- a/content/cli/gxwf/draft-extract.md
+++ b/content/cli/gxwf/draft-extract.md
@@ -3,7 +3,7 @@ type: cli-command
 tool: gxwf
 command: draft-extract
 package: "@galaxy-tool-util/cli"
-upstream: "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/gxwf.json"
+source_url: "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/gxwf.json"
 tags:
   - cli/gxwf
 status: draft

--- a/content/cli/gxwf/draft-next-step.md
+++ b/content/cli/gxwf/draft-next-step.md
@@ -3,7 +3,7 @@ type: cli-command
 tool: gxwf
 command: draft-next-step
 package: "@galaxy-tool-util/cli"
-upstream: "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/gxwf.json"
+source_url: "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/gxwf.json"
 tags:
   - cli/gxwf
 status: draft

--- a/content/cli/gxwf/draft-validate.md
+++ b/content/cli/gxwf/draft-validate.md
@@ -3,7 +3,7 @@ type: cli-command
 tool: gxwf
 command: draft-validate
 package: "@galaxy-tool-util/cli"
-upstream: "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/gxwf.json"
+source_url: "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/gxwf.json"
 tags:
   - cli/gxwf
 status: draft

--- a/content/cli/gxwf/tool-revisions.md
+++ b/content/cli/gxwf/tool-revisions.md
@@ -3,7 +3,7 @@ type: cli-command
 tool: gxwf
 command: tool-revisions
 package: "@galaxy-tool-util/cli"
-upstream: "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/gxwf.json"
+source_url: "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/gxwf.json"
 tags:
   - cli/gxwf
 status: draft

--- a/content/cli/gxwf/tool-search.md
+++ b/content/cli/gxwf/tool-search.md
@@ -3,7 +3,7 @@ type: cli-command
 tool: gxwf
 command: tool-search
 package: "@galaxy-tool-util/cli"
-upstream: "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/gxwf.json"
+source_url: "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/gxwf.json"
 tags:
   - cli/gxwf
 status: draft

--- a/content/cli/gxwf/tool-versions.md
+++ b/content/cli/gxwf/tool-versions.md
@@ -3,7 +3,7 @@ type: cli-command
 tool: gxwf
 command: tool-versions
 package: "@galaxy-tool-util/cli"
-upstream: "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/gxwf.json"
+source_url: "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/gxwf.json"
 tags:
   - cli/gxwf
 status: draft

--- a/content/cli/gxwf/validate-tests.md
+++ b/content/cli/gxwf/validate-tests.md
@@ -3,7 +3,7 @@ type: cli-command
 tool: gxwf
 command: validate-tests
 package: "@galaxy-tool-util/cli"
-upstream: "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/gxwf.json"
+source_url: "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/gxwf.json"
 tags:
   - cli/gxwf
 status: draft

--- a/content/cli/gxwf/validate.md
+++ b/content/cli/gxwf/validate.md
@@ -3,7 +3,7 @@ type: cli-command
 tool: gxwf
 command: validate
 package: "@galaxy-tool-util/cli"
-upstream: "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/gxwf.json"
+source_url: "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/gxwf.json"
 tags:
   - cli/gxwf
 status: draft

--- a/content/cli/planemo/planemo-cli_metadata.md
+++ b/content/cli/planemo/planemo-cli_metadata.md
@@ -3,7 +3,7 @@ type: cli-command
 tool: planemo
 command: cli_metadata
 package: "planemo"
-upstream: "https://github.com/galaxyproject/planemo/blob/0.75.45/planemo/commands/cmd_cli_metadata.py"
+source_url: "https://github.com/galaxyproject/planemo/blob/0.75.45/planemo/commands/cmd_cli_metadata.py"
 tags:
   - cli/planemo
 status: draft

--- a/content/cli/planemo/planemo-lint.md
+++ b/content/cli/planemo/planemo-lint.md
@@ -3,7 +3,7 @@ type: cli-command
 tool: planemo
 command: lint
 package: "planemo"
-upstream: "https://github.com/galaxyproject/planemo/blob/0.75.45/planemo/commands/cmd_lint.py"
+source_url: "https://github.com/galaxyproject/planemo/blob/0.75.45/planemo/commands/cmd_lint.py"
 tags:
   - cli/planemo
 status: draft

--- a/content/cli/planemo/planemo-output_schema.md
+++ b/content/cli/planemo/planemo-output_schema.md
@@ -3,7 +3,7 @@ type: cli-command
 tool: planemo
 command: output_schema
 package: "planemo"
-upstream: "https://github.com/galaxyproject/planemo/blob/0.75.45/planemo/commands/cmd_output_schema.py"
+source_url: "https://github.com/galaxyproject/planemo/blob/0.75.45/planemo/commands/cmd_output_schema.py"
 tags:
   - cli/planemo
 status: draft

--- a/content/cli/planemo/planemo-test.md
+++ b/content/cli/planemo/planemo-test.md
@@ -3,7 +3,7 @@ type: cli-command
 tool: planemo
 command: test
 package: "planemo"
-upstream: "https://github.com/galaxyproject/planemo/blob/0.75.45/planemo/commands/cmd_test.py"
+source_url: "https://github.com/galaxyproject/planemo/blob/0.75.45/planemo/commands/cmd_test.py"
 tags:
   - cli/planemo
 status: draft

--- a/content/cli/planemo/planemo-workflow_test_init.md
+++ b/content/cli/planemo/planemo-workflow_test_init.md
@@ -3,7 +3,7 @@ type: cli-command
 tool: planemo
 command: workflow_test_init
 package: "planemo"
-upstream: "https://github.com/galaxyproject/planemo/blob/0.75.45/planemo/commands/cmd_workflow_test_init.py"
+source_url: "https://github.com/galaxyproject/planemo/blob/0.75.45/planemo/commands/cmd_workflow_test_init.py"
 tags:
   - cli/planemo
 status: draft

--- a/content/cli/planemo/planemo-workflow_test_on_invocation.md
+++ b/content/cli/planemo/planemo-workflow_test_on_invocation.md
@@ -3,7 +3,7 @@ type: cli-command
 tool: planemo
 command: workflow_test_on_invocation
 package: "planemo"
-upstream: "https://github.com/galaxyproject/planemo/blob/0.75.45/planemo/commands/cmd_workflow_test_on_invocation.py"
+source_url: "https://github.com/galaxyproject/planemo/blob/0.75.45/planemo/commands/cmd_workflow_test_on_invocation.py"
 tags:
   - cli/planemo
 status: draft

--- a/packages/build-cli/src/commands/validate.ts
+++ b/packages/build-cli/src/commands/validate.ts
@@ -45,6 +45,16 @@ const CLI_METADATA_KEYS = new Set([
     .map((command) => `${planemoCliMeta.program}/${command.name}`),
 ]);
 
+/**
+ * The commands THIS repository implements, as opposed to the three programs whose metadata it
+ * merely reads. A page for one of these summarizes nothing: the code is in the same tree, and a
+ * `source_url` pointing back at our own `program.ts` gives a reader no second place to check.
+ * Every other cli-command page is a summary of an external document and owes one.
+ */
+const OWN_CLI_KEYS = new Set(
+  foundryCliMeta.commands.map((command) => `${foundryCliMeta.name}/${command.name}`),
+);
+
 /** Single-value vs array wiki-link fields. Schema's regex catches missing brackets; this catches whitespace-only inner text. */
 const WIKI_LINK_FIELDS: Record<string, "single" | "array"> = {
   parent_pattern: "single",
@@ -1044,11 +1054,21 @@ function validateCliCommandDocs(files: FileMeta[]): CrossFileFinding[] {
         message: "cli-command must declare package for metadata-backed rendering",
       });
     }
-    if (typeof f.meta.upstream !== "string" || f.meta.upstream.length === 0) {
+    const sourceUrl = f.meta.source_url;
+    const hasSourceUrl = typeof sourceUrl === "string" && sourceUrl.length > 0;
+    if (OWN_CLI_KEYS.has(key)) {
+      if (hasSourceUrl) {
+        findings.push({
+          path: f.path,
+          severity: "error",
+          message: `cli-command ${key} is implemented in this repository and must not declare source_url`,
+        });
+      }
+    } else if (!hasSourceUrl) {
       findings.push({
         path: f.path,
         severity: "error",
-        message: "cli-command must declare upstream for metadata-backed rendering",
+        message: "cli-command must declare source_url — the external document this page summarizes",
       });
     }
     const body = readMarkdown(f.path).body;

--- a/packages/note-schema/src/types/cli-command/example.md
+++ b/packages/note-schema/src/types/cli-command/example.md
@@ -3,6 +3,7 @@ type: cli-command
 tool: gxwf
 command: validate
 package: "@galaxy-tool-util/cli"
+source_url: "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/gxwf.json"
 tags:
   - target/galaxy
 status: reviewed

--- a/packages/note-schema/src/types/cli-command/kind.md
+++ b/packages/note-schema/src/types/cli-command/kind.md
@@ -18,8 +18,16 @@ casts run real binaries.
 
 ## Optional fields
 
-- **`package`** / **`upstream`** — where the command's implementation lives, for the reader who
-  needs to check the page against the source.
+- **`package`** — the distribution the command ships in.
+- **`source_url`** — the external document this page summarizes: the spec entry or the command
+  implementation, ideally at a pinned ref, so a reader can check the page against what it was
+  written from. It earns its place only where the page really is a summary of something else; a
+  command implemented in this repository has no upstream to name, and pointing the field back at
+  our own source says nothing a reader could act on.
+
+  The name is shared with the sibling Foundry, which spells the same idea `source_url` and
+  constrains it the same way. `upstream` on a `schema` note is a different field for a different
+  job — see that kind.
 
 ## Body convention
 

--- a/packages/note-schema/src/types/cli-command/schema.ts
+++ b/packages/note-schema/src/types/cli-command/schema.ts
@@ -22,7 +22,14 @@ export const kind = defineKind({
         tool: ctx.toolSlug,
         command: z.string(),
         package: z.string().optional(),
-        upstream: z.string().optional(),
+        // The document this page summarizes — a spec file, a command implementation at a pinned
+        // ref. `source_url` and `z.url()` are the sibling instance's name and constraint for the
+        // same thing, so one field means one thing across both.
+        //
+        // Distinct from the `schema` kind's `upstream`, which is where a VENDORED artifact came
+        // from and carries a cross-field rule keying off whether it points outside this
+        // repository. Summarizing an external command is not vendoring it.
+        source_url: z.url().optional(),
         ...ctx.base,
       })
       .strict(),

--- a/packages/note-schema/src/types/kinds.generated.json
+++ b/packages/note-schema/src/types/kinds.generated.json
@@ -601,7 +601,7 @@
       "locations": [
         "content/cli"
       ],
-      "doc": "# CLI Command\n\nA **CLI Command** note is a manual page for one subcommand, authored so a cast reads the real\nflags instead of inventing plausible ones.\n\nThis is the kind that most directly buys correctness: hallucinated command-line flags are\nsyntactically perfect and completely wrong, and no amount of prompt care fixes that. Writing the\npage down and referencing it does.\n\nThis kind is **instance-specific**, and pairs with `cli-tool`: both exist because this Foundry's\ncasts run real binaries.\n\n## Why each required field is required\n\n- **`tool`** — the `cli-tool` slug this command belongs to. The join key.\n- **`command`** — the subcommand itself. Together with `tool` it identifies the page.\n- The **base envelope** — as on every kind.\n\n## Optional fields\n\n- **`package`** / **`upstream`** — where the command's implementation lives, for the reader who\n  needs to check the page against the source.\n\n## Body convention\n\nThe validator warns when the body omits a `## Gotchas` section. That is deliberate: the flags\nare recoverable from `--help`, but the failure modes are exactly what a cast cannot discover on\nits own, and they are the reason the note is worth its tokens.",
+      "doc": "# CLI Command\n\nA **CLI Command** note is a manual page for one subcommand, authored so a cast reads the real\nflags instead of inventing plausible ones.\n\nThis is the kind that most directly buys correctness: hallucinated command-line flags are\nsyntactically perfect and completely wrong, and no amount of prompt care fixes that. Writing the\npage down and referencing it does.\n\nThis kind is **instance-specific**, and pairs with `cli-tool`: both exist because this Foundry's\ncasts run real binaries.\n\n## Why each required field is required\n\n- **`tool`** — the `cli-tool` slug this command belongs to. The join key.\n- **`command`** — the subcommand itself. Together with `tool` it identifies the page.\n- The **base envelope** — as on every kind.\n\n## Optional fields\n\n- **`package`** — the distribution the command ships in.\n- **`source_url`** — the external document this page summarizes: the spec entry or the command\n  implementation, ideally at a pinned ref, so a reader can check the page against what it was\n  written from. It earns its place only where the page really is a summary of something else; a\n  command implemented in this repository has no upstream to name, and pointing the field back at\n  our own source says nothing a reader could act on.\n\n  The name is shared with the sibling Foundry, which spells the same idea `source_url` and\n  constrains it the same way. `upstream` on a `schema` note is a different field for a different\n  job — see that kind.\n\n## Body convention\n\nThe validator warns when the body omits a `## Gotchas` section. That is deliberate: the flags\nare recoverable from `--help`, but the failure modes are exactly what a cast cannot discover on\nits own, and they are the reason the note is worth its tokens.",
       "fields": [
         {
           "name": "command",
@@ -674,17 +674,17 @@
           "type": "string[]"
         },
         {
+          "name": "source_url",
+          "required": false,
+          "type": "string"
+        },
+        {
           "name": "sources",
           "required": false,
           "type": "string[]"
         },
         {
           "name": "title",
-          "required": false,
-          "type": "string"
-        },
-        {
-          "name": "upstream",
           "required": false,
           "type": "string"
         }

--- a/scripts/sync-planemo-cli.ts
+++ b/scripts/sync-planemo-cli.ts
@@ -198,7 +198,7 @@ function renderFrontmatter(meta: CliMetadata, summary: string): string {
     "tool: planemo",
     `command: ${meta.name}`,
     'package: "planemo"',
-    `upstream: "https://github.com/galaxyproject/planemo/blob/${PIN.ref}/${meta.module.replace(/\./g, "/")}.py"`,
+    `source_url: "https://github.com/galaxyproject/planemo/blob/${PIN.ref}/${meta.module.replace(/\./g, "/")}.py"`,
     "tags:",
     "  - cli/planemo",
     "status: draft",

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -868,7 +868,7 @@ describe("validateDirectory (cross-file)", () => {
         tool: "gxwf",
         command: "validate",
         package: "@galaxy-tool-util/cli",
-        upstream:
+        source_url:
           "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/gxwf.json",
       }),
     });
@@ -913,7 +913,7 @@ describe("validateDirectory (cross-file)", () => {
         tool: "gxwf",
         command: "validate",
         package: "@galaxy-tool-util/cli",
-        upstream:
+        source_url:
           "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/gxwf.json",
       }),
     });
@@ -930,7 +930,7 @@ describe("validateDirectory (cross-file)", () => {
     ).toBeGreaterThanOrEqual(1);
   });
 
-  it("rejects CLI command notes missing upstream metadata", () => {
+  it("rejects a CLI command absent from the upstream CLI metadata", () => {
     writeFm(path.join(dir, "cli/gxwf/not-real.md"), {
       ...baseRequired({
         type: "cli-command",
@@ -938,7 +938,7 @@ describe("validateDirectory (cross-file)", () => {
         tool: "gxwf",
         command: "not-real",
         package: "@galaxy-tool-util/cli",
-        upstream:
+        source_url:
           "https://github.com/jmchilton/galaxy-tool-util-ts/tree/main/packages/cli/spec/gxwf.json",
       }),
     });
@@ -948,6 +948,57 @@ describe("validateDirectory (cross-file)", () => {
       tagsPath: TAGS_PATH,
     });
     expect(r.errors).toBeGreaterThanOrEqual(1);
+  });
+
+  // `source_url` is owed by exactly the pages that summarize someone else's document, which is
+  // every cli-command except the ones this repository implements. Both directions are asserted
+  // because only one of them fails loudly: a missing field is a page a reader cannot check, and a
+  // present one on our own command is a link back to the tree the reader is already in.
+  it("rejects a CLI command with no source_url to check the page against", () => {
+    writeFm(path.join(dir, "cli/gxwf/validate.md"), {
+      ...baseRequired({
+        type: "cli-command",
+        tags: ["cli/gxwf"],
+        tool: "gxwf",
+        command: "validate",
+        package: "@galaxy-tool-util/cli",
+      }),
+    });
+
+    const r = validateDirectory({ directory: dir, tagsPath: TAGS_PATH });
+    expect(r.errors).toBeGreaterThanOrEqual(1);
+  });
+
+  it("rejects a source_url on a command this repository implements", () => {
+    writeFm(path.join(dir, "cli/foundry/validate-tests-format.md"), {
+      ...baseRequired({
+        type: "cli-command",
+        tags: ["cli/foundry"],
+        tool: "foundry",
+        command: "validate-tests-format",
+        package: "@galaxy-foundry/foundry",
+        source_url:
+          "https://github.com/galaxyproject/foundry/blob/main/packages/foundry/src/program.ts",
+      }),
+    });
+
+    const r = validateDirectory({ directory: dir, tagsPath: TAGS_PATH });
+    expect(r.errors).toBeGreaterThanOrEqual(1);
+  });
+
+  it("accepts a command this repository implements with no source_url", () => {
+    writeFm(path.join(dir, "cli/foundry/validate-tests-format.md"), {
+      ...baseRequired({
+        type: "cli-command",
+        tags: ["cli/foundry"],
+        tool: "foundry",
+        command: "validate-tests-format",
+        package: "@galaxy-foundry/foundry",
+      }),
+    });
+
+    const r = validateDirectory({ directory: dir, tagsPath: TAGS_PATH });
+    expect(r.errors).toBe(0);
   });
 
   it("rejects typed references that resolve to the wrong type", () => {


### PR DESCRIPTION
> Opened by Claude (AI assistant) on jmchilton's behalf — they did not write this text.

`cli-command` notes called the document they summarize `upstream`. The `schema` kind uses that
same name for something else — where a **vendored** artifact came from, with a cross-field rule
keying off whether it points outside this repository — and summarizing an external command is not
vendoring it. This kind now calls the field `source_url`, which is what the sibling Foundry calls
the same thing, constrained the same way (`z.url()`).

## Where the value was worth keeping, and where it was not

| directory | value | kept? |
|---|---|---|
| `cli/gxwf` (9) | `galaxy-tool-util-ts/…/spec/gxwf.json` | renamed — the spec entry the page documents |
| `cli/galaxy-tool-cache` (3) | `…/spec/galaxy-tool-cache.json` | renamed — same shape |
| `cli/planemo` (6) | per-command, pinned at `blob/0.75.45/` | renamed — the clearest case: one page, one file, one version |
| `cli/foundry` (8) | **one identical URL on all eight** → this repo's own `packages/foundry/src/program.ts` | **dropped** |

Those eight named a second place for a reader to check that was the first place — the same file,
on a branch ref, in the tree already open. Nothing was recorded that the note did not already say.

## The validator rule this replaces

`validateCliCommandDocs` required the field of every cli-command "for metadata-backed rendering".
That reason does not hold: `CliCommandBody` renders `reg?.upstream` out of `cliRegistry`, and the
note's own field reaches no page in the site. So the requirement was enforcing a link nothing
rendered, which is how eight pages ended up pointing at ourselves to satisfy it.

The condition that does hold is whether a page summarizes an external document, and the module
already knows which commands are ours — `foundryCliMeta` is imported two lines above, for the
corpus check. The rule keys off that rather than a package-name pattern, so a command added to our
own CLI is classified by the thing that defines it rather than by how it happens to be named.

Both directions are asserted, because only one of them fails loudly:

- a page that summarizes something and declares no `source_url` — a page a reader cannot check
- a `source_url` on a command we implement — a link that looks checkable and is not

Written red: with the branch's rule reverted, both new tests fail; the third (`accepts a command
this repository implements with no source_url`) fails against the rule as it stands on `main`.

## What is generated, and one thing found rather than caused

The planemo pages are emitted by `scripts/sync-planemo-cli.ts`, so it emits the new name too —
without that the next sync would quietly restore the old one.

`pnpm check:planemo-cli` reports **1 page out of date**, and **already does on `main`**:
`content/cli/planemo/planemo-test.md` holds newer planemo options (`--failed_json`,
`--shed_tool_data_table_config`, `--shed_data_dir`) than the pinned `@galaxy-foundry/planemo-cli-meta`
generates. Regenerating would have reverted them. That is a content change, and hiding one inside
a rename is how it goes unnoticed, so this branch leaves it exactly as it found it. Worth its own
issue — either the pin moves forward or those rows are lost on the next sync by whoever runs it
next.

## Verification

`validate` 242 files / 0 errors / 49 warnings (unchanged), 302 tests (3 new), `packages-test` 213,
`typecheck:root`, `packages-typecheck`, `packages-lint`, `packages-format`, `check:kinds`,
`check:index`, `check:readme` all clean. `site:typecheck` 69 files, 0/0/0.

Content diff is frontmatter-only — no note body changes in the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
