### PR TITLE
Let molds.md own the Mold set's shape, not its membership

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@
 - `content/meta/content-model.md` — note kinds, frontmatter, tags, links, references, and companions.
 - `content/meta/build-and-validation.md` — validation, generation, casting, assembly, site builds, and drift gates.
 - `content/meta/repository-layout.md` — physical placement and authored/generated ownership boundaries.
-- `content/meta/molds.md` — Mold inventory and bucketing axes.
+- `content/meta/molds.md` — Mold bucketing axes and the Mold-versus-reference boundary. Membership lives in `content/molds/`.
 - `content/meta/mold-spec.md` — Mold authoring contract (frontmatter, references, eval/usage/refinement). Load when authoring or editing a Mold or its `eval.md`.
 - `content/meta/harness-pipelines.md` — pipeline narrative behind `content/pipelines/`.
 - `content/meta/casting.md` — casting design.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ so the collection, not this list, is the authority on which records exist. Read 
 
 1. [`guiding-principles.md`](content/meta/guiding-principles.md) — why the Foundry prioritizes upstream authority, provenance, deterministic tooling, portability, actionable knowledge, and corpus grounding.
 2. [`architecture.md`](content/meta/architecture.md) — directory layout, types, validation pipeline, site rendering.
-3. [`molds.md`](content/meta/molds.md) — Mold inventory rationale and bucketing axes.
+3. [`molds.md`](content/meta/molds.md) — the axes a Mold buckets on and the boundary against reference content.
 4. [`mold-spec.md`](content/meta/mold-spec.md) — the Mold authoring contract: source layout, which files may sit beside `index.md`, and who enforces it.
 5. [`casting.md`](content/meta/casting.md) — how typed Mold references become target-specific cast artifacts with provenance.
 6. [`cast-walkthrough.md`](content/meta/cast-walkthrough.md) — one real committed cast annotated end to end.

--- a/content/Index.md
+++ b/content/Index.md
@@ -264,7 +264,7 @@ Generated from content frontmatter. Do not edit by hand.
 - [[guiding-principles]] — The design pressure behind source authority, progressive disclosure, validation, portability, and corpus grounding. *(reviewed)*
 - [[harness-pipelines]] — The source-to-target journeys that compose Molds, loops, and branch phases. *(reviewed)*
 - [[mold-spec]] — The Mold authoring contract: source layout, which files may sit beside index.md, and who enforces it. *(reviewed)*
-- [[molds]] — The Mold inventory, bucketing axes, and boundaries between Molds and reference content. *(reviewed)*
+- [[molds]] — The axes a Mold buckets on, the boundary against reference content, and where the Mold set is still uneven. *(reviewed)*
 - [[pattern-authorship]] — Developer-facing authorship rules for operation-named, corpus-grounded pattern pages. *(reviewed)*
 - [[repository-layout]] — Where authored source, implementation code, generated artifacts, fixtures, and site files belong. *(reviewed)*
 - [[schema-packages]] — Where a Mold IO schema lives, how cast resolves one through a schema note, and why there is no separate schema package. *(reviewed)*

--- a/content/meta/harness-pipelines.md
+++ b/content/meta/harness-pipelines.md
@@ -12,7 +12,7 @@ revision: 17
 summary: "The source-to-target journeys that compose Molds, loops, and branch phases."
 ---
 
-Harness pipelines for the Galaxy Workflow Foundry. Each named pipeline phase corresponds to one atomic, harness-step-sized Mold, and the union of phases across pipelines is the Mold catalog. See [[molds]].
+Harness pipelines for the Galaxy Workflow Foundry. Each named pipeline phase corresponds to one atomic, harness-step-sized Mold. The union of phases is not the Mold set: leaf Molds invoked inside an orchestrator are independently castable without appearing as a phase. `content/molds/` is the membership; [[molds]] owns the axes and the boundary.
 
 ## Framing
 

--- a/content/meta/molds.md
+++ b/content/meta/molds.md
@@ -7,169 +7,56 @@ tags:
   - meta
 status: reviewed
 created: 2026-04-30
-revised: 2026-07-27
-revision: 21
-summary: "The Mold inventory, bucketing axes, and boundaries between Molds and reference content."
+revised: 2026-08-06
+revision: 22
+summary: "The axes a Mold buckets on, the boundary against reference content, and where the Mold set is still uneven."
 ---
 
