### PR TITLE
Adopt content-reader for the corpus walk and wiki-link addressing

### DIFF
--- a/content/meta/code-architecture.md
+++ b/content/meta/code-architecture.md
@@ -28,7 +28,7 @@ This record answers one question: **how is the implementation divided, and which
        shared substrate     summarize-nextflow
 
 shared substrate = cast, kind-schema, kind-manifest, tag-registry,
-reference-contract, wiki-links, and license-policy packages
+reference-contract, wiki-links, content-reader, and license-policy packages
 ```
 
 The arrows point toward dependencies. The site and build CLI are composition layers: they join instance contracts, shared substrate packages, and runtime packages into user-facing behavior. Lower layers do not import either application.
@@ -84,6 +84,7 @@ A domain runtime package that summarizes Nextflow source and owns the schemas pr
 - **Tags:** `@galaxy-foundry/tag-registry` owns the registry format and how tags browse — grouping by declaring facet, facet labels; `meta_tags.yml` owns this instance's vocabulary, and the site owns only what counts as a tagged note.
 - **References:** `@galaxy-foundry/reference-contract` owns shared reference behavior; `reference_contract.yml` owns instance reference kinds and permitted combinations.
 - **Wiki links:** `@galaxy-foundry/wiki-links` owns parsing, slugging, resolution, and tree traversal; the site and validator supply the instance link map.
+- **Reading the content tree:** `@galaxy-foundry/content-reader` owns the walk, the frontmatter read, and the address-precedence rule that turns a routed note into the slugs reaching it. `build-cli` supplies the collection table and this instance's aliases, and the validator and the caster project their maps from one reader so a link one calls good cannot fail in the other. The site still builds its own map from `astro:content`, which is already loaded there.
 - **Licenses:** `@galaxy-foundry/license-policy` answers general redistribution questions; instance validation owns coherence rules for its notes.
 
 Composition happens at narrow adapters such as the schema context, registries, and site link-map builder. Application code imports the shared package directly when no instance-specific composition is required.

--- a/content/meta/content-model.md
+++ b/content/meta/content-model.md
@@ -24,7 +24,9 @@ The kinds fall into four groups. **`meta`** is the design record — the one kin
 
 Kind is never inferred from a tag, and every kind is its own literal rather than a member of one broad kind carrying a discriminating enum field. The literal is what makes the collection and the declared kind agree, or fail: a shared enum makes every field legal on every member, and would let a `cli-command` note sit at `content/cli/<tool>/index.md` — where a `cli-tool` belongs — and still validate. Paths route files into collections; the note's literal `type` must agree with the collection's declared kind.
 
-Identity is the note's basename — a link's target is slugified and matched against it. The instance's link map adds the kind-specific aliases — a Mold's `name`, a `tool command` pair — while the grammar and the lookup rule come from `@galaxy-foundry/wiki-links`.
+Identity is the note's path within its collection, slugified — `gxwf-validate` for `content/cli/gxwf/validate.md`, `summarize-nextflow` for a Mold that sits at the root of its own. A link's target is slugified and matched against that. Around it the instance registers aliases, which fill an address only if no note already holds it outright: the note's **basename**, which is how nearly every link in `content/` is written and the only address this corpus had for most of its life; and a `tool command` pair, because a Mold author writes `[[gxwf validate]]` rather than the slug. The walk, the precedence and the lookup come from `@galaxy-foundry/content-reader` and `@galaxy-foundry/wiki-links`; which aliases exist is ours.
+
+Precedence is why the qualified form is the primary. Two notes can share a basename — a Mold and a CLI page both called `summarize-nextflow` do — and under basename-only addressing which one `[[summarize-nextflow]]` reached depended on which collection was walked last. It now reaches the note whose identity that *is*, and the other keeps `foundry-summarize-nextflow`.
 
 ## Frontmatter envelope
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "foundry",
   "version": "0.0.0",
   "private": true,
-  "description": "Galaxy Workflow Foundry \u2014 knowledge base + casting pipeline for Galaxy workflows.",
+  "description": "Galaxy Workflow Foundry — knowledge base + casting pipeline for Galaxy workflows.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",
   "scripts": {
@@ -48,6 +48,7 @@
     "@eslint/js": "^10.0.1",
     "@galaxy-foundry/build-cli": "workspace:*",
     "@galaxy-foundry/cast": "^0.12.2",
+    "@galaxy-foundry/content-reader": "^0.3.1",
     "@galaxy-foundry/foundry": "workspace:*",
     "@galaxy-foundry/license-policy": "^0.8.1",
     "@galaxy-foundry/note-schema": "workspace:*",

--- a/packages/build-cli/package.json
+++ b/packages/build-cli/package.json
@@ -38,8 +38,9 @@
   "license": "MIT",
   "dependencies": {
     "@galaxy-foundry/cast": "^0.12.2",
+    "@galaxy-foundry/content-reader": "^0.3.1",
     "@galaxy-foundry/foundry": "workspace:*",
-    "@galaxy-foundry/kind-schema": "^0.5.2",
+    "@galaxy-foundry/kind-schema": "^0.6.0",
     "@galaxy-foundry/license-policy": "^0.8.1",
     "@galaxy-foundry/note-schema": "workspace:*",
     "@galaxy-foundry/planemo-cli-meta": "workspace:*",

--- a/packages/build-cli/src/commands/validate.ts
+++ b/packages/build-cli/src/commands/validate.ts
@@ -25,10 +25,10 @@ import { bundledPolicy, resolveLicenseRow } from "@galaxy-foundry/license-policy
 import { readMarkdown } from "../lib/frontmatter.js";
 import { parsePhases, phaseMoldPaths, type ParsedPhase } from "../lib/pipeline-phases.js";
 import { loadTagRegistry } from "../lib/schema.js";
-import { GALAXY_SLUG_ALIASES } from "../lib/slug-map.js";
+import { GALAXY_SLUG_ALIASES, readContent } from "../lib/slug-map.js";
 import type { FileMeta, Frontmatter, ValidationResult } from "../lib/types.js";
 import { fileSlug, findMdFiles, routablePath } from "../lib/walk.js";
-import { resolveWikiLink, slugify, WIKI_LINK_RE } from "../lib/wiki-links.js";
+import { resolveWikiLink, WIKI_LINK_RE } from "../lib/wiki-links.js";
 
 interface CliArgs {
   directory: string;
@@ -158,13 +158,18 @@ interface CrossFileFinding {
 // the whole corpus. It lives in tests/registry-drift.test.ts instead.
 
 // Addressing has to match what casting resolves against, or a link this command calls good
-// fails at cast time. Same rule imported, rather than the same rule restated a third time —
-// assemble-pipeline's copy carried a comment claiming parity with cast's instead of holding it.
-function buildSlugMap(files: FileMeta[]): Map<string, string> {
+// fails at cast time. The whole map is taken from the same reader the caster's is projected
+// from, rather than the same rule restated a third time — assemble-pipeline's copy carried a
+// comment claiming parity with cast's instead of holding it.
+//
+// Narrowed to files that validated, which is this command's own rule and not the reader's: a
+// note whose frontmatter is broken should not be reachable by a link the same run calls good.
+function buildSlugMap(files: FileMeta[], contentRoot: string): Map<string, string> {
+  const valid = new Map(files.map((f) => [path.resolve(f.path), f.path]));
   const m = new Map<string, string>();
-  for (const f of files) {
-    m.set(slugify(f.slug), f.path);
-    for (const alias of GALAXY_SLUG_ALIASES(f.meta)) m.set(slugify(alias), f.path);
+  for (const [address, note] of readContent(contentRoot, GALAXY_SLUG_ALIASES).notesByAddress) {
+    const full = valid.get(path.resolve(contentRoot, path.relative(CONTENT_DIR, note.file)));
+    if (full) m.set(address, full);
   }
   return m;
 }
@@ -1444,7 +1449,7 @@ export function validateDirectory(opts: ValidateOptions): {
   }
 
   // Cross-file passes.
-  const slugMap = buildSlugMap(validFiles);
+  const slugMap = buildSlugMap(validFiles, opts.directory);
   const metaByPath = new Map<string, Frontmatter>();
   for (const f of validFiles) metaByPath.set(f.path, f.meta);
 

--- a/packages/build-cli/src/lib/slug-map.ts
+++ b/packages/build-cli/src/lib/slug-map.ts
@@ -4,13 +4,17 @@
 // addressable as `[[gxwf validate]]` as well as by filename. assemble-pipeline's copy carried a
 // comment saying "parity with cast's buildSlugMap" — parity asserted in prose rather than held
 // by construction, which is the arrangement that lets two of the three drift and nothing notice.
+//
+// The walk, the frontmatter read and the precedence rule now ship in
+// @galaxy-foundry/content-reader. What stays here is this instance's vocabulary: which second
+// addresses a Galaxy note answers to, and the frame its paths are stated in.
 
 import path from "node:path";
 
-import { readMarkdown } from "./frontmatter.js";
+import { createContentReader, type ContentAliases } from "@galaxy-foundry/content-reader";
+import { COLLECTIONS, CONTENT_DIR } from "@galaxy-foundry/note-schema";
+
 import type { Frontmatter } from "./types.js";
-import { fileSlug, findMdFiles } from "./walk.js";
-import { slugify } from "./wiki-links.js";
 
 /**
  * Extra addresses a note answers to, beyond the slug of its own filename.
@@ -35,6 +39,43 @@ export const GALAXY_SLUG_ALIASES: SlugAliases = (meta) =>
     : [];
 
 /**
+ * The basename of a note's id, which is the address this corpus was written against.
+ *
+ * The reader's primary address is the full collection-relative id — `nextflow/mix-collect-…` for
+ * a source pattern, `galaxy/custom-tool-critic` for a prompt — and 174 links in `content/` are
+ * written to the basename alone. Registered as an ALIAS, both spellings resolve and the qualified
+ * one becomes available without a rewrite.
+ *
+ * Alias rather than a change to the reader because the precedence is the point: an alias never
+ * takes an address a routed note already holds. `[[summarize-nextflow]]` is the Mold, whose id IS
+ * `summarize-nextflow`, and the CLI note of the same basename can no longer take it depending on
+ * which collection was walked last.
+ */
+const basenameOf = (id: string): string => id.split("/").pop()!;
+
+/**
+ * One walk of a content tree, addressed by this instance's rules.
+ *
+ * `contentRoot` is the content directory itself, under whatever name a checkout gives it — the
+ * same frame `findMdFiles` takes, so a caller that has one has the other.
+ */
+export function readContent(contentRoot: string, aliases: SlugAliases) {
+  const contentAliases: ContentAliases<typeof COLLECTIONS> = (meta, id) => [
+    basenameOf(id),
+    ...aliases(meta),
+  ];
+  return createContentReader({
+    collections: COLLECTIONS,
+    // COLLECTIONS states its bases repo-relative — `content/molds` — so a path the reader hands
+    // back is already in the frame `slugMap` publishes. Rebasing onto whatever the content
+    // directory is called on disk is the whole of the translation.
+    contentPath: (relativePath) => path.join(contentRoot, path.relative(CONTENT_DIR, relativePath)),
+    aliases: contentAliases,
+    targetOf: (collection, id) => ({ path: `${collection}/${id}` }),
+  }).contentIndex();
+}
+
+/**
  * Every note in the corpus, indexed by the slugs that address it and by its repo-relative path.
  *
  * `aliases` is asked of every note. A note's own filename slug is always registered; anything
@@ -47,15 +88,15 @@ export function buildSlugMap(
   slugMap: ReadonlyMap<string, string>;
   metaByPath: ReadonlyMap<string, Frontmatter>;
 } {
-  const slugMap = new Map<string, string>();
-  const metaByPath = new Map<string, Frontmatter>();
-  for (const abs of findMdFiles(path.join(repoRoot, "content"))) {
-    const parsed = readMarkdown(abs);
-    if (!parsed.hasFrontmatter) continue;
-    const rel = path.relative(repoRoot, abs);
-    slugMap.set(slugify(fileSlug(rel)), rel);
-    metaByPath.set(rel, parsed.meta);
-    for (const alias of aliases(parsed.meta)) slugMap.set(slugify(alias), rel);
-  }
+  const index = readContent(path.join(repoRoot, CONTENT_DIR), aliases);
+  const slugMap = new Map<string, string>(
+    [...index.notesByAddress].map(([address, note]) => [address, note.file]),
+  );
+  // Keyed off `notes` and not the address map: every note has a path whether or not it kept an
+  // address, and a meta lookup that silently misses is a cross-file check that passes for the
+  // wrong reason.
+  const metaByPath = new Map<string, Frontmatter>(
+    index.notes.map((note) => [note.file, note.meta ?? {}]),
+  );
   return { slugMap, metaByPath };
 }

--- a/packages/note-schema/package.json
+++ b/packages/note-schema/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@galaxy-foundry/cast": "^0.12.2",
     "@galaxy-foundry/kind-manifest": "^0.4.0",
-    "@galaxy-foundry/kind-schema": "^0.5.2",
+    "@galaxy-foundry/kind-schema": "^0.6.0",
     "@galaxy-foundry/license-policy": "^0.8.1",
     "@galaxy-foundry/reference-contract": "^0.4.1",
     "@galaxy-foundry/tag-registry": "^0.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@galaxy-foundry/cast':
         specifier: ^0.12.2
         version: 0.12.2(zod@4.4.3)
+      '@galaxy-foundry/content-reader':
+        specifier: ^0.3.1
+        version: 0.3.1(zod@4.4.3)
       '@galaxy-foundry/foundry':
         specifier: workspace:*
         version: link:packages/foundry
@@ -102,12 +105,15 @@ importers:
       '@galaxy-foundry/cast':
         specifier: ^0.12.2
         version: 0.12.2(zod@4.4.3)
+      '@galaxy-foundry/content-reader':
+        specifier: ^0.3.1
+        version: 0.3.1(zod@4.4.3)
       '@galaxy-foundry/foundry':
         specifier: workspace:*
         version: link:../foundry
       '@galaxy-foundry/kind-schema':
-        specifier: ^0.5.2
-        version: 0.5.2(zod@4.4.3)
+        specifier: ^0.6.0
+        version: 0.6.0(zod@4.4.3)
       '@galaxy-foundry/license-policy':
         specifier: ^0.8.1
         version: 0.8.1
@@ -189,8 +195,8 @@ importers:
         specifier: ^0.4.0
         version: 0.4.0(zod@4.4.3)
       '@galaxy-foundry/kind-schema':
-        specifier: ^0.5.2
-        version: 0.5.2(zod@4.4.3)
+        specifier: ^0.6.0
+        version: 0.6.0(zod@4.4.3)
       '@galaxy-foundry/license-policy':
         specifier: ^0.8.1
         version: 0.8.1
@@ -291,8 +297,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/foundry
       '@galaxy-foundry/kind-schema':
-        specifier: ^0.5.2
-        version: 0.5.2(zod@4.4.3)
+        specifier: ^0.6.0
+        version: 0.6.0(zod@4.4.3)
       '@galaxy-foundry/license-policy':
         specifier: ^0.8.1
         version: 0.8.1
@@ -1021,14 +1027,18 @@ packages:
     resolution: {integrity: sha512-JBU1QwueejR09e3EID8as8hrpqttTpi2YccMjsOzNiG7bCP2xBMHle13EB7x7FB0Y7+5PPcJqOLHPBpRmSUW5g==}
     engines: {node: '>=20'}
 
+  '@galaxy-foundry/content-reader@0.3.1':
+    resolution: {integrity: sha512-7IvNFS8umF14z6A2tUpCNcJDiqBBuQ1IULlmlJoMIgAXf+3ApwLe0bqB5NQyvAJ7oecZsvftcxDjhdtpfWSJow==}
+    engines: {node: '>=20'}
+
   '@galaxy-foundry/kind-manifest@0.4.0':
     resolution: {integrity: sha512-4u19jRuIyg4+FJfoDbGtZOeXVgTmPcuqDOx9plo2uLJxMegDh8sRnppXIVlzZq5zCm03UJA+ThQue2D9jFPCGg==}
     engines: {node: '>=20'}
     peerDependencies:
       zod: ^4.0.0
 
-  '@galaxy-foundry/kind-schema@0.5.2':
-    resolution: {integrity: sha512-zRBr5MgHpWTaHWUEQwDX61a4g/8ELO/9z/dr7qhk6igPEz9HkF2WR3hG7a/kuImxCeQ5yW3faIqatej13xrgWQ==}
+  '@galaxy-foundry/kind-schema@0.6.0':
+    resolution: {integrity: sha512-cVe5oSS74kKRWQwGp/su4nlfsKbz/cYZE0L6zeAY1VWp0GJyydDJpPKZso2ZkGa58fXR4MdaWAkKxIzluJvctg==}
     engines: {node: '>=20'}
     peerDependencies:
       zod: ^4.0.0
@@ -4482,11 +4492,19 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
+  '@galaxy-foundry/content-reader@0.3.1(zod@4.4.3)':
+    dependencies:
+      '@galaxy-foundry/kind-schema': 0.6.0(zod@4.4.3)
+      '@galaxy-foundry/wiki-links': 0.4.0
+      js-yaml: 4.3.0
+    transitivePeerDependencies:
+      - zod
+
   '@galaxy-foundry/kind-manifest@0.4.0(zod@4.4.3)':
     dependencies:
       zod: 4.4.3
 
-  '@galaxy-foundry/kind-schema@0.5.2(zod@4.4.3)':
+  '@galaxy-foundry/kind-schema@0.6.0(zod@4.4.3)':
     dependencies:
       '@galaxy-foundry/kind-manifest': 0.4.0(zod@4.4.3)
       zod: 4.4.3

--- a/site/package.json
+++ b/site/package.json
@@ -14,7 +14,7 @@
     "@astrojs/markdown-remark": "^7.2.2",
     "@fontsource/atkinson-hyperlegible": "^5.2.8",
     "@galaxy-foundry/foundry": "workspace:*",
-    "@galaxy-foundry/kind-schema": "^0.5.2",
+    "@galaxy-foundry/kind-schema": "^0.6.0",
     "@galaxy-foundry/license-policy": "^0.8.1",
     "@galaxy-foundry/note-schema": "workspace:*",
     "@galaxy-foundry/reference-contract": "^0.4.1",

--- a/tests/collection-routing.test.ts
+++ b/tests/collection-routing.test.ts
@@ -13,6 +13,7 @@ import {
   nonNoteAllowanceOf,
 } from "@galaxy-foundry/note-schema";
 import { readMarkdown } from "../packages/build-cli/src/lib/frontmatter.js";
+import { GALAXY_SLUG_ALIASES, readContent } from "../packages/build-cli/src/lib/slug-map.js";
 import { findMdFiles } from "../packages/build-cli/src/lib/walk.js";
 
 // The path→kind table and the corpus must agree BOTH ways, and the table must agree with
@@ -119,6 +120,19 @@ describe("collection routing (path table vs corpus)", () => {
       { missed, extra },
       `\nclaimed but not walked:\n  ${missed.join("\n  ")}\nwalked but not claimed:\n  ${extra.join("\n  ")}`,
     ).toEqual({ missed: [], extra: [] });
+  });
+
+  // Two walkers read this table now: `findMdFiles`, which the validator drives file by file so
+  // it can report a missing frontmatter block against a path, and the reader in
+  // `@galaxy-foundry/content-reader`, which answers addressing. Both route from COLLECTIONS, so
+  // they cannot disagree about the rule — but they match it with different code, and a glob
+  // corner one implements and the other does not is a note that is validated and unaddressable,
+  // or addressable and unvalidated. Neither is visible from the side that still works.
+  it("finds the same notes however the tree is walked", () => {
+    const read = readContent(path.join(repoRoot, CONTENT_DIR), GALAXY_SLUG_ALIASES)
+      .notes.map((note) => note.file)
+      .sort();
+    expect(read).toEqual([...corpusFiles].sort());
   });
 
   // A kind's `shape` and the glob its notes are found by are two statements of one fact, and

--- a/tests/wiki-addressing.test.ts
+++ b/tests/wiki-addressing.test.ts
@@ -1,0 +1,85 @@
+// Which slug reaches which note, asserted against the real corpus.
+//
+// `wiki-links.test.ts` covers the grammar — what `[[Foo|bar]]` parses to. This is the other
+// half: given the corpus, what does `[[foo]]` FIND. The rule ships in
+// `@galaxy-foundry/content-reader`; the vocabulary it is given is ours, and the two together
+// are what every `[[...]]` in `content/` was written against.
+//
+// The corpus was addressed by BASENAME for as long as it existed, so `content/cli/gxwf/
+// draft-validate.md` answered to `[[draft-validate]]` and nothing else. The reader's primary
+// address is the collection-relative id — `gxwf-draft-validate` — and the basename rides along
+// as an alias, which is what keeps 174 existing links resolving. Both halves are pinned here
+// because dropping either is silent: the links that break are in prose, and the addresses that
+// never appear are ones nothing has written yet.
+
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { slugify } from "@galaxy-foundry/wiki-links";
+
+import { GALAXY_SLUG_ALIASES, readContent } from "../packages/build-cli/src/lib/slug-map.js";
+import { REPO_ROOT } from "./site-sources";
+
+const index = readContent(path.join(REPO_ROOT, "content"), GALAXY_SLUG_ALIASES);
+const fileFor = (address: string): string | undefined => index.notesByAddress.get(address)?.file;
+
+describe("the addresses this corpus answers to", () => {
+  it("still reaches a nested note by its basename alone", () => {
+    // The spelling every link in `content/` uses today. A note one directory down inside its
+    // collection — a CLI command, a prompt, a source pattern — is the case that changes if the
+    // alias is ever dropped, and each of the three is one directory down for a different reason.
+    expect(fileFor("draft-validate")).toBe("content/cli/gxwf/draft-validate.md");
+    expect(fileFor("custom-tool-critic")).toBe(
+      "content/prompts/galaxy/custom-tool-critic/index.md",
+    );
+    expect(fileFor("mix-collect-to-report-aggregation")).toBe(
+      "content/source-patterns/nextflow/mix-collect-to-report-aggregation.md",
+    );
+  });
+
+  it("also reaches it by the qualified id, which is the address that cannot collide", () => {
+    expect(fileFor("gxwf-draft-validate")).toBe("content/cli/gxwf/draft-validate.md");
+    expect(fileFor("galaxy-custom-tool-critic")).toBe(
+      "content/prompts/galaxy/custom-tool-critic/index.md",
+    );
+    expect(fileFor("nextflow-mix-collect-to-report-aggregation")).toBe(
+      "content/source-patterns/nextflow/mix-collect-to-report-aggregation.md",
+    );
+  });
+
+  it("reaches a cli command by the pair a Mold author writes", () => {
+    // `[[gxwf validate]]`, not `[[gxwf-validate]]` — the instance vocabulary alias. It lands on
+    // the same address the qualified id produces, which is why the two agree by construction
+    // rather than by anyone keeping them in step.
+    expect(fileFor("gxwf-validate")).toBe("content/cli/gxwf/validate.md");
+  });
+
+  it("never lets an alias take an address a note holds outright", () => {
+    // The one real basename collision in the corpus: a Mold and a CLI note both called
+    // `summarize-nextflow`. The Mold's id IS `summarize-nextflow`, so the address is its
+    // primary and the CLI note's basename alias cannot land on it. This used to depend on
+    // which collection was walked last.
+    expect(fileFor("summarize-nextflow")).toBe("content/molds/summarize-nextflow/index.md");
+    expect(fileFor("foundry-summarize-nextflow")).toBe("content/cli/foundry/summarize-nextflow.md");
+  });
+
+  it("gives every routed note an address that finds it back", () => {
+    // The qualified id is the address no note can be denied: it is the primary, and primaries
+    // are registered before any alias. A note reachable by nothing is a page the corpus can
+    // publish and never link, which is invisible from either end.
+    const unreachable = index.notes
+      .filter((note) => index.notesByAddress.get(qualified(note.id))?.file !== note.file)
+      .map((note) => note.file);
+    expect(unreachable, "\nrouted notes no address resolves to").toEqual([]);
+  });
+});
+
+/**
+ * The reader's primary address for an id: the collection-relative path, flattened, slugified.
+ *
+ * `slugify` is not decoration. `planemo/planemo-cli_metadata` addresses as
+ * `planemo-planemo-climetadata` and `cwl-v1.2-schemas` as `cwl-v1-2-schemas`; a flatten alone
+ * finds neither, which is how the first draft of this file reported five healthy notes missing.
+ */
+const qualified = (id: string): string => slugify(id.replace(/\//g, "-"));


### PR DESCRIPTION
> **Posted by Claude (AI assistant) on jmchilton's behalf.** They did not write this text.

Adopts `@galaxy-foundry/content-reader@^0.3.1` — the fourth and last item from the site-kit/content-reader convergence list. Bumps `kind-schema` to `^0.6.0`, which the reader requires.

## What was written three times

`buildSlugMap` in `build-cli/src/lib/slug-map.ts` walked `content/`, parsed frontmatter, and built address → path. Its own header comment records why it exists: three commands had built that map separately, and `assemble-pipeline`'s copy carried a comment *claiming* parity with cast's rather than holding it. The package now does the walk, the read, and the precedence rule; what stays here is this instance's vocabulary.

`validate.ts` kept a **fourth** copy — it builds from already-validated files, so it never folded into the first three. It now projects from the same reader, narrowed to files that passed. That narrowing is the validator's own rule, not the reader's: a note with broken frontmatter should not be reachable by a link the same run calls good.

## The addressing change, measured before it was made

The reader's primary address is the collection-relative id; ours was the basename. Adopting it bare would have broken **174 links across 28 distinct targets** — every CLI command by its bare name (`[[validate]]`, `[[add]]`, `[[convert]]`), both prompts under `prompts/galaxy/`, and all eight `source-patterns/nextflow/` pages.

So the basename is registered as an **alias**. Aliases fill empty addresses and never overwrite a primary, so:

- 0 addresses lost, 0 links redirected, verified over all 3,664 `[[...]]` in `content/`
- 15 qualified addresses gained — `nextflow-mix-collect-to-report-aggregation`, `galaxy-custom-tool-critic`, `foundry-summarize-nextflow`

Nothing needs rewriting; the qualified form is simply available now.

## Precedence stops depending on walk order

`NOTE_COLLECTIONS` in `site/src/lib/notes.ts` carries a comment saying its order is load-bearing: the map keyed by basename and overwrote, so `[[summarize-nextflow]]` reached the Mold rather than the CLI page only because `molds` was listed after `cli-tools`. That was a real hazard written down rather than fixed.

It now reaches the Mold because `summarize-nextflow` **is** the Mold's id, and an alias cannot take an address a routed note holds outright. The CLI note keeps `foundry-summarize-nextflow`. The ordering is no longer what decides.

## Tests

`tests/wiki-addressing.test.ts` is new and runs against the real corpus, pinning both halves — the basename form because the links that break are in prose and nothing else would catch it, the qualified form because nothing has written one yet, so an alias-only regression would look exactly like a healthy corpus. Two of its five cases would fail on the old map.

`collection-routing.test.ts` gains one: `build-cli` now has two walkers over one table (`findMdFiles`, which the validator drives file by file so it can report a missing frontmatter block against a path, and the reader). They cannot disagree about the *rule*, but they match it with different code, and a glob corner one implements and the other does not is a note that is validated and unaddressable, or addressable and unvalidated.

## Checks

`validate` — 242 files, 0 errors, 49 advisory warnings, byte-identical to `main`. Root suite 315/315. `check-casts`, `check-verify`, `check-assemble-pipelines` all clean, so no bundle changed. Both typechecks, format, lint, `site:build` (386 pages).

`summarize-nextflow`'s `bacass` integration test times out fetching remote nf-core test data. Network-gated; this branch's diff for that package is empty.

## Not in this PR

The site builds a **fifth** copy of the map, in `site/src/lib/wiki-links.ts`, from `astro:content` rather than the filesystem — so the reader is the wrong tool there, and a filesystem walk would be a regression when Astro has already loaded the entries. Worth knowing that it registers a mold-`name` alias which `build-cli` does not: latent drift, not live, since every Mold's `name` currently slugifies to its own directory name. Left alone deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
