### PR TITLE
Add ncbi/egapx end-to-end case to NEXTFLOW → GALAXY scenarios

### DIFF
--- a/content/log.md
+++ b/content/log.md
@@ -204,3 +204,50 @@ Two new fidelity cases to add to `content/molds/summarize-nextflow/eval.md`:
 ### Recommended next step
 
 File a follow-up issue: "summarize-nextflow resolver: walk all .nf files, support multi-process-per-file, auto-detect pipeline root." This is independent of issue #110 (per-module tests + meta.yml) and should land first — there's no point capturing per-module tests while the resolver finds zero modules.
+
+## 2026-08-19 — summarize-nextflow on ncbi/egapx (supersedes the 2026-05-03 hard-failure entry)
+
+The 2026-05-03 sweep recorded egapx as a **hard failure** — "sources under `nf/`,
+no `nextflow.config` at repo root; resolver throws `not a Nextflow pipeline
+root`." That is no longer true. Fix-list items 3 (pipeline-root auto-detect) and
+4 (entrypoint detection beyond `main.nf`) both landed. Re-run against the pinned
+fixture (`ncbi/egapx @ 40ec736`, v0.5.2):
+
+```
+warnings: auto-detected Nextflow pipeline root from workflow block: nf
+          selected Nextflow entrypoint: ui.nf
+```
+
+Exits 0, schema-valid. Counts: 95 `processes[]`, 68 `subworkflows[]`, 54 edges,
+6 conditionals.
+
+### What is still empty, and why it isn't the resolver's fault
+
+`params`, `tools`, `sample_sheets`, `profiles`, `reference_assets`, `nf_tests`
+all come back `[]`, and `container`/`conda` are null on all 95 processes. Two
+causes, both properties of egapx rather than resolver gaps:
+
+- **One global container, declared outside the detected root.**
+  `process.container = 'ncbi/egapx:0.5.2'` lives in
+  `ui/assets/config/docker_image.config` — under `ui/`, not the auto-detected
+  `nf/` root, and pulled in by the Python launcher rather than by a
+  `nextflow.config` the resolver would read. Per-process directives genuinely do
+  not exist; every step is a distinct NCBI C++ toolkit binary inside one image.
+- **No flat `params.*`.** The entrypoint reads `params.get('input', [:])` and
+  `params.get('tasks', [:])` — nested maps supplied by a YAML input file
+  (`examples/input_D_farinae_small.yaml`) plus `ui/assets/default_task_params.yaml`.
+  There is no `nextflow_schema.json` and nothing flat to extract.
+
+Worth naming as a resolver question rather than a bug: **root auto-detect and
+config discovery are now coupled.** Choosing `nf/` as the root is correct for
+process discovery and simultaneously puts `ui/assets/config/*.config` out of
+reach. Whether config discovery should search above the detected root is open.
+
+### Where this landed
+
+`content/pipelines/nextflow-to-galaxy/scenarios.md` gains a **ncbi/egapx**
+end-to-end case built around the empty summary — the journey's obligation is to
+treat empty `tools[]`/`params[]` as *absent evidence* and say so, not as "this
+pipeline has no tools". The mold-level case
+(`content/molds/summarize-nextflow/scenarios.md`, "pipeline-root auto-detect")
+already covered the exit-0-plus-warnings half and needs no change.

--- a/content/pipelines/nextflow-to-galaxy/scenarios.md
+++ b/content/pipelines/nextflow-to-galaxy/scenarios.md
@@ -141,3 +141,72 @@ Three caveats to keep the comparison honest:
 - expect: the branch control reaches the final workflow as an optional path or
   an explicit design decision; it is never silently folded away between the
   interface brief and the template.