-Mold inventory for the Galaxy Workflow Foundry, derived as the **union of phases** across the harness pipelines in [[harness-pipelines]]. CLI command knowledge is reference content used by action Molds, not a separate whole-CLI Mold tier. Each Mold is atomic at the harness-step tier (not necessarily small in content).
+A Mold is the Foundry's unit of action: an abstract, typed source artifact that casting turns into a skill an agent runs. Each is atomic at the harness-step tier, which is a statement about granularity, not size. [[mold-spec]] owns the authoring contract, [[casting]] owns what a cast does with one, and [[harness-pipelines]] owns which Molds each journey composes.
 
-This is the inventory, not the Mold source-layout contract. [[mold-spec]] owns Mold authoring rules, the procedural Mold body, and the `references:` manifest; `reference_contract.yml` owns the reference `kinds`, and `@galaxy-foundry/reference-contract` the four vocabularies every Foundry shares. Mold IO contracts live on `input_artifacts[]` / `output_artifacts[]`; producer-owned `output_artifacts[].schema` wiki-links attach schemas to emitted artifact IDs. Cast skills are deterministic renderings of Mold body + artifact contracts + typed references, so any improvement to a generated skill belongs back in the Mold or its referenced notes.
+This record owns the **shape** of the Mold set rather than its membership — the axes a Mold buckets on, the boundary that decides whether a piece of knowledge becomes a Mold at all, and where the set is still uneven. It does not list the Molds that exist. `content/molds/` is the membership; the generated `content/Index.md` and `content/Dashboard.md` project it with summaries; the site's Mold browse renders it. A hand-kept catalog here would be a fourth copy of that, and the first Mold authored after it was written would make it wrong.
 
-## Bucketing axes
+## The axes a Mold buckets on
 
-Each Mold falls along these axes:
+`axis` is a required frontmatter enum, not a mental model for grouping: `source-specific`, `target-specific`, `tool-specific`, or `generic`. The chosen value requires the field that names the specialization — `source`, `target`, or `tool` — and the schema rejects an axis whose companion field is missing. [[mold-spec]] owns that contract. What each value *means* is here.
 
-- **Source-specific** — input format determines content (`PAPER`, `NEXTFLOW`, `CWL`).
-- **Target-specific** — output target determines content (`GALAXY`, `CWL`).
-- **Tool-specific** — reserved for a future action that genuinely depends on one external tool's behavior. Whole-CLI reference surfaces are not Molds.
-- **Generic** — none of the above.
+- **`source-specific`** — the input format determines the content. A paper, a Nextflow tree, a CWL document, and an existing Galaxy workflow each demand different reading, and no shared summary shape survives forcing them together.
+- **`target-specific`** — the output target determines the content. Galaxy and CWL disagree about what a step, a test, and a validation failure are.
+- **`tool-specific`** — reserved for an action that genuinely depends on one external tool's behavior. No Mold carries it. Whole-CLI reference surfaces are not what it is for.
+- **`generic`** — none of the above.
 
-This isn't a frontmatter schema; it's a mental model for grouping. `tool-specific` is reserved for actions that depend on one external tool's behavior and should not be used for whole-CLI catalogs.
+The enum records one specialization, not a pair. Many Molds are genuinely source × target — `nextflow-summary-to-galaxy-interface` reads a Nextflow summary and designs a Galaxy interface — and declare `source-specific`, leaving the target to the Mold's name and its `input_artifacts[]` / `output_artifacts[]` contracts, which is where the handoff is actually pinned. Whether one value plus the artifact contracts carries enough is open below.
 
-## Catalog
+## Mold or reference content
 
-### Source summarization (source-specific, target-agnostic)
+A Mold acts; reference content explains. The test is whether the content terminates in a decision — emit this artifact, pick this wrapper, route back to that phase — or whether a reader consults it. Getting this wrong toward reference is cheap: a pattern page that should have been a Mold just sits there being read. The other direction puts explanation inside a cast bundle, where nothing cites it and nothing keeps it current.
 
