### PR TITLE
Both sweeps are one command, and the loop is the package's

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,25 +23,15 @@ check-generated:
 	npm run check:index
 	npm run check:readme
 
+# Both sweeps are one command. The loop and the report are @galaxy-foundry/cast;
+# which Molds to sweep, and what to tell a reader who finds drift, are ours and
+# are arguments. The rationale for sweeping every Mold rather than a
+# representative one moved to the command, beside the enumeration it explains.
 casts:
-	@for m in $(MOLD_SLUGS); do echo "cast $$m"; $(FOUNDRY_BUILD) cast --root . $$m || exit 1; done
+	@$(FOUNDRY_BUILD) cast-all --root .
 
-# Every Mold, not a representative one. A verbatim ref's guarantee is
-# src_hash == dst_hash, and a bundle whose source moved on satisfies it against
-# a note that no longer exists — self-consistent and stale. Only re-hashing the
-# source against the record catches that, and only over the whole corpus: seven
-# bundles carried a dead doc path for two weeks while the one Mold CI checked
-# stayed green.
 check-casts:
-	@fail=0; for m in $(MOLD_SLUGS); do \
-	  out=$$($(FOUNDRY_BUILD) cast --root . $$m --check 2>&1) || { \
-	    echo "$$m:"; echo "$$out" | sed 's/^/  /'; fail=1; }; \
-	done; \
-	if [ $$fail -ne 0 ]; then \
-	  echo "cast --check failed above. Drift is fixed by 'make casts' + commit;"; \
-	  echo "an error (unresolved ref, bad declaration) is fixed at the source."; \
-	  exit 1; \
-	fi
+	@$(FOUNDRY_BUILD) cast-all --root . --check
 
 # The other half of the same lesson, and it went unlearned twice. `cast --check`
 # re-derives a bundle from its sources; the verifier asks a different question —

--- a/content/meta/casting.md
+++ b/content/meta/casting.md
@@ -67,7 +67,7 @@ Three triggers, in increasing automation:
 2. **CI on Mold change.** When a PR touches `molds/<name>/`, CI re-casts that Mold against all configured targets and surfaces the diff in review.
 3. **Watch-on-change** for development convenience.
 
-Drift surfaces via `foundry-build cast <mold> --check` (per-Mold) and `cast-skill-verify.ts <mold>` (verifier rejects hash drift, missing dst, schema violations, and missing or stale `SKILL.md`). `make check-casts` and `make check-verify` run each over every Mold.
+Drift surfaces via `foundry-build cast <mold> --check` (per-Mold) and `cast-skill-verify.ts <mold>` (verifier rejects hash drift, missing dst, schema violations, and missing or stale `SKILL.md`). `make check-casts` and `make check-verify` run each over every Mold — the first as `foundry-build cast-all --check`, which sweeps in one process and says nothing when nothing moved. The sweep is `@galaxy-foundry/cast`; the list of Molds it sweeps is this Foundry's, because every Mold here is expected to be cast.
 
 ## Input contract
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@changesets/cli": "^2.31.0",
     "@eslint/js": "^10.0.1",
     "@galaxy-foundry/build-cli": "workspace:*",
-    "@galaxy-foundry/cast": "^0.9.0",
+    "@galaxy-foundry/cast": "^0.10.0",
     "@galaxy-foundry/foundry": "workspace:*",
     "@galaxy-foundry/license-policy": "^0.4.0",
     "@galaxy-foundry/note-schema": "workspace:*",

--- a/packages/build-cli/package.json
+++ b/packages/build-cli/package.json
@@ -37,7 +37,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@galaxy-foundry/cast": "^0.9.0",
+    "@galaxy-foundry/cast": "^0.10.0",
     "@galaxy-foundry/foundry": "workspace:*",
     "@galaxy-foundry/kind-schema": "^0.5.0",
     "@galaxy-foundry/license-policy": "^0.4.0",

--- a/packages/build-cli/src/bin/foundry-build.ts
+++ b/packages/build-cli/src/bin/foundry-build.ts
@@ -3,6 +3,7 @@
 import process from "node:process";
 import { runAssemblePipelineCommand } from "../commands/assemble-pipeline.js";
 import { runCastMoldCommand } from "../commands/cast-mold.js";
+import { runCastSweepCommand } from "../commands/cast-sweep.js";
 import { runGenerateDashboardCommand } from "../commands/generate-dashboard.js";
 import { runGenerateIndexCommand } from "../commands/generate-index.js";
 import { runGenerateKindManifestCommand } from "../commands/generate-kind-manifest.js";
