### PR TITLE
Name what Nextflow declares, carry what the script says

### DIFF
--- a/casts/claude/skills/author-galaxy-tool-wrapper/_provenance.json
+++ b/casts/claude/skills/author-galaxy-tool-wrapper/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/author-galaxy-tool-wrapper/index.md",
     "revision": 4,
     "content_hash": "f9c208c6c9e6cc4b6515ae68c3dcacb60b682eeee7e60d65d24c179faee75de2",
-    "commit": "a56c6127966e59c75cf67d1d41ca03c8b4cf45dd"
+    "commit": "1d78353a524732d43051be70cbed34cc70b8d4f7"
   },
-  "cast_at": "2026-08-02T22:04:17.980Z",
+  "cast_at": "2026-08-19T19:03:40.477Z",
   "cast_date": "2026-05-08",
   "cast_revision": 1,
   "cast_history": [
@@ -97,8 +97,8 @@
       "evidence": "corpus-observed",
       "purpose": "Read process tool, container, conda, inputs, outputs, script summary, and test fixture evidence from the source pipeline summary.",
       "license": "MIT",
-      "src_hash": "946330cc314556e77bb41725fa294e2496fe99b618888c660b7e8be7dc62ee5a",
-      "dst_hash": "946330cc314556e77bb41725fa294e2496fe99b618888c660b7e8be7dc62ee5a",
+      "src_hash": "201a42699572c0300cae59fb6b434c6a75fbc95f45d048132ec4299dd6741a4b",
+      "dst_hash": "201a42699572c0300cae59fb6b434c6a75fbc95f45d048132ec4299dd6741a4b",
       "source": "deterministic"
     }
   ],

--- a/casts/claude/skills/author-galaxy-tool-wrapper/references/schemas/summary-nextflow.schema.json
+++ b/casts/claude/skills/author-galaxy-tool-wrapper/references/schemas/summary-nextflow.schema.json
@@ -612,7 +612,14 @@
         },
         "script_summary": {
           "type": "string",
-          "description": "One-line LLM-derived summary of what the `script:` body does. Free text."
+          "description": "One-line LLM-derived summary of what the `script:` body does. Free text. The deterministic CLI does not emit it — it emits `script_excerpt` instead, and the cast skill's LLM pass fills this in."
+        },
+        "script_excerpt": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Verbatim `script:`/`shell:`/`exec:` body, dedented and truncated at 4000 characters, or null when the process declares none. Deterministic. For ad-hoc pipelines with no `meta.yml` this is the only evidence of what a process does."
         },
         "publish_dir": {
           "type": [

--- a/casts/claude/skills/nextflow-summary-to-cwl-data-flow/_provenance.json
+++ b/casts/claude/skills/nextflow-summary-to-cwl-data-flow/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/nextflow-summary-to-cwl-data-flow/index.md",
     "revision": 1,
     "content_hash": "68a75d5f934610fd9bf95434c94c3965dc2c591ea33160e911a3662f1f290aaa",
-    "commit": "a56c6127966e59c75cf67d1d41ca03c8b4cf45dd"
+    "commit": "1d78353a524732d43051be70cbed34cc70b8d4f7"
   },
-  "cast_at": "2026-08-02T22:04:50.184Z",
+  "cast_at": "2026-08-19T19:03:45.411Z",
   "refs": [
     {
       "kind": "schema",
@@ -21,8 +21,8 @@
       "evidence": "corpus-observed",
       "purpose": "Read process, channel, operator, and fixture structure while drafting CWL-facing abstract data flow.",
       "license": "MIT",
-      "src_hash": "946330cc314556e77bb41725fa294e2496fe99b618888c660b7e8be7dc62ee5a",
-      "dst_hash": "946330cc314556e77bb41725fa294e2496fe99b618888c660b7e8be7dc62ee5a",
+      "src_hash": "201a42699572c0300cae59fb6b434c6a75fbc95f45d048132ec4299dd6741a4b",
+      "dst_hash": "201a42699572c0300cae59fb6b434c6a75fbc95f45d048132ec4299dd6741a4b",
       "source": "deterministic"
     }
   ],

--- a/casts/claude/skills/nextflow-summary-to-cwl-data-flow/references/schemas/summary-nextflow.schema.json
+++ b/casts/claude/skills/nextflow-summary-to-cwl-data-flow/references/schemas/summary-nextflow.schema.json
@@ -612,7 +612,14 @@
         },
         "script_summary": {
           "type": "string",
-          "description": "One-line LLM-derived summary of what the `script:` body does. Free text."
+          "description": "One-line LLM-derived summary of what the `script:` body does. Free text. The deterministic CLI does not emit it — it emits `script_excerpt` instead, and the cast skill's LLM pass fills this in."
+        },
+        "script_excerpt": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Verbatim `script:`/`shell:`/`exec:` body, dedented and truncated at 4000 characters, or null when the process declares none. Deterministic. For ad-hoc pipelines with no `meta.yml` this is the only evidence of what a process does."
         },
         "publish_dir": {
           "type": [

--- a/casts/claude/skills/nextflow-summary-to-cwl-interface/_provenance.json
+++ b/casts/claude/skills/nextflow-summary-to-cwl-interface/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/nextflow-summary-to-cwl-interface/index.md",
     "revision": 1,
     "content_hash": "3fc1ccd78b3828e77382b921fc547a4ea2f56d7123cd92cf0e1cfefd4561984f",
-    "commit": "a56c6127966e59c75cf67d1d41ca03c8b4cf45dd"
+    "commit": "1d78353a524732d43051be70cbed34cc70b8d4f7"
   },
-  "cast_at": "2026-08-02T22:04:51.152Z",
+  "cast_at": "2026-08-19T19:03:45.547Z",
   "refs": [
     {
       "kind": "schema",
@@ -21,8 +21,8 @@
       "evidence": "corpus-observed",
       "purpose": "Read source-level channel, parameter, process, and test-fixture evidence before choosing CWL Workflow inputs and outputs.",
       "license": "MIT",
-      "src_hash": "946330cc314556e77bb41725fa294e2496fe99b618888c660b7e8be7dc62ee5a",
-      "dst_hash": "946330cc314556e77bb41725fa294e2496fe99b618888c660b7e8be7dc62ee5a",
+      "src_hash": "201a42699572c0300cae59fb6b434c6a75fbc95f45d048132ec4299dd6741a4b",
+      "dst_hash": "201a42699572c0300cae59fb6b434c6a75fbc95f45d048132ec4299dd6741a4b",
       "source": "deterministic"
     }
   ],

--- a/casts/claude/skills/nextflow-summary-to-cwl-interface/references/schemas/summary-nextflow.schema.json
+++ b/casts/claude/skills/nextflow-summary-to-cwl-interface/references/schemas/summary-nextflow.schema.json
@@ -612,7 +612,14 @@
         },
         "script_summary": {
           "type": "string",
-          "description": "One-line LLM-derived summary of what the `script:` body does. Free text."
+          "description": "One-line LLM-derived summary of what the `script:` body does. Free text. The deterministic CLI does not emit it — it emits `script_excerpt` instead, and the cast skill's LLM pass fills this in."
+        },
+        "script_excerpt": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Verbatim `script:`/`shell:`/`exec:` body, dedented and truncated at 4000 characters, or null when the process declares none. Deterministic. For ad-hoc pipelines with no `meta.yml` this is the only evidence of what a process does."
         },
         "publish_dir": {
           "type": [

--- a/casts/claude/skills/nextflow-summary-to-galaxy-data-flow/_provenance.json
+++ b/casts/claude/skills/nextflow-summary-to-galaxy-data-flow/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/nextflow-summary-to-galaxy-data-flow/index.md",
     "revision": 5,
     "content_hash": "ab1fde58ac26d8d204e39eca5032fe304ad01c5128eb82b5f06bd2321426b174",
-    "commit": "aede1aeab8ceb890192c9606a6e967a36fcf2224"
+    "commit": "1d78353a524732d43051be70cbed34cc70b8d4f7"
   },
-  "cast_at": "2026-08-03T23:37:55.552Z",
+  "cast_at": "2026-08-19T19:03:45.878Z",
   "cast_date": "2026-05-07",
   "cast_revision": 3,
   "cast_history": [
@@ -233,8 +233,8 @@
       "evidence": "corpus-observed",
       "purpose": "Read process, channel, operator, and fixture structure while drafting Galaxy-facing abstract data flow.",
       "license": "MIT",
-      "src_hash": "946330cc314556e77bb41725fa294e2496fe99b618888c660b7e8be7dc62ee5a",
-      "dst_hash": "946330cc314556e77bb41725fa294e2496fe99b618888c660b7e8be7dc62ee5a",
+      "src_hash": "201a42699572c0300cae59fb6b434c6a75fbc95f45d048132ec4299dd6741a4b",
+      "dst_hash": "201a42699572c0300cae59fb6b434c6a75fbc95f45d048132ec4299dd6741a4b",
       "source": "deterministic"
     }
   ],

