### PR TITLE
Bar the data-flow brief from ruling tools out

### DIFF
--- a/casts/claude/skills/nextflow-summary-to-galaxy-data-flow/SKILL.md
+++ b/casts/claude/skills/nextflow-summary-to-galaxy-data-flow/SKILL.md
@@ -20,7 +20,7 @@ Follow the procedure below and use the artifact/reference sections as the runtim
 
 ## Outputs
 
-- Write artifact `nextflow-galaxy-data-flow` as `nextflow-galaxy-data-flow.md`. Format: `markdown`. Reviewable Markdown brief: abstract operations, collection map/reduce choices, shape-changing placeholder steps, unresolved Galaxy tool needs, confidence, open questions.
+- Write artifact `nextflow-galaxy-data-flow` as `nextflow-galaxy-data-flow.md`. Format: `markdown`. Reviewable Markdown brief: abstract operations, collection map/reduce choices, shape-changing placeholder steps, Galaxy tool needs, confidence, open questions.
 - Write artifact `open-requirements-ledger` as `open-requirements.ledger.yml`. Format: `yaml`. Carried obligations ledger re-emitted by this step: entries it appended or closed updated, every other entry passed through with its provenance intact.
 
 ## Required Tools
@@ -53,9 +53,9 @@ Follow the procedure below and use the artifact/reference sections as the runtim
 
 ## Procedure
 
-Read a Nextflow summary plus the preceding Galaxy interface brief and emit a reviewable Markdown data-flow brief. Capture abstract operations, collection map/reduce choices, shape-changing placeholder transformations, unresolved Galaxy tool needs, confidence, and open questions.
+Read a Nextflow summary plus the preceding Galaxy interface brief and emit a reviewable Markdown data-flow brief. Capture abstract operations, collection map/reduce choices, shape-changing placeholder transformations, Galaxy tool needs, confidence, and open questions.
 
-The output is not gxformat2 and should not resolve exact Tool Shed tools. nextflow-summary-to-galaxy-template turns this handoff and the interface brief into a skeleton.
+The output is not gxformat2 and should not resolve exact Tool Shed tools. Nor does it rule them out. Recording that a step's tool does not exist, will not be found, or must be authored is the same adjudication made negative, and it belongs to advance-galaxy-draft-step, which owns routing. Say what each step needs a tool to *do*; let discovery report what exists. Justify step granularity from the source's own structure — subworkflow boundaries, the ratio of plumbing to scientific work. A guess about tool availability is not a justification.
 
 ## Feedback Mode
 

--- a/casts/claude/skills/nextflow-summary-to-galaxy-data-flow/_provenance.json
+++ b/casts/claude/skills/nextflow-summary-to-galaxy-data-flow/_provenance.json
@@ -4,11 +4,11 @@
   "mold": {
     "name": "nextflow-summary-to-galaxy-data-flow",
     "path": "content/molds/nextflow-summary-to-galaxy-data-flow/index.md",
-    "revision": 6,
-    "content_hash": "fac99ab0c394f3a68e7cc4cb34c3a7ebb43063e0593486bc1a48318ecbd0bd0c",
-    "commit": "95b5659f39847237122809c4eda2b71b89bd38e7"
+    "revision": 7,
+    "content_hash": "1f98fd5cf9a54fd81e48db957f7451760f5e97629748f3d39fd66dc59b2ac765",
+    "commit": "fd2fa33c5647f382c790996e2ec62edd541080c7"
   },
