### PR TITLE
The gallery renders the kit's cases in this instance's theme

### DIFF
--- a/site/src/components/GallerySpecimen.astro
+++ b/site/src/components/GallerySpecimen.astro
@@ -1,0 +1,38 @@
+---
+import { specimenPath, type Specimen, type SpecimenGroup } from "@galaxy-foundry/site-kit/specimens";
+
+/**
+ * The frame around one specimen: what it is called, what it is evidence of, and the thing itself.
+ *
+ * The `why` line is not decoration. Several of these cases render correctly as nothing much — a
+ * card with no accent bar, a header with no overflow button, a component that emits no markup at
+ * all — and a gallery that shows only the result cannot tell a reader which of those is the point
+ * and which is a fault.
+ */
+interface Props {
+  group: SpecimenGroup;
+  specimen: Specimen;
+}
+
+const { group, specimen } = Astro.props;
+// `/` is legal in an id and awkward in a fragment, so the address the kit derives is spelled once
+// more here rather than twice differently.
+const anchor = specimenPath(group, specimen).replace("/", "--");
+---
+
+<section id={anchor} class="not-prose mb-8 scroll-mt-24">
+  <header class="mb-3">
+    <h3 class="text-base font-bold" style="color: var(--color-text-primary)">
+      <a href={`#${anchor}`} class="no-underline hover:underline">{specimen.name}</a>
+    </h3>
+    <p class="mt-1 max-w-[70ch] text-sm leading-relaxed" style="color: var(--color-text-secondary)">
+      {specimen.why}
+    </p>
+  </header>
+  <div
+    class="rounded-lg border p-4"
+    style="border-color: var(--color-border-subtle); background: var(--color-surface)"
+  >
+    <slot />
+  </div>
+</section>

--- a/site/src/lib/gallery.ts
+++ b/site/src/lib/gallery.ts
@@ -1,0 +1,59 @@
+import { contractKeys } from "@galaxy-foundry/reference-contract";
+import type { ReferenceContractProps } from "@galaxy-foundry/site-kit";
+import type { Specimen, SpecimenGroup } from "@galaxy-foundry/site-kit/specimens";
+
+import { referenceContract } from "./registries";
+
+/**
+ * This instance's own specimens, in the shape the kit ships.
+ *
+ * The kit's specimens are authored against a contract of their own, and they have to be: half of
+ * them are about terms no real instance declares. What they cannot show is OUR vocabulary — and
+ * the accent bar on a reference card is the one part of that component this repo styles, in
+ * `global.css`, by naming three of our seven kinds.
+ *
+ * Three of seven is not a fact this repo checks anywhere. It is two lists — the kinds in
+ * `reference_contract.yml` and the selectors in a stylesheet — that nothing compares, and a kind
+ * added to the contract gets the brand fallback with nobody deciding that. So this group renders
+ * every kind we declare, derived from the contract rather than listed here, and the page shows
+ * which ones a rule reaches.
+ *
+ * That is what a per-instance gallery is FOR. The kit's specimens are the same everywhere; these
+ * are only true here.
+ */
+const kindSpecimen = (kind: string): Specimen<ReferenceContractProps> => {
+  const term = referenceContract.kinds[kind];
+  return {
+    id: kind,
+    name: term?.label ?? kind,
+    why: term?.description ?? `The \`${kind}\` kind.`,
+    props: {
+      contract: referenceContract,
+      // No `resolveRef`: the ref below names no note in this corpus, and a resolver would render
+      // it as a dangling link — a defect of the specimen rather than a case worth showing. Left
+      // unresolved, the card prints the ref as an author wrote it, which is the other real state.
+      references: [
+        {
+          kind,
+          ref: `[[a-${kind}-reference]]`,
+          used_at: "runtime",
+          load: "upfront",
+          mode: "verbatim",
+          evidence: "corpus-observed",
+        },
+      ],
+    },
+  };
+};
+
+export const KIND_TINT_SPECIMENS: SpecimenGroup<ReferenceContractProps> = {
+  // Not the kit group's `reference-contract`: same component, different group, and `id` is the
+  // address both sections and both route prefixes are built from.
+  id: "foundry-kinds",
+  component: "ReferenceContract",
+  importPath: "@galaxy-foundry/site-kit/ReferenceContract.astro",
+  summary:
+    "Every kind this instance declares, one card each. The accent bar is ours — `global.css` names three of them, and the rest take the brand fallback. Which is which is visible here and nowhere else.",
+  surface: "inline",
+  specimens: contractKeys(referenceContract, "kinds").map(kindSpecimen),
+};

