### PR TITLE
The target names the document a cast writes, and the command keeps only what Galaxy can answer

### DIFF
--- a/casts/claude/_target.yml
+++ b/casts/claude/_target.yml
@@ -18,11 +18,25 @@
 # bundle_path gets one directory per bundle, named for it.
 bundle_path: skills/{mold}
 
-# Required runtime artifacts the generated skill must produce.
-# The deterministic verifier checks these before any agentic review.
-required_outputs:
-  - SKILL.md
-  - _provenance.json
+# What a cast of a Mold is here: the file it writes, and the word it calls itself.
+#
+# Both are Claude's, not casting's. `SKILL.md` is the filename this harness looks for, and
+# `skill` is what it calls what it finds — the caster substitutes the noun for `Mold` through
+# the cast body, so a target shipping something else says so once, here.
+#
+# `_provenance.json` is deliberately absent. The record is the CASTER's account of what it did,
+# and everything that reads a bundle without knowing which target made it finds it by that name.
+document:
+  path: SKILL.md
+  noun: skill
+
+# Required runtime artifacts the generated skill must produce, checked by the deterministic
+# verifier before any agentic review.
+#
+# Not declared, because the default is exactly these two: `document.path` and the provenance
+# record. Spelling them out restated what casting always writes, and a target that merely agrees
+# with the caster has only created somewhere for the two to disagree. Declare this to require
+# something ELSE.
 
 # Per-reference-kind PLACEMENT: where this target puts each kind, and under what extension.
 # `dst` is computed from the source slug; the verifier enforces 1:1.

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@changesets/cli": "^2.31.0",
     "@eslint/js": "^10.0.1",
     "@galaxy-foundry/build-cli": "workspace:*",
-    "@galaxy-foundry/cast": "^0.7.0",
+    "@galaxy-foundry/cast": "^0.9.0",
     "@galaxy-foundry/foundry": "workspace:*",
     "@galaxy-foundry/license-policy": "^0.4.0",
     "@galaxy-foundry/note-schema": "workspace:*",

--- a/packages/build-cli/package.json
+++ b/packages/build-cli/package.json
@@ -37,7 +37,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@galaxy-foundry/cast": "^0.7.0",
+    "@galaxy-foundry/cast": "^0.9.0",
     "@galaxy-foundry/foundry": "workspace:*",
     "@galaxy-foundry/kind-schema": "^0.5.0",
     "@galaxy-foundry/license-policy": "^0.4.0",