-Structured sources emit their **own schema** by design — Nextflow and CWL are different enough that forcing a shared summary shape would either lose detail or bloat both. Paper and interview starts share a Markdown `freeform-summary` handoff because both are narrative, incomplete, and uncertainty-heavy.
+Excluded by design, named so the boundary stays visible:
 
-- `summarize-paper` — extract methods, tools/algorithms, sample data, metrics, references from a paper; emit `freeform-summary`.
-- `interview-to-freeform-summary` — normalize a user interview transcript or interactive session into `freeform-summary`.
-- `summarize-nextflow` — enumerate processes, channels, conditionals, containers (biocontainers / Docker / Singularity refs and their bioconda equivalents), test fixtures from an NF source tree. Container-and-env info is structured output, consumed downstream by `author-galaxy-tool-wrapper` when discovery fails.
-- `summarize-cwl` — read CWL Workflow + referenced `CommandLineTool`s; surface inputs/outputs, scatter, conditional logic, and `DockerRequirement` / `SoftwareRequirement` blocks. Container-and-env info structured for downstream consumption analogous to `summarize-nextflow`.
-- `summarize-galaxy-workflow` — read an existing Galaxy workflow (converting `.ga` → gxformat2 first if needed); emit a `summary-galaxy-workflow` recording inputs, outputs, per-step `tool_id`/`tool_version`/`tool_state`, the edge graph, and any existing tests as a regression baseline. Galaxy-as-source, target-agnostic; mirrors `summarize-cwl`. Feeds the edit pipeline and `compare-against-iwc-exemplar`.
+- **Pure reference content.** Pattern pages, CLI manual pages under `content/cli/<tool>/<command>.md`, schema notes, prompt fragments, examples, and research notes are *referenced by* Molds, not Molds themselves. `reference_contract.yml` registers the kinds and [[casting]] dispatches each one.
+- **Harnesses.** Hand-authored orchestration that sequences Molds and is never cast from one.
+- **Approval gates, scope confirmation, plan presentation, and tool-discovery routing.** Harness-level concerns; [[harness-pipelines]] holds the reasoning for each.
+- **Hand-authored prior-art skills.** The `gxwf-cli` help-text dump and the `find-shed-tool` skill design are prior art. Their content feeds CLI manual pages and action Molds; their form does not.
 
