### PR TITLE
Ask the token assertions of :root, where the light theme lives

### DIFF
--- a/tests/built-shell.test.ts
+++ b/tests/built-shell.test.ts
@@ -173,6 +173,16 @@ const emittedCss = (): string =>
     .map((entry) => read(path.join(DIST, "_astro", entry)))
     .join("\n");
 
+/**
+ * The `:root` declarations alone — the light theme, and the only place a "did this token survive"
+ * question can be asked honestly.
+ *
+ * `.dark` is a class, and a class is not tree-shaken. A token declared under it emits whether or
+ * not anything reads it, so the same token missing from `:root` is invisible to any search of the
+ * whole file. Both assertions that ask about tokens go through here.
+ */
+const rootCss = (): string => (emittedCss().match(/:root[^{]*\{[^}]*\}/g) ?? []).join("");
+
 describe("the stylesheet the shell depends on", () => {
   it("emits a utility that only the kit names", () => {
     const css = emittedCss();
@@ -208,9 +218,7 @@ describe("the palette this stylesheet declares", () => {
     const block = source.slice(source.indexOf("@theme"), source.indexOf("\n}", source.indexOf("@theme")));
     const declared = [...block.matchAll(/^\s*(--[\w-]+):/gm)].map((m) => m[1]!);
 
-    const css = emittedCss();
-    const root = (css.match(/:root[^{]*\{[^}]*\}/g) ?? []).join("");
-    const dead = declared.filter((token) => !root.includes(`${token}:`));
+    const dead = declared.filter((token) => !rootCss().includes(`${token}:`));
 
     expect(declared.length, "\nno tokens parsed out of @theme — has the block moved?").toBeGreaterThan(20);
     expect(
@@ -235,15 +243,22 @@ describe("the tokens the licence components name", () => {
   // Worth asserting here rather than trusting the move, because these three used to be literals
   // INSIDE the component — `#16a34a`, `#d97706`, `#dc2626`. Nothing had to be declared for them to
   // work, and the adoption is exactly the moment that stops being true.
-  it("declares every one, in the stylesheet the build emitted", () => {
-    const css = emittedCss();
+  it("declares every one where the light theme can reach it", () => {
+    // `:root`, for the reason the palette block above spells out, and this is the second time that
+    // trap has been walked into rather than the first. Asked of the whole emitted stylesheet, this
+    // passes with a token declared ONLY under `.dark`: the class is not tree-shaken, so the search
+    // finds the dark value and reports the light one healthy. Every chip on the site then renders
+    // backgroundless in light mode and correct in dark, which is close to the least likely
+    // combination to be noticed in review.
+    const root = rootCss();
 
-    expect(css).not.toHaveLength(0);
-    expect(licenseBadgeStyleGaps(css), "\ntokens the badge reads and this site never declares").toEqual(
-      [],
-    );
+    expect(root).not.toHaveLength(0);
     expect(
-      licenseFileStyleGaps(css),
+      licenseBadgeStyleGaps(root),
+      "\ntokens the badge reads and this site never declares",
+    ).toEqual([]);
+    expect(
+      licenseFileStyleGaps(root),
       "\ntokens the licence-file body reads and this site never declares",
     ).toEqual([]);
   });


### PR DESCRIPTION
A defect in the assertion #453 added, found while writing the sibling instance's copy of it — that repo asks this question of `:root` and carries a comment explaining why, because it had already been caught by it once.

## What was wrong

`licenseBadgeStyleGaps` was handed the whole emitted stylesheet. `.dark` is a class, and a class is not tree-shaken — so a token declared **only** under `.dark` is present in that string whether or not `:root` ever got one. The search finds the dark value and reports the light theme healthy.

Demonstrated rather than reasoned about. Moving `--color-license-verbatim` out of `@theme` and into `.dark`:

- all **18** assertions in the file passed
- `declares no token that reaches no stylesheet` also passed, correctly — the token is no longer declared in `@theme`, so it is not a dead token
- and every `verbatim OK` chip on the site renders with no background in light mode, correct in dark

That is close to the least likely combination to be caught in review: the reviewer on a dark editor sees nothing wrong.

## The fix

The palette check one screen above was already written about this exact trap — its comment names `--color-rail-on` and `--color-tag-bg-hover` as tokens it caught that way. It extracted `:root` inline. That extraction is now a named `rootCss()` helper, and both assertions go through it.

Re-running the same simulation against the fix fails it, naming the token:

```
tokens the badge reads and this site never declares: expected [ '--color-license-verbatim' ] to deeply equal []
```

## Verification

303 tests across 21 files, `astro check` 0 errors. No source or stylesheet change — this is the test file only.