--- a/packages/build-cli/src/commands/cast-mold.ts
+++ b/packages/build-cli/src/commands/cast-mold.ts
@@ -16,8 +16,6 @@ import process from "node:process";
 
 import {
   bulletSection,
-  castMold,
-  loadTargetConfig,
   refRows,
   runtimeProcedureBody,
   scalar,
@@ -25,10 +23,9 @@ import {
   skillSummary,
   stripWikiLinks,
   type CastHooks,
-  type CastOutcome,
   type ProvenanceRefEntry,
 } from "@galaxy-foundry/cast";
-import { loadCastReferenceContract } from "@galaxy-foundry/note-schema";
+import { castCommand } from "@galaxy-foundry/cast/command";
 
 import type {
   ProvenanceArtifactInput,
@@ -36,52 +33,13 @@ import type {
   ProvenanceArtifacts,
 } from "../lib/artifact-contract.js";
 import { payloadCompanionOf } from "../lib/dispositions.js";
-import { errorMessage } from "../lib/errors.js";
 import { readMarkdown } from "../lib/frontmatter.js";
-import { sha256File } from "../lib/reconcile.js";
 import { aggregateRequiredTools, requiredToolRows } from "../lib/required-tools.js";
 import { validateRuns } from "../lib/runs-check.js";
 import { buildSlugMap, GALAXY_SLUG_ALIASES } from "../lib/slug-map.js";
-import { bundleDir, castsTargetDir } from "../lib/target-layout.js";
 import type { Frontmatter } from "../lib/types.js";
 import { fileSlug } from "../lib/walk.js";
 import { resolveWikiLink } from "../lib/wiki-links.js";
-
-// ---- argv ----
-
-interface Args {
-  moldName: string;
-  target: string;
-  check: boolean;
-  note: string | null;
-  root: string | null;
-}
-
-function parseArgs(argv: string[]): Args {
-  const positional: string[] = [];
-  let target = "claude";
-  let check = false;
-  let note: string | null = null;
-  let root: string | null = null;
-  for (let i = 0; i < argv.length; i++) {
-    const a = argv[i]!;
-    if (a === "--check") check = true;
-    else if (a.startsWith("--target=")) target = a.slice("--target=".length);
-    else if (a === "--target") target = argv[++i] ?? target;
-    else if (a.startsWith("--note=")) note = a.slice("--note=".length);
-    else if (a === "--note") note = argv[++i] ?? note;
-    else if (a.startsWith("--root=")) root = a.slice("--root=".length);
-    else if (a === "--root") root = argv[++i] ?? ".";
-    else if (!a.startsWith("--")) positional.push(a);
-    else throw new Error(`unknown flag: ${a}`);
-  }
-  if (positional.length !== 1) {
-    throw new Error(
-      'usage: foundry-build cast <mold-name> [--target=claude] [--check] [--note="..."]',
-    );
-  }
-  return { moldName: positional[0]!, target, check, note, root };
-}
 
 // ---- the sidecar this Foundry renders ----
 
@@ -583,111 +541,22 @@ function schemaValidationRows(
  * `errors`: whether a bundle was written is the caster's decision, and a second copy of that
  * decision here could only ever disagree with the first.
  */
-function reportCast(outcome: CastOutcome, check: boolean, repoRoot: string): void {
-  for (const e of outcome.errors) console.error(`error: ${e}`);
-  for (const d of outcome.drift) console.error(`drift: ${d.file} — ${d.reason}`);
-
-  if (check) {
-    if (outcome.errors.length || outcome.drift.length) {
-      console.error(
-        `check failed: ${outcome.errors.length} error(s), ${outcome.drift.length} drift(s)`,
-      );
-      process.exitCode = 1;
-      return;
-    }
-    console.log("clean: no drift, no errors");
-    return;
-  }
-
-  if (!outcome.wrote) {
-    console.error(`refusing to update provenance: ${outcome.errors.length} error(s)`);
-    process.exitCode = 1;
-    return;
-  }
-
-  console.log(`wrote ${path.relative(repoRoot, outcome.wrote)}`);
-  if (outcome.drift.length) console.log(`reconciled ${outcome.drift.length} drifted file(s)`);
-}
-
 export async function runCastMoldCommand(argv = process.argv.slice(2)): Promise<void> {
-  const args = parseArgs(argv);
-  if (args.root) process.chdir(args.root);
-  const repoRoot = process.cwd();
-
-  // Where this Foundry keeps its targets and its Molds. Both are layout facts about this repo,
-  // stated here rather than reached for from inside the caster.
-  const targetDir = castsTargetDir(repoRoot, args.target);
-
-  // A malformed target declaration is an authoring error in a YAML file, same as the contract
-  // below, and reports the same way. The loader checks the kind table nothing else did, so this
-  // catch is the difference between a named message and a stack trace for most of what it finds.
-  let target: ReturnType<typeof loadTargetConfig>;
-  try {
-    target = loadTargetConfig(targetDir);
-  } catch (e) {
-    console.error(errorMessage(e));
-    process.exit(2);
-  }
-
-  const moldRel = path.posix.join("content", "molds", args.moldName, "index.md");
-  const moldAbs = path.join(repoRoot, moldRel);
-  if (!existsSync(moldAbs)) {
-    console.error(`mold source missing: ${moldRel}`);
-    process.exit(2);
-  }
-
-  const moldParsed = readMarkdown(moldAbs);
-  if (moldParsed.meta.type !== "mold") {
-    console.error(`${moldRel}: type is not 'mold' (got ${String(moldParsed.meta.type)})`);
-    process.exit(2);
-  }
-  const moldHash = sha256File(moldAbs);
-
-  const bundleRoot = bundleDir(repoRoot, args.target, args.moldName);
-  const { slugMap, metaByPath } = buildSlugMap(repoRoot, GALAXY_SLUG_ALIASES);
-  const producerIndex = producerIndexFor(metaByPath);
-
-  // A malformed contract is an authoring error in a YAML file, not a bug in the caster, so it
-  // reports like every other bad input here rather than as a stack trace. Same reasoning as
-  // catching a broken companion declaration during resolution: the message is already good, the
-  // delivery was not.
-  let refContract: ReturnType<typeof loadCastReferenceContract>["contract"];
-  let castContract: ReturnType<typeof loadCastReferenceContract>["cast"];
-  try {
-    ({ contract: refContract, cast: castContract } = loadCastReferenceContract(
-      path.join(repoRoot, "reference_contract.yml"),
-    ));
-  } catch (e) {
-    console.error(errorMessage(e));
-    process.exit(2);
-  }
-
-  const outcome = await castMold<{ artifacts?: ProvenanceArtifacts }>({
-    repoRoot,
-    bundleRoot,
-    targetName: args.target,
-    target,
-    mold: {
-      name: args.moldName,
-      path: moldRel,
-      meta: moldParsed.meta,
-      body: moldParsed.body,
-      contentHash: moldHash,
-    },
-    castContract,
-    refKinds: refContract.kinds,
-    slugMap,
-    metaByPath,
+  // Flags, target and contract loading, the Mold's own file, and which of four endings this run
+  // had are all the same for any Foundry that casts, and live in the package. What is left here
+  // is what only this one can answer.
+  await castCommand<{ artifacts?: ProvenanceArtifacts }>(argv, {
+    usage: "foundry-build cast",
+    defaultTarget: "claude",
     hooks: GALAXY_HOOKS,
+    corpus: (repoRoot) => buildSlugMap(repoRoot, GALAXY_SLUG_ALIASES),
     // What this Foundry records in the slot the record reserves beside `refs`. A Mold that
     // declares no handoff supplies `undefined` and the key is simply absent — which is also what
     // a Foundry with no artifacts at all gets, by passing no extensions.
-    extensions: { artifacts: readArtifactContracts(moldParsed.meta, producerIndex) },
-    check: args.check,
-    note: args.note,
+    extensions: ({ meta, corpus }) => ({
+      artifacts: readArtifactContracts(meta, producerIndexFor(corpus.metaByPath)),
+    }),
   });
-
-  reportCast(outcome, args.check, repoRoot);
 }
 
 const isDirectInvocation = import.meta.url === `file://${process.argv[1]}`;

--- a/packages/build-cli/src/commands/cast-mold.ts
+++ b/packages/build-cli/src/commands/cast-mold.ts
@@ -212,13 +212,13 @@ const GALAXY_HOOKS: CastHooks = {
   ],
   skillLede:
     "Follow the procedure below and use the artifact/reference sections as the runtime contract.",
-  skillSections: ({ moldName, meta, body, refs, metaByPath, slugMap }) => {
-    const summary = skillSummary(meta, moldName);
+  skillSections: ({ moldName, meta, body, noun, refs, metaByPath, slugMap }) => {
+    const summary = skillSummary(meta, moldName, noun);
     const artifacts = readArtifactContracts(meta, producerIndexFor(metaByPath));
     const produces = artifacts?.produces ?? [];
     const runtime = refs.filter((r) => r.used_at !== "cast-time");
     const describe = { kindLabel: refKindLabel, modePhrase: refModePhrase };
-    const procedure = runtimeProcedureBody(body, moldName);
+    const procedure = runtimeProcedureBody(body, moldName, noun);
     return [
       bulletSection("When To Use", [`- ${stripWikiLinks(summary)}`]),
       bulletSection(

--- a/packages/note-schema/package.json
+++ b/packages/note-schema/package.json
@@ -37,7 +37,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@galaxy-foundry/cast": "^0.7.0",
+    "@galaxy-foundry/cast": "^0.9.0",
     "@galaxy-foundry/kind-manifest": "^0.4.0",
     "@galaxy-foundry/kind-schema": "^0.5.0",
     "@galaxy-foundry/license-policy": "^0.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
         specifier: workspace:*
         version: link:packages/build-cli
       '@galaxy-foundry/cast':
-        specifier: ^0.7.0
-        version: 0.7.1
+        specifier: ^0.9.0
+        version: 0.9.0
       '@galaxy-foundry/foundry':
         specifier: workspace:*
         version: link:packages/foundry
@@ -100,8 +100,8 @@ importers:
   packages/build-cli:
     dependencies:
       '@galaxy-foundry/cast':
-        specifier: ^0.7.0
-        version: 0.7.1
+        specifier: ^0.9.0
+        version: 0.9.0
       '@galaxy-foundry/foundry':
         specifier: workspace:*
         version: link:../foundry
@@ -183,8 +183,8 @@ importers:
   packages/note-schema:
     dependencies:
       '@galaxy-foundry/cast':
-        specifier: ^0.7.0
-        version: 0.7.1
+        specifier: ^0.9.0
+        version: 0.9.0
       '@galaxy-foundry/kind-manifest':
         specifier: ^0.4.0
         version: 0.4.0(zod@4.4.3)
@@ -1017,8 +1017,8 @@ packages:
   '@fontsource/atkinson-hyperlegible@5.2.8':
     resolution: {integrity: sha512-HciLcJ5DIK/OVOdo71EbEN4NnvDFlp6/SpAxtcbWf2aAdcsOuPqITxj5KNEXb48qSPSdnnZdGGnSJChPKi3/bA==}
 
-  '@galaxy-foundry/cast@0.7.1':
-    resolution: {integrity: sha512-slykgtXCuRVdWvCQoJVr7M7t5rJn2up8+cl7wSdv4k1Txoh5sfydXb//NY0svRI1m4CYfsHUD0M3+pbYKvGbyw==}
+  '@galaxy-foundry/cast@0.9.0':
+    resolution: {integrity: sha512-ydGGOm6NLwdpKD0uuNEni1AetIU692sSX1rzCToaf1PvglFYDP3+KwVSjZxqW4uzoOo0ASaAXF5EbJKXiBC9dQ==}
     engines: {node: '>=20'}
 
   '@galaxy-foundry/kind-manifest@0.4.0':
@@ -4471,7 +4471,7 @@ snapshots:
 
   '@fontsource/atkinson-hyperlegible@5.2.8': {}
 
-  '@galaxy-foundry/cast@0.7.1':
+  '@galaxy-foundry/cast@0.9.0':
     dependencies:
       '@galaxy-foundry/license-policy': 0.4.0
       '@galaxy-foundry/reference-contract': 0.4.0

--- a/tests/cast-mold.test.ts
+++ b/tests/cast-mold.test.ts
@@ -16,7 +16,11 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import yaml from "js-yaml";
 import { describe, expect, it } from "vitest";
-import { PROVENANCE_SCHEMA_VERSION, type CastHooks } from "@galaxy-foundry/cast";
+import {
+  PROVENANCE_SCHEMA_VERSION,
+  type CastHooks,
+  type TargetConfig,
+} from "@galaxy-foundry/cast";
 import { fileSlug } from "../packages/build-cli/src/lib/walk.js";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
@@ -485,7 +489,7 @@ describe("cast-mold prompt refs", () => {
         [
           "provenance_schema_version: 4",
           "bundle_path: skills/{mold}",
-          "required_outputs: [SKILL.md, _provenance.json]",
+          "document: { path: SKILL.md, noun: skill }",
           "kinds:",
           "  prompt:",
           "    dst_dir: references/prompts/",
@@ -572,7 +576,7 @@ describe("the provenance record's shape is the caster's", () => {
           // document announcing a contract nothing writes and nothing validates.
           "provenance_schema_version: 99",
           "bundle_path: skills/{mold}",
-          "required_outputs: [SKILL.md, _provenance.json]",
+          "document: { path: SKILL.md, noun: skill }",
           "kinds:",
           "  prompt:",
           "    dst_dir: references/prompts/",
@@ -790,7 +794,7 @@ describe("cast-mold cli-command meta injection", () => {
         [
           "provenance_schema_version: 4",
           "bundle_path: skills/{mold}",
-          "required_outputs: [SKILL.md, _provenance.json]",
+          "document: { path: SKILL.md, noun: skill }",
           "kinds:",
           "  cli-command:",
           "    dst_dir: references/cli/",
@@ -894,7 +898,7 @@ describe("cast-mold companion files", () => {
       [
         "provenance_schema_version: 4",
         "bundle_path: skills/{mold}",
-        "required_outputs: [SKILL.md, _provenance.json]",
+        "document: { path: SKILL.md, noun: skill }",
         "kinds:",
         "  research:",
         "    dst_dir: references/notes/",
@@ -1414,7 +1418,7 @@ describe("cast-mold negative cases", () => {
         [
           "provenance_schema_version: 4",
           "bundle_path: skills/{mold}",
-          "required_outputs: [SKILL.md, _provenance.json]",
+          "document: { path: SKILL.md, noun: skill }",
           "kinds: {}",
           "skill_constraints:",
           "  frontmatter_required: [name, description]",
@@ -1474,7 +1478,7 @@ describe("cast-mold license → redistribution-policy enforcement", () => {
       [
         "provenance_schema_version: 4",
         "bundle_path: skills/{mold}",
-        "required_outputs: [SKILL.md, _provenance.json]",
+        "document: { path: SKILL.md, noun: skill }",
         "kinds:",
         "  research:",
         "    dst_dir: references/notes/",
@@ -1697,6 +1701,7 @@ describe("the skill document is the sections it was handed", () => {
     const doc = renderSkillMarkdown({
       moldName: "m",
       meta: { summary: "Summarize a thing." },
+      noun: "skill",
       lede: "Lede line.",
       sections: [
         { title: "Second", body: "- b" },
@@ -1734,6 +1739,7 @@ describe("the skill document is the sections it was handed", () => {
     const doc = renderSkillMarkdown({
       moldName: "m",
       meta: { summary: 'Handle a "quoted" [[thing|name]].' },
+      noun: "skill",
       lede: "L",
       sections: [],
     });
@@ -1756,7 +1762,8 @@ describe("the skill document is the sections it was handed", () => {
 // which file beside the note IS the payload. The kind layer holding that answer is this
 // Foundry's, so the answer arrives as a hook — and the caster must never spell the filename.
 describe("the payload a companion strategy ships is the instance's answer", () => {
-  const target = {
+  const target: TargetConfig = {
+    document: { path: "SKILL.md", noun: "skill" },
     required_outputs: [],
     kinds: { prompt: { dst_dir: "references/prompts", dst_extension: ".md", modes: ["verbatim"] } },
     skill_constraints: { frontmatter_required: [], forbidden_runtime_paths: [] },
@@ -1955,7 +1962,7 @@ describe("cast declarations the corpus does not currently exercise", () => {
     return [
       "provenance_schema_version: 4",
       `bundle_path: ${bundlePath}`,
-      "required_outputs: [SKILL.md, _provenance.json]",
+      "document: { path: SKILL.md, noun: skill }",
       "kinds:",
       `  ${kind}:`,
       `    dst_dir: ${dstDir}`,
@@ -2365,7 +2372,7 @@ describe("cast declarations: stricter than before, on purpose", () => {
       [
         "provenance_schema_version: 4",
         "bundle_path: skills/{mold}",
-        "required_outputs: [SKILL.md, _provenance.json]",
+        "document: { path: SKILL.md, noun: skill }",
         "kinds:",
         "  pattern:",
         "    dst_dir: references/patterns/",


### PR DESCRIPTION
`casts/claude/_target.yml` says what a cast of a Mold is here — the file it writes and the word it calls itself — and the cast command drops everything that was never Galaxy's to answer. Stacked on #452, which moved the caster into `@galaxy-foundry/cast`.

`make check-casts` is byte-silent across all 47 Molds, which proves nothing about the leak itself: the oracle re-casts the one instance whose vocabulary `SKILL.md` and "skill" already are. The wrong answer and the right answer are the same bytes here. That is the point — a second Foundry shipping pages or cards is where it shows, and it cannot be caught from inside this repo.

## The target names its own document

```yaml
document:
  path: SKILL.md
  noun: skill
```

Both were written into the caster. `runtimeProcedureBody` substituted "skill" for `Mold` through every cast body and `skillSummary` fell back to it, so a target shipping something else was told by its own documents that it shipped skills.

`required_outputs` goes away rather than moving. The default is exactly `document.path` plus the provenance record, and a target that merely agrees with the caster has only made somewhere for the two to disagree. Eight test fixtures restated the same pair and lose it the same way.

## The command shell is not Galaxy's

Flags, target and contract loading, reading the Mold's own file, and deciding which of four endings a run had are the same for any Foundry that casts. They live behind `@galaxy-foundry/cast/command` now. What is left in `runCastMoldCommand` is the hooks, the corpus and the artifacts block — 131 lines lighter, and the second instance never has to grow its own copy.

## Why the pins move first

`^0.7.0` on a 0.x caret is patch-only, so it would never have reached 0.8.0, where `document.path`/`document.noun` became required — nor 0.9.0, which adds `cast.note_types` and refuses a value-taking flag given no value. The three pin sites (root, `build-cli`, `note-schema`) move together and ahead of the declaration, so no commit declares a `document:` block while asking for a caster that does not read it.

## Verification

- `make check-casts`, `make check-verify`, `make check-generated` — silent
- `make validate` — 242 files, 0 errors
- `pnpm test` — 310 passed; `pnpm packages-test` — 155 passed
- `packages-build`, `packages-typecheck`, `typecheck`, `packages-lint`, `packages-format`, `smoke:packages` — clean
- `pnpm install --frozen-lockfile` — lockfile up to date