-### Edit-in-place modification (Galaxy → Galaxy)
-
-The `UPDATE-INTERVIEW → GALAXY` pipeline modifies an existing workflow rather than generating one. Two front-half Molds turn interview intent into edits and a dedicated test-plan Mold carries the shipped tests forward as a regression baseline; everything else downstream reuses the per-step loop and test/validate/run tail. Key insight: *an edit is a drafty region*, so tool-introducing edits are drained by the existing `advance-galaxy-draft-step` loop.
-
-- `interview-to-galaxy-workflow-changeset` — interview a user against a `summary-galaxy-workflow` and emit a reviewable, step-anchored change-set (edit kinds: `add-step`, `replace-tool`, `remove-step`, `change-parameter`, `add/remove-input`, `add/expose-output`, `rewire`, `relabel`). The human approval gate; unsupported requests go to the open-requirements ledger.
-- `apply-galaxy-workflow-changeset` — apply the change-set to the concrete workflow: direct edits inline, tool-introducing/replacing edits injected as drafty steps with `_plan_*`; emit a `galaxy-workflow-draft` with untouched regions byte-stable.
-- `changeset-to-galaxy-test-plan` — carry the existing workflow's tests forward as a regression baseline (`source.derived_from: mixed`) and augment them for the change-set's behavioral deltas, emitting the `galaxy-test-plan` that `implement-galaxy-workflow-test` authors. The update pipeline's dedicated test-plan producer, analogous to `nextflow-test-to-galaxy-test-plan` but translate-and-augment rather than translate-only.
-
-### Interface and data-flow design (source × target)
-
-Split by source and target where the handoff shape is specific enough to be useful. These Molds emit reviewable Markdown design briefs, not rich workflow schemas:
-
-- `nextflow-summary-to-galaxy-interface` — Galaxy workflow inputs, outputs, labels, collection shapes, checkpoint outputs, confidence, and provenance from a Nextflow summary.
-- `nextflow-summary-to-galaxy-data-flow` — Galaxy-facing abstract topology, collection operations, unresolved tool needs, and shape transformations from a Nextflow summary plus interface brief.
-- `cwl-summary-to-galaxy-interface` — Galaxy workflow interface design from a CWL summary.
-- `cwl-summary-to-galaxy-data-flow` — Galaxy-facing abstract topology from a CWL summary plus interface brief.
-- `nextflow-summary-to-cwl-interface` — CWL Workflow interface design from a Nextflow summary.
-- `nextflow-summary-to-cwl-data-flow` — CWL-facing abstract topology, scatter/gather choices, and unresolved CommandLineTool needs from a Nextflow summary plus interface brief.
-- `freeform-summary-to-galaxy-interface` — Galaxy workflow interface design brief from a free-form summary.
-- `freeform-summary-to-galaxy-data-flow` — Galaxy-facing abstract data-flow brief from a free-form summary plus interface brief.
-- `freeform-summary-to-cwl-design` — combined CWL interface and data-flow design brief from a free-form summary; split later if examples justify it.
-
-### Template generation (source × target for Galaxy, target-specific for CWL)
-
-Galaxy template generation is split by source so each Mold understands its own upstream design-brief shape:
-
-- `nextflow-summary-to-galaxy-template` — `gxformat2` skeleton from a Nextflow summary plus the Nextflow-to-Galaxy interface and data-flow briefs.
-- `cwl-summary-to-galaxy-template` — `gxformat2` skeleton from a CWL summary plus the CWL-to-Galaxy interface and data-flow briefs.
-- `freeform-summary-to-galaxy-template` — `gxformat2` skeleton from a free-form summary plus the freeform-to-Galaxy design brief.
-- `summary-to-cwl-template` — CWL Workflow skeleton with per-step TODOs. Reads the source artifact, source summary, and previous design handoffs.
-
-### Per-step tool work (target-specific, runs in `[loop]`)
-
-For Galaxy targets, the harness performs **discover-first, author-on-fallthrough**: try `discover-shed-tool` first, and only invoke `author-galaxy-tool-wrapper` when no acceptable existing wrapper is found. The branch is harness logic; the Molds cleanly split the two cases.
-
-- `discover-shed-tool` — search the Galaxy Tool Shed for an existing wrapper matching an abstract step's needs; classify candidates by owner trust, version proximity, container availability, and `+galaxyN` revision posture; recommend a pick or fall through. References the relevant `gxwf` manual pages (`tool-search`, `tool-versions`, `tool-revisions`) and `galaxy-tool-cache`. Named for the *mechanism* (Tool Shed); leaves slots for siblings — `discover-tool-via-galaxy-api`, `discover-tool-on-github` — if/when other discovery sources are wrapped. Replaces the prior-art hand-authored `find-shed-tool` skill (see `old/PLAN_SEARCH_CLI.md` for the original CLI mapping; that work feeds this Mold's content).
-- `summarize-galaxy-tool` — pull JSON schema, container, source, inputs/outputs for a candidate Galaxy tool (existing wrapper, found via `discover-shed-tool`).
-- `summarize-cwl-tool` — derive a `CommandLineTool` description (container, baseCommand, inputs/outputs) for a CWL target.
-- `author-galaxy-tool-wrapper` — author a new Galaxy user-defined tool (`GalaxyUserTool`) YAML definition when discovery yields nothing acceptable. Consumes container/environment info from the source summary (`summarize-nextflow` / `summarize-cwl` already gathered biocontainer / bioconda references) and translates it into the UDT command, inputs, outputs, and container contract. Wiki-links prompt/reference material for structured generation and mandatory critique. **This is an action**, not a pattern — it replaces the previous `design-custom-galaxy-tool` framing as a knowledge skill.
-- `implement-galaxy-tool-step` — convert an abstract step + a `summarize-galaxy-tool` output into a concrete `gxformat2` step. Consumes Galaxy pattern pages via wiki link.
-- `implement-cwl-tool-step` — concrete `CommandLineTool` + Workflow step.
-
-### Tests (mixed)
-
-Two-step shape (translation/derivation, then assembly):
-
-**Derivation** (gets the raw fixtures):
-- `paper-to-test-data` — derive workflow test inputs from a paper (sample data, expected outputs, parameter values). Source-specific (paper), target-agnostic. Fails often because papers rarely ship usable fixtures; falls through to `find-test-data`.
-- `nextflow-to-test-data` — resolve the Nextflow pipeline's own declared `test_fixtures` / `nf_tests` (role, url, sha1, filetype) into Galaxy `test-data-refs`. Source-specific (nextflow), target-agnostic. First leg of the chain; falls through to `find-test-data` for inputs it can't resolve.
-- `cwl-to-test-data` — resolve the CWL source's own declared `tests[]` (job-file inputs, expected outputs) into Galaxy `test-data-refs`. Source-specific (cwl), target-agnostic. First leg of the chain; falls through to `find-test-data`.
-- `find-test-data` — fallback when derivation from a source fails. Search IWC test fixtures, public databases, sibling workflows for usable test data matching a data-flow description (input shapes, expected output shapes, organism / data type). Source-agnostic, target-agnostic. The harness escalates to a user-supplied-data gate if `find-test-data` also fails.
-- `nextflow-test-to-galaxy-test-plan` — translate NF test fixtures, profiles, params, expected outputs, and snapshot evidence into a Galaxy workflow test plan. Source × target.
-- `cwl-test-to-galaxy-test-plan` — translate CWL test fixtures into a Galaxy workflow test plan. Source × target.
-- `nextflow-test-to-cwl-test-plan` — translate NF test fixtures into a CWL workflow test plan. Source × target.
-
-**Assembly** (turns fixtures into the final test artifact):
-- `implement-galaxy-workflow-test` — assemble the Galaxy workflow test JSON (or `.gxwf-tests.yml`) from a translated/derived test plan, with assertions.
-- `implement-cwl-workflow-test` — assemble CWL job file(s) and expected-output assertions from translated/derived fixtures.
-
-The derivation/test-plan Molds and assembly Molds are complementary, not redundant: derivation produces fixtures or a reviewable test plan; assembly produces the test artifact. Both fire in NF→Galaxy, CWL→Galaxy, etc.
-
-### Validation (target-specific)
-
-Validate Molds describe the **step in the process** even where they wrap a static / structured CLI. The underlying validation is deterministic, but the generated skill is the Mold-shaped procedural description (when to run, how to interpret results, what to recommend on failure, when to loop back to authoring). Wraps gxwf / cwltool but is *not* a hand-authored CLI skill — it's a Mold that references the relevant CLI manual pages.
-
-- `validate-galaxy-workflow` — run gxwf validation after workflow assembly, classify workflow-level failures, and route back to the responsible authoring phase when possible.
-- `validate-cwl` — analogous: `cwltool --validate` / schema lint, interpret, recommend/apply fixes.
-
-Per-step Galaxy validation is no longer a standalone Mold; `advance-galaxy-draft-step` (the per-step Galaxy orchestrator) runs `gxwf draft-validate --concrete` inline at the end of each iteration and routes failures locally. See [[harness-pipelines]] § Orchestrator-as-contract.
-
-### Run & debug (Planemo-backed runtime)
-
-**Planemo is the runtime tool** (it can run both Galaxy and CWL workflows); **gxwf is the design-time tool**. Run/debug Molds reference Planemo's CLI manual pages.
-
-- `run-workflow-test` — execute a workflow's tests via Planemo; emit structured pass/fail and outputs. Target-agnostic interface; per-target adapters if needed. References `cli/planemo/test` (and run, etc.).
-- `debug-galaxy-workflow-output` — given a failing Galaxy run's outputs/logs/import warnings, classify the failure and propose fixes. Uses validation output and on-demand operational references for failure interpretation; the Foundry does not maintain a parallel prose caveat catalog.
-- `debug-cwl-workflow-output` — given a failing CWL run's outputs/logs, classify the failure and propose fixes.
-
-Note: this run/debug tier is sized for "smart enough as a Claude skill, but Claude could often do it ad-hoc without one." Treat them as nominally Mold-shaped for inventory completeness, but accept that they may end up thinner than the authoring Molds.
-
-### Generated skill bodies
-
-Claude `SKILL.md` bodies are not hand-maintained. Casting renders them from the Mold `summary`, `input_artifacts[]`, `output_artifacts[]`, inherited producer/schema metadata, typed `references[]`, and the body of `index.md`. Hand-polished behavior discovered in a generated skill should be migrated into the Mold body or supporting reference notes before recasting.
-
-### CLI reference content
-
-CLI command docs live under `content/cli/<tool>/<command>.md`. Action Molds reference the exact commands they need via `references:`. Casting can still produce structured sidecars for those command references, but there is no whole-CLI Mold unless a real action emerges beyond reference lookup.
-
-### Corpus-grounding (Galaxy-specific, generic in source)
-
-- `compare-against-iwc-exemplar` — given the upstream Galaxy design briefs (interface + data-flow), find the nearest IWC exemplar(s) and surface a **structural diff** (this branch differs / IWC consistently uses pattern X here / unexpected step ordering / missing common pre-step) to guide template authoring. Retrieval is part of the comparison — there is no separate retrieval Mold. Galaxy-target only; this is the corpus-first principle delivered before per-step effort begins.
-
-## Not Molds
-
-Excluded from the inventory by design. Naming them keeps the boundary visible.
-
-- **Pure reference content.** Pattern pages (`design-galaxy-tabular-manipulation`, `design-galaxy-collection-manipulation`, `design-galaxy-conditional-handling`, the custom-tool-authoring pattern, ...), CLI manual pages (`content/cli/<tool>/<cmd>.md`), IO schemas (`content/schemas/<name>.md` schema notes, with the JSON itself in `packages/<name>-schema/src/`), prompt fragments, examples, and operational research notes are **referenced by** Molds, not Molds themselves. Casting handles each kind according to the [[mold-spec]] and `reference_contract.yml` contract.
-- **Harnesses.** `nf-to-galaxy`, the conjectural Archon harness, lightweight orchestration skills — all hand-authored, sequence Molds, never cast.
-- **Approval gates / scope confirmation / plan presentation.** Harness-level concerns, not Molds. See [[harness-pipelines]] for the rationale.
-- **Hand-authored prior-art skills (being replaced).** The current `~/.claude/skills/gxwf-cli` (help-text dump) and the `find-shed-tool` skill design (`old/PLAN_SEARCH_CLI.md`) are *not* Foundry artifacts; they are prior art. Their content feeds CLI manual pages and action Molds; their form does not.
-
-**Wrapping a CLI is *not* a Mold disqualifier.** `discover-shed-tool`, `advance-galaxy-draft-step`, `validate-galaxy-workflow`, and `run-workflow-test` all wrap CLIs and are Molds. The criterion is whether there is procedural content worth casting (when to run, how to interpret, when to loop back), not whether the underlying mechanism is a CLI.
+**Wrapping a CLI is not a disqualifier.** `discover-shed-tool`, `advance-galaxy-draft-step`, `validate-galaxy-workflow`, and `run-workflow-test` all wrap CLIs and are Molds. The criterion is whether there is procedural content worth casting — when to run, how to read the result, when to loop back — not whether the mechanism underneath is deterministic.
 
 ### Worked example: `compare-against-iwc-exemplar`
 
