### PR TITLE
Count what the run carried, not just what it owes

### DIFF
--- a/casts/claude/skills/advance-galaxy-draft-step/_provenance.json
+++ b/casts/claude/skills/advance-galaxy-draft-step/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/advance-galaxy-draft-step/index.md",
     "revision": 4,
     "content_hash": "1b210c9ae8dda41e59701ff4a87098be8c2c6dcb1947da026544392dc13e2b3f",
-    "commit": "95b5659f39847237122809c4eda2b71b89bd38e7"
+    "commit": "7b2cb7d53366177b004557cadb4784fd699bf155"
   },
-  "cast_at": "2026-08-25T21:03:41.676Z",
+  "cast_at": "2026-08-29T20:49:14.475Z",
   "refs": [
     {
       "kind": "cli-command",
@@ -84,8 +84,8 @@
       "evidence": "hypothesis",
       "purpose": "Read the ledger after each step implementation for a newly appended blocking entry, count the open blocking entries the convergence gate reads, and maintain the topology_repair escalation budget the loop's termination guard depends on.",
       "verification": "Promote after a run where a blocking entry appended by implement is detected here and drives an escalation that strictly reduces the open count.",
-      "src_hash": "10e84fa97b4e5c14ca78320b25cb9e419b7e98e0f2e676c09dd4deaf68a801fc",
-      "dst_hash": "10e84fa97b4e5c14ca78320b25cb9e419b7e98e0f2e676c09dd4deaf68a801fc",
+      "src_hash": "7ac93cdd192d3e42544ac0ffcecef7aa86d9b450608d9a41c25e6d5f8963af24",
+      "dst_hash": "7ac93cdd192d3e42544ac0ffcecef7aa86d9b450608d9a41c25e6d5f8963af24",
       "source": "deterministic"
     },
     {

--- a/casts/claude/skills/advance-galaxy-draft-step/references/notes/open-requirements-ledger.md
+++ b/casts/claude/skills/advance-galaxy-draft-step/references/notes/open-requirements-ledger.md
@@ -5,8 +5,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-06-16
-revised: 2026-08-19
-revision: 2
+revised: 2026-08-29
+revision: 3
 related_notes:
   - "[[galaxy-workflow-draft-format]]"
 related_molds:
@@ -18,7 +18,7 @@ summary: "Carried unresolved-requirements artifact the source→Galaxy pipeline 
 
 # Open-requirements ledger
 
-The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact.
+The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact. Alongside the entries it carries one run-level count — how much of the source the run actually carried — because a list of individually reasonable gaps can still add up to a pipeline that translated almost none of its source.
 
 ## Framing: obligations the pipeline discharges, not questions a human answers
 
@@ -64,6 +64,12 @@ This section is the runtime protocol for every Mold that carries the ledger. A M
 
 **Record a surrender note; leave the status to the terminal.** When you cannot close an entry and nothing downstream can either — no producer is discoverable, the output cannot be honestly narrowed — leave it `open` and say so in `note`. `surrendered` is a terminal status, set at the end of a run: the escalation cap reached, or the final artifact emitted with the obligation still unmet. Either way the entry stays visible and is written into the final artifact as a labelled gap, never dropped.
 
+**Maintain coverage.** Whenever a decision you make changes what the run will carry from
+the source, move the affected units between `coverage` buckets — never let them vanish.
+Narrowing a design moves units from `carried` to `surrendered`; deciding the target
+subsumes a mechanism moves them to `subsumed` with a reason. The buckets must still sum to
+`source_units` when you re-emit the ledger. See **Coverage (run-level state)** below.
+
 **Maintain the escalation budget** — loop Molds only. The `topology_repair` header is loop-level state, described under **Escalation budget (loop-level state)** below. On each escalation the orchestrator increments `escalations`, appends the post-repair open blocking-entry count to `open_history`, and surrenders the still-open blocking entries once `escalations` reaches `cap`.
 
 ## Role in topology repair
@@ -98,6 +104,56 @@ entries:
 
 This block lives in the ledger as a v1 expedient: the ledger is already the carried, cast-visible state the loop reads each iteration. Its better long-term home is the **draft itself** — a workflow-level annotation that travels with the artifact it bounds, so the budget survives even when the ledger is stripped at the terminal. Recorded here for now; migrate when the draft grows a home for it.
 
+## Coverage (run-level state)
+
+The decreasing-blocker invariant guards one failure — spin-or-fabricate during repair. It
+is blind to the opposite one, and blind by construction: **a run satisfies "strictly reduce
+the open blocking count" by deleting the steps that carried the blockers.** Dropping work
+drives the count to zero faster than doing it. Every invariant the ledger had was monotone
+in the direction that rewards shrinking.
+
+`coverage` is the counterweight — a conservation rule rather than a reduction one, in a
+second header beside `topology_repair`:
+
+```yaml
+coverage:
+  unit: nextflow-process     # what a source unit is, for this source kind
+  source_units: 95           # fixed by the first Mold; never re-based
+  carried: 68                # unit's work lives inside some step of the design
+  subsumed: 21               # target does this itself — reason required
+  surrendered: 6             # not carried, and nothing downstream will
+entries:
+  - id: sccmec-evidence-missing
+    # … per-entry shape above
+```
+
+The invariant is arithmetic: `carried + subsumed + surrendered == source_units`, checked
+whenever the ledger is re-emitted. Shrinking cannot satisfy it. A phase that cuts 25 nodes
+does not reduce a count — it moves 25 units into `surrendered`, where the terminal readout
+states them.
+
+- `unit` — the source's own granularity (`nextflow-process`, `cwl-step`), named once so the
+  denominator is not silently re-based mid-run. A Mold that re-groups units into coarser
+  steps has not changed `source_units`; merging N processes into one tool leaves all N
+  `carried`, which is why this is a partition and not a step-count ratio. A ratio would
+  flag legitimate re-granularization as loss.
+- `source_units` — set by the first Mold from the source summary, then read-only. Nothing
+  downstream may lower it; a design that carries less lowers `carried`.
+- `carried` — the unit's work reaches the target design, at whatever granularity.
+- `subsumed` — the target performs this itself, so translating it would be wrong. Real and
+  necessary: a Nextflow pipeline's grid-dispatch scatter/gather substrate is work Galaxy's
+  scheduler already does. It requires a stated reason, because it is the bucket a lazy run
+  would reach for.
+- `surrendered` — not carried and nothing downstream will carry it. Unlike per-entry
+  `surrendered`, this is not terminal-only: a phase that cuts scope surrenders units at the
+  moment it cuts, because a count nobody may update until the terminal is a count nobody
+  checks.
+
+Coverage answers a question no entry can: not *is each obligation tracked* but *how much of
+the source came out the other end*. On the run that motivated this, the six scope-cut
+entries were individually well-written and collectively described dropping 92 of 95
+processes. No phase ever computed that product, and every phase was reading the ledger.
+
 ## Threaded through the whole design tier
 
 The ledger is not loop-only. Every design-tier Mold in the source→Galaxy pipelines **consumes and re-emits** it — the interface, reference-data, data-flow, IWC-comparison, and template Molds (`*-summary-to-galaxy-interface`, `*-summary-to-galaxy-data-flow`, `*-summary-to-galaxy-reference-data`, `compare-against-iwc-exemplar`, `*-summary-to-galaxy-template`), alongside the change-set Molds on the update path. This is the direct answer to #281: the chain stops re-deriving the same unknowns because each Mold inherits them.
@@ -106,6 +162,7 @@ The template Mold's computability review pass is the notable appender ahead of t
 
 ## Open work
 
+- Decide who sets `coverage.subsumed` reasons and where they live — a free-text field on the header, or `kind`-tagged entries the header counts. Left loose here, like the rest of v1.
 - Decide whether entry structure should harden (typed `unmet` / `missing`, links back to source-summary evidence, machine-checkable `status` transitions) once two or three worked runs exercise it. Hardening it would also give the producing Molds an `output_artifacts[].schema` to cite, which none carry today.
 - Assign terminal surrender of *non-blocking* entries. [[advance-galaxy-draft-step]] surrenders open blocking entries at the escalation cap, but an unpinned-parameter entry the design tier appended and nobody closed currently rides out the run without ever being marked `surrendered`. Nothing owns that pass today.
 - Reconcile the design-tier briefs' free-text "open questions" sections with the ledger. Every design Mold still emits both, with no rule for which destination an unresolved choice belongs in.

--- a/casts/claude/skills/apply-galaxy-workflow-changeset/_provenance.json
+++ b/casts/claude/skills/apply-galaxy-workflow-changeset/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/apply-galaxy-workflow-changeset/index.md",
     "revision": 3,
     "content_hash": "82d8e6e440fc48fdb4e7c5a5e25591ecc8e8a248ea03cc950df5096256656b62",
-    "commit": "95b5659f39847237122809c4eda2b71b89bd38e7"
+    "commit": "7b2cb7d53366177b004557cadb4784fd699bf155"
   },
-  "cast_at": "2026-08-25T21:03:41.801Z",
+  "cast_at": "2026-08-29T20:49:14.576Z",
   "refs": [
     {
       "kind": "cli-command",
@@ -52,8 +52,8 @@
       "evidence": "hypothesis",
       "purpose": "Close the open entries the change-set discharges, and append a blocking entry for an edited region whose output the rewired inputs cannot supply, so an edit-introduced gap is recorded rather than discovered downstream.",
       "verification": "Promote after a worked run shows entries this Mold appends or resolves are consumed downstream without re-derivation.",
-      "src_hash": "10e84fa97b4e5c14ca78320b25cb9e419b7e98e0f2e676c09dd4deaf68a801fc",
-      "dst_hash": "10e84fa97b4e5c14ca78320b25cb9e419b7e98e0f2e676c09dd4deaf68a801fc",
+      "src_hash": "7ac93cdd192d3e42544ac0ffcecef7aa86d9b450608d9a41c25e6d5f8963af24",
+      "dst_hash": "7ac93cdd192d3e42544ac0ffcecef7aa86d9b450608d9a41c25e6d5f8963af24",
       "source": "deterministic"
     },
     {

--- a/casts/claude/skills/apply-galaxy-workflow-changeset/references/notes/open-requirements-ledger.md
+++ b/casts/claude/skills/apply-galaxy-workflow-changeset/references/notes/open-requirements-ledger.md
@@ -5,8 +5,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-06-16
-revised: 2026-08-19
-revision: 2
+revised: 2026-08-29
+revision: 3
 related_notes:
   - "[[galaxy-workflow-draft-format]]"
 related_molds:
@@ -18,7 +18,7 @@ summary: "Carried unresolved-requirements artifact the source→Galaxy pipeline 
 
 # Open-requirements ledger
 
-The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact.
+The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact. Alongside the entries it carries one run-level count — how much of the source the run actually carried — because a list of individually reasonable gaps can still add up to a pipeline that translated almost none of its source.
 
 ## Framing: obligations the pipeline discharges, not questions a human answers
 
@@ -64,6 +64,12 @@ This section is the runtime protocol for every Mold that carries the ledger. A M
 
 **Record a surrender note; leave the status to the terminal.** When you cannot close an entry and nothing downstream can either — no producer is discoverable, the output cannot be honestly narrowed — leave it `open` and say so in `note`. `surrendered` is a terminal status, set at the end of a run: the escalation cap reached, or the final artifact emitted with the obligation still unmet. Either way the entry stays visible and is written into the final artifact as a labelled gap, never dropped.
 
+**Maintain coverage.** Whenever a decision you make changes what the run will carry from
+the source, move the affected units between `coverage` buckets — never let them vanish.
+Narrowing a design moves units from `carried` to `surrendered`; deciding the target
+subsumes a mechanism moves them to `subsumed` with a reason. The buckets must still sum to
+`source_units` when you re-emit the ledger. See **Coverage (run-level state)** below.
+
 **Maintain the escalation budget** — loop Molds only. The `topology_repair` header is loop-level state, described under **Escalation budget (loop-level state)** below. On each escalation the orchestrator increments `escalations`, appends the post-repair open blocking-entry count to `open_history`, and surrenders the still-open blocking entries once `escalations` reaches `cap`.
 
 ## Role in topology repair
@@ -98,6 +104,56 @@ entries:
 
 This block lives in the ledger as a v1 expedient: the ledger is already the carried, cast-visible state the loop reads each iteration. Its better long-term home is the **draft itself** — a workflow-level annotation that travels with the artifact it bounds, so the budget survives even when the ledger is stripped at the terminal. Recorded here for now; migrate when the draft grows a home for it.
 
+## Coverage (run-level state)
+
+The decreasing-blocker invariant guards one failure — spin-or-fabricate during repair. It
+is blind to the opposite one, and blind by construction: **a run satisfies "strictly reduce
+the open blocking count" by deleting the steps that carried the blockers.** Dropping work
+drives the count to zero faster than doing it. Every invariant the ledger had was monotone
+in the direction that rewards shrinking.
+
+`coverage` is the counterweight — a conservation rule rather than a reduction one, in a
+second header beside `topology_repair`:
+
+```yaml
+coverage:
+  unit: nextflow-process     # what a source unit is, for this source kind
+  source_units: 95           # fixed by the first Mold; never re-based
+  carried: 68                # unit's work lives inside some step of the design
+  subsumed: 21               # target does this itself — reason required
+  surrendered: 6             # not carried, and nothing downstream will
+entries:
+  - id: sccmec-evidence-missing
+    # … per-entry shape above
+```
+
+The invariant is arithmetic: `carried + subsumed + surrendered == source_units`, checked
+whenever the ledger is re-emitted. Shrinking cannot satisfy it. A phase that cuts 25 nodes
+does not reduce a count — it moves 25 units into `surrendered`, where the terminal readout
+states them.
+
+- `unit` — the source's own granularity (`nextflow-process`, `cwl-step`), named once so the
+  denominator is not silently re-based mid-run. A Mold that re-groups units into coarser
+  steps has not changed `source_units`; merging N processes into one tool leaves all N
+  `carried`, which is why this is a partition and not a step-count ratio. A ratio would
+  flag legitimate re-granularization as loss.
+- `source_units` — set by the first Mold from the source summary, then read-only. Nothing
+  downstream may lower it; a design that carries less lowers `carried`.
+- `carried` — the unit's work reaches the target design, at whatever granularity.
+- `subsumed` — the target performs this itself, so translating it would be wrong. Real and
+  necessary: a Nextflow pipeline's grid-dispatch scatter/gather substrate is work Galaxy's
+  scheduler already does. It requires a stated reason, because it is the bucket a lazy run
+  would reach for.
+- `surrendered` — not carried and nothing downstream will carry it. Unlike per-entry
+  `surrendered`, this is not terminal-only: a phase that cuts scope surrenders units at the
+  moment it cuts, because a count nobody may update until the terminal is a count nobody
+  checks.
+
+Coverage answers a question no entry can: not *is each obligation tracked* but *how much of
+the source came out the other end*. On the run that motivated this, the six scope-cut
+entries were individually well-written and collectively described dropping 92 of 95
+processes. No phase ever computed that product, and every phase was reading the ledger.
+
 ## Threaded through the whole design tier
 
 The ledger is not loop-only. Every design-tier Mold in the source→Galaxy pipelines **consumes and re-emits** it — the interface, reference-data, data-flow, IWC-comparison, and template Molds (`*-summary-to-galaxy-interface`, `*-summary-to-galaxy-data-flow`, `*-summary-to-galaxy-reference-data`, `compare-against-iwc-exemplar`, `*-summary-to-galaxy-template`), alongside the change-set Molds on the update path. This is the direct answer to #281: the chain stops re-deriving the same unknowns because each Mold inherits them.
@@ -106,6 +162,7 @@ The template Mold's computability review pass is the notable appender ahead of t
 
 ## Open work
 
+- Decide who sets `coverage.subsumed` reasons and where they live — a free-text field on the header, or `kind`-tagged entries the header counts. Left loose here, like the rest of v1.
 - Decide whether entry structure should harden (typed `unmet` / `missing`, links back to source-summary evidence, machine-checkable `status` transitions) once two or three worked runs exercise it. Hardening it would also give the producing Molds an `output_artifacts[].schema` to cite, which none carry today.
 - Assign terminal surrender of *non-blocking* entries. [[advance-galaxy-draft-step]] surrenders open blocking entries at the escalation cap, but an unpinned-parameter entry the design tier appended and nobody closed currently rides out the run without ever being marked `surrendered`. Nothing owns that pass today.
 - Reconcile the design-tier briefs' free-text "open questions" sections with the ledger. Every design Mold still emits both, with no rule for which destination an unresolved choice belongs in.

--- a/casts/claude/skills/compare-against-iwc-exemplar/_provenance.json
+++ b/casts/claude/skills/compare-against-iwc-exemplar/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/compare-against-iwc-exemplar/index.md",
     "revision": 10,
     "content_hash": "5b198e9b87cf554cb01aceaa14a5aaa3ab24c6a35afc35dab7d09ce154cc3a77",
-    "commit": "95b5659f39847237122809c4eda2b71b89bd38e7"
+    "commit": "7b2cb7d53366177b004557cadb4784fd699bf155"
   },
-  "cast_at": "2026-08-25T21:03:42.380Z",
+  "cast_at": "2026-08-29T20:49:15.014Z",
   "cast_date": "2026-05-07",
   "cast_revision": 3,
   "cast_history": [
@@ -101,8 +101,8 @@
       "evidence": "hypothesis",
       "purpose": "Close the open entries a corpus exemplar answers — a collection idiom, a label convention, a structural shape the corpus already settles — and append the ones no exemplar covers, so a structural divergence with no corpus precedent reaches the template tier as a recorded obligation.",
       "verification": "Promote after a worked run shows entries this Mold appends or resolves are consumed downstream without re-derivation.",
-      "src_hash": "10e84fa97b4e5c14ca78320b25cb9e419b7e98e0f2e676c09dd4deaf68a801fc",
-      "dst_hash": "10e84fa97b4e5c14ca78320b25cb9e419b7e98e0f2e676c09dd4deaf68a801fc",
+      "src_hash": "7ac93cdd192d3e42544ac0ffcecef7aa86d9b450608d9a41c25e6d5f8963af24",
+      "dst_hash": "7ac93cdd192d3e42544ac0ffcecef7aa86d9b450608d9a41c25e6d5f8963af24",
       "source": "deterministic"
     }
   ],

--- a/casts/claude/skills/compare-against-iwc-exemplar/references/notes/open-requirements-ledger.md
+++ b/casts/claude/skills/compare-against-iwc-exemplar/references/notes/open-requirements-ledger.md
@@ -5,8 +5,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-06-16
-revised: 2026-08-19
-revision: 2
+revised: 2026-08-29
+revision: 3
 related_notes:
   - "[[galaxy-workflow-draft-format]]"
 related_molds:
@@ -18,7 +18,7 @@ summary: "Carried unresolved-requirements artifact the source→Galaxy pipeline 
 
 # Open-requirements ledger
 
-The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact.
+The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact. Alongside the entries it carries one run-level count — how much of the source the run actually carried — because a list of individually reasonable gaps can still add up to a pipeline that translated almost none of its source.
 
 ## Framing: obligations the pipeline discharges, not questions a human answers
 
@@ -64,6 +64,12 @@ This section is the runtime protocol for every Mold that carries the ledger. A M
 
 **Record a surrender note; leave the status to the terminal.** When you cannot close an entry and nothing downstream can either — no producer is discoverable, the output cannot be honestly narrowed — leave it `open` and say so in `note`. `surrendered` is a terminal status, set at the end of a run: the escalation cap reached, or the final artifact emitted with the obligation still unmet. Either way the entry stays visible and is written into the final artifact as a labelled gap, never dropped.
 
+**Maintain coverage.** Whenever a decision you make changes what the run will carry from
+the source, move the affected units between `coverage` buckets — never let them vanish.
+Narrowing a design moves units from `carried` to `surrendered`; deciding the target
+subsumes a mechanism moves them to `subsumed` with a reason. The buckets must still sum to
+`source_units` when you re-emit the ledger. See **Coverage (run-level state)** below.
+
 **Maintain the escalation budget** — loop Molds only. The `topology_repair` header is loop-level state, described under **Escalation budget (loop-level state)** below. On each escalation the orchestrator increments `escalations`, appends the post-repair open blocking-entry count to `open_history`, and surrenders the still-open blocking entries once `escalations` reaches `cap`.
 
 ## Role in topology repair
@@ -98,6 +104,56 @@ entries:
 
 This block lives in the ledger as a v1 expedient: the ledger is already the carried, cast-visible state the loop reads each iteration. Its better long-term home is the **draft itself** — a workflow-level annotation that travels with the artifact it bounds, so the budget survives even when the ledger is stripped at the terminal. Recorded here for now; migrate when the draft grows a home for it.
 
+## Coverage (run-level state)
+
+The decreasing-blocker invariant guards one failure — spin-or-fabricate during repair. It
+is blind to the opposite one, and blind by construction: **a run satisfies "strictly reduce
+the open blocking count" by deleting the steps that carried the blockers.** Dropping work
+drives the count to zero faster than doing it. Every invariant the ledger had was monotone
+in the direction that rewards shrinking.
+
+`coverage` is the counterweight — a conservation rule rather than a reduction one, in a
+second header beside `topology_repair`:
+
+```yaml
+coverage:
+  unit: nextflow-process     # what a source unit is, for this source kind
+  source_units: 95           # fixed by the first Mold; never re-based
+  carried: 68                # unit's work lives inside some step of the design
+  subsumed: 21               # target does this itself — reason required
+  surrendered: 6             # not carried, and nothing downstream will
+entries:
+  - id: sccmec-evidence-missing
+    # … per-entry shape above
+```
+
+The invariant is arithmetic: `carried + subsumed + surrendered == source_units`, checked
+whenever the ledger is re-emitted. Shrinking cannot satisfy it. A phase that cuts 25 nodes
+does not reduce a count — it moves 25 units into `surrendered`, where the terminal readout
+states them.
+
+- `unit` — the source's own granularity (`nextflow-process`, `cwl-step`), named once so the
+  denominator is not silently re-based mid-run. A Mold that re-groups units into coarser
+  steps has not changed `source_units`; merging N processes into one tool leaves all N
+  `carried`, which is why this is a partition and not a step-count ratio. A ratio would
+  flag legitimate re-granularization as loss.
+- `source_units` — set by the first Mold from the source summary, then read-only. Nothing
+  downstream may lower it; a design that carries less lowers `carried`.
+- `carried` — the unit's work reaches the target design, at whatever granularity.
+- `subsumed` — the target performs this itself, so translating it would be wrong. Real and
+  necessary: a Nextflow pipeline's grid-dispatch scatter/gather substrate is work Galaxy's
+  scheduler already does. It requires a stated reason, because it is the bucket a lazy run
+  would reach for.
+- `surrendered` — not carried and nothing downstream will carry it. Unlike per-entry
+  `surrendered`, this is not terminal-only: a phase that cuts scope surrenders units at the
+  moment it cuts, because a count nobody may update until the terminal is a count nobody
+  checks.
+
+Coverage answers a question no entry can: not *is each obligation tracked* but *how much of
+the source came out the other end*. On the run that motivated this, the six scope-cut
+entries were individually well-written and collectively described dropping 92 of 95
+processes. No phase ever computed that product, and every phase was reading the ledger.
+
 ## Threaded through the whole design tier
 
 The ledger is not loop-only. Every design-tier Mold in the source→Galaxy pipelines **consumes and re-emits** it — the interface, reference-data, data-flow, IWC-comparison, and template Molds (`*-summary-to-galaxy-interface`, `*-summary-to-galaxy-data-flow`, `*-summary-to-galaxy-reference-data`, `compare-against-iwc-exemplar`, `*-summary-to-galaxy-template`), alongside the change-set Molds on the update path. This is the direct answer to #281: the chain stops re-deriving the same unknowns because each Mold inherits them.
@@ -106,6 +162,7 @@ The template Mold's computability review pass is the notable appender ahead of t
 
 ## Open work
 
+- Decide who sets `coverage.subsumed` reasons and where they live — a free-text field on the header, or `kind`-tagged entries the header counts. Left loose here, like the rest of v1.
 - Decide whether entry structure should harden (typed `unmet` / `missing`, links back to source-summary evidence, machine-checkable `status` transitions) once two or three worked runs exercise it. Hardening it would also give the producing Molds an `output_artifacts[].schema` to cite, which none carry today.
 - Assign terminal surrender of *non-blocking* entries. [[advance-galaxy-draft-step]] surrenders open blocking entries at the escalation cap, but an unpinned-parameter entry the design tier appended and nobody closed currently rides out the run without ever being marked `surrendered`. Nothing owns that pass today.
 - Reconcile the design-tier briefs' free-text "open questions" sections with the ledger. Every design Mold still emits both, with no rule for which destination an unresolved choice belongs in.

--- a/casts/claude/skills/cwl-summary-to-galaxy-data-flow/_provenance.json
+++ b/casts/claude/skills/cwl-summary-to-galaxy-data-flow/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/cwl-summary-to-galaxy-data-flow/index.md",
     "revision": 3,
     "content_hash": "ed3f1d14cab3958ec321bcc108dd6274bec965cd502763ce0d5abd060a90f28b",
-    "commit": "95b5659f39847237122809c4eda2b71b89bd38e7"
+    "commit": "7b2cb7d53366177b004557cadb4784fd699bf155"
   },