--- a/site/src/pages/design/index.astro
+++ b/site/src/pages/design/index.astro
@@ -49,6 +49,23 @@ const groups = await Promise.all(
       </div>
     </section>
   ))}
+
+  <section class="design-doc-section" aria-labelledby="design-gallery">
+    <div class="design-section-heading">
+      <div>
+        <h2 id="design-gallery">The components these pages are drawn with</h2>
+        <p>
+          Every case <code>@galaxy-foundry/site-kit</code> says its components handle, rendered in
+          this instance's theme — plus one group that is ours alone: every kind we declare, one card
+          each, which is where a kind taking the brand fallback becomes visible.
+        </p>
+      </div>
+      <span class="font-mono">live</span>
+    </div>
+    <p>
+      <a href={`${base}/gallery/`}>Open the gallery</a>
+    </p>
+  </section>
 </Base>
 
 <style>

--- a/site/src/pages/gallery/[...specimen].astro
+++ b/site/src/pages/gallery/[...specimen].astro
@@ -1,0 +1,89 @@
+---
+// `global.css` FIRST, as in `layouts/Base.astro` — import order decides where Astro puts the
+// <link>, and these pages do not go through that layout. They cannot: one of the two components
+// below IS the layout, and the other has to sit in a document with nothing else in it.
+import "../../styles/global.css";
+
+import SiteHeader from "@galaxy-foundry/site-kit/SiteHeader.astro";
+import SiteShell from "@galaxy-foundry/site-kit/SiteShell.astro";
+import {
+  HEADER_SPECIMENS,
+  SHELL_SPECIMENS,
+  SPECIMENS,
+  sharesPage,
+  specimenPath,
+} from "@galaxy-foundry/site-kit/specimens";
+
+import { base } from "../../lib/site-base";
+
+/**
+ * A page per specimen that cannot share one.
+ *
+ * The route list is derived from the kit's own `surface`, not from a list here — a group that
+ * changes its answer gets a route, or stops getting one, without this file being edited. What this
+ * file does hold is which component renders which, and that is checked below rather than assumed:
+ * a new non-inline group with no branch here would otherwise emit a route that renders an empty
+ * page, which looks exactly like a specimen whose case is "renders nothing".
+ */
+export function getStaticPaths() {
+  return SPECIMENS.filter((group) => !sharesPage(group)).flatMap((group) =>
+    group.specimens.map((specimen) => ({
+      params: { specimen: specimenPath(group, specimen) },
+      props: { groupId: group.id, id: specimen.id },
+    })),
+  );
+}
+
+const { groupId, id } = Astro.props;
+
+const shell =
+  groupId === SHELL_SPECIMENS.id
+    ? SHELL_SPECIMENS.specimens.find((specimen) => specimen.id === id)
+    : undefined;
+const header =
+  groupId === HEADER_SPECIMENS.id
+    ? HEADER_SPECIMENS.specimens.find((specimen) => specimen.id === id)
+    : undefined;
+if (!shell && !header) {
+  throw new Error(`gallery has no standalone route for ${groupId}/${id}`);
+}
+---
+
+{
+  shell ? (
+    <SiteShell {...shell.props}>
+      <h1>{shell.name}</h1>
+      <p>{shell.why}</p>
+      <p>
+        A <code>SiteShell</code> specimen from the Foundry gallery. The chrome above and below is the
+        component; this column is its slot.
+      </p>
+      <p>
+        <a href={`${base}/gallery/#${SHELL_SPECIMENS.id}`}>Back to the gallery</a>
+      </p>
+    </SiteShell>
+  ) : (
+    <html lang="en">
+      <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>{header?.name} - Foundry gallery</title>
+        {/* Not in the search index, and there is no `<main>` here to mark. The list in
+            `tests/built-shell.test.ts` is what makes that a decision rather than an oversight. */}
+        <meta name="robots" content="noindex" />
+        {/* The shell's own pre-paint script, because this page is framed INSIDE a page that ran
+            it. Reading only `prefers-color-scheme` here renders a dark header in a light gallery
+            for any reader who chose light against a dark OS — and the toggle in the header being
+            demonstrated writes `localStorage.theme`, so the frame would ignore its own component. */}
+        <script is:inline>
+          {`const dark = localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches);
+document.documentElement.classList.toggle('dark', dark);
+document.documentElement.dataset.pfTheme = dark ? 'dark' : 'light';`}
+        </script>
+      </head>
+      <body style="background: var(--color-surface)">
+        <SiteHeader {...header!.props} />
+      </body>
+    </html>
+  )
+}