-A case that genuinely could have gone the other way. "Compare the design against the IWC corpus" sounds like *knowledge*: the corpus-first principle is already reference content ([[corpus]], the IWC-grounding research notes). One plausible shape was a pattern page describing the corpus-first idiom, referenced by the template Mold — no separate Mold.
+A case that could have gone the other way. "Compare the design against the IWC corpus" sounds like knowledge: the corpus-first principle is already reference content ([[corpus]]), and one plausible shape was a pattern page describing the idiom, cited by the template Mold.
 
-It landed as an **action Mold** (`content/molds/compare-against-iwc-exemplar/`) because the deciding criterion from the rule above resolves the same way it does for the CLI wrappers — there is procedural content worth casting:
+It landed as an action Mold because the criterion above resolves the same way it does for the CLI wrappers — there is procedure worth casting. It runs after the design briefs and before the template Mold, so corpus divergence is caught before per-step effort is spent; it ranks candidates by a feature hierarchy rather than superficial similarity; and it hands off a structural-diff artifact the template Mold consumes. The corpus-first *principle* stays reference content; the *act* of locating the nearest exemplar, ranking it, and gating the template step is a Mold.
 
-- **When to run** — after the interface/data-flow (or combined paper) briefs, before the `*-summary-to-galaxy-template` Mold, so corpus divergence is caught before per-step authoring effort is spent.
-- **How to interpret** — rank candidates by the feature hierarchy (domain intent → input topology → tool families → DAG motifs), not by superficial similarity.
-- **What it hands off** — a structural-diff artifact (`iwc-comparison-notes`) the downstream template Mold consumes by shared `id`.
+## Where the Mold set is uneven
 