--- a/casts/claude/skills/nextflow-summary-to-galaxy-data-flow/references/schemas/summary-nextflow.schema.json
+++ b/casts/claude/skills/nextflow-summary-to-galaxy-data-flow/references/schemas/summary-nextflow.schema.json
@@ -612,7 +612,14 @@
         },
         "script_summary": {
           "type": "string",
-          "description": "One-line LLM-derived summary of what the `script:` body does. Free text."
+          "description": "One-line LLM-derived summary of what the `script:` body does. Free text. The deterministic CLI does not emit it — it emits `script_excerpt` instead, and the cast skill's LLM pass fills this in."
+        },
+        "script_excerpt": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Verbatim `script:`/`shell:`/`exec:` body, dedented and truncated at 4000 characters, or null when the process declares none. Deterministic. For ad-hoc pipelines with no `meta.yml` this is the only evidence of what a process does."
         },
         "publish_dir": {
           "type": [

--- a/casts/claude/skills/nextflow-summary-to-galaxy-interface/_provenance.json
+++ b/casts/claude/skills/nextflow-summary-to-galaxy-interface/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/nextflow-summary-to-galaxy-interface/index.md",
     "revision": 5,
     "content_hash": "dcebf8087554cd90d5f9e7da322551dd2f76883369db0eef8f028bf6f85a0f7a",
-    "commit": "a56c6127966e59c75cf67d1d41ca03c8b4cf45dd"
+    "commit": "1d78353a524732d43051be70cbed34cc70b8d4f7"
   },
-  "cast_at": "2026-08-02T22:04:53.079Z",
+  "cast_at": "2026-08-19T19:03:46.085Z",
   "cast_date": "2026-05-07",
   "cast_revision": 3,
   "cast_history": [
@@ -157,8 +157,8 @@
       "evidence": "corpus-observed",
       "purpose": "Read source-level channel, parameter, process, and test-fixture evidence before choosing Galaxy workflow inputs and outputs.",
       "license": "MIT",
-      "src_hash": "946330cc314556e77bb41725fa294e2496fe99b618888c660b7e8be7dc62ee5a",
-      "dst_hash": "946330cc314556e77bb41725fa294e2496fe99b618888c660b7e8be7dc62ee5a",
+      "src_hash": "201a42699572c0300cae59fb6b434c6a75fbc95f45d048132ec4299dd6741a4b",
+      "dst_hash": "201a42699572c0300cae59fb6b434c6a75fbc95f45d048132ec4299dd6741a4b",
       "source": "deterministic"
     }
   ],