-  "cast_at": "2026-08-25T21:03:42.809Z",
+  "cast_at": "2026-08-29T20:49:15.410Z",
   "refs": [
     {
       "kind": "pattern",
@@ -177,8 +177,8 @@
       "evidence": "hypothesis",
       "purpose": "Inherit open entries rather than re-deriving them, close the ones this brief's wiring and collection decisions settle, and append data-flow obligations the CWL summary can't settle — a scatter shape Galaxy can't express directly, an expression-derived value with no Galaxy equivalent, a `linkMerge`/`pickValue` fan-in with no settled Galaxy form.",
       "verification": "Promote after a worked run shows entries this Mold appends or resolves are consumed downstream without re-derivation.",
-      "src_hash": "10e84fa97b4e5c14ca78320b25cb9e419b7e98e0f2e676c09dd4deaf68a801fc",
-      "dst_hash": "10e84fa97b4e5c14ca78320b25cb9e419b7e98e0f2e676c09dd4deaf68a801fc",
+      "src_hash": "7ac93cdd192d3e42544ac0ffcecef7aa86d9b450608d9a41c25e6d5f8963af24",
+      "dst_hash": "7ac93cdd192d3e42544ac0ffcecef7aa86d9b450608d9a41c25e6d5f8963af24",
       "source": "deterministic"
     },
     {

--- a/casts/claude/skills/cwl-summary-to-galaxy-data-flow/references/notes/open-requirements-ledger.md
+++ b/casts/claude/skills/cwl-summary-to-galaxy-data-flow/references/notes/open-requirements-ledger.md
@@ -5,8 +5,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-06-16
-revised: 2026-08-19
-revision: 2
+revised: 2026-08-29
+revision: 3
 related_notes:
   - "[[galaxy-workflow-draft-format]]"
 related_molds:
@@ -18,7 +18,7 @@ summary: "Carried unresolved-requirements artifact the source→Galaxy pipeline 
 
 # Open-requirements ledger
 
-The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact.
+The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact. Alongside the entries it carries one run-level count — how much of the source the run actually carried — because a list of individually reasonable gaps can still add up to a pipeline that translated almost none of its source.
 
 ## Framing: obligations the pipeline discharges, not questions a human answers
 
@@ -64,6 +64,12 @@ This section is the runtime protocol for every Mold that carries the ledger. A M
 
 **Record a surrender note; leave the status to the terminal.** When you cannot close an entry and nothing downstream can either — no producer is discoverable, the output cannot be honestly narrowed — leave it `open` and say so in `note`. `surrendered` is a terminal status, set at the end of a run: the escalation cap reached, or the final artifact emitted with the obligation still unmet. Either way the entry stays visible and is written into the final artifact as a labelled gap, never dropped.
 
+**Maintain coverage.** Whenever a decision you make changes what the run will carry from
+the source, move the affected units between `coverage` buckets — never let them vanish.
+Narrowing a design moves units from `carried` to `surrendered`; deciding the target
+subsumes a mechanism moves them to `subsumed` with a reason. The buckets must still sum to
+`source_units` when you re-emit the ledger. See **Coverage (run-level state)** below.
+
 **Maintain the escalation budget** — loop Molds only. The `topology_repair` header is loop-level state, described under **Escalation budget (loop-level state)** below. On each escalation the orchestrator increments `escalations`, appends the post-repair open blocking-entry count to `open_history`, and surrenders the still-open blocking entries once `escalations` reaches `cap`.
 
 ## Role in topology repair
@@ -98,6 +104,56 @@ entries:
 
 This block lives in the ledger as a v1 expedient: the ledger is already the carried, cast-visible state the loop reads each iteration. Its better long-term home is the **draft itself** — a workflow-level annotation that travels with the artifact it bounds, so the budget survives even when the ledger is stripped at the terminal. Recorded here for now; migrate when the draft grows a home for it.
 
+## Coverage (run-level state)
+
+The decreasing-blocker invariant guards one failure — spin-or-fabricate during repair. It
+is blind to the opposite one, and blind by construction: **a run satisfies "strictly reduce
+the open blocking count" by deleting the steps that carried the blockers.** Dropping work
+drives the count to zero faster than doing it. Every invariant the ledger had was monotone
+in the direction that rewards shrinking.
+
+`coverage` is the counterweight — a conservation rule rather than a reduction one, in a
+second header beside `topology_repair`:
+
+```yaml
+coverage:
+  unit: nextflow-process     # what a source unit is, for this source kind
+  source_units: 95           # fixed by the first Mold; never re-based
+  carried: 68                # unit's work lives inside some step of the design
+  subsumed: 21               # target does this itself — reason required
+  surrendered: 6             # not carried, and nothing downstream will
+entries:
+  - id: sccmec-evidence-missing
+    # … per-entry shape above
+```
+
+The invariant is arithmetic: `carried + subsumed + surrendered == source_units`, checked
+whenever the ledger is re-emitted. Shrinking cannot satisfy it. A phase that cuts 25 nodes
+does not reduce a count — it moves 25 units into `surrendered`, where the terminal readout
+states them.
+
+- `unit` — the source's own granularity (`nextflow-process`, `cwl-step`), named once so the
+  denominator is not silently re-based mid-run. A Mold that re-groups units into coarser
+  steps has not changed `source_units`; merging N processes into one tool leaves all N
+  `carried`, which is why this is a partition and not a step-count ratio. A ratio would
+  flag legitimate re-granularization as loss.
+- `source_units` — set by the first Mold from the source summary, then read-only. Nothing
+  downstream may lower it; a design that carries less lowers `carried`.
+- `carried` — the unit's work reaches the target design, at whatever granularity.
+- `subsumed` — the target performs this itself, so translating it would be wrong. Real and
+  necessary: a Nextflow pipeline's grid-dispatch scatter/gather substrate is work Galaxy's
+  scheduler already does. It requires a stated reason, because it is the bucket a lazy run
+  would reach for.
+- `surrendered` — not carried and nothing downstream will carry it. Unlike per-entry
+  `surrendered`, this is not terminal-only: a phase that cuts scope surrenders units at the
+  moment it cuts, because a count nobody may update until the terminal is a count nobody
+  checks.
+
+Coverage answers a question no entry can: not *is each obligation tracked* but *how much of
+the source came out the other end*. On the run that motivated this, the six scope-cut
+entries were individually well-written and collectively described dropping 92 of 95
+processes. No phase ever computed that product, and every phase was reading the ledger.
+
 ## Threaded through the whole design tier
 
 The ledger is not loop-only. Every design-tier Mold in the source→Galaxy pipelines **consumes and re-emits** it — the interface, reference-data, data-flow, IWC-comparison, and template Molds (`*-summary-to-galaxy-interface`, `*-summary-to-galaxy-data-flow`, `*-summary-to-galaxy-reference-data`, `compare-against-iwc-exemplar`, `*-summary-to-galaxy-template`), alongside the change-set Molds on the update path. This is the direct answer to #281: the chain stops re-deriving the same unknowns because each Mold inherits them.
@@ -106,6 +162,7 @@ The template Mold's computability review pass is the notable appender ahead of t
 
 ## Open work
 
+- Decide who sets `coverage.subsumed` reasons and where they live — a free-text field on the header, or `kind`-tagged entries the header counts. Left loose here, like the rest of v1.
 - Decide whether entry structure should harden (typed `unmet` / `missing`, links back to source-summary evidence, machine-checkable `status` transitions) once two or three worked runs exercise it. Hardening it would also give the producing Molds an `output_artifacts[].schema` to cite, which none carry today.
 - Assign terminal surrender of *non-blocking* entries. [[advance-galaxy-draft-step]] surrenders open blocking entries at the escalation cap, but an unpinned-parameter entry the design tier appended and nobody closed currently rides out the run without ever being marked `surrendered`. Nothing owns that pass today.
 - Reconcile the design-tier briefs' free-text "open questions" sections with the ledger. Every design Mold still emits both, with no rule for which destination an unresolved choice belongs in.

--- a/casts/claude/skills/cwl-summary-to-galaxy-interface/_provenance.json
+++ b/casts/claude/skills/cwl-summary-to-galaxy-interface/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/cwl-summary-to-galaxy-interface/index.md",
     "revision": 3,
     "content_hash": "9e6b0aaea5d1662a0515cd932352e418d1539da95ed81b4e8193ce0c98d48640",
-    "commit": "95b5659f39847237122809c4eda2b71b89bd38e7"
+    "commit": "7b2cb7d53366177b004557cadb4784fd699bf155"
   },
-  "cast_at": "2026-08-25T21:03:43.076Z",
+  "cast_at": "2026-08-29T20:49:15.478Z",
   "refs": [
     {
       "kind": "research",
@@ -118,8 +118,8 @@
       "evidence": "hypothesis",
       "purpose": "Inherit open entries rather than re-deriving them, close the ones this brief's input, output, and label decisions settle, and append interface obligations the CWL summary leaves open — an unmapped secondaryFiles bundle, an unpinned parameter default, a collection shape the source types don't determine.",
       "verification": "Promote after a worked run shows entries this Mold appends or resolves are consumed downstream without re-derivation.",
-      "src_hash": "10e84fa97b4e5c14ca78320b25cb9e419b7e98e0f2e676c09dd4deaf68a801fc",
-      "dst_hash": "10e84fa97b4e5c14ca78320b25cb9e419b7e98e0f2e676c09dd4deaf68a801fc",
+      "src_hash": "7ac93cdd192d3e42544ac0ffcecef7aa86d9b450608d9a41c25e6d5f8963af24",
+      "dst_hash": "7ac93cdd192d3e42544ac0ffcecef7aa86d9b450608d9a41c25e6d5f8963af24",
       "source": "deterministic"
     },
     {

--- a/casts/claude/skills/cwl-summary-to-galaxy-interface/references/notes/open-requirements-ledger.md
+++ b/casts/claude/skills/cwl-summary-to-galaxy-interface/references/notes/open-requirements-ledger.md
@@ -5,8 +5,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-06-16
-revised: 2026-08-19
-revision: 2
+revised: 2026-08-29
+revision: 3
 related_notes:
   - "[[galaxy-workflow-draft-format]]"
 related_molds:
@@ -18,7 +18,7 @@ summary: "Carried unresolved-requirements artifact the source→Galaxy pipeline 
 
 # Open-requirements ledger
 
-The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact.
+The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact. Alongside the entries it carries one run-level count — how much of the source the run actually carried — because a list of individually reasonable gaps can still add up to a pipeline that translated almost none of its source.
 
 ## Framing: obligations the pipeline discharges, not questions a human answers
 
@@ -64,6 +64,12 @@ This section is the runtime protocol for every Mold that carries the ledger. A M
 
 **Record a surrender note; leave the status to the terminal.** When you cannot close an entry and nothing downstream can either — no producer is discoverable, the output cannot be honestly narrowed — leave it `open` and say so in `note`. `surrendered` is a terminal status, set at the end of a run: the escalation cap reached, or the final artifact emitted with the obligation still unmet. Either way the entry stays visible and is written into the final artifact as a labelled gap, never dropped.
 
+**Maintain coverage.** Whenever a decision you make changes what the run will carry from
+the source, move the affected units between `coverage` buckets — never let them vanish.
+Narrowing a design moves units from `carried` to `surrendered`; deciding the target
+subsumes a mechanism moves them to `subsumed` with a reason. The buckets must still sum to
+`source_units` when you re-emit the ledger. See **Coverage (run-level state)** below.
+
 **Maintain the escalation budget** — loop Molds only. The `topology_repair` header is loop-level state, described under **Escalation budget (loop-level state)** below. On each escalation the orchestrator increments `escalations`, appends the post-repair open blocking-entry count to `open_history`, and surrenders the still-open blocking entries once `escalations` reaches `cap`.
 
 ## Role in topology repair
@@ -98,6 +104,56 @@ entries:
 
 This block lives in the ledger as a v1 expedient: the ledger is already the carried, cast-visible state the loop reads each iteration. Its better long-term home is the **draft itself** — a workflow-level annotation that travels with the artifact it bounds, so the budget survives even when the ledger is stripped at the terminal. Recorded here for now; migrate when the draft grows a home for it.
 
+## Coverage (run-level state)
+
+The decreasing-blocker invariant guards one failure — spin-or-fabricate during repair. It
+is blind to the opposite one, and blind by construction: **a run satisfies "strictly reduce
+the open blocking count" by deleting the steps that carried the blockers.** Dropping work
+drives the count to zero faster than doing it. Every invariant the ledger had was monotone
+in the direction that rewards shrinking.
+
+`coverage` is the counterweight — a conservation rule rather than a reduction one, in a
+second header beside `topology_repair`:
+
+```yaml
+coverage:
+  unit: nextflow-process     # what a source unit is, for this source kind
+  source_units: 95           # fixed by the first Mold; never re-based
+  carried: 68                # unit's work lives inside some step of the design
+  subsumed: 21               # target does this itself — reason required
+  surrendered: 6             # not carried, and nothing downstream will
+entries:
+  - id: sccmec-evidence-missing
+    # … per-entry shape above
+```
+
+The invariant is arithmetic: `carried + subsumed + surrendered == source_units`, checked
+whenever the ledger is re-emitted. Shrinking cannot satisfy it. A phase that cuts 25 nodes
+does not reduce a count — it moves 25 units into `surrendered`, where the terminal readout
+states them.
+
+- `unit` — the source's own granularity (`nextflow-process`, `cwl-step`), named once so the
+  denominator is not silently re-based mid-run. A Mold that re-groups units into coarser
+  steps has not changed `source_units`; merging N processes into one tool leaves all N
+  `carried`, which is why this is a partition and not a step-count ratio. A ratio would
+  flag legitimate re-granularization as loss.
+- `source_units` — set by the first Mold from the source summary, then read-only. Nothing
+  downstream may lower it; a design that carries less lowers `carried`.
+- `carried` — the unit's work reaches the target design, at whatever granularity.
+- `subsumed` — the target performs this itself, so translating it would be wrong. Real and
+  necessary: a Nextflow pipeline's grid-dispatch scatter/gather substrate is work Galaxy's
+  scheduler already does. It requires a stated reason, because it is the bucket a lazy run
+  would reach for.
+- `surrendered` — not carried and nothing downstream will carry it. Unlike per-entry
+  `surrendered`, this is not terminal-only: a phase that cuts scope surrenders units at the
+  moment it cuts, because a count nobody may update until the terminal is a count nobody
+  checks.
+
+Coverage answers a question no entry can: not *is each obligation tracked* but *how much of
+the source came out the other end*. On the run that motivated this, the six scope-cut
+entries were individually well-written and collectively described dropping 92 of 95
+processes. No phase ever computed that product, and every phase was reading the ledger.
+
 ## Threaded through the whole design tier
 
 The ledger is not loop-only. Every design-tier Mold in the source→Galaxy pipelines **consumes and re-emits** it — the interface, reference-data, data-flow, IWC-comparison, and template Molds (`*-summary-to-galaxy-interface`, `*-summary-to-galaxy-data-flow`, `*-summary-to-galaxy-reference-data`, `compare-against-iwc-exemplar`, `*-summary-to-galaxy-template`), alongside the change-set Molds on the update path. This is the direct answer to #281: the chain stops re-deriving the same unknowns because each Mold inherits them.
@@ -106,6 +162,7 @@ The template Mold's computability review pass is the notable appender ahead of t
 
 ## Open work
 
+- Decide who sets `coverage.subsumed` reasons and where they live — a free-text field on the header, or `kind`-tagged entries the header counts. Left loose here, like the rest of v1.
 - Decide whether entry structure should harden (typed `unmet` / `missing`, links back to source-summary evidence, machine-checkable `status` transitions) once two or three worked runs exercise it. Hardening it would also give the producing Molds an `output_artifacts[].schema` to cite, which none carry today.
 - Assign terminal surrender of *non-blocking* entries. [[advance-galaxy-draft-step]] surrenders open blocking entries at the escalation cap, but an unpinned-parameter entry the design tier appended and nobody closed currently rides out the run without ever being marked `surrendered`. Nothing owns that pass today.
 - Reconcile the design-tier briefs' free-text "open questions" sections with the ledger. Every design Mold still emits both, with no rule for which destination an unresolved choice belongs in.

--- a/casts/claude/skills/cwl-summary-to-galaxy-template/_provenance.json
+++ b/casts/claude/skills/cwl-summary-to-galaxy-template/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/cwl-summary-to-galaxy-template/index.md",
     "revision": 5,
     "content_hash": "9e53cc268a919b22f0d481226224630b865005aaa990f9bbdd72711e7f5ebdc8",
-    "commit": "95b5659f39847237122809c4eda2b71b89bd38e7"
+    "commit": "7b2cb7d53366177b004557cadb4784fd699bf155"
   },
-  "cast_at": "2026-08-25T21:03:43.540Z",
+  "cast_at": "2026-08-29T20:49:15.736Z",
   "refs": [
     {
       "kind": "cli-command",
@@ -245,8 +245,8 @@
       "evidence": "hypothesis",
       "purpose": "Close the open entries the settled topology discharges, and append a blocking entry for any settled step whose declared output no wired input can supply — the computability gap gxwf validation cannot see, raised here rather than left for the per-step loop to hit.",
       "verification": "Promote after a worked run shows entries this Mold appends or resolves are consumed downstream without re-derivation.",
-      "src_hash": "10e84fa97b4e5c14ca78320b25cb9e419b7e98e0f2e676c09dd4deaf68a801fc",
-      "dst_hash": "10e84fa97b4e5c14ca78320b25cb9e419b7e98e0f2e676c09dd4deaf68a801fc",
+      "src_hash": "7ac93cdd192d3e42544ac0ffcecef7aa86d9b450608d9a41c25e6d5f8963af24",
+      "dst_hash": "7ac93cdd192d3e42544ac0ffcecef7aa86d9b450608d9a41c25e6d5f8963af24",
       "source": "deterministic"
     },
     {

--- a/casts/claude/skills/cwl-summary-to-galaxy-template/references/notes/open-requirements-ledger.md
+++ b/casts/claude/skills/cwl-summary-to-galaxy-template/references/notes/open-requirements-ledger.md
@@ -5,8 +5,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-06-16
-revised: 2026-08-19
-revision: 2
+revised: 2026-08-29
+revision: 3
 related_notes:
   - "[[galaxy-workflow-draft-format]]"
 related_molds:
@@ -18,7 +18,7 @@ summary: "Carried unresolved-requirements artifact the source→Galaxy pipeline 
 
 # Open-requirements ledger
 
-The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact.
+The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact. Alongside the entries it carries one run-level count — how much of the source the run actually carried — because a list of individually reasonable gaps can still add up to a pipeline that translated almost none of its source.
 
 ## Framing: obligations the pipeline discharges, not questions a human answers
 
@@ -64,6 +64,12 @@ This section is the runtime protocol for every Mold that carries the ledger. A M
 
 **Record a surrender note; leave the status to the terminal.** When you cannot close an entry and nothing downstream can either — no producer is discoverable, the output cannot be honestly narrowed — leave it `open` and say so in `note`. `surrendered` is a terminal status, set at the end of a run: the escalation cap reached, or the final artifact emitted with the obligation still unmet. Either way the entry stays visible and is written into the final artifact as a labelled gap, never dropped.
 
+**Maintain coverage.** Whenever a decision you make changes what the run will carry from
+the source, move the affected units between `coverage` buckets — never let them vanish.
+Narrowing a design moves units from `carried` to `surrendered`; deciding the target
+subsumes a mechanism moves them to `subsumed` with a reason. The buckets must still sum to
+`source_units` when you re-emit the ledger. See **Coverage (run-level state)** below.
+
 **Maintain the escalation budget** — loop Molds only. The `topology_repair` header is loop-level state, described under **Escalation budget (loop-level state)** below. On each escalation the orchestrator increments `escalations`, appends the post-repair open blocking-entry count to `open_history`, and surrenders the still-open blocking entries once `escalations` reaches `cap`.
 
 ## Role in topology repair
@@ -98,6 +104,56 @@ entries:
 
 This block lives in the ledger as a v1 expedient: the ledger is already the carried, cast-visible state the loop reads each iteration. Its better long-term home is the **draft itself** — a workflow-level annotation that travels with the artifact it bounds, so the budget survives even when the ledger is stripped at the terminal. Recorded here for now; migrate when the draft grows a home for it.
 
+## Coverage (run-level state)
+
+The decreasing-blocker invariant guards one failure — spin-or-fabricate during repair. It
+is blind to the opposite one, and blind by construction: **a run satisfies "strictly reduce
+the open blocking count" by deleting the steps that carried the blockers.** Dropping work
+drives the count to zero faster than doing it. Every invariant the ledger had was monotone
+in the direction that rewards shrinking.
+
+`coverage` is the counterweight — a conservation rule rather than a reduction one, in a
+second header beside `topology_repair`:
+
+```yaml
+coverage:
+  unit: nextflow-process     # what a source unit is, for this source kind
+  source_units: 95           # fixed by the first Mold; never re-based
+  carried: 68                # unit's work lives inside some step of the design
+  subsumed: 21               # target does this itself — reason required
+  surrendered: 6             # not carried, and nothing downstream will
+entries:
+  - id: sccmec-evidence-missing
+    # … per-entry shape above
+```
+
+The invariant is arithmetic: `carried + subsumed + surrendered == source_units`, checked
+whenever the ledger is re-emitted. Shrinking cannot satisfy it. A phase that cuts 25 nodes
+does not reduce a count — it moves 25 units into `surrendered`, where the terminal readout
+states them.
+
+- `unit` — the source's own granularity (`nextflow-process`, `cwl-step`), named once so the
+  denominator is not silently re-based mid-run. A Mold that re-groups units into coarser
+  steps has not changed `source_units`; merging N processes into one tool leaves all N
+  `carried`, which is why this is a partition and not a step-count ratio. A ratio would
+  flag legitimate re-granularization as loss.
+- `source_units` — set by the first Mold from the source summary, then read-only. Nothing
+  downstream may lower it; a design that carries less lowers `carried`.
+- `carried` — the unit's work reaches the target design, at whatever granularity.
+- `subsumed` — the target performs this itself, so translating it would be wrong. Real and
+  necessary: a Nextflow pipeline's grid-dispatch scatter/gather substrate is work Galaxy's
+  scheduler already does. It requires a stated reason, because it is the bucket a lazy run
+  would reach for.
+- `surrendered` — not carried and nothing downstream will carry it. Unlike per-entry
+  `surrendered`, this is not terminal-only: a phase that cuts scope surrenders units at the
+  moment it cuts, because a count nobody may update until the terminal is a count nobody
+  checks.
+
+Coverage answers a question no entry can: not *is each obligation tracked* but *how much of
+the source came out the other end*. On the run that motivated this, the six scope-cut
+entries were individually well-written and collectively described dropping 92 of 95
+processes. No phase ever computed that product, and every phase was reading the ledger.
+
 ## Threaded through the whole design tier
 
 The ledger is not loop-only. Every design-tier Mold in the source→Galaxy pipelines **consumes and re-emits** it — the interface, reference-data, data-flow, IWC-comparison, and template Molds (`*-summary-to-galaxy-interface`, `*-summary-to-galaxy-data-flow`, `*-summary-to-galaxy-reference-data`, `compare-against-iwc-exemplar`, `*-summary-to-galaxy-template`), alongside the change-set Molds on the update path. This is the direct answer to #281: the chain stops re-deriving the same unknowns because each Mold inherits them.
@@ -106,6 +162,7 @@ The template Mold's computability review pass is the notable appender ahead of t
 
 ## Open work
 
+- Decide who sets `coverage.subsumed` reasons and where they live — a free-text field on the header, or `kind`-tagged entries the header counts. Left loose here, like the rest of v1.
 - Decide whether entry structure should harden (typed `unmet` / `missing`, links back to source-summary evidence, machine-checkable `status` transitions) once two or three worked runs exercise it. Hardening it would also give the producing Molds an `output_artifacts[].schema` to cite, which none carry today.
 - Assign terminal surrender of *non-blocking* entries. [[advance-galaxy-draft-step]] surrenders open blocking entries at the escalation cap, but an unpinned-parameter entry the design tier appended and nobody closed currently rides out the run without ever being marked `surrendered`. Nothing owns that pass today.
 - Reconcile the design-tier briefs' free-text "open questions" sections with the ledger. Every design Mold still emits both, with no rule for which destination an unresolved choice belongs in.

--- a/casts/claude/skills/freeform-summary-to-galaxy-data-flow/_provenance.json
+++ b/casts/claude/skills/freeform-summary-to-galaxy-data-flow/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/freeform-summary-to-galaxy-data-flow/index.md",
     "revision": 3,
     "content_hash": "22613db4e710f58b29bfd2d6fe1d49f167afe451e09afefb2efd755b4a6e4da1",
-    "commit": "95b5659f39847237122809c4eda2b71b89bd38e7"
+    "commit": "7b2cb7d53366177b004557cadb4784fd699bf155"
   },
-  "cast_at": "2026-08-25T21:03:44.884Z",
+  "cast_at": "2026-08-29T20:49:16.596Z",
   "refs": [
     {
       "kind": "pattern",
@@ -111,8 +111,8 @@
       "evidence": "hypothesis",
       "purpose": "Inherit open entries rather than re-deriving them, close the ones this brief's wiring and collection decisions settle, and append data-flow obligations the narrative leaves open — a described transformation with no named tool, an implied intermediate the source never states, an ordering the prose doesn't fix.",
       "verification": "Promote after a worked run shows entries this Mold appends or resolves are consumed downstream without re-derivation.",
-      "src_hash": "10e84fa97b4e5c14ca78320b25cb9e419b7e98e0f2e676c09dd4deaf68a801fc",
-      "dst_hash": "10e84fa97b4e5c14ca78320b25cb9e419b7e98e0f2e676c09dd4deaf68a801fc",
+      "src_hash": "7ac93cdd192d3e42544ac0ffcecef7aa86d9b450608d9a41c25e6d5f8963af24",
+      "dst_hash": "7ac93cdd192d3e42544ac0ffcecef7aa86d9b450608d9a41c25e6d5f8963af24",
       "source": "deterministic"
     }
   ],

--- a/casts/claude/skills/freeform-summary-to-galaxy-data-flow/references/notes/open-requirements-ledger.md
+++ b/casts/claude/skills/freeform-summary-to-galaxy-data-flow/references/notes/open-requirements-ledger.md
@@ -5,8 +5,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-06-16
-revised: 2026-08-19
-revision: 2
+revised: 2026-08-29
+revision: 3
 related_notes:
   - "[[galaxy-workflow-draft-format]]"
 related_molds:
@@ -18,7 +18,7 @@ summary: "Carried unresolved-requirements artifact the source→Galaxy pipeline 
 
 # Open-requirements ledger
 
-The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact.
+The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact. Alongside the entries it carries one run-level count — how much of the source the run actually carried — because a list of individually reasonable gaps can still add up to a pipeline that translated almost none of its source.
 
 ## Framing: obligations the pipeline discharges, not questions a human answers
 
@@ -64,6 +64,12 @@ This section is the runtime protocol for every Mold that carries the ledger. A M
 
 **Record a surrender note; leave the status to the terminal.** When you cannot close an entry and nothing downstream can either — no producer is discoverable, the output cannot be honestly narrowed — leave it `open` and say so in `note`. `surrendered` is a terminal status, set at the end of a run: the escalation cap reached, or the final artifact emitted with the obligation still unmet. Either way the entry stays visible and is written into the final artifact as a labelled gap, never dropped.
 
+**Maintain coverage.** Whenever a decision you make changes what the run will carry from
+the source, move the affected units between `coverage` buckets — never let them vanish.
+Narrowing a design moves units from `carried` to `surrendered`; deciding the target
+subsumes a mechanism moves them to `subsumed` with a reason. The buckets must still sum to
+`source_units` when you re-emit the ledger. See **Coverage (run-level state)** below.
+
 **Maintain the escalation budget** — loop Molds only. The `topology_repair` header is loop-level state, described under **Escalation budget (loop-level state)** below. On each escalation the orchestrator increments `escalations`, appends the post-repair open blocking-entry count to `open_history`, and surrenders the still-open blocking entries once `escalations` reaches `cap`.
 
 ## Role in topology repair
@@ -98,6 +104,56 @@ entries:
 
 This block lives in the ledger as a v1 expedient: the ledger is already the carried, cast-visible state the loop reads each iteration. Its better long-term home is the **draft itself** — a workflow-level annotation that travels with the artifact it bounds, so the budget survives even when the ledger is stripped at the terminal. Recorded here for now; migrate when the draft grows a home for it.
 
+## Coverage (run-level state)
+
+The decreasing-blocker invariant guards one failure — spin-or-fabricate during repair. It
+is blind to the opposite one, and blind by construction: **a run satisfies "strictly reduce
+the open blocking count" by deleting the steps that carried the blockers.** Dropping work
+drives the count to zero faster than doing it. Every invariant the ledger had was monotone
+in the direction that rewards shrinking.
+
+`coverage` is the counterweight — a conservation rule rather than a reduction one, in a
+second header beside `topology_repair`:
+
+```yaml
+coverage:
+  unit: nextflow-process     # what a source unit is, for this source kind
+  source_units: 95           # fixed by the first Mold; never re-based
+  carried: 68                # unit's work lives inside some step of the design
+  subsumed: 21               # target does this itself — reason required
+  surrendered: 6             # not carried, and nothing downstream will
+entries:
+  - id: sccmec-evidence-missing
+    # … per-entry shape above
+```
+
+The invariant is arithmetic: `carried + subsumed + surrendered == source_units`, checked
+whenever the ledger is re-emitted. Shrinking cannot satisfy it. A phase that cuts 25 nodes
+does not reduce a count — it moves 25 units into `surrendered`, where the terminal readout
+states them.
+
+- `unit` — the source's own granularity (`nextflow-process`, `cwl-step`), named once so the
+  denominator is not silently re-based mid-run. A Mold that re-groups units into coarser
+  steps has not changed `source_units`; merging N processes into one tool leaves all N
+  `carried`, which is why this is a partition and not a step-count ratio. A ratio would
+  flag legitimate re-granularization as loss.
+- `source_units` — set by the first Mold from the source summary, then read-only. Nothing
+  downstream may lower it; a design that carries less lowers `carried`.
+- `carried` — the unit's work reaches the target design, at whatever granularity.
+- `subsumed` — the target performs this itself, so translating it would be wrong. Real and
+  necessary: a Nextflow pipeline's grid-dispatch scatter/gather substrate is work Galaxy's
+  scheduler already does. It requires a stated reason, because it is the bucket a lazy run
+  would reach for.
+- `surrendered` — not carried and nothing downstream will carry it. Unlike per-entry
+  `surrendered`, this is not terminal-only: a phase that cuts scope surrenders units at the
+  moment it cuts, because a count nobody may update until the terminal is a count nobody
+  checks.
+
+Coverage answers a question no entry can: not *is each obligation tracked* but *how much of
+the source came out the other end*. On the run that motivated this, the six scope-cut
+entries were individually well-written and collectively described dropping 92 of 95
+processes. No phase ever computed that product, and every phase was reading the ledger.
+
 ## Threaded through the whole design tier
 
 The ledger is not loop-only. Every design-tier Mold in the source→Galaxy pipelines **consumes and re-emits** it — the interface, reference-data, data-flow, IWC-comparison, and template Molds (`*-summary-to-galaxy-interface`, `*-summary-to-galaxy-data-flow`, `*-summary-to-galaxy-reference-data`, `compare-against-iwc-exemplar`, `*-summary-to-galaxy-template`), alongside the change-set Molds on the update path. This is the direct answer to #281: the chain stops re-deriving the same unknowns because each Mold inherits them.
@@ -106,6 +162,7 @@ The template Mold's computability review pass is the notable appender ahead of t
 
 ## Open work
 
+- Decide who sets `coverage.subsumed` reasons and where they live — a free-text field on the header, or `kind`-tagged entries the header counts. Left loose here, like the rest of v1.
 - Decide whether entry structure should harden (typed `unmet` / `missing`, links back to source-summary evidence, machine-checkable `status` transitions) once two or three worked runs exercise it. Hardening it would also give the producing Molds an `output_artifacts[].schema` to cite, which none carry today.
 - Assign terminal surrender of *non-blocking* entries. [[advance-galaxy-draft-step]] surrenders open blocking entries at the escalation cap, but an unpinned-parameter entry the design tier appended and nobody closed currently rides out the run without ever being marked `surrendered`. Nothing owns that pass today.
 - Reconcile the design-tier briefs' free-text "open questions" sections with the ledger. Every design Mold still emits both, with no rule for which destination an unresolved choice belongs in.

--- a/casts/claude/skills/freeform-summary-to-galaxy-interface/_provenance.json
+++ b/casts/claude/skills/freeform-summary-to-galaxy-interface/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/freeform-summary-to-galaxy-interface/index.md",
     "revision": 3,
     "content_hash": "de0cb02532205ad18f4aa1ab2881cac725a3191b448468a8a11d0663ff1ec97d",
-    "commit": "95b5659f39847237122809c4eda2b71b89bd38e7"
+    "commit": "7b2cb7d53366177b004557cadb4784fd699bf155"
   },
-  "cast_at": "2026-08-25T21:03:45.147Z",
+  "cast_at": "2026-08-29T20:49:16.748Z",
   "refs": [
     {
       "kind": "research",
@@ -88,8 +88,8 @@
       "evidence": "hypothesis",
       "purpose": "Inherit open entries rather than re-deriving them, close the ones this brief's input, output, and label decisions settle, and append interface obligations the narrative never settles — an output the source names but never specifies, a parameter stated only qualitatively, a collection shape the prose doesn't determine.",
       "verification": "Promote after a worked run shows entries this Mold appends or resolves are consumed downstream without re-derivation.",
-      "src_hash": "10e84fa97b4e5c14ca78320b25cb9e419b7e98e0f2e676c09dd4deaf68a801fc",
-      "dst_hash": "10e84fa97b4e5c14ca78320b25cb9e419b7e98e0f2e676c09dd4deaf68a801fc",
+      "src_hash": "7ac93cdd192d3e42544ac0ffcecef7aa86d9b450608d9a41c25e6d5f8963af24",
+      "dst_hash": "7ac93cdd192d3e42544ac0ffcecef7aa86d9b450608d9a41c25e6d5f8963af24",
       "source": "deterministic"
     }
   ],

--- a/casts/claude/skills/freeform-summary-to-galaxy-interface/references/notes/open-requirements-ledger.md
+++ b/casts/claude/skills/freeform-summary-to-galaxy-interface/references/notes/open-requirements-ledger.md
@@ -5,8 +5,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-06-16
-revised: 2026-08-19
-revision: 2
+revised: 2026-08-29
+revision: 3
 related_notes:
   - "[[galaxy-workflow-draft-format]]"
 related_molds:
@@ -18,7 +18,7 @@ summary: "Carried unresolved-requirements artifact the source→Galaxy pipeline 
 
 # Open-requirements ledger
 
-The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact.
+The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact. Alongside the entries it carries one run-level count — how much of the source the run actually carried — because a list of individually reasonable gaps can still add up to a pipeline that translated almost none of its source.
 
 ## Framing: obligations the pipeline discharges, not questions a human answers
 
@@ -64,6 +64,12 @@ This section is the runtime protocol for every Mold that carries the ledger. A M
 
 **Record a surrender note; leave the status to the terminal.** When you cannot close an entry and nothing downstream can either — no producer is discoverable, the output cannot be honestly narrowed — leave it `open` and say so in `note`. `surrendered` is a terminal status, set at the end of a run: the escalation cap reached, or the final artifact emitted with the obligation still unmet. Either way the entry stays visible and is written into the final artifact as a labelled gap, never dropped.
 
+**Maintain coverage.** Whenever a decision you make changes what the run will carry from
+the source, move the affected units between `coverage` buckets — never let them vanish.
+Narrowing a design moves units from `carried` to `surrendered`; deciding the target
+subsumes a mechanism moves them to `subsumed` with a reason. The buckets must still sum to
+`source_units` when you re-emit the ledger. See **Coverage (run-level state)** below.
+
 **Maintain the escalation budget** — loop Molds only. The `topology_repair` header is loop-level state, described under **Escalation budget (loop-level state)** below. On each escalation the orchestrator increments `escalations`, appends the post-repair open blocking-entry count to `open_history`, and surrenders the still-open blocking entries once `escalations` reaches `cap`.
 
 ## Role in topology repair
@@ -98,6 +104,56 @@ entries:
 
 This block lives in the ledger as a v1 expedient: the ledger is already the carried, cast-visible state the loop reads each iteration. Its better long-term home is the **draft itself** — a workflow-level annotation that travels with the artifact it bounds, so the budget survives even when the ledger is stripped at the terminal. Recorded here for now; migrate when the draft grows a home for it.
 
+## Coverage (run-level state)
+
+The decreasing-blocker invariant guards one failure — spin-or-fabricate during repair. It
+is blind to the opposite one, and blind by construction: **a run satisfies "strictly reduce
+the open blocking count" by deleting the steps that carried the blockers.** Dropping work
+drives the count to zero faster than doing it. Every invariant the ledger had was monotone
+in the direction that rewards shrinking.
+
+`coverage` is the counterweight — a conservation rule rather than a reduction one, in a
+second header beside `topology_repair`:
+
+```yaml
+coverage:
+  unit: nextflow-process     # what a source unit is, for this source kind
+  source_units: 95           # fixed by the first Mold; never re-based
+  carried: 68                # unit's work lives inside some step of the design
+  subsumed: 21               # target does this itself — reason required
+  surrendered: 6             # not carried, and nothing downstream will
+entries:
+  - id: sccmec-evidence-missing
+    # … per-entry shape above
+```
+
+The invariant is arithmetic: `carried + subsumed + surrendered == source_units`, checked
+whenever the ledger is re-emitted. Shrinking cannot satisfy it. A phase that cuts 25 nodes
+does not reduce a count — it moves 25 units into `surrendered`, where the terminal readout
+states them.
+
+- `unit` — the source's own granularity (`nextflow-process`, `cwl-step`), named once so the
+  denominator is not silently re-based mid-run. A Mold that re-groups units into coarser
+  steps has not changed `source_units`; merging N processes into one tool leaves all N
+  `carried`, which is why this is a partition and not a step-count ratio. A ratio would
+  flag legitimate re-granularization as loss.
+- `source_units` — set by the first Mold from the source summary, then read-only. Nothing
+  downstream may lower it; a design that carries less lowers `carried`.
+- `carried` — the unit's work reaches the target design, at whatever granularity.
+- `subsumed` — the target performs this itself, so translating it would be wrong. Real and
+  necessary: a Nextflow pipeline's grid-dispatch scatter/gather substrate is work Galaxy's
+  scheduler already does. It requires a stated reason, because it is the bucket a lazy run
+  would reach for.
+- `surrendered` — not carried and nothing downstream will carry it. Unlike per-entry
+  `surrendered`, this is not terminal-only: a phase that cuts scope surrenders units at the
+  moment it cuts, because a count nobody may update until the terminal is a count nobody
+  checks.
+
+Coverage answers a question no entry can: not *is each obligation tracked* but *how much of
+the source came out the other end*. On the run that motivated this, the six scope-cut
+entries were individually well-written and collectively described dropping 92 of 95
+processes. No phase ever computed that product, and every phase was reading the ledger.
+
 ## Threaded through the whole design tier
 
 The ledger is not loop-only. Every design-tier Mold in the source→Galaxy pipelines **consumes and re-emits** it — the interface, reference-data, data-flow, IWC-comparison, and template Molds (`*-summary-to-galaxy-interface`, `*-summary-to-galaxy-data-flow`, `*-summary-to-galaxy-reference-data`, `compare-against-iwc-exemplar`, `*-summary-to-galaxy-template`), alongside the change-set Molds on the update path. This is the direct answer to #281: the chain stops re-deriving the same unknowns because each Mold inherits them.
@@ -106,6 +162,7 @@ The template Mold's computability review pass is the notable appender ahead of t
 
 ## Open work
 
+- Decide who sets `coverage.subsumed` reasons and where they live — a free-text field on the header, or `kind`-tagged entries the header counts. Left loose here, like the rest of v1.
 - Decide whether entry structure should harden (typed `unmet` / `missing`, links back to source-summary evidence, machine-checkable `status` transitions) once two or three worked runs exercise it. Hardening it would also give the producing Molds an `output_artifacts[].schema` to cite, which none carry today.
 - Assign terminal surrender of *non-blocking* entries. [[advance-galaxy-draft-step]] surrenders open blocking entries at the escalation cap, but an unpinned-parameter entry the design tier appended and nobody closed currently rides out the run without ever being marked `surrendered`. Nothing owns that pass today.
 - Reconcile the design-tier briefs' free-text "open questions" sections with the ledger. Every design Mold still emits both, with no rule for which destination an unresolved choice belongs in.

--- a/casts/claude/skills/freeform-summary-to-galaxy-template/_provenance.json
+++ b/casts/claude/skills/freeform-summary-to-galaxy-template/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/freeform-summary-to-galaxy-template/index.md",
     "revision": 6,
     "content_hash": "e868bae6a3fa5c20bba280b8ad7d823dae51fb78600f666f9d4dd53b30d9f760",
-    "commit": "95b5659f39847237122809c4eda2b71b89bd38e7"
+    "commit": "7b2cb7d53366177b004557cadb4784fd699bf155"
   },
-  "cast_at": "2026-08-25T21:03:45.433Z",
+  "cast_at": "2026-08-29T20:49:16.955Z",
   "refs": [
     {
       "kind": "cli-command",
@@ -195,8 +195,8 @@
       "evidence": "hypothesis",
       "purpose": "Close the open entries the settled topology discharges, and append a blocking entry for any settled step whose declared output no wired input can supply — the computability gap gxwf validation cannot see, raised here rather than left for the per-step loop to hit.",
       "verification": "Promote after a worked run shows entries this Mold appends or resolves are consumed downstream without re-derivation.",
-      "src_hash": "10e84fa97b4e5c14ca78320b25cb9e419b7e98e0f2e676c09dd4deaf68a801fc",
-      "dst_hash": "10e84fa97b4e5c14ca78320b25cb9e419b7e98e0f2e676c09dd4deaf68a801fc",
+      "src_hash": "7ac93cdd192d3e42544ac0ffcecef7aa86d9b450608d9a41c25e6d5f8963af24",
+      "dst_hash": "7ac93cdd192d3e42544ac0ffcecef7aa86d9b450608d9a41c25e6d5f8963af24",
       "source": "deterministic"
     },
     {

--- a/casts/claude/skills/freeform-summary-to-galaxy-template/references/notes/open-requirements-ledger.md
+++ b/casts/claude/skills/freeform-summary-to-galaxy-template/references/notes/open-requirements-ledger.md
@@ -5,8 +5,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-06-16
-revised: 2026-08-19
-revision: 2
+revised: 2026-08-29
+revision: 3
 related_notes:
   - "[[galaxy-workflow-draft-format]]"
 related_molds:
@@ -18,7 +18,7 @@ summary: "Carried unresolved-requirements artifact the source→Galaxy pipeline 
 
 # Open-requirements ledger
 
-The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact.
+The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact. Alongside the entries it carries one run-level count — how much of the source the run actually carried — because a list of individually reasonable gaps can still add up to a pipeline that translated almost none of its source.
 
 ## Framing: obligations the pipeline discharges, not questions a human answers
 
@@ -64,6 +64,12 @@ This section is the runtime protocol for every Mold that carries the ledger. A M
 
 **Record a surrender note; leave the status to the terminal.** When you cannot close an entry and nothing downstream can either — no producer is discoverable, the output cannot be honestly narrowed — leave it `open` and say so in `note`. `surrendered` is a terminal status, set at the end of a run: the escalation cap reached, or the final artifact emitted with the obligation still unmet. Either way the entry stays visible and is written into the final artifact as a labelled gap, never dropped.
 
+**Maintain coverage.** Whenever a decision you make changes what the run will carry from
+the source, move the affected units between `coverage` buckets — never let them vanish.
+Narrowing a design moves units from `carried` to `surrendered`; deciding the target
+subsumes a mechanism moves them to `subsumed` with a reason. The buckets must still sum to
+`source_units` when you re-emit the ledger. See **Coverage (run-level state)** below.
+
 **Maintain the escalation budget** — loop Molds only. The `topology_repair` header is loop-level state, described under **Escalation budget (loop-level state)** below. On each escalation the orchestrator increments `escalations`, appends the post-repair open blocking-entry count to `open_history`, and surrenders the still-open blocking entries once `escalations` reaches `cap`.
 
 ## Role in topology repair
@@ -98,6 +104,56 @@ entries:
 
 This block lives in the ledger as a v1 expedient: the ledger is already the carried, cast-visible state the loop reads each iteration. Its better long-term home is the **draft itself** — a workflow-level annotation that travels with the artifact it bounds, so the budget survives even when the ledger is stripped at the terminal. Recorded here for now; migrate when the draft grows a home for it.
 
+## Coverage (run-level state)
+
+The decreasing-blocker invariant guards one failure — spin-or-fabricate during repair. It
+is blind to the opposite one, and blind by construction: **a run satisfies "strictly reduce
+the open blocking count" by deleting the steps that carried the blockers.** Dropping work
+drives the count to zero faster than doing it. Every invariant the ledger had was monotone
+in the direction that rewards shrinking.
+
+`coverage` is the counterweight — a conservation rule rather than a reduction one, in a
+second header beside `topology_repair`:
+
+```yaml
+coverage:
+  unit: nextflow-process     # what a source unit is, for this source kind
+  source_units: 95           # fixed by the first Mold; never re-based
+  carried: 68                # unit's work lives inside some step of the design
+  subsumed: 21               # target does this itself — reason required
+  surrendered: 6             # not carried, and nothing downstream will
+entries:
+  - id: sccmec-evidence-missing
+    # … per-entry shape above
+```
+
+The invariant is arithmetic: `carried + subsumed + surrendered == source_units`, checked
+whenever the ledger is re-emitted. Shrinking cannot satisfy it. A phase that cuts 25 nodes
+does not reduce a count — it moves 25 units into `surrendered`, where the terminal readout
+states them.
+
+- `unit` — the source's own granularity (`nextflow-process`, `cwl-step`), named once so the
+  denominator is not silently re-based mid-run. A Mold that re-groups units into coarser
+  steps has not changed `source_units`; merging N processes into one tool leaves all N
+  `carried`, which is why this is a partition and not a step-count ratio. A ratio would
+  flag legitimate re-granularization as loss.
+- `source_units` — set by the first Mold from the source summary, then read-only. Nothing
+  downstream may lower it; a design that carries less lowers `carried`.
+- `carried` — the unit's work reaches the target design, at whatever granularity.
+- `subsumed` — the target performs this itself, so translating it would be wrong. Real and
+  necessary: a Nextflow pipeline's grid-dispatch scatter/gather substrate is work Galaxy's
+  scheduler already does. It requires a stated reason, because it is the bucket a lazy run
+  would reach for.
+- `surrendered` — not carried and nothing downstream will carry it. Unlike per-entry
+  `surrendered`, this is not terminal-only: a phase that cuts scope surrenders units at the
+  moment it cuts, because a count nobody may update until the terminal is a count nobody
+  checks.
+
+Coverage answers a question no entry can: not *is each obligation tracked* but *how much of
+the source came out the other end*. On the run that motivated this, the six scope-cut
+entries were individually well-written and collectively described dropping 92 of 95
+processes. No phase ever computed that product, and every phase was reading the ledger.
+
 ## Threaded through the whole design tier
 
 The ledger is not loop-only. Every design-tier Mold in the source→Galaxy pipelines **consumes and re-emits** it — the interface, reference-data, data-flow, IWC-comparison, and template Molds (`*-summary-to-galaxy-interface`, `*-summary-to-galaxy-data-flow`, `*-summary-to-galaxy-reference-data`, `compare-against-iwc-exemplar`, `*-summary-to-galaxy-template`), alongside the change-set Molds on the update path. This is the direct answer to #281: the chain stops re-deriving the same unknowns because each Mold inherits them.
@@ -106,6 +162,7 @@ The template Mold's computability review pass is the notable appender ahead of t
 
 ## Open work
 
+- Decide who sets `coverage.subsumed` reasons and where they live — a free-text field on the header, or `kind`-tagged entries the header counts. Left loose here, like the rest of v1.
 - Decide whether entry structure should harden (typed `unmet` / `missing`, links back to source-summary evidence, machine-checkable `status` transitions) once two or three worked runs exercise it. Hardening it would also give the producing Molds an `output_artifacts[].schema` to cite, which none carry today.
 - Assign terminal surrender of *non-blocking* entries. [[advance-galaxy-draft-step]] surrenders open blocking entries at the escalation cap, but an unpinned-parameter entry the design tier appended and nobody closed currently rides out the run without ever being marked `surrendered`. Nothing owns that pass today.
 - Reconcile the design-tier briefs' free-text "open questions" sections with the ledger. Every design Mold still emits both, with no rule for which destination an unresolved choice belongs in.

--- a/casts/claude/skills/implement-galaxy-tool-step/_provenance.json
+++ b/casts/claude/skills/implement-galaxy-tool-step/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/implement-galaxy-tool-step/index.md",
     "revision": 9,
     "content_hash": "bd96cf67a5478cab941c05e4997e403e40ee6d11ffb1472e3ecd0740fcf1baaf",
-    "commit": "95b5659f39847237122809c4eda2b71b89bd38e7"
+    "commit": "7b2cb7d53366177b004557cadb4784fd699bf155"
   },
-  "cast_at": "2026-08-25T21:03:46.214Z",
+  "cast_at": "2026-08-29T20:49:17.229Z",
   "refs": [
     {
       "kind": "cli-command",
@@ -164,8 +164,8 @@
       "evidence": "hypothesis",
       "purpose": "Read the entries the design tier recorded against this step before implementing it, and append a blocking entry when the step's declared output cannot be computed from its wired inputs — the fall-through to topology repair, in place of fabricating the missing evidence.",
       "verification": "Promote after a worked run shows entries this Mold appends or resolves are consumed downstream without re-derivation.",
-      "src_hash": "10e84fa97b4e5c14ca78320b25cb9e419b7e98e0f2e676c09dd4deaf68a801fc",
-      "dst_hash": "10e84fa97b4e5c14ca78320b25cb9e419b7e98e0f2e676c09dd4deaf68a801fc",
+      "src_hash": "7ac93cdd192d3e42544ac0ffcecef7aa86d9b450608d9a41c25e6d5f8963af24",
+      "dst_hash": "7ac93cdd192d3e42544ac0ffcecef7aa86d9b450608d9a41c25e6d5f8963af24",
       "source": "deterministic"
     },
     {

--- a/casts/claude/skills/implement-galaxy-tool-step/references/notes/open-requirements-ledger.md
+++ b/casts/claude/skills/implement-galaxy-tool-step/references/notes/open-requirements-ledger.md
@@ -5,8 +5,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-06-16
-revised: 2026-08-19
-revision: 2
+revised: 2026-08-29
+revision: 3
 related_notes:
   - "[[galaxy-workflow-draft-format]]"
 related_molds:
@@ -18,7 +18,7 @@ summary: "Carried unresolved-requirements artifact the source→Galaxy pipeline 
 
 # Open-requirements ledger
 
-The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact.
+The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact. Alongside the entries it carries one run-level count — how much of the source the run actually carried — because a list of individually reasonable gaps can still add up to a pipeline that translated almost none of its source.
 
 ## Framing: obligations the pipeline discharges, not questions a human answers
 
@@ -64,6 +64,12 @@ This section is the runtime protocol for every Mold that carries the ledger. A M
 
 **Record a surrender note; leave the status to the terminal.** When you cannot close an entry and nothing downstream can either — no producer is discoverable, the output cannot be honestly narrowed — leave it `open` and say so in `note`. `surrendered` is a terminal status, set at the end of a run: the escalation cap reached, or the final artifact emitted with the obligation still unmet. Either way the entry stays visible and is written into the final artifact as a labelled gap, never dropped.
 
+**Maintain coverage.** Whenever a decision you make changes what the run will carry from
+the source, move the affected units between `coverage` buckets — never let them vanish.
+Narrowing a design moves units from `carried` to `surrendered`; deciding the target
+subsumes a mechanism moves them to `subsumed` with a reason. The buckets must still sum to
+`source_units` when you re-emit the ledger. See **Coverage (run-level state)** below.
+
 **Maintain the escalation budget** — loop Molds only. The `topology_repair` header is loop-level state, described under **Escalation budget (loop-level state)** below. On each escalation the orchestrator increments `escalations`, appends the post-repair open blocking-entry count to `open_history`, and surrenders the still-open blocking entries once `escalations` reaches `cap`.
 
 ## Role in topology repair
@@ -98,6 +104,56 @@ entries:
 
 This block lives in the ledger as a v1 expedient: the ledger is already the carried, cast-visible state the loop reads each iteration. Its better long-term home is the **draft itself** — a workflow-level annotation that travels with the artifact it bounds, so the budget survives even when the ledger is stripped at the terminal. Recorded here for now; migrate when the draft grows a home for it.
 
+## Coverage (run-level state)
+
+The decreasing-blocker invariant guards one failure — spin-or-fabricate during repair. It
+is blind to the opposite one, and blind by construction: **a run satisfies "strictly reduce
+the open blocking count" by deleting the steps that carried the blockers.** Dropping work
+drives the count to zero faster than doing it. Every invariant the ledger had was monotone
+in the direction that rewards shrinking.
+
+`coverage` is the counterweight — a conservation rule rather than a reduction one, in a
+second header beside `topology_repair`:
+
+```yaml
+coverage:
+  unit: nextflow-process     # what a source unit is, for this source kind
+  source_units: 95           # fixed by the first Mold; never re-based
+  carried: 68                # unit's work lives inside some step of the design
+  subsumed: 21               # target does this itself — reason required
+  surrendered: 6             # not carried, and nothing downstream will
+entries:
+  - id: sccmec-evidence-missing
+    # … per-entry shape above
+```
+
+The invariant is arithmetic: `carried + subsumed + surrendered == source_units`, checked
+whenever the ledger is re-emitted. Shrinking cannot satisfy it. A phase that cuts 25 nodes
+does not reduce a count — it moves 25 units into `surrendered`, where the terminal readout
+states them.
+
+- `unit` — the source's own granularity (`nextflow-process`, `cwl-step`), named once so the
+  denominator is not silently re-based mid-run. A Mold that re-groups units into coarser
+  steps has not changed `source_units`; merging N processes into one tool leaves all N
+  `carried`, which is why this is a partition and not a step-count ratio. A ratio would
+  flag legitimate re-granularization as loss.
+- `source_units` — set by the first Mold from the source summary, then read-only. Nothing
+  downstream may lower it; a design that carries less lowers `carried`.
+- `carried` — the unit's work reaches the target design, at whatever granularity.
+- `subsumed` — the target performs this itself, so translating it would be wrong. Real and
+  necessary: a Nextflow pipeline's grid-dispatch scatter/gather substrate is work Galaxy's
+  scheduler already does. It requires a stated reason, because it is the bucket a lazy run
+  would reach for.
+- `surrendered` — not carried and nothing downstream will carry it. Unlike per-entry
+  `surrendered`, this is not terminal-only: a phase that cuts scope surrenders units at the
+  moment it cuts, because a count nobody may update until the terminal is a count nobody
+  checks.
+
+Coverage answers a question no entry can: not *is each obligation tracked* but *how much of
+the source came out the other end*. On the run that motivated this, the six scope-cut
+entries were individually well-written and collectively described dropping 92 of 95
+processes. No phase ever computed that product, and every phase was reading the ledger.
+
 ## Threaded through the whole design tier
 
 The ledger is not loop-only. Every design-tier Mold in the source→Galaxy pipelines **consumes and re-emits** it — the interface, reference-data, data-flow, IWC-comparison, and template Molds (`*-summary-to-galaxy-interface`, `*-summary-to-galaxy-data-flow`, `*-summary-to-galaxy-reference-data`, `compare-against-iwc-exemplar`, `*-summary-to-galaxy-template`), alongside the change-set Molds on the update path. This is the direct answer to #281: the chain stops re-deriving the same unknowns because each Mold inherits them.
@@ -106,6 +162,7 @@ The template Mold's computability review pass is the notable appender ahead of t
 
 ## Open work
 
+- Decide who sets `coverage.subsumed` reasons and where they live — a free-text field on the header, or `kind`-tagged entries the header counts. Left loose here, like the rest of v1.
 - Decide whether entry structure should harden (typed `unmet` / `missing`, links back to source-summary evidence, machine-checkable `status` transitions) once two or three worked runs exercise it. Hardening it would also give the producing Molds an `output_artifacts[].schema` to cite, which none carry today.
 - Assign terminal surrender of *non-blocking* entries. [[advance-galaxy-draft-step]] surrenders open blocking entries at the escalation cap, but an unpinned-parameter entry the design tier appended and nobody closed currently rides out the run without ever being marked `surrendered`. Nothing owns that pass today.
 - Reconcile the design-tier briefs' free-text "open questions" sections with the ledger. Every design Mold still emits both, with no rule for which destination an unresolved choice belongs in.

--- a/casts/claude/skills/interview-to-galaxy-workflow-changeset/_provenance.json
+++ b/casts/claude/skills/interview-to-galaxy-workflow-changeset/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/interview-to-galaxy-workflow-changeset/index.md",
     "revision": 3,
     "content_hash": "9e2b8567ee121020d44ac03ff4e119393e799c6cb35a0f21b9d2ce1d4a21dce1",
-    "commit": "95b5659f39847237122809c4eda2b71b89bd38e7"
+    "commit": "7b2cb7d53366177b004557cadb4784fd699bf155"
   },
-  "cast_at": "2026-08-25T21:03:46.716Z",
+  "cast_at": "2026-08-29T20:49:17.614Z",
   "refs": [
     {
       "kind": "research",
@@ -21,8 +21,8 @@
       "evidence": "hypothesis",
       "purpose": "Record a requested change the workflow cannot support as described as an open entry, so an unsupportable request survives as a tracked obligation rather than a fabricated anchor or a silent drop.",
       "verification": "Promote after a worked run shows entries this Mold appends are consumed by apply-galaxy-workflow-changeset or a reviewer without re-derivation.",
-      "src_hash": "10e84fa97b4e5c14ca78320b25cb9e419b7e98e0f2e676c09dd4deaf68a801fc",
-      "dst_hash": "10e84fa97b4e5c14ca78320b25cb9e419b7e98e0f2e676c09dd4deaf68a801fc",
+      "src_hash": "7ac93cdd192d3e42544ac0ffcecef7aa86d9b450608d9a41c25e6d5f8963af24",
+      "dst_hash": "7ac93cdd192d3e42544ac0ffcecef7aa86d9b450608d9a41c25e6d5f8963af24",
       "source": "deterministic"
     },
     {

--- a/casts/claude/skills/interview-to-galaxy-workflow-changeset/references/notes/open-requirements-ledger.md
+++ b/casts/claude/skills/interview-to-galaxy-workflow-changeset/references/notes/open-requirements-ledger.md
@@ -5,8 +5,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-06-16
-revised: 2026-08-19
-revision: 2
+revised: 2026-08-29
+revision: 3
 related_notes:
   - "[[galaxy-workflow-draft-format]]"
 related_molds:
@@ -18,7 +18,7 @@ summary: "Carried unresolved-requirements artifact the source→Galaxy pipeline 
 
 # Open-requirements ledger
 
-The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact.
+The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact. Alongside the entries it carries one run-level count — how much of the source the run actually carried — because a list of individually reasonable gaps can still add up to a pipeline that translated almost none of its source.
 
 ## Framing: obligations the pipeline discharges, not questions a human answers
 
@@ -64,6 +64,12 @@ This section is the runtime protocol for every Mold that carries the ledger. A M
 
 **Record a surrender note; leave the status to the terminal.** When you cannot close an entry and nothing downstream can either — no producer is discoverable, the output cannot be honestly narrowed — leave it `open` and say so in `note`. `surrendered` is a terminal status, set at the end of a run: the escalation cap reached, or the final artifact emitted with the obligation still unmet. Either way the entry stays visible and is written into the final artifact as a labelled gap, never dropped.
 
+**Maintain coverage.** Whenever a decision you make changes what the run will carry from
+the source, move the affected units between `coverage` buckets — never let them vanish.
+Narrowing a design moves units from `carried` to `surrendered`; deciding the target
+subsumes a mechanism moves them to `subsumed` with a reason. The buckets must still sum to
+`source_units` when you re-emit the ledger. See **Coverage (run-level state)** below.
+
 **Maintain the escalation budget** — loop Molds only. The `topology_repair` header is loop-level state, described under **Escalation budget (loop-level state)** below. On each escalation the orchestrator increments `escalations`, appends the post-repair open blocking-entry count to `open_history`, and surrenders the still-open blocking entries once `escalations` reaches `cap`.
 
 ## Role in topology repair
@@ -98,6 +104,56 @@ entries:
 
 This block lives in the ledger as a v1 expedient: the ledger is already the carried, cast-visible state the loop reads each iteration. Its better long-term home is the **draft itself** — a workflow-level annotation that travels with the artifact it bounds, so the budget survives even when the ledger is stripped at the terminal. Recorded here for now; migrate when the draft grows a home for it.
 
+## Coverage (run-level state)
+
+The decreasing-blocker invariant guards one failure — spin-or-fabricate during repair. It
+is blind to the opposite one, and blind by construction: **a run satisfies "strictly reduce
+the open blocking count" by deleting the steps that carried the blockers.** Dropping work
+drives the count to zero faster than doing it. Every invariant the ledger had was monotone
+in the direction that rewards shrinking.
+
+`coverage` is the counterweight — a conservation rule rather than a reduction one, in a
+second header beside `topology_repair`:
+
+```yaml
+coverage:
+  unit: nextflow-process     # what a source unit is, for this source kind
+  source_units: 95           # fixed by the first Mold; never re-based
+  carried: 68                # unit's work lives inside some step of the design
+  subsumed: 21               # target does this itself — reason required
+  surrendered: 6             # not carried, and nothing downstream will
+entries:
+  - id: sccmec-evidence-missing
+    # … per-entry shape above
+```
+
+The invariant is arithmetic: `carried + subsumed + surrendered == source_units`, checked
+whenever the ledger is re-emitted. Shrinking cannot satisfy it. A phase that cuts 25 nodes
+does not reduce a count — it moves 25 units into `surrendered`, where the terminal readout
+states them.
+
+- `unit` — the source's own granularity (`nextflow-process`, `cwl-step`), named once so the
+  denominator is not silently re-based mid-run. A Mold that re-groups units into coarser
+  steps has not changed `source_units`; merging N processes into one tool leaves all N
+  `carried`, which is why this is a partition and not a step-count ratio. A ratio would
+  flag legitimate re-granularization as loss.
+- `source_units` — set by the first Mold from the source summary, then read-only. Nothing
+  downstream may lower it; a design that carries less lowers `carried`.
+- `carried` — the unit's work reaches the target design, at whatever granularity.
+- `subsumed` — the target performs this itself, so translating it would be wrong. Real and
+  necessary: a Nextflow pipeline's grid-dispatch scatter/gather substrate is work Galaxy's
+  scheduler already does. It requires a stated reason, because it is the bucket a lazy run
+  would reach for.
+- `surrendered` — not carried and nothing downstream will carry it. Unlike per-entry
+  `surrendered`, this is not terminal-only: a phase that cuts scope surrenders units at the
+  moment it cuts, because a count nobody may update until the terminal is a count nobody
+  checks.
+
+Coverage answers a question no entry can: not *is each obligation tracked* but *how much of
+the source came out the other end*. On the run that motivated this, the six scope-cut
+entries were individually well-written and collectively described dropping 92 of 95
+processes. No phase ever computed that product, and every phase was reading the ledger.
+
 ## Threaded through the whole design tier
 
 The ledger is not loop-only. Every design-tier Mold in the source→Galaxy pipelines **consumes and re-emits** it — the interface, reference-data, data-flow, IWC-comparison, and template Molds (`*-summary-to-galaxy-interface`, `*-summary-to-galaxy-data-flow`, `*-summary-to-galaxy-reference-data`, `compare-against-iwc-exemplar`, `*-summary-to-galaxy-template`), alongside the change-set Molds on the update path. This is the direct answer to #281: the chain stops re-deriving the same unknowns because each Mold inherits them.
@@ -106,6 +162,7 @@ The template Mold's computability review pass is the notable appender ahead of t
 
 ## Open work
 
+- Decide who sets `coverage.subsumed` reasons and where they live — a free-text field on the header, or `kind`-tagged entries the header counts. Left loose here, like the rest of v1.
 - Decide whether entry structure should harden (typed `unmet` / `missing`, links back to source-summary evidence, machine-checkable `status` transitions) once two or three worked runs exercise it. Hardening it would also give the producing Molds an `output_artifacts[].schema` to cite, which none carry today.
 - Assign terminal surrender of *non-blocking* entries. [[advance-galaxy-draft-step]] surrenders open blocking entries at the escalation cap, but an unpinned-parameter entry the design tier appended and nobody closed currently rides out the run without ever being marked `surrendered`. Nothing owns that pass today.
 - Reconcile the design-tier briefs' free-text "open questions" sections with the ledger. Every design Mold still emits both, with no rule for which destination an unresolved choice belongs in.

--- a/casts/claude/skills/nextflow-summary-to-galaxy-data-flow/_provenance.json
+++ b/casts/claude/skills/nextflow-summary-to-galaxy-data-flow/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/nextflow-summary-to-galaxy-data-flow/index.md",
     "revision": 6,
     "content_hash": "fac99ab0c394f3a68e7cc4cb34c3a7ebb43063e0593486bc1a48318ecbd0bd0c",
-    "commit": "95b5659f39847237122809c4eda2b71b89bd38e7"
+    "commit": "7b2cb7d53366177b004557cadb4784fd699bf155"
   },
-  "cast_at": "2026-08-25T21:03:47.021Z",
+  "cast_at": "2026-08-29T20:49:17.778Z",
   "cast_date": "2026-05-07",
   "cast_revision": 3,
   "cast_history": [
@@ -218,8 +218,8 @@
       "evidence": "hypothesis",
       "purpose": "Inherit open entries rather than re-deriving them, close the ones this brief's wiring and collection decisions settle, and append data-flow obligations the channel topology leaves open — an operator with no Galaxy collection recipe, a value channel with no Galaxy carrier, a join whose key Galaxy can't reconstruct.",
       "verification": "Promote after a worked run shows entries this Mold appends or resolves are consumed downstream without re-derivation.",
-      "src_hash": "10e84fa97b4e5c14ca78320b25cb9e419b7e98e0f2e676c09dd4deaf68a801fc",
-      "dst_hash": "10e84fa97b4e5c14ca78320b25cb9e419b7e98e0f2e676c09dd4deaf68a801fc",
+      "src_hash": "7ac93cdd192d3e42544ac0ffcecef7aa86d9b450608d9a41c25e6d5f8963af24",
+      "dst_hash": "7ac93cdd192d3e42544ac0ffcecef7aa86d9b450608d9a41c25e6d5f8963af24",
       "source": "deterministic"
     },
     {

--- a/casts/claude/skills/nextflow-summary-to-galaxy-data-flow/references/notes/open-requirements-ledger.md
+++ b/casts/claude/skills/nextflow-summary-to-galaxy-data-flow/references/notes/open-requirements-ledger.md
@@ -5,8 +5,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-06-16
-revised: 2026-08-19
-revision: 2
+revised: 2026-08-29
+revision: 3
 related_notes:
   - "[[galaxy-workflow-draft-format]]"
 related_molds:
@@ -18,7 +18,7 @@ summary: "Carried unresolved-requirements artifact the source→Galaxy pipeline 
 
 # Open-requirements ledger
 
-The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact.
+The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact. Alongside the entries it carries one run-level count — how much of the source the run actually carried — because a list of individually reasonable gaps can still add up to a pipeline that translated almost none of its source.
 
 ## Framing: obligations the pipeline discharges, not questions a human answers
 
@@ -64,6 +64,12 @@ This section is the runtime protocol for every Mold that carries the ledger. A M
 
 **Record a surrender note; leave the status to the terminal.** When you cannot close an entry and nothing downstream can either — no producer is discoverable, the output cannot be honestly narrowed — leave it `open` and say so in `note`. `surrendered` is a terminal status, set at the end of a run: the escalation cap reached, or the final artifact emitted with the obligation still unmet. Either way the entry stays visible and is written into the final artifact as a labelled gap, never dropped.
 
+**Maintain coverage.** Whenever a decision you make changes what the run will carry from
+the source, move the affected units between `coverage` buckets — never let them vanish.
+Narrowing a design moves units from `carried` to `surrendered`; deciding the target
+subsumes a mechanism moves them to `subsumed` with a reason. The buckets must still sum to
+`source_units` when you re-emit the ledger. See **Coverage (run-level state)** below.
+
 **Maintain the escalation budget** — loop Molds only. The `topology_repair` header is loop-level state, described under **Escalation budget (loop-level state)** below. On each escalation the orchestrator increments `escalations`, appends the post-repair open blocking-entry count to `open_history`, and surrenders the still-open blocking entries once `escalations` reaches `cap`.
 
 ## Role in topology repair
@@ -98,6 +104,56 @@ entries:
 
 This block lives in the ledger as a v1 expedient: the ledger is already the carried, cast-visible state the loop reads each iteration. Its better long-term home is the **draft itself** — a workflow-level annotation that travels with the artifact it bounds, so the budget survives even when the ledger is stripped at the terminal. Recorded here for now; migrate when the draft grows a home for it.
 
+## Coverage (run-level state)
+
+The decreasing-blocker invariant guards one failure — spin-or-fabricate during repair. It
+is blind to the opposite one, and blind by construction: **a run satisfies "strictly reduce
+the open blocking count" by deleting the steps that carried the blockers.** Dropping work
+drives the count to zero faster than doing it. Every invariant the ledger had was monotone
+in the direction that rewards shrinking.
+
+`coverage` is the counterweight — a conservation rule rather than a reduction one, in a
+second header beside `topology_repair`:
+
+```yaml
+coverage:
+  unit: nextflow-process     # what a source unit is, for this source kind
+  source_units: 95           # fixed by the first Mold; never re-based
+  carried: 68                # unit's work lives inside some step of the design
+  subsumed: 21               # target does this itself — reason required
+  surrendered: 6             # not carried, and nothing downstream will
+entries:
+  - id: sccmec-evidence-missing
+    # … per-entry shape above
+```
+
+The invariant is arithmetic: `carried + subsumed + surrendered == source_units`, checked
+whenever the ledger is re-emitted. Shrinking cannot satisfy it. A phase that cuts 25 nodes
+does not reduce a count — it moves 25 units into `surrendered`, where the terminal readout
+states them.
+
+- `unit` — the source's own granularity (`nextflow-process`, `cwl-step`), named once so the
+  denominator is not silently re-based mid-run. A Mold that re-groups units into coarser
+  steps has not changed `source_units`; merging N processes into one tool leaves all N
+  `carried`, which is why this is a partition and not a step-count ratio. A ratio would
+  flag legitimate re-granularization as loss.
+- `source_units` — set by the first Mold from the source summary, then read-only. Nothing
+  downstream may lower it; a design that carries less lowers `carried`.
+- `carried` — the unit's work reaches the target design, at whatever granularity.
+- `subsumed` — the target performs this itself, so translating it would be wrong. Real and
+  necessary: a Nextflow pipeline's grid-dispatch scatter/gather substrate is work Galaxy's
+  scheduler already does. It requires a stated reason, because it is the bucket a lazy run
+  would reach for.
+- `surrendered` — not carried and nothing downstream will carry it. Unlike per-entry
+  `surrendered`, this is not terminal-only: a phase that cuts scope surrenders units at the
+  moment it cuts, because a count nobody may update until the terminal is a count nobody
+  checks.
+
+Coverage answers a question no entry can: not *is each obligation tracked* but *how much of
+the source came out the other end*. On the run that motivated this, the six scope-cut
+entries were individually well-written and collectively described dropping 92 of 95
+processes. No phase ever computed that product, and every phase was reading the ledger.
+
 ## Threaded through the whole design tier
 
 The ledger is not loop-only. Every design-tier Mold in the source→Galaxy pipelines **consumes and re-emits** it — the interface, reference-data, data-flow, IWC-comparison, and template Molds (`*-summary-to-galaxy-interface`, `*-summary-to-galaxy-data-flow`, `*-summary-to-galaxy-reference-data`, `compare-against-iwc-exemplar`, `*-summary-to-galaxy-template`), alongside the change-set Molds on the update path. This is the direct answer to #281: the chain stops re-deriving the same unknowns because each Mold inherits them.
@@ -106,6 +162,7 @@ The template Mold's computability review pass is the notable appender ahead of t
 
 ## Open work
 
+- Decide who sets `coverage.subsumed` reasons and where they live — a free-text field on the header, or `kind`-tagged entries the header counts. Left loose here, like the rest of v1.
 - Decide whether entry structure should harden (typed `unmet` / `missing`, links back to source-summary evidence, machine-checkable `status` transitions) once two or three worked runs exercise it. Hardening it would also give the producing Molds an `output_artifacts[].schema` to cite, which none carry today.
 - Assign terminal surrender of *non-blocking* entries. [[advance-galaxy-draft-step]] surrenders open blocking entries at the escalation cap, but an unpinned-parameter entry the design tier appended and nobody closed currently rides out the run without ever being marked `surrendered`. Nothing owns that pass today.
 - Reconcile the design-tier briefs' free-text "open questions" sections with the ledger. Every design Mold still emits both, with no rule for which destination an unresolved choice belongs in.

--- a/casts/claude/skills/nextflow-summary-to-galaxy-interface/_provenance.json
+++ b/casts/claude/skills/nextflow-summary-to-galaxy-interface/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/nextflow-summary-to-galaxy-interface/index.md",
     "revision": 6,
     "content_hash": "43966773391578490688098c9333f6eb2eaa94574755f5b6554e7f9b72a605c0",
-    "commit": "95b5659f39847237122809c4eda2b71b89bd38e7"
+    "commit": "7b2cb7d53366177b004557cadb4784fd699bf155"
   },
-  "cast_at": "2026-08-25T21:03:47.309Z",
+  "cast_at": "2026-08-29T20:49:17.839Z",
   "cast_date": "2026-05-07",
   "cast_revision": 3,
   "cast_history": [
@@ -142,8 +142,8 @@
       "evidence": "hypothesis",
       "purpose": "Inherit open entries rather than re-deriving them, close the ones this brief's input, output, and label decisions settle, and append interface obligations the pipeline leaves open — a params entry with no Galaxy input, an emitted-but-unpublished output, a channel shape no collection maps cleanly onto.",
       "verification": "Promote after a worked run shows entries this Mold appends or resolves are consumed downstream without re-derivation.",
-      "src_hash": "10e84fa97b4e5c14ca78320b25cb9e419b7e98e0f2e676c09dd4deaf68a801fc",
-      "dst_hash": "10e84fa97b4e5c14ca78320b25cb9e419b7e98e0f2e676c09dd4deaf68a801fc",
+      "src_hash": "7ac93cdd192d3e42544ac0ffcecef7aa86d9b450608d9a41c25e6d5f8963af24",
+      "dst_hash": "7ac93cdd192d3e42544ac0ffcecef7aa86d9b450608d9a41c25e6d5f8963af24",
       "source": "deterministic"
     },
     {

--- a/casts/claude/skills/nextflow-summary-to-galaxy-interface/references/notes/open-requirements-ledger.md
+++ b/casts/claude/skills/nextflow-summary-to-galaxy-interface/references/notes/open-requirements-ledger.md
@@ -5,8 +5,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-06-16
-revised: 2026-08-19
-revision: 2
+revised: 2026-08-29
+revision: 3
 related_notes:
   - "[[galaxy-workflow-draft-format]]"
 related_molds:
@@ -18,7 +18,7 @@ summary: "Carried unresolved-requirements artifact the source→Galaxy pipeline 
 
 # Open-requirements ledger
 
-The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact.
+The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact. Alongside the entries it carries one run-level count — how much of the source the run actually carried — because a list of individually reasonable gaps can still add up to a pipeline that translated almost none of its source.
 
 ## Framing: obligations the pipeline discharges, not questions a human answers
 
@@ -64,6 +64,12 @@ This section is the runtime protocol for every Mold that carries the ledger. A M
 
 **Record a surrender note; leave the status to the terminal.** When you cannot close an entry and nothing downstream can either — no producer is discoverable, the output cannot be honestly narrowed — leave it `open` and say so in `note`. `surrendered` is a terminal status, set at the end of a run: the escalation cap reached, or the final artifact emitted with the obligation still unmet. Either way the entry stays visible and is written into the final artifact as a labelled gap, never dropped.
 
+**Maintain coverage.** Whenever a decision you make changes what the run will carry from
+the source, move the affected units between `coverage` buckets — never let them vanish.
+Narrowing a design moves units from `carried` to `surrendered`; deciding the target
+subsumes a mechanism moves them to `subsumed` with a reason. The buckets must still sum to
+`source_units` when you re-emit the ledger. See **Coverage (run-level state)** below.
+
 **Maintain the escalation budget** — loop Molds only. The `topology_repair` header is loop-level state, described under **Escalation budget (loop-level state)** below. On each escalation the orchestrator increments `escalations`, appends the post-repair open blocking-entry count to `open_history`, and surrenders the still-open blocking entries once `escalations` reaches `cap`.
 
 ## Role in topology repair
@@ -98,6 +104,56 @@ entries:
 
 This block lives in the ledger as a v1 expedient: the ledger is already the carried, cast-visible state the loop reads each iteration. Its better long-term home is the **draft itself** — a workflow-level annotation that travels with the artifact it bounds, so the budget survives even when the ledger is stripped at the terminal. Recorded here for now; migrate when the draft grows a home for it.
 
+## Coverage (run-level state)
+
+The decreasing-blocker invariant guards one failure — spin-or-fabricate during repair. It
+is blind to the opposite one, and blind by construction: **a run satisfies "strictly reduce
+the open blocking count" by deleting the steps that carried the blockers.** Dropping work
+drives the count to zero faster than doing it. Every invariant the ledger had was monotone
+in the direction that rewards shrinking.
+
+`coverage` is the counterweight — a conservation rule rather than a reduction one, in a
+second header beside `topology_repair`:
+
+```yaml
+coverage:
+  unit: nextflow-process     # what a source unit is, for this source kind
+  source_units: 95           # fixed by the first Mold; never re-based
+  carried: 68                # unit's work lives inside some step of the design
+  subsumed: 21               # target does this itself — reason required
+  surrendered: 6             # not carried, and nothing downstream will
+entries:
+  - id: sccmec-evidence-missing
+    # … per-entry shape above
+```
+
+The invariant is arithmetic: `carried + subsumed + surrendered == source_units`, checked
+whenever the ledger is re-emitted. Shrinking cannot satisfy it. A phase that cuts 25 nodes
+does not reduce a count — it moves 25 units into `surrendered`, where the terminal readout
+states them.
+
+- `unit` — the source's own granularity (`nextflow-process`, `cwl-step`), named once so the
+  denominator is not silently re-based mid-run. A Mold that re-groups units into coarser
+  steps has not changed `source_units`; merging N processes into one tool leaves all N
+  `carried`, which is why this is a partition and not a step-count ratio. A ratio would
+  flag legitimate re-granularization as loss.
+- `source_units` — set by the first Mold from the source summary, then read-only. Nothing
+  downstream may lower it; a design that carries less lowers `carried`.
+- `carried` — the unit's work reaches the target design, at whatever granularity.
+- `subsumed` — the target performs this itself, so translating it would be wrong. Real and
+  necessary: a Nextflow pipeline's grid-dispatch scatter/gather substrate is work Galaxy's
+  scheduler already does. It requires a stated reason, because it is the bucket a lazy run
+  would reach for.
+- `surrendered` — not carried and nothing downstream will carry it. Unlike per-entry
+  `surrendered`, this is not terminal-only: a phase that cuts scope surrenders units at the
+  moment it cuts, because a count nobody may update until the terminal is a count nobody
+  checks.
+
+Coverage answers a question no entry can: not *is each obligation tracked* but *how much of
+the source came out the other end*. On the run that motivated this, the six scope-cut
+entries were individually well-written and collectively described dropping 92 of 95
+processes. No phase ever computed that product, and every phase was reading the ledger.
+
 ## Threaded through the whole design tier
 
 The ledger is not loop-only. Every design-tier Mold in the source→Galaxy pipelines **consumes and re-emits** it — the interface, reference-data, data-flow, IWC-comparison, and template Molds (`*-summary-to-galaxy-interface`, `*-summary-to-galaxy-data-flow`, `*-summary-to-galaxy-reference-data`, `compare-against-iwc-exemplar`, `*-summary-to-galaxy-template`), alongside the change-set Molds on the update path. This is the direct answer to #281: the chain stops re-deriving the same unknowns because each Mold inherits them.
@@ -106,6 +162,7 @@ The template Mold's computability review pass is the notable appender ahead of t
 
 ## Open work
 
+- Decide who sets `coverage.subsumed` reasons and where they live — a free-text field on the header, or `kind`-tagged entries the header counts. Left loose here, like the rest of v1.
 - Decide whether entry structure should harden (typed `unmet` / `missing`, links back to source-summary evidence, machine-checkable `status` transitions) once two or three worked runs exercise it. Hardening it would also give the producing Molds an `output_artifacts[].schema` to cite, which none carry today.
 - Assign terminal surrender of *non-blocking* entries. [[advance-galaxy-draft-step]] surrenders open blocking entries at the escalation cap, but an unpinned-parameter entry the design tier appended and nobody closed currently rides out the run without ever being marked `surrendered`. Nothing owns that pass today.
 - Reconcile the design-tier briefs' free-text "open questions" sections with the ledger. Every design Mold still emits both, with no rule for which destination an unresolved choice belongs in.

--- a/casts/claude/skills/nextflow-summary-to-galaxy-reference-data/_provenance.json
+++ b/casts/claude/skills/nextflow-summary-to-galaxy-reference-data/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/nextflow-summary-to-galaxy-reference-data/index.md",
     "revision": 5,
     "content_hash": "b49bae31e3b8918b45f852b8f50e1101e71837380b97f8e8ec237a5dd2955f7f",
-    "commit": "95b5659f39847237122809c4eda2b71b89bd38e7"
+    "commit": "7b2cb7d53366177b004557cadb4784fd699bf155"
   },
-  "cast_at": "2026-08-25T21:03:47.415Z",
+  "cast_at": "2026-08-29T20:49:18.068Z",
   "refs": [
     {
       "kind": "research",
@@ -64,8 +64,8 @@
       "evidence": "hypothesis",
       "purpose": "Inherit open entries rather than re-deriving them, close the ones a settled reference-data shape discharges, and append reference obligations the pipeline leaves open — a genome key with no Galaxy data table, a reference the pipeline builds at runtime, a build the corpus doesn't carry.",
       "verification": "Promote after a worked run shows entries this Mold appends or resolves are consumed downstream without re-derivation.",
-      "src_hash": "10e84fa97b4e5c14ca78320b25cb9e419b7e98e0f2e676c09dd4deaf68a801fc",
-      "dst_hash": "10e84fa97b4e5c14ca78320b25cb9e419b7e98e0f2e676c09dd4deaf68a801fc",
+      "src_hash": "7ac93cdd192d3e42544ac0ffcecef7aa86d9b450608d9a41c25e6d5f8963af24",
+      "dst_hash": "7ac93cdd192d3e42544ac0ffcecef7aa86d9b450608d9a41c25e6d5f8963af24",
       "source": "deterministic"
     },
     {

--- a/casts/claude/skills/nextflow-summary-to-galaxy-reference-data/references/notes/open-requirements-ledger.md
+++ b/casts/claude/skills/nextflow-summary-to-galaxy-reference-data/references/notes/open-requirements-ledger.md
@@ -5,8 +5,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-06-16
-revised: 2026-08-19
-revision: 2
+revised: 2026-08-29
+revision: 3
 related_notes:
   - "[[galaxy-workflow-draft-format]]"
 related_molds:
@@ -18,7 +18,7 @@ summary: "Carried unresolved-requirements artifact the source→Galaxy pipeline 
 
 # Open-requirements ledger
 
-The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact.
+The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact. Alongside the entries it carries one run-level count — how much of the source the run actually carried — because a list of individually reasonable gaps can still add up to a pipeline that translated almost none of its source.
 
 ## Framing: obligations the pipeline discharges, not questions a human answers
 
@@ -64,6 +64,12 @@ This section is the runtime protocol for every Mold that carries the ledger. A M
 
 **Record a surrender note; leave the status to the terminal.** When you cannot close an entry and nothing downstream can either — no producer is discoverable, the output cannot be honestly narrowed — leave it `open` and say so in `note`. `surrendered` is a terminal status, set at the end of a run: the escalation cap reached, or the final artifact emitted with the obligation still unmet. Either way the entry stays visible and is written into the final artifact as a labelled gap, never dropped.
 
+**Maintain coverage.** Whenever a decision you make changes what the run will carry from
+the source, move the affected units between `coverage` buckets — never let them vanish.
+Narrowing a design moves units from `carried` to `surrendered`; deciding the target
+subsumes a mechanism moves them to `subsumed` with a reason. The buckets must still sum to
+`source_units` when you re-emit the ledger. See **Coverage (run-level state)** below.
+
 **Maintain the escalation budget** — loop Molds only. The `topology_repair` header is loop-level state, described under **Escalation budget (loop-level state)** below. On each escalation the orchestrator increments `escalations`, appends the post-repair open blocking-entry count to `open_history`, and surrenders the still-open blocking entries once `escalations` reaches `cap`.
 
 ## Role in topology repair
@@ -98,6 +104,56 @@ entries:
 
 This block lives in the ledger as a v1 expedient: the ledger is already the carried, cast-visible state the loop reads each iteration. Its better long-term home is the **draft itself** — a workflow-level annotation that travels with the artifact it bounds, so the budget survives even when the ledger is stripped at the terminal. Recorded here for now; migrate when the draft grows a home for it.
 
+## Coverage (run-level state)
+
+The decreasing-blocker invariant guards one failure — spin-or-fabricate during repair. It
+is blind to the opposite one, and blind by construction: **a run satisfies "strictly reduce
+the open blocking count" by deleting the steps that carried the blockers.** Dropping work
+drives the count to zero faster than doing it. Every invariant the ledger had was monotone
+in the direction that rewards shrinking.
+
+`coverage` is the counterweight — a conservation rule rather than a reduction one, in a
+second header beside `topology_repair`:
+
+```yaml
+coverage:
+  unit: nextflow-process     # what a source unit is, for this source kind
+  source_units: 95           # fixed by the first Mold; never re-based
+  carried: 68                # unit's work lives inside some step of the design
+  subsumed: 21               # target does this itself — reason required
+  surrendered: 6             # not carried, and nothing downstream will
+entries:
+  - id: sccmec-evidence-missing
+    # … per-entry shape above
+```
+
+The invariant is arithmetic: `carried + subsumed + surrendered == source_units`, checked
+whenever the ledger is re-emitted. Shrinking cannot satisfy it. A phase that cuts 25 nodes
+does not reduce a count — it moves 25 units into `surrendered`, where the terminal readout
+states them.
+
+- `unit` — the source's own granularity (`nextflow-process`, `cwl-step`), named once so the
+  denominator is not silently re-based mid-run. A Mold that re-groups units into coarser
+  steps has not changed `source_units`; merging N processes into one tool leaves all N
+  `carried`, which is why this is a partition and not a step-count ratio. A ratio would
+  flag legitimate re-granularization as loss.
+- `source_units` — set by the first Mold from the source summary, then read-only. Nothing
+  downstream may lower it; a design that carries less lowers `carried`.
+- `carried` — the unit's work reaches the target design, at whatever granularity.
+- `subsumed` — the target performs this itself, so translating it would be wrong. Real and
+  necessary: a Nextflow pipeline's grid-dispatch scatter/gather substrate is work Galaxy's
+  scheduler already does. It requires a stated reason, because it is the bucket a lazy run
+  would reach for.
+- `surrendered` — not carried and nothing downstream will carry it. Unlike per-entry
+  `surrendered`, this is not terminal-only: a phase that cuts scope surrenders units at the
+  moment it cuts, because a count nobody may update until the terminal is a count nobody
+  checks.
+
+Coverage answers a question no entry can: not *is each obligation tracked* but *how much of
+the source came out the other end*. On the run that motivated this, the six scope-cut
+entries were individually well-written and collectively described dropping 92 of 95
+processes. No phase ever computed that product, and every phase was reading the ledger.
+
 ## Threaded through the whole design tier
 
 The ledger is not loop-only. Every design-tier Mold in the source→Galaxy pipelines **consumes and re-emits** it — the interface, reference-data, data-flow, IWC-comparison, and template Molds (`*-summary-to-galaxy-interface`, `*-summary-to-galaxy-data-flow`, `*-summary-to-galaxy-reference-data`, `compare-against-iwc-exemplar`, `*-summary-to-galaxy-template`), alongside the change-set Molds on the update path. This is the direct answer to #281: the chain stops re-deriving the same unknowns because each Mold inherits them.
@@ -106,6 +162,7 @@ The template Mold's computability review pass is the notable appender ahead of t
 
 ## Open work
 
+- Decide who sets `coverage.subsumed` reasons and where they live — a free-text field on the header, or `kind`-tagged entries the header counts. Left loose here, like the rest of v1.
 - Decide whether entry structure should harden (typed `unmet` / `missing`, links back to source-summary evidence, machine-checkable `status` transitions) once two or three worked runs exercise it. Hardening it would also give the producing Molds an `output_artifacts[].schema` to cite, which none carry today.
 - Assign terminal surrender of *non-blocking* entries. [[advance-galaxy-draft-step]] surrenders open blocking entries at the escalation cap, but an unpinned-parameter entry the design tier appended and nobody closed currently rides out the run without ever being marked `surrendered`. Nothing owns that pass today.
 - Reconcile the design-tier briefs' free-text "open questions" sections with the ledger. Every design Mold still emits both, with no rule for which destination an unresolved choice belongs in.

--- a/casts/claude/skills/nextflow-summary-to-galaxy-template/_provenance.json
+++ b/casts/claude/skills/nextflow-summary-to-galaxy-template/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/nextflow-summary-to-galaxy-template/index.md",
     "revision": 9,
     "content_hash": "9876c401eddeef629d6475f7cf3c9ffe822a7007baea733bf6a9dfa5c314d836",
-    "commit": "95b5659f39847237122809c4eda2b71b89bd38e7"
+    "commit": "7b2cb7d53366177b004557cadb4784fd699bf155"
   },
-  "cast_at": "2026-08-25T21:03:47.734Z",
+  "cast_at": "2026-08-29T20:49:18.162Z",
   "cast_date": "2026-05-07",
   "cast_revision": 3,
   "cast_history": [
@@ -294,8 +294,8 @@
       "evidence": "hypothesis",
       "purpose": "Close the open entries the settled topology discharges, and append a blocking entry for any settled step whose declared output no wired input can supply — the computability gap gxwf validation cannot see, raised here rather than left for the per-step loop to hit.",
       "verification": "Promote after a worked run shows entries this Mold appends or resolves are consumed downstream without re-derivation.",
-      "src_hash": "10e84fa97b4e5c14ca78320b25cb9e419b7e98e0f2e676c09dd4deaf68a801fc",
-      "dst_hash": "10e84fa97b4e5c14ca78320b25cb9e419b7e98e0f2e676c09dd4deaf68a801fc",
+      "src_hash": "7ac93cdd192d3e42544ac0ffcecef7aa86d9b450608d9a41c25e6d5f8963af24",
+      "dst_hash": "7ac93cdd192d3e42544ac0ffcecef7aa86d9b450608d9a41c25e6d5f8963af24",
       "source": "deterministic"
     },
     {

--- a/casts/claude/skills/nextflow-summary-to-galaxy-template/references/notes/open-requirements-ledger.md
+++ b/casts/claude/skills/nextflow-summary-to-galaxy-template/references/notes/open-requirements-ledger.md
@@ -5,8 +5,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-06-16
-revised: 2026-08-19
-revision: 2
+revised: 2026-08-29
+revision: 3
 related_notes:
   - "[[galaxy-workflow-draft-format]]"
 related_molds:
@@ -18,7 +18,7 @@ summary: "Carried unresolved-requirements artifact the source→Galaxy pipeline 
 
 # Open-requirements ledger
 
-The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact.
+The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact. Alongside the entries it carries one run-level count — how much of the source the run actually carried — because a list of individually reasonable gaps can still add up to a pipeline that translated almost none of its source.
 
 ## Framing: obligations the pipeline discharges, not questions a human answers
 
@@ -64,6 +64,12 @@ This section is the runtime protocol for every Mold that carries the ledger. A M
 
 **Record a surrender note; leave the status to the terminal.** When you cannot close an entry and nothing downstream can either — no producer is discoverable, the output cannot be honestly narrowed — leave it `open` and say so in `note`. `surrendered` is a terminal status, set at the end of a run: the escalation cap reached, or the final artifact emitted with the obligation still unmet. Either way the entry stays visible and is written into the final artifact as a labelled gap, never dropped.
 
+**Maintain coverage.** Whenever a decision you make changes what the run will carry from
+the source, move the affected units between `coverage` buckets — never let them vanish.
+Narrowing a design moves units from `carried` to `surrendered`; deciding the target
+subsumes a mechanism moves them to `subsumed` with a reason. The buckets must still sum to
+`source_units` when you re-emit the ledger. See **Coverage (run-level state)** below.
+
 **Maintain the escalation budget** — loop Molds only. The `topology_repair` header is loop-level state, described under **Escalation budget (loop-level state)** below. On each escalation the orchestrator increments `escalations`, appends the post-repair open blocking-entry count to `open_history`, and surrenders the still-open blocking entries once `escalations` reaches `cap`.
 
 ## Role in topology repair
@@ -98,6 +104,56 @@ entries:
 
 This block lives in the ledger as a v1 expedient: the ledger is already the carried, cast-visible state the loop reads each iteration. Its better long-term home is the **draft itself** — a workflow-level annotation that travels with the artifact it bounds, so the budget survives even when the ledger is stripped at the terminal. Recorded here for now; migrate when the draft grows a home for it.
 
+## Coverage (run-level state)
+
+The decreasing-blocker invariant guards one failure — spin-or-fabricate during repair. It
+is blind to the opposite one, and blind by construction: **a run satisfies "strictly reduce
+the open blocking count" by deleting the steps that carried the blockers.** Dropping work
+drives the count to zero faster than doing it. Every invariant the ledger had was monotone
+in the direction that rewards shrinking.
+
+`coverage` is the counterweight — a conservation rule rather than a reduction one, in a
+second header beside `topology_repair`:
+
+```yaml
+coverage:
+  unit: nextflow-process     # what a source unit is, for this source kind
+  source_units: 95           # fixed by the first Mold; never re-based
+  carried: 68                # unit's work lives inside some step of the design
+  subsumed: 21               # target does this itself — reason required
+  surrendered: 6             # not carried, and nothing downstream will
+entries:
+  - id: sccmec-evidence-missing
+    # … per-entry shape above
+```
+
+The invariant is arithmetic: `carried + subsumed + surrendered == source_units`, checked
+whenever the ledger is re-emitted. Shrinking cannot satisfy it. A phase that cuts 25 nodes
+does not reduce a count — it moves 25 units into `surrendered`, where the terminal readout
+states them.
+
+- `unit` — the source's own granularity (`nextflow-process`, `cwl-step`), named once so the
+  denominator is not silently re-based mid-run. A Mold that re-groups units into coarser
+  steps has not changed `source_units`; merging N processes into one tool leaves all N
+  `carried`, which is why this is a partition and not a step-count ratio. A ratio would
+  flag legitimate re-granularization as loss.
+- `source_units` — set by the first Mold from the source summary, then read-only. Nothing
+  downstream may lower it; a design that carries less lowers `carried`.
+- `carried` — the unit's work reaches the target design, at whatever granularity.
+- `subsumed` — the target performs this itself, so translating it would be wrong. Real and
+  necessary: a Nextflow pipeline's grid-dispatch scatter/gather substrate is work Galaxy's
+  scheduler already does. It requires a stated reason, because it is the bucket a lazy run
+  would reach for.
+- `surrendered` — not carried and nothing downstream will carry it. Unlike per-entry
+  `surrendered`, this is not terminal-only: a phase that cuts scope surrenders units at the
+  moment it cuts, because a count nobody may update until the terminal is a count nobody
+  checks.
+
+Coverage answers a question no entry can: not *is each obligation tracked* but *how much of
+the source came out the other end*. On the run that motivated this, the six scope-cut
+entries were individually well-written and collectively described dropping 92 of 95
+processes. No phase ever computed that product, and every phase was reading the ledger.
+
 ## Threaded through the whole design tier
 
 The ledger is not loop-only. Every design-tier Mold in the source→Galaxy pipelines **consumes and re-emits** it — the interface, reference-data, data-flow, IWC-comparison, and template Molds (`*-summary-to-galaxy-interface`, `*-summary-to-galaxy-data-flow`, `*-summary-to-galaxy-reference-data`, `compare-against-iwc-exemplar`, `*-summary-to-galaxy-template`), alongside the change-set Molds on the update path. This is the direct answer to #281: the chain stops re-deriving the same unknowns because each Mold inherits them.
@@ -106,6 +162,7 @@ The template Mold's computability review pass is the notable appender ahead of t
 
 ## Open work
 
+- Decide who sets `coverage.subsumed` reasons and where they live — a free-text field on the header, or `kind`-tagged entries the header counts. Left loose here, like the rest of v1.
 - Decide whether entry structure should harden (typed `unmet` / `missing`, links back to source-summary evidence, machine-checkable `status` transitions) once two or three worked runs exercise it. Hardening it would also give the producing Molds an `output_artifacts[].schema` to cite, which none carry today.
 - Assign terminal surrender of *non-blocking* entries. [[advance-galaxy-draft-step]] surrenders open blocking entries at the escalation cap, but an unpinned-parameter entry the design tier appended and nobody closed currently rides out the run without ever being marked `surrendered`. Nothing owns that pass today.
 - Reconcile the design-tier briefs' free-text "open questions" sections with the ledger. Every design Mold still emits both, with no rule for which destination an unresolved choice belongs in.

--- a/casts/claude/skills/repair-galaxy-draft-topology/_provenance.json
+++ b/casts/claude/skills/repair-galaxy-draft-topology/_provenance.json
@@ -6,9 +6,9 @@
     "path": "content/molds/repair-galaxy-draft-topology/index.md",
     "revision": 3,
     "content_hash": "cafba235f3bb41612216f766eb390ee6fddcb1192ddf445b6d9eb7f2c132678c",
-    "commit": "95b5659f39847237122809c4eda2b71b89bd38e7"
+    "commit": "7b2cb7d53366177b004557cadb4784fd699bf155"
   },
-  "cast_at": "2026-08-25T21:03:48.315Z",
+  "cast_at": "2026-08-29T20:49:18.903Z",
   "refs": [
     {
       "kind": "pattern",
@@ -118,8 +118,8 @@
       "evidence": "hypothesis",
       "purpose": "Scope the repair from the open blocking entries — each names the step, the uncomputable output, and the missing evidence — then mark resolved each one repaired, and leave any it cannot close open with a surrender note for the terminal path.",
       "verification": "Promote after a run closes a blocking entry and the loop terminates on the reduced open count.",
-      "src_hash": "10e84fa97b4e5c14ca78320b25cb9e419b7e98e0f2e676c09dd4deaf68a801fc",
-      "dst_hash": "10e84fa97b4e5c14ca78320b25cb9e419b7e98e0f2e676c09dd4deaf68a801fc",
+      "src_hash": "7ac93cdd192d3e42544ac0ffcecef7aa86d9b450608d9a41c25e6d5f8963af24",
+      "dst_hash": "7ac93cdd192d3e42544ac0ffcecef7aa86d9b450608d9a41c25e6d5f8963af24",
       "source": "deterministic"
     },
     {

--- a/casts/claude/skills/repair-galaxy-draft-topology/references/notes/open-requirements-ledger.md
+++ b/casts/claude/skills/repair-galaxy-draft-topology/references/notes/open-requirements-ledger.md
@@ -5,8 +5,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-06-16
-revised: 2026-08-19
-revision: 2
+revised: 2026-08-29
+revision: 3
 related_notes:
   - "[[galaxy-workflow-draft-format]]"
 related_molds:
@@ -18,7 +18,7 @@ summary: "Carried unresolved-requirements artifact the source→Galaxy pipeline 
 
 # Open-requirements ledger
 
-The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact.
+The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact. Alongside the entries it carries one run-level count — how much of the source the run actually carried — because a list of individually reasonable gaps can still add up to a pipeline that translated almost none of its source.
 
 ## Framing: obligations the pipeline discharges, not questions a human answers
 
@@ -64,6 +64,12 @@ This section is the runtime protocol for every Mold that carries the ledger. A M
 
 **Record a surrender note; leave the status to the terminal.** When you cannot close an entry and nothing downstream can either — no producer is discoverable, the output cannot be honestly narrowed — leave it `open` and say so in `note`. `surrendered` is a terminal status, set at the end of a run: the escalation cap reached, or the final artifact emitted with the obligation still unmet. Either way the entry stays visible and is written into the final artifact as a labelled gap, never dropped.
 
+**Maintain coverage.** Whenever a decision you make changes what the run will carry from
+the source, move the affected units between `coverage` buckets — never let them vanish.
+Narrowing a design moves units from `carried` to `surrendered`; deciding the target
+subsumes a mechanism moves them to `subsumed` with a reason. The buckets must still sum to
+`source_units` when you re-emit the ledger. See **Coverage (run-level state)** below.
+
 **Maintain the escalation budget** — loop Molds only. The `topology_repair` header is loop-level state, described under **Escalation budget (loop-level state)** below. On each escalation the orchestrator increments `escalations`, appends the post-repair open blocking-entry count to `open_history`, and surrenders the still-open blocking entries once `escalations` reaches `cap`.
 
 ## Role in topology repair
@@ -98,6 +104,56 @@ entries:
 
 This block lives in the ledger as a v1 expedient: the ledger is already the carried, cast-visible state the loop reads each iteration. Its better long-term home is the **draft itself** — a workflow-level annotation that travels with the artifact it bounds, so the budget survives even when the ledger is stripped at the terminal. Recorded here for now; migrate when the draft grows a home for it.
 
+## Coverage (run-level state)
+
+The decreasing-blocker invariant guards one failure — spin-or-fabricate during repair. It
+is blind to the opposite one, and blind by construction: **a run satisfies "strictly reduce
+the open blocking count" by deleting the steps that carried the blockers.** Dropping work
+drives the count to zero faster than doing it. Every invariant the ledger had was monotone
+in the direction that rewards shrinking.
+
+`coverage` is the counterweight — a conservation rule rather than a reduction one, in a
+second header beside `topology_repair`:
+
+```yaml
+coverage:
+  unit: nextflow-process     # what a source unit is, for this source kind
+  source_units: 95           # fixed by the first Mold; never re-based
+  carried: 68                # unit's work lives inside some step of the design
+  subsumed: 21               # target does this itself — reason required
+  surrendered: 6             # not carried, and nothing downstream will
+entries:
+  - id: sccmec-evidence-missing
+    # … per-entry shape above
+```
+
+The invariant is arithmetic: `carried + subsumed + surrendered == source_units`, checked
+whenever the ledger is re-emitted. Shrinking cannot satisfy it. A phase that cuts 25 nodes
+does not reduce a count — it moves 25 units into `surrendered`, where the terminal readout
+states them.
+
+- `unit` — the source's own granularity (`nextflow-process`, `cwl-step`), named once so the
+  denominator is not silently re-based mid-run. A Mold that re-groups units into coarser
+  steps has not changed `source_units`; merging N processes into one tool leaves all N
+  `carried`, which is why this is a partition and not a step-count ratio. A ratio would
+  flag legitimate re-granularization as loss.
+- `source_units` — set by the first Mold from the source summary, then read-only. Nothing
+  downstream may lower it; a design that carries less lowers `carried`.
+- `carried` — the unit's work reaches the target design, at whatever granularity.
+- `subsumed` — the target performs this itself, so translating it would be wrong. Real and
+  necessary: a Nextflow pipeline's grid-dispatch scatter/gather substrate is work Galaxy's
+  scheduler already does. It requires a stated reason, because it is the bucket a lazy run
+  would reach for.
+- `surrendered` — not carried and nothing downstream will carry it. Unlike per-entry
+  `surrendered`, this is not terminal-only: a phase that cuts scope surrenders units at the
+  moment it cuts, because a count nobody may update until the terminal is a count nobody
+  checks.
+
+Coverage answers a question no entry can: not *is each obligation tracked* but *how much of
+the source came out the other end*. On the run that motivated this, the six scope-cut
+entries were individually well-written and collectively described dropping 92 of 95
+processes. No phase ever computed that product, and every phase was reading the ledger.
+
 ## Threaded through the whole design tier
 
 The ledger is not loop-only. Every design-tier Mold in the source→Galaxy pipelines **consumes and re-emits** it — the interface, reference-data, data-flow, IWC-comparison, and template Molds (`*-summary-to-galaxy-interface`, `*-summary-to-galaxy-data-flow`, `*-summary-to-galaxy-reference-data`, `compare-against-iwc-exemplar`, `*-summary-to-galaxy-template`), alongside the change-set Molds on the update path. This is the direct answer to #281: the chain stops re-deriving the same unknowns because each Mold inherits them.
@@ -106,6 +162,7 @@ The template Mold's computability review pass is the notable appender ahead of t
 
 ## Open work
 
+- Decide who sets `coverage.subsumed` reasons and where they live — a free-text field on the header, or `kind`-tagged entries the header counts. Left loose here, like the rest of v1.
 - Decide whether entry structure should harden (typed `unmet` / `missing`, links back to source-summary evidence, machine-checkable `status` transitions) once two or three worked runs exercise it. Hardening it would also give the producing Molds an `output_artifacts[].schema` to cite, which none carry today.
 - Assign terminal surrender of *non-blocking* entries. [[advance-galaxy-draft-step]] surrenders open blocking entries at the escalation cap, but an unpinned-parameter entry the design tier appended and nobody closed currently rides out the run without ever being marked `surrendered`. Nothing owns that pass today.
 - Reconcile the design-tier briefs' free-text "open questions" sections with the ledger. Every design Mold still emits both, with no rule for which destination an unresolved choice belongs in.

--- a/content/research/open-requirements-ledger/index.md
+++ b/content/research/open-requirements-ledger/index.md
@@ -5,8 +5,8 @@ tags:
   - target/galaxy
 status: draft
 created: 2026-06-16
-revised: 2026-08-19
-revision: 2
+revised: 2026-08-29
+revision: 3
 related_notes:
   - "[[galaxy-workflow-draft-format]]"
 related_molds:
@@ -18,7 +18,7 @@ summary: "Carried unresolved-requirements artifact the source→Galaxy pipeline 
 
 # Open-requirements ledger
 
-The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact.
+The `open-requirements-ledger` is a single artifact threaded through the source→Galaxy pipeline that records **obligations the pipeline has taken on but not yet met** — a declared output with no producer, a parameter whose value the source never pinned, a tool with no corpus exemplar. Each Mold that surfaces one **appends** it; each Mold whose decision closes one **marks it resolved**; the terminal path **surrenders** whatever remains open, explicitly, into the final artifact. Alongside the entries it carries one run-level count — how much of the source the run actually carried — because a list of individually reasonable gaps can still add up to a pipeline that translated almost none of its source.
 
 ## Framing: obligations the pipeline discharges, not questions a human answers
 
@@ -64,6 +64,12 @@ This section is the runtime protocol for every Mold that carries the ledger. A M
 
 **Record a surrender note; leave the status to the terminal.** When you cannot close an entry and nothing downstream can either — no producer is discoverable, the output cannot be honestly narrowed — leave it `open` and say so in `note`. `surrendered` is a terminal status, set at the end of a run: the escalation cap reached, or the final artifact emitted with the obligation still unmet. Either way the entry stays visible and is written into the final artifact as a labelled gap, never dropped.
 
+**Maintain coverage.** Whenever a decision you make changes what the run will carry from
+the source, move the affected units between `coverage` buckets — never let them vanish.
+Narrowing a design moves units from `carried` to `surrendered`; deciding the target
+subsumes a mechanism moves them to `subsumed` with a reason. The buckets must still sum to
+`source_units` when you re-emit the ledger. See **Coverage (run-level state)** below.
+
 **Maintain the escalation budget** — loop Molds only. The `topology_repair` header is loop-level state, described under **Escalation budget (loop-level state)** below. On each escalation the orchestrator increments `escalations`, appends the post-repair open blocking-entry count to `open_history`, and surrenders the still-open blocking entries once `escalations` reaches `cap`.
 
 ## Role in topology repair
@@ -98,6 +104,56 @@ entries:
 
 This block lives in the ledger as a v1 expedient: the ledger is already the carried, cast-visible state the loop reads each iteration. Its better long-term home is the **draft itself** — a workflow-level annotation that travels with the artifact it bounds, so the budget survives even when the ledger is stripped at the terminal. Recorded here for now; migrate when the draft grows a home for it.
 
+## Coverage (run-level state)
+
+The decreasing-blocker invariant guards one failure — spin-or-fabricate during repair. It
+is blind to the opposite one, and blind by construction: **a run satisfies "strictly reduce
+the open blocking count" by deleting the steps that carried the blockers.** Dropping work
+drives the count to zero faster than doing it. Every invariant the ledger had was monotone
+in the direction that rewards shrinking.
+
+`coverage` is the counterweight — a conservation rule rather than a reduction one, in a
+second header beside `topology_repair`:
+
+```yaml
+coverage:
+  unit: nextflow-process     # what a source unit is, for this source kind
+  source_units: 95           # fixed by the first Mold; never re-based
+  carried: 68                # unit's work lives inside some step of the design
+  subsumed: 21               # target does this itself — reason required
+  surrendered: 6             # not carried, and nothing downstream will
+entries:
+  - id: sccmec-evidence-missing
+    # … per-entry shape above
+```
+
+The invariant is arithmetic: `carried + subsumed + surrendered == source_units`, checked
+whenever the ledger is re-emitted. Shrinking cannot satisfy it. A phase that cuts 25 nodes
+does not reduce a count — it moves 25 units into `surrendered`, where the terminal readout
+states them.
+
+- `unit` — the source's own granularity (`nextflow-process`, `cwl-step`), named once so the
+  denominator is not silently re-based mid-run. A Mold that re-groups units into coarser
+  steps has not changed `source_units`; merging N processes into one tool leaves all N
+  `carried`, which is why this is a partition and not a step-count ratio. A ratio would
+  flag legitimate re-granularization as loss.
+- `source_units` — set by the first Mold from the source summary, then read-only. Nothing
+  downstream may lower it; a design that carries less lowers `carried`.
+- `carried` — the unit's work reaches the target design, at whatever granularity.
+- `subsumed` — the target performs this itself, so translating it would be wrong. Real and
+  necessary: a Nextflow pipeline's grid-dispatch scatter/gather substrate is work Galaxy's
+  scheduler already does. It requires a stated reason, because it is the bucket a lazy run
+  would reach for.
+- `surrendered` — not carried and nothing downstream will carry it. Unlike per-entry
+  `surrendered`, this is not terminal-only: a phase that cuts scope surrenders units at the
+  moment it cuts, because a count nobody may update until the terminal is a count nobody
+  checks.
+
+Coverage answers a question no entry can: not *is each obligation tracked* but *how much of
+the source came out the other end*. On the run that motivated this, the six scope-cut
+entries were individually well-written and collectively described dropping 92 of 95
+processes. No phase ever computed that product, and every phase was reading the ledger.
+
 ## Threaded through the whole design tier
 
 The ledger is not loop-only. Every design-tier Mold in the source→Galaxy pipelines **consumes and re-emits** it — the interface, reference-data, data-flow, IWC-comparison, and template Molds (`*-summary-to-galaxy-interface`, `*-summary-to-galaxy-data-flow`, `*-summary-to-galaxy-reference-data`, `compare-against-iwc-exemplar`, `*-summary-to-galaxy-template`), alongside the change-set Molds on the update path. This is the direct answer to #281: the chain stops re-deriving the same unknowns because each Mold inherits them.
@@ -106,6 +162,7 @@ The template Mold's computability review pass is the notable appender ahead of t
 
 ## Open work
 
+- Decide who sets `coverage.subsumed` reasons and where they live — a free-text field on the header, or `kind`-tagged entries the header counts. Left loose here, like the rest of v1.
 - Decide whether entry structure should harden (typed `unmet` / `missing`, links back to source-summary evidence, machine-checkable `status` transitions) once two or three worked runs exercise it. Hardening it would also give the producing Molds an `output_artifacts[].schema` to cite, which none carry today.
 - Assign terminal surrender of *non-blocking* entries. [[advance-galaxy-draft-step]] surrenders open blocking entries at the escalation cap, but an unpinned-parameter entry the design tier appended and nobody closed currently rides out the run without ever being marked `surrendered`. Nothing owns that pass today.
 - Reconcile the design-tier briefs' free-text "open questions" sections with the ledger. Every design Mold still emits both, with no rule for which destination an unresolved choice belongs in.


### PR DESCRIPTION
> Posted by Claude (AI assistant) on behalf of @jmchilton — not authored by them personally.

**Competing alternative to #479.** Both PRs target the same defect from the first real
ledger run; take one, not both.

## The structural finding

The ledger already has countable state and a gate — `blocking`, `escalations`, `cap`,
`open_history`, and the **decreasing-blocker invariant**: *"each repair escalation must
strictly reduce that count."* The note calls it *"the countable state the termination guard
depends on."*

That machinery stops spin-or-fabricate. It is blind to the opposite failure, and blind **by
construction**:

> a run satisfies "strictly reduce the open blocking count" by deleting the steps that
> carried the blockers.

Dropping work drives the count to zero faster than doing it. Every invariant the ledger had
was monotone in the direction that rewards shrinking.

The `ncbi/egapx` run is the demonstration. It finished with **3 steps against 95 source
processes**. Six ledger entries described the cuts — each individually specific, sourced
and honest. No phase ever computed their product, and every phase was reading the ledger.
`egapx-v1-scope-masking-only` is `blocking: true` and was never counted by anything,
because a phase-4 blocking entry is not a computability gap in a draft step.

## The change

A `coverage` header beside `topology_repair` — a **conservation** rule rather than a
reduction one:

```yaml
coverage:
  unit: nextflow-process     # what a source unit is, for this source kind
  source_units: 95           # fixed by the first Mold; never re-based
  carried: 68                # unit's work lives inside some step of the design
  subsumed: 21               # target does this itself — reason required
  surrendered: 6             # not carried, and nothing downstream will
```

`carried + subsumed + surrendered == source_units`, checked whenever the ledger is
re-emitted. Shrinking cannot satisfy it. A phase that cuts 25 nodes does not reduce a
count — it moves 25 units into `surrendered`.

Three design points worth reviewing:

**A partition, not a ratio.** Merging N processes into one Galaxy tool leaves all N
`carried`. A naive "final steps ÷ source processes" check would flag legitimate
re-granularization as loss — on the egapx run, the honest 95→31 subworkflow-granular
design would have tripped it while the dishonest 31→3 cut was the actual problem. Only a
partition separates *merged* from *deleted*.

**`subsumed` is real and necessary.** egapx's `gpx_qsubmit`/`gpx_qdump` grid-dispatch
substrate — 21 of 95 process rows — is work Galaxy's scheduler already does. Not
translating it is correct. It requires a stated reason precisely because it is the bucket
a lazy run reaches for.

**Surrender at the cut, not at the terminal.** Unlike per-entry `surrendered`, coverage
surrender is immediate: *"a count nobody may update until the terminal is a count nobody
checks."* The motivating run ended with 17 `open` entries and **0 `surrendered`** —
line 110's known open work, confirmed empirically.

## Why this rather than #479

#479 labels each drop; nothing totals them. A run that cuts a plane four times still emits
four reasonable-looking entries. The egapx failure was not that any single entry was
dishonest — every one of them was honest — it was that six honest entries summed to 92
dropped processes and nothing performed the addition.

## Why you might prefer #479

This needs `unit` defined per source kind, needs every carrying Mold to maintain arithmetic,
and adds real ceremony to a note that calls itself "v1, loose". Labelling is cheap and may
prove sufficient.

## Scope

`content/research/open-requirements-ledger/index.md` plus the 16 cast bundles carrying it
as a reference. No Mold page changes — the note *is* the runtime protocol.

## Verification

- `make check-casts` → 0 drift (16 bundles re-cast; untargeted `cast_at`/`commit` churn from the full sweep reverted)
- `npm run validate` → 247 files, **0 errors**, 49 warnings (all pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ESJRrrY4Wdg69CWi5t4Pw3