-  "cast_at": "2026-08-25T21:03:47.021Z",
+  "cast_at": "2026-08-29T20:32:54.275Z",
   "cast_date": "2026-05-07",
   "cast_revision": 3,
   "cast_history": [
@@ -244,7 +244,7 @@
         "id": "nextflow-galaxy-data-flow",
         "kind": "markdown",
         "default_filename": "nextflow-galaxy-data-flow.md",
-        "description": "Reviewable Markdown brief: abstract operations, collection map/reduce choices, shape-changing placeholder steps, unresolved Galaxy tool needs, confidence, open questions."
+        "description": "Reviewable Markdown brief: abstract operations, collection map/reduce choices, shape-changing placeholder steps, Galaxy tool needs, confidence, open questions."
       },
       {
         "id": "open-requirements-ledger",

--- a/content/molds/nextflow-summary-to-galaxy-data-flow/index.md
+++ b/content/molds/nextflow-summary-to-galaxy-data-flow/index.md
@@ -9,8 +9,8 @@ tags:
   - target/galaxy
 status: reviewed
 created: 2026-05-05
-revised: 2026-08-19
-revision: 6
+revised: 2026-08-29
+revision: 7
 summary: "Translate a Nextflow summary into a Galaxy data-flow design brief."
 input_artifacts:
   - id: summary-nextflow
@@ -25,7 +25,7 @@ output_artifacts:
   - id: nextflow-galaxy-data-flow
     kind: markdown
     default_filename: nextflow-galaxy-data-flow.md
-    description: "Reviewable Markdown brief: abstract operations, collection map/reduce choices, shape-changing placeholder steps, unresolved Galaxy tool needs, confidence, open questions."
+    description: "Reviewable Markdown brief: abstract operations, collection map/reduce choices, shape-changing placeholder steps, Galaxy tool needs, confidence, open questions."
   - id: open-requirements-ledger
     kind: yaml
     default_filename: open-requirements.ledger.yml
@@ -150,6 +150,6 @@ related_notes:
 ---
 # nextflow-summary-to-galaxy-data-flow
 
-Read a Nextflow summary plus the preceding Galaxy interface brief and emit a reviewable Markdown data-flow brief. Capture abstract operations, collection map/reduce choices, shape-changing placeholder transformations, unresolved Galaxy tool needs, confidence, and open questions.
+Read a Nextflow summary plus the preceding Galaxy interface brief and emit a reviewable Markdown data-flow brief. Capture abstract operations, collection map/reduce choices, shape-changing placeholder transformations, Galaxy tool needs, confidence, and open questions.
 
-The output is not gxformat2 and should not resolve exact Tool Shed tools. [[nextflow-summary-to-galaxy-template]] turns this handoff and the interface brief into a skeleton.
+The output is not gxformat2 and should not resolve exact Tool Shed tools. Nor does it rule them out. Recording that a step's tool does not exist, will not be found, or must be authored is the same adjudication made negative, and it belongs to [[advance-galaxy-draft-step]], which owns routing. Say what each step needs a tool to *do*; let discovery report what exists. Justify step granularity from the source's own structure — subworkflow boundaries, the ratio of plumbing to scientific work. A guess about tool availability is not a justification.


### PR DESCRIPTION
> Posted by Claude (AI assistant) on behalf of @jmchilton — not authored by them personally.

## The gap

`nextflow-summary-to-galaxy-data-flow` already said:

> The output is not gxformat2 and should not resolve exact Tool Shed tools.

That rule forbids adjudicating tool identity **in the positive**. It says nothing about
adjudicating in the negative — and asserting that no wrapper exists *feels like
compliance*, because it is the opposite of resolving one.

A full NEXTFLOW → GALAXY test-drive on `ncbi/egapx` slid straight under it. The phase-4
brief recorded that every egapx binary "ships only inside `ncbi/egapx:0.5.2` — no
BioContainers, no bioconda, no Shed wrappers", set expected disposition to **author, not
discover**, and made a granularity decision resting on that premise. Nothing on the spine
consults the Tool Shed before phase 7, so the brief had no sanctioned way to check what it
was asserting.

It was wrong. One `gxwf tool-search` in the phase-7 loop found
`richard-burhans/ncbi_egapx` @ `fea9e5d3fb28` = `0.5.2+galaxy0` — a maintained wrapper for
the exact version the fixture pins — plus `iuc/windowmasker` covering egapx's own masking
step. The premise propagated into the template's step set, and the run finished with 3
steps against 95 source processes.

## The change

Edits to the Mold body, which is the surface that reaches a run in flight via the cast
`SKILL.md` — unlike `eval.md`, which is a post-hoc oracle and cannot steer anything.

1. **Name the negative case.** Ruling a tool out is the same adjudication made backwards,
   and it belongs to [[advance-galaxy-draft-step]], which owns routing.
2. **Require a source-structure justification for granularity.** Without this the Mold can
   still make the cut while privately reasoning from availability.
3. **Drop "unresolved" from "unresolved Galaxy tool needs"** (body + `output_artifacts[]`).
   "Unresolved" is a status word; it invites classifying resolution status, and
   "unresolvable" is one step from there.
4. **Drop the trailing "`nextflow-summary-to-galaxy-template` turns this handoff … into a
   skeleton" sentence.** Not load-bearing — the template is already in `related_notes`, and
   the pipeline spine defines phase order.

New paragraph:

> The output is not gxformat2 and should not resolve exact Tool Shed tools. Nor does it
> rule them out. Recording that a step's tool does not exist, will not be found, or must be
> authored is the same adjudication made negative, and it belongs to
> `advance-galaxy-draft-step`, which owns routing. Say what each step needs a tool to *do*;
> let discovery report what exists. Justify step granularity from the source's own
> structure — subworkflow boundaries, the ratio of plumbing to scientific work. A guess
> about tool availability is not a justification.

## Tension worth flagging

This tightens a real constraint rather than just clarifying one: the Mold now chooses step
granularity while forbidden to know what tools exist. Granularity and availability *are*
coupled in reality. Resolving it by fiat (source structure only) seems right for a design
brief, but it leaves an open question — whether this phase should get a read-only
"candidates exist" probe that stops short of pinning anything.

## Not covered

- The effort-based half of the same collapse ("31 wrappers isn't happening in one session").
- `.claude/commands/test-pipeline.md:24` cites `discover-or-author` as its `[branch]`
  example, but no pipeline spine contains that branch; the only `branch:` in all five is
  `test-data-resolution`. `discover-or-author` lives *inside* the
  `advance-galaxy-draft-step` loop.

## Verification

- `npm run cast` reconciled `SKILL.md` + `_provenance.json`; `cast-skill-verify` → `verify clean: 14 ref(s)`
- `npm run validate` → 247 files, **0 errors**, 49 warnings (all pre-existing)
- `make check-assemble-pipelines` → clean, no drift (`summary:` untouched, so assembly is unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ESJRrrY4Wdg69CWi5t4Pw3