@@ -17,6 +18,7 @@ const COMMANDS = [
   "generate-kinds",
   "generate-readme",
   "cast",
+  "cast-all",
   "assemble-pipeline",
   "validate-artifact",
 ] as const;
@@ -34,6 +36,7 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
   else if (command === "generate-kinds") runGenerateKindManifestCommand(rest);
   else if (command === "generate-readme") runGenerateReadmeStatsCommand(rest);
   else if (command === "cast") await runCastMoldCommand(rest);
+  else if (command === "cast-all") await runCastSweepCommand(rest);
   else if (command === "assemble-pipeline") await runAssemblePipelineCommand(rest);
   else if (command === "validate-artifact") runValidateArtifactCommand(rest);
   else {

--- a/packages/build-cli/src/commands/cast-mold.ts
+++ b/packages/build-cli/src/commands/cast-mold.ts
@@ -25,7 +25,7 @@ import {
   type CastHooks,
   type ProvenanceRefEntry,
 } from "@galaxy-foundry/cast";
-import { castCommand } from "@galaxy-foundry/cast/command";
+import { castCommand, type CastCommandSpec } from "@galaxy-foundry/cast/command";
 
 import type {
   ProvenanceArtifactInput,
@@ -541,22 +541,32 @@ function schemaValidationRows(
  * `errors`: whether a bundle was written is the caster's decision, and a second copy of that
  * decision here could only ever disagree with the first.
  */
+/**
+ * What this Foundry contributes to a cast.
+ *
+ * Flags, target and contract loading, the Mold's own file, and which of four endings a run had
+ * are all the same for any Foundry that casts, and live in the package. What is left here is what
+ * only this one can answer.
+ *
+ * A named value rather than a literal inside the command, because there are two commands now:
+ * `cast` for one Mold and `cast-all` for the corpus. Two copies of it would be two chances to
+ * disagree about what this Foundry is.
+ */
+export const GALAXY_CAST_SPEC: CastCommandSpec<{ artifacts?: ProvenanceArtifacts }> = {
+  usage: "foundry-build cast",
+  defaultTarget: "claude",
+  hooks: GALAXY_HOOKS,
+  corpus: (repoRoot) => buildSlugMap(repoRoot, GALAXY_SLUG_ALIASES),
+  // What this Foundry records in the slot the record reserves beside `refs`. A Mold that
+  // declares no handoff supplies `undefined` and the key is simply absent — which is also what
+  // a Foundry with no artifacts at all gets, by passing no extensions.
+  extensions: ({ meta, corpus }) => ({
+    artifacts: readArtifactContracts(meta, producerIndexFor(corpus.metaByPath)),
+  }),
+};
+
 export async function runCastMoldCommand(argv = process.argv.slice(2)): Promise<void> {
-  // Flags, target and contract loading, the Mold's own file, and which of four endings this run
-  // had are all the same for any Foundry that casts, and live in the package. What is left here
-  // is what only this one can answer.
-  await castCommand<{ artifacts?: ProvenanceArtifacts }>(argv, {
-    usage: "foundry-build cast",
-    defaultTarget: "claude",
-    hooks: GALAXY_HOOKS,
-    corpus: (repoRoot) => buildSlugMap(repoRoot, GALAXY_SLUG_ALIASES),
-    // What this Foundry records in the slot the record reserves beside `refs`. A Mold that
-    // declares no handoff supplies `undefined` and the key is simply absent — which is also what
-    // a Foundry with no artifacts at all gets, by passing no extensions.
-    extensions: ({ meta, corpus }) => ({
-      artifacts: readArtifactContracts(meta, producerIndexFor(corpus.metaByPath)),
-    }),
-  });
+  await castCommand<{ artifacts?: ProvenanceArtifacts }>(argv, GALAXY_CAST_SPEC);
 }
 
 const isDirectInvocation = import.meta.url === `file://${process.argv[1]}`;

--- a/packages/build-cli/src/commands/cast-sweep.ts
+++ b/packages/build-cli/src/commands/cast-sweep.ts
@@ -1,0 +1,68 @@
+#!/usr/bin/env tsx
+// This Foundry's `cast-all` command: every Mold, checked or written, in one run.
+//
+// The sweep itself is @galaxy-foundry/cast. It used to be two shell loops in the Makefile, and
+// the reason it moved is not tidiness — a loop in a Makefile cannot be tested, and the second
+// Foundry had written its own with different answers to every question this one had already
+// settled. The package now owns the loop and the report; what stays here is the LIST.
+//
+// Every Mold, not a representative one, and not only the ones already cast. A verbatim ref's
+// guarantee is src_hash == dst_hash, and a bundle whose source moved on satisfies it against a
+// note that no longer exists — self-consistent and stale. Only re-hashing the source against the
+// record catches that, and only over the whole corpus: seven bundles carried a dead doc path for
+// two weeks while the one Mold CI checked stayed green.
+//
+// That is a policy about THIS corpus, which is why the caster takes the list rather than deriving
+// it. The second Foundry sweeps its bundles instead, because an uncast Mold there is a decision.
+//
+// Usage:
+//   foundry-build cast-all [--check] [--target=claude] [--root=.]
+
+import { readdirSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+import { castSweep, sweepReport } from "@galaxy-foundry/cast/command";
+
+import { GALAXY_CAST_SPEC } from "./cast-mold.js";
+
+/** Every Mold in the corpus, by slug, in a stable order. */
+function moldSlugs(repoRoot: string): string[] {
+  return readdirSync(path.join(repoRoot, "content", "molds"), { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .sort();
+}
+
+function flagValue(argv: readonly string[], flag: string): string | undefined {
+  const joined = argv.find((a) => a.startsWith(`${flag}=`));
+  if (joined) return joined.slice(flag.length + 1);
+  const i = argv.indexOf(flag);
+  return i >= 0 ? argv[i + 1] : undefined;
+}
+
+export async function runCastSweepCommand(argv = process.argv.slice(2)): Promise<void> {
+  const check = argv.includes("--check");
+  const root = path.resolve(flagValue(argv, "--root") ?? ".");
+  const target = flagValue(argv, "--target");
+
+  const result = await castSweep(GALAXY_CAST_SPEC, {
+    molds: moldSlugs(root),
+    root,
+    check,
+    ...(target === undefined ? {} : { target }),
+  });
+
+  const verdict = sweepReport(result, {
+    repoRoot: root,
+    check,
+    remediation: [
+      "Drift is fixed by 'make casts' + commit;",
+      "an error (unresolved ref, bad declaration) is fixed at the source.",
+    ],
+  });
+
+  for (const line of verdict.err) console.error(line);
+  for (const line of verdict.out) console.log(line);
+  if (verdict.exitCode !== 0) process.exitCode = verdict.exitCode;
+}

--- a/packages/note-schema/package.json
+++ b/packages/note-schema/package.json
@@ -37,7 +37,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@galaxy-foundry/cast": "^0.9.0",
+    "@galaxy-foundry/cast": "^0.10.0",
     "@galaxy-foundry/kind-manifest": "^0.4.0",
     "@galaxy-foundry/kind-schema": "^0.5.0",
     "@galaxy-foundry/license-policy": "^0.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
         specifier: workspace:*
         version: link:packages/build-cli
       '@galaxy-foundry/cast':
-        specifier: ^0.9.0
-        version: 0.9.0
+        specifier: ^0.10.0
+        version: 0.10.0
       '@galaxy-foundry/foundry':
         specifier: workspace:*
         version: link:packages/foundry
@@ -100,8 +100,8 @@ importers:
   packages/build-cli:
     dependencies:
       '@galaxy-foundry/cast':
-        specifier: ^0.9.0
-        version: 0.9.0
+        specifier: ^0.10.0
+        version: 0.10.0
       '@galaxy-foundry/foundry':
         specifier: workspace:*
         version: link:../foundry
@@ -183,8 +183,8 @@ importers:
   packages/note-schema:
     dependencies:
       '@galaxy-foundry/cast':
-        specifier: ^0.9.0
-        version: 0.9.0
+        specifier: ^0.10.0
+        version: 0.10.0
       '@galaxy-foundry/kind-manifest':
         specifier: ^0.4.0
         version: 0.4.0(zod@4.4.3)
@@ -1017,8 +1017,8 @@ packages:
   '@fontsource/atkinson-hyperlegible@5.2.8':
     resolution: {integrity: sha512-HciLcJ5DIK/OVOdo71EbEN4NnvDFlp6/SpAxtcbWf2aAdcsOuPqITxj5KNEXb48qSPSdnnZdGGnSJChPKi3/bA==}
 
-  '@galaxy-foundry/cast@0.9.0':
-    resolution: {integrity: sha512-ydGGOm6NLwdpKD0uuNEni1AetIU692sSX1rzCToaf1PvglFYDP3+KwVSjZxqW4uzoOo0ASaAXF5EbJKXiBC9dQ==}
+  '@galaxy-foundry/cast@0.10.0':
+    resolution: {integrity: sha512-p9ml9l2PkTSXcFWCF5GeyqOTGvEbKg6ZPD71g/o6k5YIz1LUtQE409/sJ0XpHg4ODqr5fofZIv5FB5P2IOMAiw==}
     engines: {node: '>=20'}
 
   '@galaxy-foundry/kind-manifest@0.4.0':
@@ -1035,6 +1035,10 @@ packages:
 
   '@galaxy-foundry/license-policy@0.4.0':
     resolution: {integrity: sha512-CSLk8Joh2eaqWW13bYctK/69/iPCxHPXKgvuxtgAnIUYto8grbviLCD+IxXShOnc0f5Mw00ZT5TcD080jTjqyw==}
+    engines: {node: '>=20'}
+
+  '@galaxy-foundry/license-policy@0.4.1':
+    resolution: {integrity: sha512-h2MHq9C47RYlkT+mwZeHisnEku0+1FCPS3WfWTVWwzaMWRcywfKUAjvVz7s/8I9gBu5tIu8k4vaonvVGBk2asQ==}
     engines: {node: '>=20'}
 
   '@galaxy-foundry/reference-contract@0.4.0':
@@ -4471,9 +4475,9 @@ snapshots:
 
   '@fontsource/atkinson-hyperlegible@5.2.8': {}
 
-  '@galaxy-foundry/cast@0.9.0':
+  '@galaxy-foundry/cast@0.10.0':
     dependencies:
-      '@galaxy-foundry/license-policy': 0.4.0
+      '@galaxy-foundry/license-policy': 0.4.1
       '@galaxy-foundry/reference-contract': 0.4.0
       '@galaxy-foundry/wiki-links': 0.4.0
       gray-matter: 4.0.3
@@ -4489,6 +4493,10 @@ snapshots:
       zod: 4.4.3
 
   '@galaxy-foundry/license-policy@0.4.0':
+    dependencies:
+      js-yaml: 4.3.0
+
+  '@galaxy-foundry/license-policy@0.4.1':
     dependencies:
       js-yaml: 4.3.0
 


### PR DESCRIPTION
Adopts `castSweep`/`sweepReport` from `@galaxy-foundry/cast` 0.10.0 (jmchilton/foundry-lib#91). `make casts` and `make check-casts` were shell loops over `MOLD_SLUGS`; they are now one `foundry-build cast-all`.

## Nothing a reader sees changes

That is the point worth stating first. Silence on success was already this repo's behaviour — though by accident, since `out=$$(...)` captured the caster's per-run `clean` line and discarded it — and the failure block the package emits is byte-identical to the one the Makefile assembled with `sed`:

```
interview-to-freeform-summary:
  drift: SKILL.md — SKILL.md content drifted
1 of 47 cast(s) failed
Drift is fixed by 'make casts' + commit;
an error (unresolved ref, bad declaration) is fixed at the source.
```

What changes is that this shape is now a tested value rather than shell, and that the second Foundry gets it instead of having invented a different one. It had no remediation line at all.

## 61s → 13s

The old loop spawned a `tsx` process per Mold: 47 boots, 47 target loads, 47 contract loads, 47 corpus reads. Measured on this branch, over the same 47 Molds:

| | |
|---|---|
| per-Mold-process loop | **61s** |
| `cast-all` | **13s** |

`prepareCast` reads the target, the contract and the corpus once; `castOne` runs per Mold against that. Those are properties of the repository, not of any one Mold.

## What stayed ours

**The list.** Every Mold, not a representative one, and not only the ones already cast — a verbatim ref's guarantee is `src_hash == dst_hash`, and a bundle whose source moved on satisfies it against a note that no longer exists. Only re-hashing the source over the whole corpus catches that; seven bundles carried a dead doc path for two weeks while the one Mold CI checked stayed green.

That rationale moved out of the Makefile and into `cast-sweep.ts`, beside the enumeration it explains. The caster takes the list rather than deriving it, because an uncast Mold is drift here and a deliberate decision in the second instance.

`GALAXY_CAST_SPEC` is split out of `runCastMoldCommand` so `cast` and `cast-all` hand the caster the same value.

## `check-verify` keeps its loop

Deliberately. It asks a different question — is the committed bundle internally consistent, does its provenance still satisfy the schema, does it honour the target's constraints — and it is not a cast. `MOLD_SLUGS` stays for it.

## Verification

- `make check-casts` — silent over 47 Molds, exit 0
- Negative test — edited a committed `SKILL.md`, got the block above and exit 1; restored, clean again
- `make check-generated`, `make check-verify` — silent
- `pnpm validate` — 242 files, 0 errors
- `pnpm test` — 305; `pnpm packages-test` — 160
- `packages-build`, `packages-typecheck`, `typecheck`, `packages-lint`, `packages-format`, `smoke:packages` — clean
- `pnpm install --frozen-lockfile` — clean