--- a/casts/claude/skills/nextflow-summary-to-galaxy-interface/references/schemas/summary-nextflow.schema.json
+++ b/casts/claude/skills/nextflow-summary-to-galaxy-interface/references/schemas/summary-nextflow.schema.json
@@ -612,7 +612,14 @@
         },
         "script_summary": {
           "type": "string",
-          "description": "One-line LLM-derived summary of what the `script:` body does. Free text."
+          "description": "One-line LLM-derived summary of what the `script:` body does. Free text. The deterministic CLI does not emit it — it emits `script_excerpt` instead, and the cast skill's LLM pass fills this in."
+        },
+        "script_excerpt": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Verbatim `script:`/`shell:`/`exec:` body, dedented and truncated at 4000 characters, or null when the process declares none. Deterministic. For ad-hoc pipelines with no `meta.yml` this is the only evidence of what a process does."
         },
         "publish_dir": {
           "type": [

--- a/casts/claude/skills/nextflow-summary-to-galaxy-reference-data/_provenance.json
+++ b/casts/claude/skills/nextflow-summary-to-galaxy-reference-data/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/nextflow-summary-to-galaxy-reference-data/index.md",
     "revision": 4,
     "content_hash": "788baae784e8c75ed2c390af073212bc258fd541c6eba2b9b4374292b7db96b2",
-    "commit": "a56c6127966e59c75cf67d1d41ca03c8b4cf45dd"
+    "commit": "1d78353a524732d43051be70cbed34cc70b8d4f7"
   },
-  "cast_at": "2026-08-02T22:04:54.012Z",
+  "cast_at": "2026-08-19T19:03:46.302Z",
   "refs": [
     {
       "kind": "research",
@@ -79,8 +79,8 @@
       "evidence": "corpus-observed",
       "purpose": "Read `reference_assets[]` (curated path-typed inputs with `used_by` attribution to consuming subworkflows), `reference_rebuilds[]` (compute-if-missing rebuild rules with builder process and guard), and `params[]` provenance (`source_kind`, including `getGenomeAttribute` for nf-core key-expanded bundles) to determine which reference assets the source pipeline consumes and how it rebuilds them when absent.",
       "license": "MIT",
-      "src_hash": "946330cc314556e77bb41725fa294e2496fe99b618888c660b7e8be7dc62ee5a",
-      "dst_hash": "946330cc314556e77bb41725fa294e2496fe99b618888c660b7e8be7dc62ee5a",
+      "src_hash": "201a42699572c0300cae59fb6b434c6a75fbc95f45d048132ec4299dd6741a4b",
+      "dst_hash": "201a42699572c0300cae59fb6b434c6a75fbc95f45d048132ec4299dd6741a4b",
       "source": "deterministic"
     }
   ],

--- a/casts/claude/skills/nextflow-summary-to-galaxy-reference-data/references/schemas/summary-nextflow.schema.json
+++ b/casts/claude/skills/nextflow-summary-to-galaxy-reference-data/references/schemas/summary-nextflow.schema.json
@@ -612,7 +612,14 @@
         },
         "script_summary": {
           "type": "string",
-          "description": "One-line LLM-derived summary of what the `script:` body does. Free text."
+          "description": "One-line LLM-derived summary of what the `script:` body does. Free text. The deterministic CLI does not emit it — it emits `script_excerpt` instead, and the cast skill's LLM pass fills this in."
+        },
+        "script_excerpt": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Verbatim `script:`/`shell:`/`exec:` body, dedented and truncated at 4000 characters, or null when the process declares none. Deterministic. For ad-hoc pipelines with no `meta.yml` this is the only evidence of what a process does."
         },
         "publish_dir": {
           "type": [

--- a/casts/claude/skills/nextflow-summary-to-galaxy-template/_provenance.json
+++ b/casts/claude/skills/nextflow-summary-to-galaxy-template/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/nextflow-summary-to-galaxy-template/index.md",
     "revision": 8,
     "content_hash": "23676d3bdc6a728949f757ae221a7e40153666e7028f671ea8ab52fe5b9f2686",
-    "commit": "b9590579bec9fec7caeb35f2274c3a9639d665d6"
+    "commit": "1d78353a524732d43051be70cbed34cc70b8d4f7"
   },
-  "cast_at": "2026-08-05T22:29:37.296Z",
+  "cast_at": "2026-08-19T19:03:46.581Z",
   "cast_date": "2026-05-07",
   "cast_revision": 3,
   "cast_history": [
@@ -326,8 +326,8 @@
       "evidence": "corpus-observed",
       "purpose": "Read process, channel, operator, and fixture structure when emitting placeholder steps and TODO context.",
       "license": "MIT",
-      "src_hash": "946330cc314556e77bb41725fa294e2496fe99b618888c660b7e8be7dc62ee5a",
-      "dst_hash": "946330cc314556e77bb41725fa294e2496fe99b618888c660b7e8be7dc62ee5a",
+      "src_hash": "201a42699572c0300cae59fb6b434c6a75fbc95f45d048132ec4299dd6741a4b",
+      "dst_hash": "201a42699572c0300cae59fb6b434c6a75fbc95f45d048132ec4299dd6741a4b",
       "source": "deterministic"
     }
   ],