--- a/site/src/pages/gallery/index.astro
+++ b/site/src/pages/gallery/index.astro
@@ -1,0 +1,155 @@
+---
+import type { ReferenceContractProps, SiteFooterProps } from "@galaxy-foundry/site-kit";
+import ReferenceContract from "@galaxy-foundry/site-kit/ReferenceContract.astro";
+import SiteFooter from "@galaxy-foundry/site-kit/SiteFooter.astro";
+import {
+  FOOTER_SPECIMENS,
+  HEADER_SPECIMENS,
+  REFERENCE_SPECIMENS,
+  SHELL_SPECIMENS,
+  SPECIMENS,
+  sharesPage,
+  specimenPath,
+  type Specimen,
+  type SpecimenGroup,
+} from "@galaxy-foundry/site-kit/specimens";
+
+import GallerySpecimen from "../../components/GallerySpecimen.astro";
+import Base from "../../layouts/Base.astro";
+import { KIND_TINT_SPECIMENS } from "../../lib/gallery";
+import { base } from "../../lib/site-base";
+
+// The shell's components, rendered in THIS instance's theme.
+//
+// Nothing on this page supplies a colour. The kit names six tokens and three classes and defines
+// none of them, so what a reader sees below is `global.css` — the same file every other page here
+// is drawn with. That is the whole of what makes this gallery ours rather than a copy of the
+// package's: run the same specimens under a sibling instance's stylesheet and the same data is a
+// different page.
+//
+// Which groups may share this page is the KIT's answer and not ours — `sharesPage`. A header
+// carries document-unique ids, so two on one page is one working overflow menu and one that binds
+// nothing at all, and it renders cleanly either way. Those go in frames.
+const referenceGroups: SpecimenGroup<ReferenceContractProps>[] = [
+  REFERENCE_SPECIMENS,
+  KIND_TINT_SPECIMENS,
+];
+const footerGroups: SpecimenGroup<SiteFooterProps>[] = [FOOTER_SPECIMENS];
+const framedGroups: SpecimenGroup[] = [HEADER_SPECIMENS, SHELL_SPECIMENS];
+const inlineGroups: SpecimenGroup[] = [...referenceGroups, ...footerGroups];
+
+// A group the kit adds, or one that changes its surface, belongs in exactly one of the lists above
+// and this page has nothing to say about it either way. Better a build that stops than a gallery
+// that quietly stops covering the kit.
+const covered = [...inlineGroups, ...framedGroups].map((group) => group.id);
+const uncovered = SPECIMENS.filter((group) => !covered.includes(group.id));
+if (uncovered.length > 0) {
+  throw new Error(`gallery has no section for: ${uncovered.map((g) => g.id).join(", ")}`);
+}
+for (const group of inlineGroups) {
+  if (!sharesPage(group)) {
+    throw new Error(`${group.id} declares \`${group.surface}\` and cannot share a page`);
+  }
+}
+
+// The same address the standalone route is built at. Derived from the kit rather than spelled
+// again, so a frame cannot point somewhere the route is not.
+const specimenHref = (group: SpecimenGroup, specimen: Specimen): string =>
+  `${base}/gallery/${specimenPath(group, specimen)}/`;
+
+// The group's own id, not its component name: this page renders two `ReferenceContract` groups —
+// the kit's cases and ours — and a name-derived anchor gave both the same one.
+const groupAnchor = (group: SpecimenGroup): string => group.id;
+const allGroups = [...inlineGroups, ...framedGroups];
+---
+
+<Base
+  title="Gallery"
+  description="The site-kit components, every case they handle, rendered in this instance's theme."
+  searchable={false}
+>
+  <h1>Gallery</h1>
+  <p>
+    Every case <code>@galaxy-foundry/site-kit</code> says its components handle, rendered here in this
+    instance's theme. The props come from the package; the colours, the type and the spacing are ours.
+    A sibling Foundry running the same specimens gets a different page from the same data.
+  </p>
+
+  <ul class="not-prose my-6 grid gap-2 sm:grid-cols-2">
+    {
+      allGroups.map((group) => (
+        <li
+          class="rounded-lg border p-3"
+          style="border-color: var(--color-border-subtle); background: var(--color-surface-raised)"
+        >
+          <a href={`#${groupAnchor(group)}`} class="font-bold no-underline hover:underline">
+            {group.component}
+          </a>
+          <span class="ml-2 text-xs uppercase tracking-wider" style="color: var(--color-text-muted)">
+            {group.specimens.length} · {group.surface}
+          </span>
+          <p class="mt-1 text-sm leading-snug" style="color: var(--color-text-secondary)">
+            {group.summary}
+          </p>
+        </li>
+      ))
+    }
+  </ul>
+
+  {
+    referenceGroups.map((group) => (
+      <section id={groupAnchor(group)} class="scroll-mt-24">
+        <h2>{group.component}</h2>
+        <p>{group.summary}</p>
+        {group.specimens.map((specimen) => (
+          <GallerySpecimen group={group} specimen={specimen}>
+            <ReferenceContract {...specimen.props} />
+          </GallerySpecimen>
+        ))}
+      </section>
+    ))
+  }
+
+  {
+    footerGroups.map((group) => (
+      <section id={groupAnchor(group)} class="scroll-mt-24">
+        <h2>{group.component}</h2>
+        <p>{group.summary}</p>
+        {group.specimens.map((specimen) => (
+          <GallerySpecimen group={group} specimen={specimen}>
+            <SiteFooter {...specimen.props} />
+          </GallerySpecimen>
+        ))}
+      </section>
+    ))
+  }
+
+  {
+    framedGroups.map((group) => (
+      <section id={groupAnchor(group)} class="scroll-mt-24">
+        <h2>{group.component}</h2>
+        <p>
+          {group.summary} Each is a page of its own — <code>{group.surface}</code> means it cannot
+          share this one — so the frames below are the real routes, at whatever width this column
+          gives them.
+        </p>
+        {group.specimens.map((specimen) => (
+          <GallerySpecimen group={group} specimen={specimen}>
+            <iframe
+              src={specimenHref(group, specimen)}
+              title={`${group.component}: ${specimen.name}`}
+              loading="lazy"
+              class="block h-96 w-full rounded border-0"
+              style="background: var(--color-surface)"
+            />
+            <p class="mt-2 text-xs">
+              <a href={specimenHref(group, specimen)}>
+                Open {specimenPath(group, specimen)} full width
+              </a>
+            </p>
+          </GallerySpecimen>
+        ))}
+      </section>
+    ))
+  }
+</Base>