-The corpus-first *principle* it rests on stays reference content; the *act* of locating the nearest exemplar, ranking it, and gating the template step is procedure. Idiom that a Mold can simply cite is reference; a repeatable decision-and-handoff is a Mold. Same test, applied to a candidate where the answer was not obvious up front.
+Direction, not inventory. Each of these is a property of the set that membership alone does not show.
 
-## Counts and reuse
+- **The Galaxy target is far ahead of the CWL target.** Galaxy paths have a per-step orchestrator, a corpus-grounding Mold, and four test-plan producers; the CWL paths have leaf-shaped per-step work and one test-plan producer, which is Nextflow-sourced. The paper-sourced CWL journey has no test-plan producer at all — [issue #448](https://github.com/galaxyproject/foundry/issues/448).
+- **The run/debug tier is thinner than the authoring tier, on purpose.** `run-workflow-test` and the two `debug-*-workflow-output` Molds are sized for work an agent could often do ad-hoc. They are Mold-shaped for inventory completeness; whether they earn casting is a question a walk should answer, not this record.
+- **Walk status is not kept here.** A Mold earns its `eval.md` and `scenarios.md` after a first walk, not before, so the validator's missing-companion warnings are the closest thing to a walk-status surface. They are meant to stand until a walk closes them, and clearing one by authoring would remove the signal without changing the fact.
 
-- 34 current candidate Molds total in `content/molds/` (Galaxy validation split into step/workflow Molds; interface/data-flow design is source-target specific; `find-test-data` included; corpus Mold renamed/reframed as `compare-against-iwc-exemplar`; `discover-shed-tool` graduated from "Not Molds"; whole-CLI catalogs are reference content, not Molds).
-- Source-summarization tier: 4 Molds. Paper and interview starts converge on `freeform-summary`; Nextflow and CWL keep their structured summaries.
-- Interface/data-flow tier: source-target Markdown design-brief Molds, currently split for Nextflow and CWL Galaxy paths and for Nextflow-to-CWL; paper paths stay combined until examples justify a split.
-- Galaxy-target tier: source-specific Galaxy template Molds (`nextflow-summary-to-galaxy-template`, `cwl-summary-to-galaxy-template`, `freeform-summary-to-galaxy-template`), `advance-galaxy-draft-step` (per-step orchestrator wrapping `discover-shed-tool`, `summarize-galaxy-tool`, `author-galaxy-tool-wrapper`, `implement-galaxy-tool-step` as leaves), `implement-galaxy-workflow-test`, `validate-galaxy-workflow`, `run-workflow-test`, `debug-galaxy-workflow-output`, `compare-against-iwc-exemplar` — used by all Galaxy-targeting pipelines.
-- CWL-target tier: `summary-to-cwl-template`, `summarize-cwl-tool`, `implement-cwl-tool-step`, `implement-cwl-workflow-test`, `validate-cwl`, `run-workflow-test`, `debug-cwl-workflow-output` — used by 2 CWL-targeting pipelines.
-- CLI command tier: `content/cli/<tool>/<command>.md` — referenced by action Molds through typed references and cast as sidecars when needed.
+## Open questions
 
-## What this list is for
-
-This list exists to keep the Mold inventory and pipeline coverage understandable. The metadata schema is carried by the shared `@galaxy-foundry/note-schema` zod contract plus the `reference_contract.yml` registry; [[mold-spec]] is the Mold authoring contract, and [[casting]] is the design narrative for casting and reference dispatch. Suggested first walks, in priority order:
-
-1. `summarize-paper` — most novel, most uncertain, exercises source-summarization shape and IO-schema reference.
-2. `implement-galaxy-tool-step` — runs in inner loop, pulls heavily from pattern pages and corpus, exercises wiki-link resolution and condensation.
-3. `advance-galaxy-draft-step` — exercises orchestrator-shaped Mold, CLI-manual-page reference, per-step loop oracle, and failure routing; surfaces what an orchestrator needs from its leaves and CLI sidecars.
-4. `validate-galaxy-workflow` — exercises terminal Galaxy validation separate from the per-step loop.
-
-After those four, the remaining work is not inventing the reference schema from scratch; it is tightening [[mold-spec]], migrating legacy reference fields where useful, and verifying that the `references:` manifest gives generated skills enough progressive-disclosure and evidence metadata to behave well.
+- Does `axis` need a pair form for source × target Molds, or do one value plus the artifact contracts carry enough?
+- `tool-specific` has no member. Does it survive the next ten Molds, or was the fourth value speculative?
+- Is the CWL-target lag a deliberate scope decision or an unclosed gap? The pipelines disagree with each other today.
+- Do the run/debug Molds survive their first walk as Molds?


### PR DESCRIPTION
> Opened by Claude (AI assistant) on jmchilton's behalf — they did not write this text.

`content/meta/molds.md` carried a hand-kept Mold catalog. It was the fourth copy of the same list, and it had drifted: the `Counts and reuse` section claimed **34 current candidate Molds** while `content/molds/` held **47**.

The other three copies are all maintained:

- `content/molds/` — the membership itself.
- `content/Index.md` and `content/Dashboard.md` — generated from frontmatter, with summaries.
- `content/meta/harness-pipelines.md` — every phase listed per pipeline, plus a `Cross-pipeline observations` section grouped by the same axes.

## The stance

Adopted from the sibling [Statistical Genomics Foundry](https://jmchilton.github.io/statistical-genomics-foundry/), whose `molds.md` declines to carry membership and says why:

> It does not list the Molds that exist; `content/molds/` and the Mold browse answer that, and a list restated here would go stale the first time one was authored.

That is the drift above, predicted. This record now owns the **shape** of the Mold set — the axes, the boundary that decides whether knowledge becomes a Mold at all, where the set is uneven, and the open questions. Structure follows the sibling's: axes → Mold-or-reference boundary → direction → open questions.

175 → 62 lines.

## Kept, because it lives nowhere else

- The Mold/reference boundary and the `Not Molds` list.
- **Wrapping a CLI is not a disqualifier** — `discover-shed-tool`, `advance-galaxy-draft-step`, `validate-galaxy-workflow`, `run-workflow-test` all wrap CLIs and are Molds.
- The `compare-against-iwc-exemplar` worked example, condensed. It is the case that could have gone either way, which is what makes it worth keeping.

Dropped `## Generated skill bodies` as well — it restated `casting.md:21`.

## Two stale claims the rewrite forced

**`axis` is schema.** The doc said "This isn't a frontmatter schema; it's a mental model for grouping." It is a required enum with conditional companion fields (`packages/note-schema/src/types/mold/schema.ts:108`, with the coherence rules at 121–133). Now stated correctly, plus the observation that the enum records one specialization rather than a pair: source × target Molds like `nextflow-summary-to-galaxy-interface` declare `source-specific` and leave the target to the Mold's name and its artifact contracts.

**`tool-specific` has no member.** Across all 47 Molds: 27 `source-specific`, 18 `target-specific`, 2 `generic`, 0 `tool-specific`. Described as "reserved for a future action" since the file was written. Now said out loud and raised as an open question.

## Direction replaces the first-walks list

The old `What this list is for` closed with four suggested first walks in priority order. That had gone stale too — three of the four already carry `eval.md` and `scenarios.md`.

Rather than mint a replacement list that rots the same way, the new section states properties of the set that membership does not show: the Galaxy target running well ahead of CWL (four `galaxy-test-plan` producers against one `cwl-test-plan` producer, which is Nextflow-sourced — see #448), the run/debug tier being deliberately thin, and walk status living in the validator's missing-companion warnings rather than here.

## Also

`harness-pipelines.md:15` claimed "the union of phases across pipelines is the Mold catalog." Line 59 of the same file contradicts it — leaf Molds invoked inside `advance-galaxy-draft-step` are independently castable without appearing as a phase. Fixed to point at `content/molds/` for membership.

One-line descriptions in `README.md` and `AGENTS.md` updated to match.

## Verification

`npm run validate` → **0 errors, 49 warnings**, warning count identical to the `main` baseline. `make check-generated` clean. `npm run test` → 302 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