+
+## Case: ncbi/egapx — non-academic provenance, monolithic container
+
+The hostile end of the ad-hoc corpus. Where nf-core/eager stresses *branch
+breadth*, egapx stresses *the absence of every nf-core affordance the pipeline's
+early phases lean on*: no `nextflow_schema.json`, no `meta.yml`, no nf-test, no
+flat `params.*`, no per-process container directives, and sources under `nf/`
+rather than the repository root. It is the case that answers "what does this
+journey do when the summary comes back mostly empty?"
+
+- fixture: `workflow-fixtures/pipelines/ncbi__egapx` (v0.5.2; large — 95
+  processes across 68 subworkflows, no `modules/` directory).
+- interface source: `examples/input_D_farinae_small.yaml` — the pipeline's real
+  user interface is a YAML input file (`genome` URL, `taxid`, `short_reads` SRA
+  accessions with public FTP mirrors, `locus_tag_prefix`, `cmsearch.enabled`,
+  `trnascan.enabled`), not a Nextflow schema. Per-task flag strings live in
+  `ui/assets/default_task_params.yaml`.
+
+- expect (summary phase): [[summarize-nextflow]] exits 0 from the repository
+  root with `warnings[]` naming both the auto-detected root (`nf`) and the
+  chosen entrypoint (`ui.nf`) — a wrong pick here silently mis-scopes every
+  downstream phase, so the choice must be reviewable, not implicit.
+
+- expect (empty-summary honesty): the summary comes back with `params`,
+  `tools`, `sample_sheets`, `profiles`, `reference_assets`, and `nf_tests` all
+  empty, and `container`/`conda` null on all 95 processes — egapx declares one
+  global `process.container = 'ncbi/egapx:0.5.2'`
+  (`ui/assets/config/docker_image.config`, which sits *outside* the detected
+  `nf/` root). Downstream phases must treat these as **absent evidence** and say
+  so, not as "this pipeline has no parameters" or "this pipeline needs no
+  tools". A journey that proceeds as if an empty `tools[]` meant zero tools has
+  failed this case regardless of what it produces.
+
+- expect (interface): the interface brief reaches egapx's actual inputs. Since
+  no `params[]` survives the summary, the brief must either mine the example
+  YAML as the interface source or record an explicit open requirement that the
+  interface is undetermined from the summary alone. Silently emitting a
+  parameterless Galaxy workflow is the failure mode this case exists to catch.
+
+- expect (conditionals): the five detected guards — `proteins`,
+  `short_reads_ids || short_reads`, `long_reads_ids || long_reads`,
+  `params?.tasks?.cmsearch?.enabled`, `params?.tasks?.trnascan?.enabled` —
+  reach the final workflow as optional inputs, gated steps, or a stated scope
+  decision. The last two correspond one-to-one with toggles the example YAML
+  actually sets, so they are user-facing choices by demonstration, not
+  inference.
+
+- expect (scope): 95 processes is not a Galaxy workflow. The journey must reach
+  a **stated scope decision** naming which annotation planes it carries
+  (`setup`, `rnaseq_short`, `rnaseq_long`, `target_proteins`, `gnomon`,
+  `annot_proc`, `busco`, `cmsearch`, `trna_scan`, `orthology`) and why, rather
+  than flattening or truncating silently.
+
+- expect (tool resolution): this is the case where discover-or-author is
+  expected to *mostly fall through to author*. egapx's steps are NCBI C++
+  toolkit binaries (`chainer_wnode`, `gnomon_wnode`, `align_sort_sa`,
+  `annot_builder_run`, …) shipped only inside `ncbi/egapx:0.5.2` — no
+  BioContainers, no bioconda, no Shed wrappers. Per `eval.md`, every carried
+  tool still needs a recorded decision; the interesting question is whether
+  [[author-galaxy-tool-wrapper]] can produce a defensible wrapper when its only
+  evidence is a `script:` block and one monolithic image, and whether it says so
+  when it cannot.
+
+- expect (test data): `test_fixtures` and `nf_tests` are empty, so
+  [[nextflow-to-test-data]] must fall through the `test-data-resolution` chain
+  rather than synthesize. `examples/input_D_farinae_small.yaml` is the intended
+  landing spot — a genuinely small subsampled *D. farinae* dataset on public
+  NCBI FTP — but nothing in the spine points a phase at it. Whether the chain
+  reaches it, and through which link, is the finding.


### PR DESCRIPTION
Adds an `ncbi/egapx` end-to-end case to the NEXTFLOW → GALAXY pipeline scenarios, and corrects a stale log entry that recorded egapx as unsummarizable.

## Why egapx

It's the hostile end of the ad-hoc corpus. Where the existing `nf-core/eager` case stresses *branch breadth*, egapx stresses *the absence of every nf-core affordance the early phases lean on*: no `nextflow_schema.json`, no `meta.yml`, no nf-test, no flat `params.*`, no per-process container directives, and sources under `nf/` rather than the repository root.

It's the case that answers "what does this journey do when the summary comes back mostly empty?"

## The resolver handles it now

`content/log.md`'s 2026-05-03 sweep recorded egapx as a **hard failure** — "resolver throws `not a Nextflow pipeline root`". That's no longer true; fix-list items 3 (pipeline-root auto-detect) and 4 (entrypoint detection beyond `main.nf`) both landed. Re-run against the pinned fixture (`ncbi/egapx @ 40ec736`, v0.5.2):

```
warnings: auto-detected Nextflow pipeline root from workflow block: nf
          selected Nextflow entrypoint: ui.nf
```

Exits 0, schema-valid. 95 `processes[]`, 68 `subworkflows[]`, 54 edges, 6 conditionals.

## What's still empty, and why that's the point

`params`, `tools`, `sample_sheets`, `profiles`, `reference_assets`, `nf_tests` all come back `[]`, and `container`/`conda` are null on all 95 processes. Both causes are properties of egapx rather than resolver gaps:

- **One global container, declared outside the detected root.** `process.container = 'ncbi/egapx:0.5.2'` lives in `ui/assets/config/docker_image.config` — under `ui/`, not the auto-detected `nf/` root. Per-process directives genuinely don't exist; every step is a distinct NCBI C++ toolkit binary inside one image.
- **No flat `params.*`.** The entrypoint reads `params.get('input', [:])` / `params.get('tasks', [:])` — nested maps supplied by a YAML input file (`examples/input_D_farinae_small.yaml`) plus `ui/assets/default_task_params.yaml`.

So the case's central expectation is **empty-summary honesty**: downstream phases must treat an empty `tools[]` as *absent evidence* and say so, not as "this pipeline has no tools". A journey that emits a parameterless Galaxy workflow has failed the case regardless of output quality.

The other expectations cover interface recovery from the example YAML, the six detected conditionals (two of which — `cmsearch.enabled`, `trnascan.enabled` — are toggles the example YAML actually sets, so they're user-facing by demonstration), a stated plane-level scope decision (95 processes is not a Galaxy workflow), discover-or-author expected to fall through to *author* almost everywhere, and the `test-data-resolution` chain reaching the D. farinae subsample rather than synthesizing.

## One open question raised, not answered

**Root auto-detect and config discovery are now coupled.** Choosing `nf/` is correct for process discovery and simultaneously puts `ui/assets/config/*.config` out of reach — that's why `tools[]` is empty. Whether config discovery should search above the detected root is left stated as open in the log rather than decided here.

## Notes

- The log entry is appended and names the superseded entry explicitly rather than editing it, per the append-only rule.
- The Mold-level case (`content/molds/summarize-nextflow/scenarios.md`, "pipeline-root auto-detect") already covered the exit-0-plus-warnings half; unchanged.
- Content-only change. `npm run validate` → 242 files, 0 errors, 49 pre-existing warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