--- a/tests/built-shell.test.ts
+++ b/tests/built-shell.test.ts
@@ -239,20 +239,14 @@ describe("the palette this stylesheet declares", () => {
   // from `:root`, used nowhere.
   it("declares no token that reaches no stylesheet", () => {
     const source = read(path.join(SITE, "src/styles/global.css"));
-    const block = source.slice(
-      source.indexOf("@theme"),
-      source.indexOf("\n}", source.indexOf("@theme")),
-    );
+    const block = source.slice(source.indexOf("@theme"), source.indexOf("\n}", source.indexOf("@theme")));
     const declared = [...block.matchAll(/^\s*(--[\w-]+):/gm)].map((m) => m[1]!);
 
     const css = emittedCss();
     const root = (css.match(/:root[^{]*\{[^}]*\}/g) ?? []).join("");
     const dead = declared.filter((token) => !root.includes(`${token}:`));
 
-    expect(
-      declared.length,
-      "\nno tokens parsed out of @theme — has the block moved?",
-    ).toBeGreaterThan(20);
+    expect(declared.length, "\nno tokens parsed out of @theme — has the block moved?").toBeGreaterThan(20);
     expect(
       dead,
       "\nthese are declared in `@theme` and referenced by nothing, so Tailwind emitted no" +
@@ -484,5 +478,34 @@ describe("what the search box can find", () => {
 
   it("puts the attribute on <main>, so chrome stays out of the excerpt", () => {
     expect(home).toMatch(/<main[^>]*\sdata-pagefind-body/);
+  });
+});
+
+describe("the gallery", () => {
+  // The one route on this site that nothing generates a link to. Every other page hangs off a
+  // collection, a tag or the nav, so an unreachable one would have to be built by hand — which is
+  // exactly what this is. It went out with no inbound link at all and looked completely finished:
+  // the routes emit, the frames render, and the only symptom is that no reader ever arrives.
+  const galleryIndex = () => read(path.join(DIST, "gallery/index.html"));
+
+  it("is linked from a page a reader can get to", () => {
+    const href = `${baseFrom(home)}/gallery/`;
+    const design = read(path.join(DIST, "design/index.html"));
+    expect(hrefsIn(design), "\nthe design record no longer links the gallery").toContain(href);
+  });
+
+  it("frames only routes the build emitted", () => {
+    // A frame whose src is a 404 renders as an empty box, which is indistinguishable from a
+    // specimen whose case is "renders nothing" — the ambiguity the specimens exist to remove.
+    const base = baseFrom(home);
+    const framed = [...galleryIndex().matchAll(/<iframe\s[^>]*src="([^"]+)"/g)].flatMap((m) =>
+      m[1] ? [m[1]] : [],
+    );
+
+    expect(framed.length, "\nno frames on the gallery index").toBeGreaterThan(0);
+    const missing = framed.filter(
+      (src) => !existsSync(path.join(DIST, src.slice(base.length), "index.html")),
+    );
+    expect(missing, "\nframed routes the build never emitted").toEqual([]);
   });
 });

--- a/tests/built-shell.test.ts
+++ b/tests/built-shell.test.ts
@@ -106,12 +106,36 @@ const read = (file: string): string => {
   return text;
 };
 
+/**
+ * Pages that are one component in an empty document, on purpose.
+ *
+ * The gallery gives a page of its own to every specimen the kit marks `isolated` — its word for
+ * valid markup carrying document-unique ids, which two of on one page leaves silently half-dead —
+ * and the index shows them in frames. Wrapping those in the shell would put a header above the
+ * header being demonstrated, and the frame would be a picture of the site rather than of the
+ * component.
+ *
+ * Only the two assertions about the shell's own furniture skip these. The theme script is NOT
+ * excused: a framed header that ignores the theme the reader chose is wrong exactly the way any
+ * other page would be.
+ */
+const COMPONENT_PAGES = [
+  "gallery/site-header/active-below-a-section/index.html",
+  "gallery/site-header/active-under-more/index.html",
+  "gallery/site-header/everything-fits/index.html",
+  "gallery/site-header/long-wordmark/index.html",
+  "gallery/site-header/overflows/index.html",
+  "gallery/site-header/sibling-prefix/index.html",
+];
+
 let pages: string[];
+let sitePages: string[];
 let home: string;
 
 beforeAll(() => {
   ensureBuilt();
   pages = builtPages();
+  sitePages = pages.filter((file) => !COMPONENT_PAGES.includes(rel(file)));
   home = read(path.join(DIST, "index.html"));
 }, 600_000);
 
@@ -121,8 +145,18 @@ describe("the document shell, on every page the build emitted", () => {
     expect(pages.length).toBeGreaterThan(300);
   });
 
+  it("excuses only routes the build still emits", () => {
+    // An entry left behind after its route is renamed excuses a page that no longer exists, and
+    // goes on excusing whatever takes its path later.
+    const emitted = new Set(pages.map(rel));
+    expect(
+      COMPONENT_PAGES.filter((page) => !emitted.has(page)),
+      "\nstale exemptions",
+    ).toEqual([]);
+  });
+
   it("offers a skip link that lands on a target that exists", () => {
-    const broken = pages.filter((file) => {
+    const broken = sitePages.filter((file) => {
       const html = read(file);
       return !html.includes('href="#main"') || !html.includes('id="main"');
     });
@@ -149,7 +183,7 @@ describe("the document shell, on every page the build emitted", () => {
   });
 
   it("carries a header and a footer", () => {
-    const broken = pages.filter((file) => {
+    const broken = sitePages.filter((file) => {
       const html = read(file);
       return !html.includes("<header") || !html.includes("<footer");
     });
@@ -205,14 +239,20 @@ describe("the palette this stylesheet declares", () => {
   // from `:root`, used nowhere.
   it("declares no token that reaches no stylesheet", () => {
     const source = read(path.join(SITE, "src/styles/global.css"));
-    const block = source.slice(source.indexOf("@theme"), source.indexOf("\n}", source.indexOf("@theme")));
+    const block = source.slice(
+      source.indexOf("@theme"),
+      source.indexOf("\n}", source.indexOf("@theme")),
+    );
     const declared = [...block.matchAll(/^\s*(--[\w-]+):/gm)].map((m) => m[1]!);
 
     const css = emittedCss();
     const root = (css.match(/:root[^{]*\{[^}]*\}/g) ?? []).join("");
     const dead = declared.filter((token) => !root.includes(`${token}:`));
 
-    expect(declared.length, "\nno tokens parsed out of @theme — has the block moved?").toBeGreaterThan(20);
+    expect(
+      declared.length,
+      "\nno tokens parsed out of @theme — has the block moved?",
+    ).toBeGreaterThan(20);
     expect(
       dead,
       "\nthese are declared in `@theme` and referenced by nothing, so Tailwind emitted no" +
@@ -384,7 +424,24 @@ describe("the container width", () => {
  * an absence has to be a DECISION — without one, "deliberately out of the index" and "nobody
  * thought about this route" are the same observation, which is how 132 of them accumulated.
  */
-const UNSEARCHABLE: string[] = [];
+const UNSEARCHABLE: string[] = [
+  // The gallery. Its pages are the kit's components rendered against invented props — a contract
+  // with two made-up kinds, a nav of seven links that go nowhere, a note that moved. Every word on
+  // them is bait: a reader searching "trimming reads" wants the note, not the card that demonstrates
+  // what a card looks like. So the gallery index and the specimens that get a route of their own
+  // stay out of the site's own index.
+  //
+  // `gallery/site-shell/searchable` is deliberately NOT here. That specimen's whole case is that a
+  // searchable shell marks its column, and the way to be sure it does is that Pagefind finds it.
+  "gallery/index.html",
+  "gallery/site-header/active-below-a-section/index.html",
+  "gallery/site-header/active-under-more/index.html",
+  "gallery/site-header/everything-fits/index.html",
+  "gallery/site-header/long-wordmark/index.html",
+  "gallery/site-header/overflows/index.html",
+  "gallery/site-header/sibling-prefix/index.html",
+  "gallery/site-shell/unsearchable/index.html",
+];
 
 describe("what the search box can find", () => {
   // The contract nothing checked, and the one place where reading the source tells you nothing.


### PR DESCRIPTION
`@galaxy-foundry/site-kit` 0.5.0 ships the cases its components handle, as props. This builds the gallery that renders them — in **this** instance's theme, which is the whole of what makes it ours rather than a copy of the package's.

Reachable from the design record: **Design Record → The components these pages are drawn with**.

## What the page is

Nothing here supplies a colour. The kit names tokens and defines none, so what a reader sees is `global.css` — the same file every other page on this site is drawn with. Run the same specimens under a sibling Foundry's stylesheet and the same data is a different page.

Eighteen cases from the package across four groups, plus one group that is ours alone.

## The group that is ours

**Every kind this instance declares, one card each.** `global.css` tints three of our seven — `research`, `schema`, `pattern` — and the other four take the brand fallback. That was two lists nothing compared: the kinds in `reference_contract.yml` and the selectors in a stylesheet. A kind added to the contract got the fallback with nobody deciding it. The specimens are derived from the contract rather than listed, so the page is now where that is visible.

This is what a per-instance gallery is *for*. The kit's specimens are the same everywhere; these are only true here.

## Which groups may share a page is the kit's answer

`sharesPage(group)` decides, not this repo. Two `SiteHeader`s on one page is two `#nav-more-trigger` and two `#theme-toggle` — the second header's menu and theme button silently bind nothing — so those get a route each and appear on the index in frames. `SiteShell` emits its own `<html>` and gets the same treatment for a harder reason.

The build **stops** if a group appears in no section, or if an inline list holds one that cannot share. A gallery that quietly stops covering the kit is worth a build error.

## A defect the gallery found in itself

The framed specimen pages read only `prefers-color-scheme`, while the component being framed is the theme toggle that writes `localStorage.theme`. A reader who chose light against a dark OS got a dark header inside a light gallery. They now run the shell's own pre-paint script.

(The gallery also found a defect in the package — two `ReferenceContract` groups collided on one anchor, since a component name is not an address. Fixed upstream in jmchilton/foundry-lib#65, which is why groups now carry an `id`.)

## Test changes worth reading

**`UNSEARCHABLE` is no longer empty.** The gallery index and the specimen routes stay out of the search index on purpose: their words are bait, and a reader searching "trimming reads" wants the note, not the card demonstrating what a card looks like. `gallery/site-shell/searchable` is deliberately *in* — Pagefind finding it is what proves that specimen's case.

**Two shell assertions now run over site pages rather than every emitted page.** The six framed header specimens carry no skip link and no footer by design; wrapping them in the shell puts a header above the header being shown. They are listed in `COMPONENT_PAGES`, and a new test fails if an entry names a route the build no longer emits. The pre-paint theme assertion is *not* excused — see above.

**Two new assertions for reachability.** The gallery shipped complete and unlinked in the first draft: routes emitted, frames rendered, no way in. Every other page here hangs off a collection, a tag or the nav, so this is the one route that has to be linked by hand. One assertion holds the design record's link; the other checks every frame points at a route the build emitted, because a frame whose src 404s renders as an empty box — indistinguishable from a specimen whose case is "renders nothing".

## Verified

`astro check` 0 errors, root `tsc --noEmit` clean, 383 pages built (up from 374), all nine gallery routes emitted, 305 tests passing.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