--- a/casts/claude/skills/nextflow-summary-to-galaxy-template/references/schemas/summary-nextflow.schema.json
+++ b/casts/claude/skills/nextflow-summary-to-galaxy-template/references/schemas/summary-nextflow.schema.json
@@ -612,7 +612,14 @@
         },
         "script_summary": {
           "type": "string",
-          "description": "One-line LLM-derived summary of what the `script:` body does. Free text."
+          "description": "One-line LLM-derived summary of what the `script:` body does. Free text. The deterministic CLI does not emit it — it emits `script_excerpt` instead, and the cast skill's LLM pass fills this in."
+        },
+        "script_excerpt": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Verbatim `script:`/`shell:`/`exec:` body, dedented and truncated at 4000 characters, or null when the process declares none. Deterministic. For ad-hoc pipelines with no `meta.yml` this is the only evidence of what a process does."
         },
         "publish_dir": {
           "type": [

--- a/casts/claude/skills/nextflow-test-to-cwl-test-plan/_provenance.json
+++ b/casts/claude/skills/nextflow-test-to-cwl-test-plan/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/nextflow-test-to-cwl-test-plan/index.md",
     "revision": 1,
     "content_hash": "6b2b5d921e5998debde2018e44ad2b117e7af6e538feddbff5a17ee21a9e256f",
-    "commit": "a56c6127966e59c75cf67d1d41ca03c8b4cf45dd"
+    "commit": "1d78353a524732d43051be70cbed34cc70b8d4f7"
   },
-  "cast_at": "2026-08-02T22:04:56.538Z",
+  "cast_at": "2026-08-19T19:03:46.825Z",
   "refs": [
     {
       "kind": "schema",
@@ -21,8 +21,8 @@
       "evidence": "corpus-observed",
       "purpose": "Read summarized nf-test profiles, snapshot fixtures, selected test data, params, and expected outputs.",
       "license": "MIT",
-      "src_hash": "946330cc314556e77bb41725fa294e2496fe99b618888c660b7e8be7dc62ee5a",
-      "dst_hash": "946330cc314556e77bb41725fa294e2496fe99b618888c660b7e8be7dc62ee5a",
+      "src_hash": "201a42699572c0300cae59fb6b434c6a75fbc95f45d048132ec4299dd6741a4b",
+      "dst_hash": "201a42699572c0300cae59fb6b434c6a75fbc95f45d048132ec4299dd6741a4b",
       "source": "deterministic"
     }
   ],

--- a/casts/claude/skills/nextflow-test-to-cwl-test-plan/references/schemas/summary-nextflow.schema.json
+++ b/casts/claude/skills/nextflow-test-to-cwl-test-plan/references/schemas/summary-nextflow.schema.json
@@ -612,7 +612,14 @@
         },
         "script_summary": {
           "type": "string",
-          "description": "One-line LLM-derived summary of what the `script:` body does. Free text."
+          "description": "One-line LLM-derived summary of what the `script:` body does. Free text. The deterministic CLI does not emit it — it emits `script_excerpt` instead, and the cast skill's LLM pass fills this in."
+        },
+        "script_excerpt": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Verbatim `script:`/`shell:`/`exec:` body, dedented and truncated at 4000 characters, or null when the process declares none. Deterministic. For ad-hoc pipelines with no `meta.yml` this is the only evidence of what a process does."
         },
         "publish_dir": {
           "type": [

--- a/casts/claude/skills/nextflow-test-to-galaxy-test-plan/_provenance.json
+++ b/casts/claude/skills/nextflow-test-to-galaxy-test-plan/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/nextflow-test-to-galaxy-test-plan/index.md",
     "revision": 5,
     "content_hash": "4507e5ff7ffaa9751cf80e33c28fec403766dc95197c0813821362711f603732",
-    "commit": "aede1aeab8ceb890192c9606a6e967a36fcf2224"
+    "commit": "1d78353a524732d43051be70cbed34cc70b8d4f7"
   },
-  "cast_at": "2026-08-03T23:38:00.340Z",
+  "cast_at": "2026-08-19T19:03:47.087Z",
   "refs": [
     {
       "kind": "research",
@@ -129,8 +129,8 @@
       "evidence": "corpus-observed",
       "purpose": "Read summarized nf-test profiles, snapshot fixtures, selected test data, params, and expected outputs.",
       "license": "MIT",
-      "src_hash": "946330cc314556e77bb41725fa294e2496fe99b618888c660b7e8be7dc62ee5a",
-      "dst_hash": "946330cc314556e77bb41725fa294e2496fe99b618888c660b7e8be7dc62ee5a",
+      "src_hash": "201a42699572c0300cae59fb6b434c6a75fbc95f45d048132ec4299dd6741a4b",
+      "dst_hash": "201a42699572c0300cae59fb6b434c6a75fbc95f45d048132ec4299dd6741a4b",
       "source": "deterministic"
     },
     {

--- a/casts/claude/skills/nextflow-test-to-galaxy-test-plan/references/schemas/summary-nextflow.schema.json
+++ b/casts/claude/skills/nextflow-test-to-galaxy-test-plan/references/schemas/summary-nextflow.schema.json
@@ -612,7 +612,14 @@
         },
         "script_summary": {
           "type": "string",
-          "description": "One-line LLM-derived summary of what the `script:` body does. Free text."
+          "description": "One-line LLM-derived summary of what the `script:` body does. Free text. The deterministic CLI does not emit it — it emits `script_excerpt` instead, and the cast skill's LLM pass fills this in."
+        },
+        "script_excerpt": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Verbatim `script:`/`shell:`/`exec:` body, dedented and truncated at 4000 characters, or null when the process declares none. Deterministic. For ad-hoc pipelines with no `meta.yml` this is the only evidence of what a process does."
         },
         "publish_dir": {
           "type": [

--- a/casts/claude/skills/nextflow-to-test-data/_provenance.json
+++ b/casts/claude/skills/nextflow-to-test-data/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/nextflow-to-test-data/index.md",
     "revision": 2,
     "content_hash": "5569467ca2b1bb6bdaec69f4d6a9482b111b4433d5a70f1bf19c29a8d511f3ca",
-    "commit": "aede1aeab8ceb890192c9606a6e967a36fcf2224"
+    "commit": "1d78353a524732d43051be70cbed34cc70b8d4f7"
   },
-  "cast_at": "2026-08-03T23:38:01.703Z",
+  "cast_at": "2026-08-19T19:03:47.360Z",
   "refs": [
     {
       "kind": "research",
@@ -83,8 +83,8 @@
       "evidence": "corpus-observed",
       "purpose": "Input contract: read the selected profile's `test_fixtures.inputs[]` and the `nf_tests[]` enumeration — role, url/path, sha1, filetype — as the declared source of test data.",
       "license": "MIT",
-      "src_hash": "946330cc314556e77bb41725fa294e2496fe99b618888c660b7e8be7dc62ee5a",
-      "dst_hash": "946330cc314556e77bb41725fa294e2496fe99b618888c660b7e8be7dc62ee5a",
+      "src_hash": "201a42699572c0300cae59fb6b434c6a75fbc95f45d048132ec4299dd6741a4b",
+      "dst_hash": "201a42699572c0300cae59fb6b434c6a75fbc95f45d048132ec4299dd6741a4b",
       "source": "deterministic"
     }
   ],

--- a/casts/claude/skills/nextflow-to-test-data/references/schemas/summary-nextflow.schema.json
+++ b/casts/claude/skills/nextflow-to-test-data/references/schemas/summary-nextflow.schema.json
@@ -612,7 +612,14 @@
         },
         "script_summary": {
           "type": "string",
-          "description": "One-line LLM-derived summary of what the `script:` body does. Free text."
+          "description": "One-line LLM-derived summary of what the `script:` body does. Free text. The deterministic CLI does not emit it — it emits `script_excerpt` instead, and the cast skill's LLM pass fills this in."
+        },
+        "script_excerpt": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Verbatim `script:`/`shell:`/`exec:` body, dedented and truncated at 4000 characters, or null when the process declares none. Deterministic. For ad-hoc pipelines with no `meta.yml` this is the only evidence of what a process does."
         },
         "publish_dir": {
           "type": [

--- a/casts/claude/skills/summarize-nextflow/SKILL.md
+++ b/casts/claude/skills/summarize-nextflow/SKILL.md
@@ -120,7 +120,7 @@ A single JSON document conforming to summary-nextflow (`packages/summarize-nextf
       "outputs": [ { "name": "paf",      "shape": "tuple(val(meta), path(\"*.paf\")) optional", "description": "...", "topic": null },
                    { "name": "versions", "shape": "path(\"versions.yml\")",                     "description": "tool versions YAML", "topic": null } ],
       "when": null,
-      "script_summary": "Align reads against reference, emit PAF or BAM.",
+      "script_excerpt": "\"\"\"\n$args\nminimap2 -t $task.cpus $reference $reads > ${prefix}.paf\n\"\"\"",   // verbatim script body; script_summary is the LLM pass's job
       "publish_dir": null }
   ],
   "subworkflows": [
@@ -187,7 +187,7 @@ Field-name parity with gxy-sketches (`SketchSource`, `ToolSpec`, `TestDataRef`, 
 The skill is **not a single LLM prompt** over the source tree. It is a small program with one or two embedded LLM calls. The split is:
 
 - **Deterministic:** locate files, parse `nextflow.config` and `nextflow_schema.json`, regex-tokenize `process` blocks for typed fields (name, container, conda, declared IO channel names, `when:` guards, `publishDir`), read nf-core module `meta.yml` verbatim, enumerate `include { X } from '...'` for the call graph, resolve biocontainer image strings.
-- **LLM-driven:** one-line summary of each process `script:` body, reconciliation of operator-chained channel paths (`A | map | join(B) | groupTuple`) into the workflow `edges[]`, free-text `description` / `notes` fields, IO inference when `meta.yml` is absent and the script is the only signal.
+- **LLM-driven:** one-line `script_summary` of each process, over the verbatim `script_excerpt` the deterministic pass carries; reconciliation of operator-chained channel paths (`A | map | join(B) | groupTuple`) into the workflow `edges[]`, free-text `description` / `notes` fields, IO inference when `meta.yml` is absent and the script is the only signal.
 
 Everything the schema demands as a typed enum or path is deterministic. Free-text fields are LLM. The schema enforces that boundary by typing.
 
@@ -233,7 +233,8 @@ For each `process <NAME> { ... }` in `main.nf`, `workflows/`, `modules/**`, `sub
 - Sweep `include { ... }` statements across the pipeline (`main.nf`, `workflows/`, `subworkflows/**`) to populate `processes[].aliases`. `include { MINIMAP2_ALIGN as MINIMAP2_CONSENSUS }` adds `MINIMAP2_CONSENSUS` to the `MINIMAP2_ALIGN` process's `aliases[]`. The same module can be re-imported under multiple aliases (bacass aliases `MINIMAP2_ALIGN` three times). Edges reference the alias name; the canonical `name` is the FK target.
 - Detect `topic: <name>` annotations on outputs (Nextflow 24+ channel topics — nf-core templates emit `tuple(val("${task.process}"), val('toolname'), eval(...)) topic: versions` for version aggregation). Record the topic name in `ChannelIO.topic`.
 - Where `meta.yml` exists, **use it** for `description` and IO documentation rather than parsing the `script:` block.
-- LLM call (one per process, batchable): summarize the `script:` body in one line. Pass the script verbatim plus the declared IO; ask only for what the tool *does*.
+- Carry the `script:`/`shell:`/`exec:` body verbatim into `script_excerpt` (dedented, truncated at 4000 characters, `stub:` dropped). For ad-hoc pipelines with no `meta.yml` this is the only evidence of what a process does.
+- LLM call (one per process, batchable): summarize `script_excerpt` in one line into `script_summary`. Ask only for what the tool *does*. Deterministic runs omit `script_summary` rather than emitting a placeholder.
 
 #### 5. Build the tool registry
 

--- a/casts/claude/skills/summarize-nextflow/_provenance.json
+++ b/casts/claude/skills/summarize-nextflow/_provenance.json
@@ -5,12 +5,12 @@
     "name": "summarize-nextflow",
     "path": "content/molds/summarize-nextflow/index.md",
     "revision": 14,
-    "content_hash": "cb1d13ddba33496cc62070c3adde6a3e4159053db8ee304fbe5a803e810f849e",
-    "commit": "aede1aeab8ceb890192c9606a6e967a36fcf2224"
+    "content_hash": "60659f52ed7278ed7ac66144c6706696b3880ee4d2db114afda7cedccde83e2e",
+    "commit": "1d78353a524732d43051be70cbed34cc70b8d4f7"
   },
   "cast_method": "hand-cast",
   "cast_agent": "claude (manual transcription, no LLM cast prompt)",
-  "cast_at": "2026-08-03T23:38:03.201Z",
+  "cast_at": "2026-08-19T19:03:49.152Z",
   "cast_date": "2026-05-08",
   "cast_revision": 11,
   "cast_history": [
@@ -226,8 +226,8 @@
       "evidence": "cast-validated",
       "purpose": "Validate the emitted Nextflow summary JSON and provide downstream consumers the output contract.",
       "license": "MIT",
-      "src_hash": "946330cc314556e77bb41725fa294e2496fe99b618888c660b7e8be7dc62ee5a",
-      "dst_hash": "946330cc314556e77bb41725fa294e2496fe99b618888c660b7e8be7dc62ee5a",
+      "src_hash": "201a42699572c0300cae59fb6b434c6a75fbc95f45d048132ec4299dd6741a4b",
+      "dst_hash": "201a42699572c0300cae59fb6b434c6a75fbc95f45d048132ec4299dd6741a4b",
       "source": "deterministic"
     }
   ],

--- a/casts/claude/skills/summarize-nextflow/references/schemas/summary-nextflow.schema.json
+++ b/casts/claude/skills/summarize-nextflow/references/schemas/summary-nextflow.schema.json
@@ -612,7 +612,14 @@
         },
         "script_summary": {
           "type": "string",
-          "description": "One-line LLM-derived summary of what the `script:` body does. Free text."
+          "description": "One-line LLM-derived summary of what the `script:` body does. Free text. The deterministic CLI does not emit it — it emits `script_excerpt` instead, and the cast skill's LLM pass fills this in."
+        },
+        "script_excerpt": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Verbatim `script:`/`shell:`/`exec:` body, dedented and truncated at 4000 characters, or null when the process declares none. Deterministic. For ad-hoc pipelines with no `meta.yml` this is the only evidence of what a process does."
         },
         "publish_dir": {
           "type": [

--- a/content/molds/summarize-nextflow/index.md
+++ b/content/molds/summarize-nextflow/index.md
@@ -155,7 +155,7 @@ A single JSON document conforming to [[summary-nextflow]] (`packages/summarize-n
       "outputs": [ { "name": "paf",      "shape": "tuple(val(meta), path(\"*.paf\")) optional", "description": "...", "topic": null },
                    { "name": "versions", "shape": "path(\"versions.yml\")",                     "description": "tool versions YAML", "topic": null } ],
       "when": null,
-      "script_summary": "Align reads against reference, emit PAF or BAM.",
+      "script_excerpt": "\"\"\"\n$args\nminimap2 -t $task.cpus $reference $reads > ${prefix}.paf\n\"\"\"",   // verbatim script body; script_summary is the LLM pass's job
       "publish_dir": null }
   ],
   "subworkflows": [
@@ -222,7 +222,7 @@ Field-name parity with gxy-sketches (`SketchSource`, `ToolSpec`, `TestDataRef`, 
 The cast skill is **not a single LLM prompt** over the source tree. It is a small program with one or two embedded LLM calls. The split is:
 
 - **Deterministic:** locate files, parse `nextflow.config` and `nextflow_schema.json`, regex-tokenize `process` blocks for typed fields (name, container, conda, declared IO channel names, `when:` guards, `publishDir`), read nf-core module `meta.yml` verbatim, enumerate `include { X } from '...'` for the call graph, resolve biocontainer image strings.
-- **LLM-driven:** one-line summary of each process `script:` body, reconciliation of operator-chained channel paths (`A | map | join(B) | groupTuple`) into the workflow `edges[]`, free-text `description` / `notes` fields, IO inference when `meta.yml` is absent and the script is the only signal.
+- **LLM-driven:** one-line `script_summary` of each process, over the verbatim `script_excerpt` the deterministic pass carries; reconciliation of operator-chained channel paths (`A | map | join(B) | groupTuple`) into the workflow `edges[]`, free-text `description` / `notes` fields, IO inference when `meta.yml` is absent and the script is the only signal.
 
 Everything the schema demands as a typed enum or path is deterministic. Free-text fields are LLM. The schema enforces that boundary by typing.
 
@@ -268,7 +268,8 @@ For each `process <NAME> { ... }` in `main.nf`, `workflows/`, `modules/**`, `sub
 - Sweep `include { ... }` statements across the pipeline (`main.nf`, `workflows/`, `subworkflows/**`) to populate `processes[].aliases`. `include { MINIMAP2_ALIGN as MINIMAP2_CONSENSUS }` adds `MINIMAP2_CONSENSUS` to the `MINIMAP2_ALIGN` process's `aliases[]`. The same module can be re-imported under multiple aliases (bacass aliases `MINIMAP2_ALIGN` three times). Edges reference the alias name; the canonical `name` is the FK target.
 - Detect `topic: <name>` annotations on outputs (Nextflow 24+ channel topics — nf-core templates emit `tuple(val("${task.process}"), val('toolname'), eval(...)) topic: versions` for version aggregation). Record the topic name in `ChannelIO.topic`.
 - Where `meta.yml` exists, **use it** for `description` and IO documentation rather than parsing the `script:` block.
-- LLM call (one per process, batchable): summarize the `script:` body in one line. Pass the script verbatim plus the declared IO; ask only for what the tool *does*.
+- Carry the `script:`/`shell:`/`exec:` body verbatim into `script_excerpt` (dedented, truncated at 4000 characters, `stub:` dropped). For ad-hoc pipelines with no `meta.yml` this is the only evidence of what a process does.
+- LLM call (one per process, batchable): summarize `script_excerpt` in one line into `script_summary`. Ask only for what the tool *does*. Deterministic runs omit `script_summary` rather than emitting a placeholder.
 
 ### 5. Build the tool registry
 

--- a/content/schemas/summary-nextflow.md
+++ b/content/schemas/summary-nextflow.md
@@ -73,7 +73,7 @@ Per `content/meta/casting.md`'s per-kind dispatch, this schema is referenced by 
 
 - **Structured channel typing.** `processes[].inputs[].shape` is a string (`"tuple(meta, [path,path])"`), not a structured type. NF channel typing is a research project; a string is enough for downstream Molds to reason about and an LLM to emit.
 - **Operator-chain semantics.** `Edge.via` records the literal operator chain (`["map", "join", "groupTuple"]`). Reconciling what the chain *does* to channel shapes is left to the LLM step that fills `Edge.notes` when confidence is low.
-- **Multi-tool processes outside decomposed mulled-v2 containers.** A process can run multiple tools (a shell pipeline of two binaries). `Process.tool` is nullable; multi-tool processes set it null and surface tool details in `script_summary` and `container`. A `tools[]` foreign-key array on `Process` would be cleaner; deferred until downstream use forces it.
+- **Multi-tool processes outside decomposed mulled-v2 containers.** A process can run multiple tools (a shell pipeline of two binaries). `Process.tool` is nullable; multi-tool processes set it null and surface tool details in `script_excerpt` and `container`. A `tools[]` foreign-key array on `Process` would be cleaner; deferred until downstream use forces it.
 
 ## Revision 2 — 2026-05-01
 

--- a/packages/summarize-nextflow/src/resolver.ts
+++ b/packages/summarize-nextflow/src/resolver.ts
@@ -198,7 +198,7 @@ interface Process {
   inputs: ChannelIO[];
   outputs: ChannelIO[];
   when: string | null;
-  script_summary: string;
+  script_excerpt: string | null;
   publish_dir: string | null;
 }
 
@@ -795,7 +795,7 @@ function parseProcessFile(pipelineRoot: string, path: string): Process[] {
       inputs: parseIoBlock(body, "input"),
       outputs: parseIoBlock(body, "output"),
       when: normalizeDirective(matchOne(body, /when:\s*\n([\s\S]*?)\n\s*script:/u)),
-      script_summary: summarizeScript(name),
+      script_excerpt: extractScript(body),
       publish_dir: normalizeDirective(matchOne(body, /publishDir\s+([^\n]+)/u)),
     };
   });
@@ -1730,11 +1730,14 @@ function parseIoBlock(text: string, blockName: "input" | "output"): ChannelIO[] 
     }));
 }
 
+// `path`/`val`/`env` bind an identifier; a quoted argument is a literal path, so it never names the channel.
 function parseIoName(line: string, blockName: "input" | "output"): string {
   return (
-    matchOne(line, /emit:\s*([A-Za-z0-9_]+)/u) ??
-    matchOne(line, /path\(?([A-Za-z0-9_]+)/u) ??
-    matchOne(line, /val\(([A-Za-z0-9_]+)/u) ??
+    matchOne(line, /emit:\s*['"]?([A-Za-z0-9_]+)/u) ??
+    matchOne(line, /\bpath\s*\(?\s*([A-Za-z0-9_]+)/u) ??
+    matchOne(line, /\bval\s*\(?\s*([A-Za-z0-9_]+)/u) ??
+    matchOne(line, /\benv\s*\(?\s*([A-Za-z0-9_]+)/u) ??
+    matchOne(line, /\beach\s+([A-Za-z0-9_]+)/u) ??
     `${blockName}_${Math.abs(hash(line))}`
   );
 }
@@ -2351,9 +2354,23 @@ function parseProseAssertions(text: string): string[] {
     .filter((assertion) => !assertion.startsWith("snapshot("));
 }
 
-function summarizeScript(name: string): string {
-  const tool = name.toLowerCase().replace(/_/gu, " ");
-  return `Run ${tool} and emit declared Nextflow outputs.`;
+const SCRIPT_EXCERPT_LIMIT = 4000;
+
+// Verbatim script body, dedented. Interpreting it is the consumer's job, not the parser's.
+function extractScript(body: string): string | null {
+  const block = matchOne(body, /(?:^|\n)[^\S\n]*(?:script|shell|exec):[^\S\n]*\n([\s\S]*)$/u);
+  if (block === null) return null;
+  const lines = block.replace(/\n[^\S\n]*stub:[^\S\n]*\n[\s\S]*$/u, "").split("\n");
+  while (lines.length && !lines[0]!.trim()) lines.shift();
+  while (lines.length && !lines[lines.length - 1]!.trim()) lines.pop();
+  if (lines.length === 0) return null;
+  const indent = Math.min(
+    ...lines.filter((line) => line.trim()).map((line) => line.length - line.trimStart().length),
+  );
+  const text = lines.map((line) => line.slice(indent)).join("\n");
+  return text.length > SCRIPT_EXCERPT_LIMIT
+    ? `${text.slice(0, SCRIPT_EXCERPT_LIMIT)}\n… [truncated]`
+    : text;
 }
 
 function extractNamedBlock(text: string, name: string): string | null {

--- a/packages/summarize-nextflow/src/schema/summary-nextflow.schema.generated.ts
+++ b/packages/summarize-nextflow/src/schema/summary-nextflow.schema.generated.ts
@@ -614,7 +614,14 @@ export const summaryNextflowSchema = {
         },
         "script_summary": {
           "type": "string",
-          "description": "One-line LLM-derived summary of what the `script:` body does. Free text."
+          "description": "One-line LLM-derived summary of what the `script:` body does. Free text. The deterministic CLI does not emit it — it emits `script_excerpt` instead, and the cast skill's LLM pass fills this in."
+        },
+        "script_excerpt": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Verbatim `script:`/`shell:`/`exec:` body, dedented and truncated at 4000 characters, or null when the process declares none. Deterministic. For ad-hoc pipelines with no `meta.yml` this is the only evidence of what a process does."
         },
         "publish_dir": {
           "type": [

--- a/packages/summarize-nextflow/src/schema/summary-nextflow.schema.json
+++ b/packages/summarize-nextflow/src/schema/summary-nextflow.schema.json
@@ -176,7 +176,8 @@
         "inputs":          { "type": "array", "items": { "$ref": "#/$defs/ChannelIO" } },
         "outputs":         { "type": "array", "items": { "$ref": "#/$defs/ChannelIO" } },
         "when":            { "type": ["string", "null"], "description": "Verbatim `when:` guard expression, or null if absent." },
-        "script_summary":  { "type": "string", "description": "One-line LLM-derived summary of what the `script:` body does. Free text." },
+        "script_summary":  { "type": "string", "description": "One-line LLM-derived summary of what the `script:` body does. Free text. The deterministic CLI does not emit it — it emits `script_excerpt` instead, and the cast skill's LLM pass fills this in." },
+        "script_excerpt":  { "type": ["string", "null"], "description": "Verbatim `script:`/`shell:`/`exec:` body, dedented and truncated at 4000 characters, or null when the process declares none. Deterministic. For ad-hoc pipelines with no `meta.yml` this is the only evidence of what a process does." },
         "publish_dir":     { "type": ["string", "null"], "description": "`publishDir` value when the process publishes outputs (or null)." }
       }
     },

--- a/packages/summarize-nextflow/test/resolver.test.ts
+++ b/packages/summarize-nextflow/test/resolver.test.ts
@@ -40,8 +40,10 @@ interface SummaryLike {
         }[];
       } | null;
     }[];
-    inputs: unknown[];
-    outputs: unknown[];
+    inputs: { name: string; shape: string; topic: string | null }[];
+    outputs: { name: string; shape: string; topic: string | null }[];
+    script_summary?: string;
+    script_excerpt: string | null;
   }[];
   subworkflows: {
     name: string;
@@ -1836,6 +1838,165 @@ workflow PIPE {
     write(root, "main.nf", "include { M } from './modules/m'\nworkflow PIPE { main: M() }\n");
     const summary = (await summarize(root)) as unknown as { reference_assets: unknown[] };
     expect(summary.reference_assets).toEqual([]);
+  });
+
+  test("names process IO from quoted emit labels and space-separated declarations", async () => {
+    const root = tempPipelineRoot();
+    write(root, "nextflow.config", "manifest { name = 'adhoc/io-names' }\n");
+    write(
+      root,
+      "modules/annot.nf",
+      `process ANNOT {
+  input:
+  path gencoll_asn, name: 'inp/*'
+  val max_intron
+  env(TOOL_VERSION)
+  each batch_id
+  output:
+  path "out/*", emit: "all"
+  path "out/ACCEPT/accept.asn", emit: 'accept_asn'
+  path "out/log.txt", emit: log
+  script:
+  'annot'
+}
+`,
+    );
+    write(
+      root,
+      "main.nf",
+      "include { ANNOT } from './modules/annot'\nworkflow PIPE { main: ANNOT() }\n",
+    );
+
+    const summary = await summarize(root);
+    const annot = summary.processes.find((process) => process.name === "ANNOT");
+
+    expect(annot?.inputs.map((io) => io.name)).toEqual([
+      "gencoll_asn",
+      "max_intron",
+      "TOOL_VERSION",
+      "batch_id",
+    ]);
+    expect(annot?.outputs.map((io) => io.name)).toEqual(["all", "accept_asn", "log"]);
+  });
+
+  test("keeps naming tuple IO after its path element, not the leading val", async () => {
+    const root = tempPipelineRoot();
+    write(root, "nextflow.config", "manifest { name = 'nf-core/tuple-io' }\n");
+    write(
+      root,
+      "modules/align.nf",
+      `process ALIGN {
+  input:
+  tuple val(meta), path(reads)
+  each path(fasta)
+  output:
+  tuple val(meta), path("*.bam"), emit: bam
+  path "versions.yml", emit: versions
+  script:
+  'align'
+}
+`,
+    );
+    write(
+      root,
+      "main.nf",
+      "include { ALIGN } from './modules/align'\nworkflow PIPE { main: ALIGN() }\n",
+    );
+
+    const summary = await summarize(root);
+    const align = summary.processes.find((process) => process.name === "ALIGN");
+
+    expect(align?.inputs.map((io) => io.name)).toEqual(["reads", "fasta"]);
+    expect(align?.outputs.map((io) => io.name)).toEqual(["bam", "versions"]);
+  });
+
+  test("falls back to a synthesized name only when no identifier is declared", async () => {
+    const root = tempPipelineRoot();
+    write(root, "nextflow.config", "manifest { name = 'adhoc/anonymous-io' }\n");
+    write(
+      root,
+      "modules/anon.nf",
+      `process ANON {
+  input:
+  path "reference/*"
+  output:
+  path("\${meta.id}.txt")
+  script:
+  'anon'
+}
+`,
+    );
+    write(
+      root,
+      "main.nf",
+      "include { ANON } from './modules/anon'\nworkflow PIPE { main: ANON() }\n",
+    );
+
+    const summary = await summarize(root);
+    const anon = summary.processes.find((process) => process.name === "ANON");
+
+    expect(anon?.inputs[0]?.name).toMatch(/^input_[0-9]+$/u);
+    expect(anon?.outputs[0]?.name).toMatch(/^output_[0-9]+$/u);
+  });
+
+  test("carries the script body verbatim and dedented, without the stub block", async () => {
+    const root = tempPipelineRoot();
+    write(root, "nextflow.config", "manifest { name = 'adhoc/script-excerpt' }\n");
+    write(
+      root,
+      "modules/divide.nf",
+      `process DIVIDE {
+  input:
+  path metadata_file
+  script:
+      """
+      mkdir -p output tmp
+      rnaseq_divide_by_strandedness -work-area tmp \\
+        -metadata $metadata_file -stranded-output output/stranded.list
+      """
+  stub:
+      """
+      touch output/stranded.list
+      """
+}
+`,
+    );
+    write(
+      root,
+      "main.nf",
+      "include { DIVIDE } from './modules/divide'\nworkflow PIPE { main: DIVIDE() }\n",
+    );
+
+    const summary = await summarize(root);
+    const divide = summary.processes.find((process) => process.name === "DIVIDE");
+
+    expect(divide?.script_excerpt).toBe(
+      [
+        '"""',
+        "mkdir -p output tmp",
+        "rnaseq_divide_by_strandedness -work-area tmp \\",
+        "  -metadata $metadata_file -stranded-output output/stranded.list",
+        '"""',
+      ].join("\n"),
+    );
+    expect(divide?.script_excerpt).not.toContain("touch");
+  });
+
+  test("emits no script_summary and a null excerpt for a process with no script block", async () => {
+    const root = tempPipelineRoot();
+    write(root, "nextflow.config", "manifest { name = 'adhoc/no-script' }\n");
+    write(root, "modules/bare.nf", "process BARE {\n  input:\n  val x\n}\n");
+    write(
+      root,
+      "main.nf",
+      "include { BARE } from './modules/bare'\nworkflow PIPE { main: BARE() }\n",
+    );
+
+    const summary = await summarize(root);
+    const bare = summary.processes.find((process) => process.name === "BARE");
+
+    expect(bare?.script_excerpt).toBeNull();
+    expect(bare).not.toHaveProperty("script_summary");
   });
 
   test("warns when an explicit mulled index path is missing", async () => {


### PR DESCRIPTION
> **Posted by Claude (AI assistant) on jmchilton's behalf.** They did not author this text.

Fixes #466, fixes #467.

## What the run was

`/test-pipeline nextflow-to-galaxy egapx` — the full NEXTFLOW → GALAXY journey against `ncbi/egapx`, the ad-hoc corpus's hostile case. It did not reach a green planemo result. Two of the five things that stopped it were mechanical; those are what this PR fixes. The other three are design questions this PR does not touch.

## `parseIoName` (#466)

`processes[].inputs[].name` / `outputs[].name` came back as synthesized hash IDs for two ordinary Nextflow declaration forms — quoted `emit: "all"` and space-separated `path gencoll_asn`. On egapx that was **528 of 548** process IO channels. Subworkflow IO was unaffected (0 of 564), which localized it to `parseIoBlock`.

nf-core fixtures mask it: `meta.yml` supplies names and nf-core modules favour `path(name)`.

The `emit:` label is the name the workflow block wires with (`annot_builder_run.out.accept_asn`), so a consumer reading `name` got an opaque hash while the declared name sat in the sibling `shape` string — re-derivation the pipeline eval explicitly forbids.

**Branch order turned out to be load-bearing**, and the fix originally suggested on #466 was wrong:

| line | before | naive merged alternation | shipped |
|---|---|---|---|
| `tuple val(meta), path(reads)` | `reads` | **`val`** ⚠️ | `reads` |
| `path gencoll_asn, name: 'inp/*'` | hash | `gencoll_asn` | `gencoll_asn` |
| `path "out/*", emit: "all"` | hash | `all` | `all` |
| `each batch_id` | hash | hash | `batch_id` |

A merged `(?:path\|val\|tuple\|…)` alternation matches `tuple` and captures the next word, regressing nf-core's most common input form. `path` must be tried before `val`. And quote tolerance belongs only on `emit:` — a quoted `path "out/*"` is a literal glob, not a channel name.

egapx: hash-named IO **528 → 36**. The 36 remaining are genuinely anonymous — `path "output/*"`, `path "job.*"`, one bare `stdout` — no identifier declared, so a synthesized name is correct.

## `script_summary` → `script_excerpt` (#467)

`summarizeScript` was a string template over the process name that never read the script:

```ts
return `Run ${name.toLowerCase().replace(/_/gu, " ")} and emit declared Nextflow outputs.`;
```

The framing that made this decidable: `script_summary` was the **only** free-text field the deterministic CLI fabricated rather than omitted. `ChannelIO.description` is null on all 548 channels; `edges[].via` carries the literal operator chain unreconciled. The schema already left `script_summary` optional, and the hand-run casts show both behaviours — `runs/nf-core__demo/summary.json` has real LLM summaries, `runs/nf-core__bacass` omits the field as optional.

So the CLI now omits it, and emits `script_excerpt` instead: the `script:`/`shell:`/`exec:` body verbatim, dedented, `stub:` dropped, truncated at 4000 characters. The LLM half stays where `content/molds/summarize-nextflow/index.md` says it lives — in the cast skill.

This matters most where the summary is thinnest. An ad-hoc pipeline has no `meta.yml`, so the script block is the only evidence of what a process does. `author-galaxy-tool-wrapper` could not author a defensible tool from the summary row alone and had to open the fixture — which its own Runtime Notes forbid.

egapx now carries excerpts for 95/95 processes (0 null, 1 truncated). `rnaseq_divide_by_strandedness` ships its full command line, including the leftover test scaffolding that nothing else surfaced:

```
if [ $bam_list == "unpacked_genome.bam" ]; then
    mv unpacked_genome.bam GCF_030936135.1_lcl-SRR10853086-Aligned.out.bam
```

## Left open

Three findings from the same run are **not** addressed here — they are design calls, not defects:

- **Whole-pipeline discovery** — egapx already ships as `richard-burhans/ncbi_egapx` in the Shed, and no spine phase asks whether the whole source pipeline is already a target-ecosystem tool.
- **`validate-galaxy-workflow` passes on a zero-step workflow.** The signal exists in `draft-extract --report-json` and `validate-tests --workflow`; it just isn't wired into the phase. That is an eval change, not a code defect.
- **`author-galaxy-tool-wrapper`** — no validation step, no `GalaxyUserTool` schema in the bundle, and the bundled prompt teaches `format: fastq` (string, should be array), `default:` on numerics, and `$(param)`. Filed as #468.

## Verification

Red-to-green: 4 new tests in `resolver.test.ts`, one failing before the `parseIoName` change.

| gate | result |
|---|---|
| `npm run test` | 22 files, 315 passed |
| `npm run packages-test` | passed (summarize-nextflow 81, build-cli 19) |
| `npm run validate` | 242 files, 0 errors, 49 warnings (baseline) |
| `make check-casts` | exit 0 |
| `npm run typecheck` | 0 errors |
| `npm run packages-lint` / `packages-format` | clean |
| CLI on egapx (schema validation on by default) | exit 0 |

One judgment call worth a reviewer's eye: `make casts` rewrites `cast_at`/`commit` in all 47 `_provenance.json` files on every run. I restored the 36 that had *only* that churn and kept the 11 with real `src_hash` changes, so the diff is 23 cast files rather than 59. `make check-casts` is green either way — say the word if you'd rather carry the full `make casts` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
